### PR TITLE
feat: Add get orb txns for did in txn graph

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -14,6 +14,6 @@ coverage:
 
 ignore:
   - "test/bdd"  # ignore bdd tests
-  - "pkg/mocks"  # ignore maocks
+  - "pkg/mocks"  # ignore mocks
   - "cmd/orb-server"  # ignore folders and all its contents
 

--- a/cmd/orb-server/main.go
+++ b/cmd/orb-server/main.go
@@ -78,7 +78,7 @@ func main() { // nolint:funlen
 
 	opStore := mocks.NewMockOperationStore()
 
-	pcp := mocks.NewMockProtocolClientProvider().WithOpStore(opStore).WithOpStoreClient(opStore).WithMethodContext(methodCtx).WithBase(baseEnabled).WithCasClient(casClient) //nolint: lll
+	pcp := mocks.NewMockProtocolClientProvider().WithOpStore(opStore).WithOpStoreClient(opStore).WithMethodContext(methodCtx).WithBase(baseEnabled).WithCasClient(casClient).WithTxnGraph(txngraph.New(casClient)) //nolint: lll
 
 	pc, err := pcp.ForNamespace(mocks.DefaultNS)
 	if err != nil {
@@ -88,7 +88,9 @@ func main() { // nolint:funlen
 
 	sidetreeTxnCh := make(chan []string, txnBuffer)
 
-	bc := txnclient.New("did:sidetree", txngraph.New(casClient), memdidtxnref.New(), sidetreeTxnCh)
+	txnGraph := txngraph.New(casClient)
+
+	bc := txnclient.New("did:sidetree", txnGraph, memdidtxnref.New(), sidetreeTxnCh)
 
 	ctx := sidetreecontext.New(pc, bc)
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
 	github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6
-	github.com/trustbloc/sidetree-core-go v0.1.6-0.20210122174942-e46167572d9c
+	github.com/trustbloc/sidetree-core-go v0.1.6-0.20210127204726-af0b0257f397
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -208,8 +208,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/sidetree-core-go v0.1.6-0.20210122174942-e46167572d9c h1:corUio6dC9h2/bn0oBzwltl2iZWmCF+k7Ibu535q/0Q=
-github.com/trustbloc/sidetree-core-go v0.1.6-0.20210122174942-e46167572d9c/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20210127204726-af0b0257f397 h1:nua70oct/sYUQ/wWhoHZCjCxIg9wqHtv/0uzD7Zwxdc=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20210127204726-af0b0257f397/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/whyrusleeping/tar-utils v0.0.0-20180509141711-8c6c8ba81d5c h1:GGsyl0dZ2jJgVT+VvWBf/cNijrHRhkrTjkmp5wg7li0=
 github.com/whyrusleeping/tar-utils v0.0.0-20180509141711-8c6c8ba81d5c/go.mod h1:xxcJeBb7SIUl/Wzkz1eVKJE/CB34YNrqX2TQI6jY9zs=

--- a/pkg/api/txn/model.go
+++ b/pkg/api/txn/model.go
@@ -4,10 +4,15 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package txngraph
+package txn
 
-// Node defines transaction information.
-type Node struct {
+// OrbTransaction defines transaction information.
+type OrbTransaction struct {
+	Payload Payload `json:"payload"`
+}
+
+// Payload defines orb transaction payload (pre-announce payload).
+type Payload struct {
 	AnchorString   string            `json:"anchorString"`
 	Namespace      string            `json:"namespace"`
 	Version        uint64            `json:"version"`

--- a/pkg/context/txnclient/client.go
+++ b/pkg/context/txnclient/client.go
@@ -12,8 +12,8 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	txnapi "github.com/trustbloc/sidetree-core-go/pkg/api/txn"
 
+	"github.com/trustbloc/orb/pkg/api/txn"
 	"github.com/trustbloc/orb/pkg/didtxnref"
-	"github.com/trustbloc/orb/pkg/txngraph"
 )
 
 // Client implements writing orb transactions.
@@ -26,7 +26,7 @@ type Client struct {
 }
 
 type txnGraph interface {
-	Add(info *txngraph.Node) (string, error)
+	Add(info *txn.OrbTransaction) (string, error)
 }
 
 type didTxns interface {
@@ -63,11 +63,13 @@ func (c *Client) WriteAnchor(anchor string, refs []*operation.Reference, version
 		}
 	}
 
-	txnInfo := &txngraph.Node{
-		AnchorString:   anchor,
-		Namespace:      c.namespace,
-		Version:        version,
-		PreviousDidTxn: previousDidTxns,
+	txnInfo := &txn.OrbTransaction{
+		Payload: txn.Payload{
+			AnchorString:   anchor,
+			Namespace:      c.namespace,
+			Version:        version,
+			PreviousDidTxn: previousDidTxns,
+		},
 	}
 
 	cid, err := c.txnGraph.Add(txnInfo)

--- a/pkg/httpserver/server.go
+++ b/pkg/httpserver/server.go
@@ -43,7 +43,14 @@ func New(url, certFile, keyFile, token string, handlers ...common.HTTPHandler) *
 		router.HandleFunc(handler.Path(), handler.Handler()).Methods(handler.Method())
 	}
 
-	handler := cors.Default().Handler(router)
+	handler := cors.New(
+		cors.Options{
+			AllowedMethods: []string{
+				http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodOptions,
+			},
+			AllowedHeaders: []string{"*"},
+		},
+	).Handler(router)
 
 	return &Server{
 		httpServer: &http.Server{

--- a/pkg/mocks/protocol.go
+++ b/pkg/mocks/protocol.go
@@ -73,6 +73,7 @@ type MockProtocolClientProvider struct {
 	opStoreClient processor.OperationStoreClient
 	opStore       txnprocessor.OperationStore
 	casClient     cas.Client
+	txnGraph      txnprocessor.TxnGraph
 	methodCtx     []string
 	baseEnabled   bool
 }
@@ -94,6 +95,13 @@ func (m *MockProtocolClientProvider) WithOpStore(opStore txnprocessor.OperationS
 // WithCasClient sets the CAS client.
 func (m *MockProtocolClientProvider) WithCasClient(casClient cas.Client) *MockProtocolClientProvider {
 	m.casClient = casClient
+
+	return m
+}
+
+// WithTxnGraph sets the transaction graph.
+func (m *MockProtocolClientProvider) WithTxnGraph(txnGraph txnprocessor.TxnGraph) *MockProtocolClientProvider {
+	m.txnGraph = txnGraph
 
 	return m
 }
@@ -160,6 +168,7 @@ func (m *MockProtocolClientProvider) create() *MockProtocolClient {
 		&txnprocessor.Providers{
 			OpStore:                   m.opStore,
 			OperationProtocolProvider: op,
+			TxnGraph:                  m.txnGraph,
 		},
 	)
 

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/txnprocessor"
 
+	orbtxn "github.com/trustbloc/orb/pkg/api/txn"
 	"github.com/trustbloc/orb/pkg/txngraph"
 )
 
@@ -56,11 +57,15 @@ func TestStartObserver(t *testing.T) {
 		var txns []string
 		txnGraph := txngraph.New(mocks.NewMockCasClient(nil))
 
-		cid, err := txnGraph.Add(&txngraph.Node{Namespace: namespace1, Version: 1, AnchorString: "1.address"})
+		payload1 := orbtxn.Payload{Namespace: namespace1, Version: 1, AnchorString: "1.address"}
+
+		cid, err := txnGraph.Add(&orbtxn.OrbTransaction{Payload: payload1})
 		require.NoError(t, err)
 		txns = append(txns, cid)
 
-		cid, err = txnGraph.Add(&txngraph.Node{Namespace: namespace2, Version: 1, AnchorString: "2.address"})
+		payload2 := orbtxn.Payload{Namespace: namespace2, Version: 1, AnchorString: "2.address"}
+
+		cid, err = txnGraph.Add(&orbtxn.OrbTransaction{Payload: payload2})
 		require.NoError(t, err)
 		txns = append(txns, cid)
 

--- a/pkg/txngraph/graph_test.go
+++ b/pkg/txngraph/graph_test.go
@@ -11,7 +11,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
+
+	"github.com/trustbloc/orb/pkg/api/txn"
 )
+
+const testDID = "did:method:abc"
 
 func TestNew(t *testing.T) {
 	log := New(mocks.NewMockCasClient(nil))
@@ -22,10 +26,12 @@ func TestGraph_Add(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		graph := New(mocks.NewMockCasClient(nil))
 
-		txnInfo := &Node{
-			AnchorString: "anchor",
-			Namespace:    "namespace",
-			Version:      1,
+		txnInfo := &txn.OrbTransaction{
+			Payload: txn.Payload{
+				AnchorString: "anchor",
+				Namespace:    "namespace",
+				Version:      1,
+			},
 		}
 
 		cid, err := graph.Add(txnInfo)
@@ -34,14 +40,16 @@ func TestGraph_Add(t *testing.T) {
 	})
 }
 
-func TestGraph_Get(t *testing.T) {
+func TestGraph_Read(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		graph := New(mocks.NewMockCasClient(nil))
 
-		txnInfo := &Node{
-			AnchorString: "anchor",
-			Namespace:    "namespace",
-			Version:      1,
+		txnInfo := &txn.OrbTransaction{
+			Payload: txn.Payload{
+				AnchorString: "anchor",
+				Namespace:    "namespace",
+				Version:      1,
+			},
 		}
 
 		txnCID, err := graph.Add(txnInfo)
@@ -59,5 +67,102 @@ func TestGraph_Get(t *testing.T) {
 		txnNode, err := graph.Read("non-existent")
 		require.Error(t, err)
 		require.Nil(t, txnNode)
+	})
+}
+
+func TestGraph_GetDidTransactions(t *testing.T) {
+	t.Run("success - first did transaction (create), no previous did transaction", func(t *testing.T) {
+		graph := New(mocks.NewMockCasClient(nil))
+
+		txnInfo := &txn.OrbTransaction{
+			Payload: txn.Payload{
+				AnchorString: "anchor",
+				Namespace:    "namespace",
+				Version:      1,
+			},
+		}
+
+		txnCID, err := graph.Add(txnInfo)
+		require.NoError(t, err)
+		require.NotNil(t, txnCID)
+
+		didTxns, err := graph.GetDidTransactions(txnCID, testDID)
+		require.NoError(t, err)
+		require.Equal(t, 0, len(didTxns))
+	})
+
+	t.Run("success - previous transaction for did exists", func(t *testing.T) {
+		graph := New(mocks.NewMockCasClient(nil))
+
+		txn1 := &txn.OrbTransaction{
+			Payload: txn.Payload{
+				AnchorString: "anchor-1",
+				Namespace:    "namespace",
+				Version:      1,
+			},
+		}
+
+		txn1CID, err := graph.Add(txn1)
+		require.NoError(t, err)
+		require.NotNil(t, txn1)
+
+		testDID := "did:method:abc"
+
+		previousDIDTxns := make(map[string]string)
+		previousDIDTxns[testDID] = txn1CID
+
+		txnInfo := &txn.OrbTransaction{
+			Payload: txn.Payload{
+				AnchorString:   "anchor-2",
+				Namespace:      "namespace",
+				Version:        1,
+				PreviousDidTxn: previousDIDTxns,
+			},
+		}
+
+		txnCID, err := graph.Add(txnInfo)
+		require.NoError(t, err)
+		require.NotNil(t, txnCID)
+
+		didTxns, err := graph.GetDidTransactions(txnCID, testDID)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(didTxns))
+		require.Equal(t, txn1CID, didTxns[0])
+	})
+
+	t.Run("error - cid referenced in previous transaction not found", func(t *testing.T) {
+		graph := New(mocks.NewMockCasClient(nil))
+
+		testDID := "did:method:abc"
+
+		previousDIDTxns := make(map[string]string)
+		previousDIDTxns[testDID] = "non-existent"
+
+		txnInfo := &txn.OrbTransaction{
+			Payload: txn.Payload{
+				AnchorString:   "anchor-2",
+				Namespace:      "namespace",
+				Version:        1,
+				PreviousDidTxn: previousDIDTxns,
+			},
+		}
+
+		txnCID, err := graph.Add(txnInfo)
+		require.NoError(t, err)
+		require.NotNil(t, txnCID)
+
+		didTxns, err := graph.GetDidTransactions(txnCID, testDID)
+		require.Error(t, err)
+		require.Nil(t, didTxns)
+		require.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("error - head cid not found", func(t *testing.T) {
+		graph := New(mocks.NewMockCasClient(nil))
+
+		txnNode, err := graph.GetDidTransactions("non-existent", "did")
+		require.Error(t, err)
+		require.Nil(t, txnNode)
+		require.Contains(t, err.Error(), "not found")
 	})
 }


### PR DESCRIPTION
Txn Graph:
-- add get did transactions to txn graph.

Txn Processor:
-- add retrieving all orb transactions for did and check them against operations in operation store.

Closes #13

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>