### PR TITLE
feat: Define the basic ActivityPub vocabulary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ test/bdd/fixtures/keys/tls
 
 test/bdd/fixtures/data
 
+/coverage.txt

--- a/pkg/activitypub/vocab/contextproperty.go
+++ b/pkg/activitypub/vocab/contextproperty.go
@@ -1,0 +1,98 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vocab
+
+import (
+	"encoding/json"
+)
+
+// ContextProperty holds one or more contexts.
+type ContextProperty struct {
+	contexts []Context
+}
+
+// NewContextProperty returns a new 'context' property. Nil is returned if no context was provided.
+func NewContextProperty(context ...Context) *ContextProperty {
+	if len(context) == 0 {
+		return nil
+	}
+
+	return &ContextProperty{contexts: context}
+}
+
+// GetContexts returns all of the contexts defined in the property.
+func (p *ContextProperty) GetContexts() []Context {
+	return p.contexts
+}
+
+// Contains returns true if the property contains all of the given contexts.
+func (p *ContextProperty) Contains(contexts ...Context) bool {
+	if len(contexts) == 0 {
+		return false
+	}
+
+	for _, t := range contexts {
+		if !p.contains(t) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// ContainsAny returns true if the property contains any of the given contexts.
+func (p *ContextProperty) ContainsAny(contexts ...Context) bool {
+	for _, t := range contexts {
+		if p.contains(t) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// MarshalJSON marshals the context property.
+func (p *ContextProperty) MarshalJSON() ([]byte, error) {
+	if len(p.contexts) == 1 {
+		return json.Marshal(p.contexts[0])
+	}
+
+	return json.Marshal(p.contexts)
+}
+
+// UnmarshalJSON unmarshals the context property.
+func (p *ContextProperty) UnmarshalJSON(bytes []byte) error {
+	var ctx Context
+
+	err := json.Unmarshal(bytes, &ctx)
+	if err == nil {
+		p.contexts = []Context{ctx}
+
+		return err
+	}
+
+	var contexts []Context
+
+	err = json.Unmarshal(bytes, &contexts)
+	if err != nil {
+		return err
+	}
+
+	p.contexts = contexts
+
+	return nil
+}
+
+func (p *ContextProperty) contains(t Context) bool {
+	for _, pt := range p.contexts {
+		if pt == t {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/activitypub/vocab/contextproperty_test.go
+++ b/pkg/activitypub/vocab/contextproperty_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vocab
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestContextProperty(t *testing.T) {
+	const (
+		jsonContext      = `"https://www.w3.org/2018/credentials/v1"`
+		jsonMultiContext = `["https://www.w3.org/2018/credentials/v1","https://w3id.org/security/v1"]`
+	)
+
+	require.Nil(t, NewContextProperty())
+
+	t.Run("Single context", func(t *testing.T) {
+		p := NewContextProperty(ContextCredentials)
+		require.NotNil(t, p)
+
+		contexts := p.GetContexts()
+		require.Len(t, contexts, 1)
+		require.Equal(t, ContextCredentials, contexts[0])
+
+		bytes, err := json.Marshal(p)
+		require.NoError(t, err)
+		require.Equal(t, jsonContext, string(bytes))
+
+		p2 := &ContextProperty{}
+		require.NoError(t, json.Unmarshal([]byte(jsonContext), p2))
+		require.True(t, p2.Contains(ContextCredentials))
+		require.False(t, p2.ContainsAny(ContextSecurity))
+	})
+
+	t.Run("Multiple contexts", func(t *testing.T) {
+		p := NewContextProperty(ContextCredentials, ContextSecurity)
+		require.NotNil(t, p)
+
+		contexts := p.GetContexts()
+		require.Len(t, contexts, 2)
+		require.Equal(t, ContextCredentials, contexts[0])
+		require.Equal(t, ContextSecurity, contexts[1])
+
+		bytes, err := json.Marshal(p)
+		require.NoError(t, err)
+		require.Equal(t, jsonMultiContext, string(bytes))
+
+		p2 := &ContextProperty{}
+		require.NoError(t, json.Unmarshal([]byte(jsonMultiContext), p2))
+		require.True(t, p2.Contains(ContextCredentials, ContextSecurity))
+		require.False(t, p2.Contains(ContextCredentials, ContextOrb))
+		require.True(t, p2.ContainsAny(ContextSecurity))
+	})
+}

--- a/pkg/activitypub/vocab/objecttype.go
+++ b/pkg/activitypub/vocab/objecttype.go
@@ -1,0 +1,154 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vocab
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// ObjectType defines an 'object'.
+type ObjectType struct {
+	object     *objectType
+	additional Document
+}
+
+// NewObject returns a new 'object'.
+func NewObject(opts ...Opt) *ObjectType {
+	options := NewOptions(opts...)
+
+	return &ObjectType{
+		object: &objectType{
+			Context:   NewContextProperty(options.Context...),
+			ID:        options.ID,
+			Type:      NewTypeProperty(options.Types...),
+			To:        NewURLCollectionProperty(options.To...),
+			Published: options.Published,
+			StartTime: options.StartTime,
+			EndTime:   options.EndTime,
+		},
+	}
+}
+
+// NewObjectWithDocument returns a new object initialized with the given document.
+func NewObjectWithDocument(doc Document, opts ...Opt) (*ObjectType, error) {
+	if doc == nil {
+		return nil, fmt.Errorf("nil document")
+	}
+
+	bytes, err := MarshalJSON(NewObject(opts...), doc)
+	if err != nil {
+		return nil, errors.WithMessage(err, "marshal error")
+	}
+
+	obj := &ObjectType{}
+
+	err = json.Unmarshal(bytes, &obj)
+	if err != nil {
+		return nil, errors.WithMessage(err, "unmarshal error")
+	}
+
+	return obj, nil
+}
+
+type objectType struct {
+	Context   *ContextProperty       `json:"@context,omitempty"`
+	ID        string                 `json:"id,omitempty"`
+	Type      *TypeProperty          `json:"type,omitempty"`
+	To        *URLCollectionProperty `json:"to,omitempty"`
+	Published *time.Time             `json:"published,omitempty"`
+	StartTime *time.Time             `json:"startTime,omitempty"`
+	EndTime   *time.Time             `json:"endTime,omitempty"`
+}
+
+// GetContext returns the context property.
+func (t *ObjectType) GetContext() *ContextProperty {
+	return t.object.Context
+}
+
+// GetID returns the object's ID.
+func (t *ObjectType) GetID() string {
+	return t.object.ID
+}
+
+// GetType returns the type of the object.
+func (t *ObjectType) GetType() *TypeProperty {
+	return t.object.Type
+}
+
+// GetPublished returns the time when the object was published.
+func (t *ObjectType) GetPublished() *time.Time {
+	return t.object.Published
+}
+
+// GetStartTime returns the start time.
+func (t *ObjectType) GetStartTime() *time.Time {
+	return t.object.StartTime
+}
+
+// GetEndTime returns the end time.
+func (t *ObjectType) GetEndTime() *time.Time {
+	return t.object.EndTime
+}
+
+// GetTo returns a set of URLs to which the object should be sent.
+func (t *ObjectType) GetTo() []*url.URL {
+	if t.object.To == nil {
+		return nil
+	}
+
+	urls := make([]*url.URL, len(t.object.To.urls))
+
+	for i, u := range t.object.To.urls {
+		urls[i] = u.u
+	}
+
+	return urls
+}
+
+// GetValue returns the value of a property.
+func (t *ObjectType) GetValue(key string) (interface{}, bool) {
+	v, ok := t.additional[key]
+
+	return v, ok
+}
+
+// MarshalJSON marshals the object.
+func (t *ObjectType) MarshalJSON() ([]byte, error) {
+	return MarshalJSON(t.object, t.additional)
+}
+
+// UnmarshalJSON unmarshals the object.
+func (t *ObjectType) UnmarshalJSON(bytes []byte) error {
+	header := &objectType{}
+
+	err := json.Unmarshal(bytes, header)
+	if err != nil {
+		return err
+	}
+
+	doc := make(Document)
+
+	err = json.Unmarshal(bytes, &doc)
+	if err != nil {
+		return err
+	}
+
+	// Delete all of the reserved ActivityStreams fields
+	for _, prop := range reservedProperties() {
+		delete(doc, prop)
+	}
+
+	t.object = header
+	t.additional = doc
+
+	return nil
+}

--- a/pkg/activitypub/vocab/objecttype_test.go
+++ b/pkg/activitypub/vocab/objecttype_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vocab
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
+)
+
+func TestObjectType_WithoutDocument(t *testing.T) {
+	const id = "http://sally.example.com/transactions/bafkreihwsn"
+
+	to1 := mustParseURL("https://to1")
+	to2 := mustParseURL("https://to2")
+
+	publishedTime := getStaticTime()
+	startTime := getStaticTime()
+	endTime := getStaticTime()
+
+	t.Run("NewObject", func(t *testing.T) {
+		obj := NewObject(
+			WithID(id),
+			WithContext(ContextCredentials, ContextOrb),
+			WithType(TypeVerifiableCredential, TypeAnchorCredential),
+			WithTo(to1, to2),
+			WithPublishedTime(&publishedTime),
+			WithStartTime(&startTime),
+			WithEndTime(&endTime),
+		)
+
+		context := obj.GetContext()
+		require.NotNil(t, context)
+		require.True(t, context.Contains(ContextCredentials, ContextOrb))
+
+		require.Equal(t, id, obj.GetID())
+
+		typeProp := obj.GetType()
+		require.NotNil(t, typeProp)
+		require.True(t, typeProp.Is(TypeVerifiableCredential, TypeAnchorCredential))
+
+		require.Equal(t, &publishedTime, obj.GetPublished())
+		require.Equal(t, &startTime, obj.GetStartTime())
+		require.Equal(t, &endTime, obj.GetEndTime())
+
+		to := obj.GetTo()
+		require.Len(t, to, 2)
+		require.Equal(t, to1.String(), to[0].String())
+		require.Equal(t, to2.String(), to[1].String())
+	})
+
+	t.Run("MarshalJSON", func(t *testing.T) {
+		obj := NewObject(
+			WithID(id),
+			WithContext(ContextCredentials, ContextOrb),
+			WithType(TypeVerifiableCredential, TypeAnchorCredential),
+			WithPublishedTime(&publishedTime),
+			WithStartTime(&startTime),
+			WithEndTime(&endTime),
+		)
+
+		bytes, err := canonicalizer.MarshalCanonical(obj)
+		require.NoError(t, err)
+		t.Log(string(bytes))
+
+		require.Equal(t, getCanonical(t, jsonObject), string(bytes))
+	})
+
+	t.Run("Unmarshal", func(t *testing.T) {
+		obj := NewObject()
+		require.NoError(t, json.Unmarshal([]byte(jsonObject), obj))
+
+		t.Logf("Types: %s", obj.object.Type.types)
+
+		context := obj.GetContext()
+		require.NotNil(t, context)
+		require.True(t, context.Contains(ContextCredentials, ContextOrb))
+
+		require.Equal(t, id, obj.GetID())
+
+		typeProp := obj.GetType()
+		require.NotNil(t, typeProp)
+		require.True(t, typeProp.Is(TypeVerifiableCredential, TypeAnchorCredential))
+
+		require.Equal(t, &publishedTime, obj.GetPublished())
+		require.Equal(t, &startTime, obj.GetStartTime())
+		require.Equal(t, &endTime, obj.GetEndTime())
+
+		require.Len(t, obj.GetTo(), 0)
+	})
+}
+
+func TestObjectType_WithDocument(t *testing.T) {
+	const id = "http://sally.example.com/transactions/bafkreihwsn"
+
+	to1 := mustParseURL("https://to1")
+	to2 := mustParseURL("https://to2")
+
+	publishedTime := getStaticTime()
+	startTime := getStaticTime()
+	endTime := getStaticTime()
+
+	t.Run("MarshalJSON", func(t *testing.T) {
+		obj, err := NewObjectWithDocument(
+			Document{
+				"credentialSubject": Document{
+					"anchorString": "bafkreihwsn",
+					"namespace":    "did:orb",
+					"previousTransactions": Document{
+						"EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
+						"EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w",
+					},
+					"version": "1",
+				},
+				"issuanceDate": "2021-01-27T09:30:10Z",
+				"issuer":       "https://sally.example.com/services/orb",
+				"proofChain":   []interface{}{},
+			},
+			WithID(id),
+			WithContext(ContextCredentials, ContextOrb),
+			WithType(TypeVerifiableCredential, TypeAnchorCredential),
+			WithTo(to1, to2),
+			WithPublishedTime(&publishedTime),
+			WithStartTime(&startTime),
+			WithEndTime(&endTime),
+		)
+		require.NoError(t, err)
+
+		bytes, err := canonicalizer.MarshalCanonical(obj)
+		require.NoError(t, err)
+		t.Log(string(bytes))
+
+		require.Equal(t, getCanonical(t, jsonObjectWithDoc), string(bytes))
+	})
+
+	t.Run("Unmarshal", func(t *testing.T) {
+		obj := &ObjectType{}
+		require.NoError(t, json.Unmarshal([]byte(jsonObjectWithDoc), obj))
+
+		t.Logf("Types: %s", obj.object.Type.types)
+
+		context := obj.GetContext()
+		require.NotNil(t, context)
+		require.True(t, context.Contains(ContextCredentials, ContextOrb))
+
+		require.Equal(t, id, obj.GetID())
+
+		typeProp := obj.GetType()
+		require.NotNil(t, typeProp)
+		require.True(t, typeProp.Is(TypeVerifiableCredential, TypeAnchorCredential))
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		obj, err := NewObjectWithDocument(nil)
+		require.EqualError(t, err, "nil document")
+		require.Nil(t, obj)
+	})
+}
+
+const (
+	jsonObject = `{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://trustbloc.github.io/Context/orb-v1.json"
+  ],
+  "endTime": "2021-01-27T09:30:10Z",
+  "id": "http://sally.example.com/transactions/bafkreihwsn",
+  "published": "2021-01-27T09:30:10Z",
+  "startTime": "2021-01-27T09:30:10Z",
+  "type": [
+    "VerifiableCredential",
+    "AnchorCredential"
+  ]
+}`
+	jsonObjectWithDoc = `{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://trustbloc.github.io/Context/orb-v1.json"
+  ],
+  "endTime": "2021-01-27T09:30:10Z",
+  "id": "http://sally.example.com/transactions/bafkreihwsn",
+  "published": "2021-01-27T09:30:10Z",
+  "startTime": "2021-01-27T09:30:10Z",
+  "to": [
+    "https://to1",
+    "https://to2"
+  ],
+  "credentialSubject": {
+    "anchorString": "bafkreihwsn",
+    "namespace": "did:orb",
+    "previousTransactions": {
+      "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
+      "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w"
+    },
+    "version": "1"
+  },
+  "id": "http://sally.example.com/transactions/bafkreihwsn",
+  "issuanceDate": "2021-01-27T09:30:10Z",
+  "issuer": "https://sally.example.com/services/orb",
+  "proofChain": [],
+  "type": [
+    "VerifiableCredential",
+    "AnchorCredential"
+  ]
+}`
+)

--- a/pkg/activitypub/vocab/options.go
+++ b/pkg/activitypub/vocab/options.go
@@ -1,0 +1,86 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vocab
+
+import (
+	"net/url"
+	"time"
+)
+
+// Options holds all of the options for building an ActivityPub object.
+type Options struct {
+	Context   []Context
+	ID        string
+	To        []*url.URL
+	Published *time.Time
+	StartTime *time.Time
+	EndTime   *time.Time
+	Types     []Type
+}
+
+// Opt is an for an object, activity, etc.
+type Opt func(opts *Options)
+
+// NewOptions returns an Options struct which is populated with the provided options.
+func NewOptions(opts ...Opt) *Options {
+	options := &Options{}
+
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	return options
+}
+
+// WithContext sets the 'context' property on the object.
+func WithContext(context ...Context) Opt {
+	return func(opts *Options) {
+		opts.Context = context
+	}
+}
+
+// WithID sets the 'id' property on the object.
+func WithID(id string) Opt {
+	return func(opts *Options) {
+		opts.ID = id
+	}
+}
+
+// WithTo sets the "to" property on the object.
+func WithTo(to ...*url.URL) Opt {
+	return func(opts *Options) {
+		opts.To = append(opts.To, to...)
+	}
+}
+
+// WithType sets tye 'type' property on the object.
+func WithType(t ...Type) Opt {
+	return func(opts *Options) {
+		opts.Types = t
+	}
+}
+
+// WithPublishedTime sets the 'publishedTime' property on the object.
+func WithPublishedTime(t *time.Time) Opt {
+	return func(opts *Options) {
+		opts.Published = t
+	}
+}
+
+// WithStartTime sets the 'startTime' property on the object.
+func WithStartTime(t *time.Time) Opt {
+	return func(opts *Options) {
+		opts.StartTime = t
+	}
+}
+
+// WithEndTime sets the 'endTime' property on the object.
+func WithEndTime(t *time.Time) Opt {
+	return func(opts *Options) {
+		opts.EndTime = t
+	}
+}

--- a/pkg/activitypub/vocab/options_test.go
+++ b/pkg/activitypub/vocab/options_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vocab
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewOptions(t *testing.T) {
+	const id = "https://example.com/1234"
+
+	to1 := mustParseURL("https://to1")
+	to2 := mustParseURL("https://to2")
+
+	publishedTime := time.Now()
+	startTime := time.Now()
+	endTime := time.Now()
+
+	opts := NewOptions(
+		WithID(id),
+		WithContext(ContextCredentials, ContextActivityStreams),
+		WithType(TypeCreate),
+		WithTo(to1, to2),
+		WithPublishedTime(&publishedTime),
+		WithStartTime(&startTime),
+		WithEndTime(&endTime),
+	)
+
+	require.NotNil(t, opts)
+
+	require.Equal(t, id, opts.ID)
+
+	require.Len(t, opts.Context, 2)
+	require.Equal(t, ContextCredentials, opts.Context[0])
+	require.Equal(t, ContextActivityStreams, opts.Context[1])
+
+	require.Len(t, opts.Types, 1)
+	require.Equal(t, TypeCreate, opts.Types[0])
+
+	require.Len(t, opts.To, 2)
+	require.Equal(t, to1.String(), opts.To[0].String())
+	require.Equal(t, to2.String(), opts.To[1].String())
+
+	require.Equal(t, &publishedTime, opts.Published)
+	require.Equal(t, &startTime, opts.StartTime)
+	require.Equal(t, &endTime, opts.EndTime)
+}

--- a/pkg/activitypub/vocab/typeproperty.go
+++ b/pkg/activitypub/vocab/typeproperty.go
@@ -1,0 +1,99 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vocab
+
+import (
+	"encoding/json"
+)
+
+// TypeProperty defines a 'type' property on an abject which
+// can hold one or more types.
+type TypeProperty struct {
+	types []Type
+}
+
+// NewTypeProperty returns a new 'type' property. Nil is returned if no types were provided.
+func NewTypeProperty(t ...Type) *TypeProperty {
+	if len(t) == 0 {
+		return nil
+	}
+
+	return &TypeProperty{types: t}
+}
+
+// MarshalJSON marshals the type property.
+func (p *TypeProperty) MarshalJSON() ([]byte, error) {
+	if len(p.types) == 1 {
+		return json.Marshal(p.types[0])
+	}
+
+	return json.Marshal(p.types)
+}
+
+// UnmarshalJSON unmarshals the type property.
+func (p *TypeProperty) UnmarshalJSON(bytes []byte) error {
+	var ctx Type
+
+	err := json.Unmarshal(bytes, &ctx)
+	if err == nil {
+		p.types = []Type{ctx}
+
+		return err
+	}
+
+	var types []Type
+
+	err = json.Unmarshal(bytes, &types)
+	if err != nil {
+		return err
+	}
+
+	p.types = types
+
+	return nil
+}
+
+// GetTypes returns all types.
+func (p *TypeProperty) GetTypes() []Type {
+	return p.types
+}
+
+// Is returns true if the property has all of the given types.
+func (p *TypeProperty) Is(types ...Type) bool {
+	if len(types) == 0 {
+		return false
+	}
+
+	for _, t := range types {
+		if !p.is(t) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// IsAny returns true if the property has any of the given types.
+func (p *TypeProperty) IsAny(types ...Type) bool {
+	for _, t := range types {
+		if p.Is(t) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (p *TypeProperty) is(t Type) bool {
+	for _, pt := range p.types {
+		if pt == t {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/activitypub/vocab/typeproperty_test.go
+++ b/pkg/activitypub/vocab/typeproperty_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vocab
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTypeProperty(t *testing.T) {
+	const (
+		jsonType      = `"Create"`
+		jsonMultiType = `["Create","AnchorCredential"]`
+	)
+
+	require.Nil(t, NewTypeProperty())
+
+	t.Run("Single type", func(t *testing.T) {
+		p := NewTypeProperty(TypeCreate)
+		require.NotNil(t, p)
+
+		types := p.GetTypes()
+		require.Len(t, types, 1)
+		require.Equal(t, TypeCreate, types[0])
+
+		bytes, err := json.Marshal(p)
+		require.NoError(t, err)
+		require.Equal(t, jsonType, string(bytes))
+
+		p2 := &TypeProperty{}
+		require.NoError(t, json.Unmarshal([]byte(jsonType), p2))
+		require.True(t, p2.Is(TypeCreate))
+		require.False(t, p2.IsAny(TypeAnchorCredential))
+	})
+
+	t.Run("Multiple types", func(t *testing.T) {
+		p := NewTypeProperty(TypeCreate, TypeAnchorCredential)
+		require.NotNil(t, p)
+
+		types := p.GetTypes()
+		require.Len(t, types, 2)
+		require.Equal(t, TypeCreate, types[0])
+		require.Equal(t, TypeAnchorCredential, types[1])
+
+		bytes, err := json.Marshal(p)
+		require.NoError(t, err)
+		require.Equal(t, jsonMultiType, string(bytes))
+
+		p2 := &TypeProperty{}
+		require.NoError(t, json.Unmarshal([]byte(jsonMultiType), p2))
+		require.True(t, p2.Is(TypeCreate, TypeAnchorCredential))
+		require.False(t, p2.Is(TypeCreate, TypeFollow))
+		require.True(t, p2.IsAny(TypeAnchorCredential))
+	})
+}

--- a/pkg/activitypub/vocab/urlproperty.go
+++ b/pkg/activitypub/vocab/urlproperty.go
@@ -1,0 +1,127 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vocab
+
+import (
+	"encoding/json"
+	"net/url"
+)
+
+// URLProperty holds a URL.
+type URLProperty struct {
+	u *url.URL
+}
+
+// NewURLProperty returns a new URL property with the given URL. Nil is returned if the provided URL is nil.
+func NewURLProperty(u *url.URL) *URLProperty {
+	if u == nil {
+		return nil
+	}
+
+	return &URLProperty{u: u}
+}
+
+// String returns the string representation of the URL.
+func (t *URLProperty) String() string {
+	if t.u == nil {
+		return ""
+	}
+
+	return t.u.String()
+}
+
+// GetURL returns the contained URL.
+func (t *URLProperty) GetURL() *url.URL {
+	return t.u
+}
+
+// MarshalJSON marshals the URL property.
+func (t *URLProperty) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.u.String())
+}
+
+// UnmarshalJSON unmarshals the URL property.
+func (t *URLProperty) UnmarshalJSON(bytes []byte) error {
+	var iri string
+
+	err := json.Unmarshal(bytes, &iri)
+	if err != nil {
+		return err
+	}
+
+	u, err := url.Parse(iri)
+	if err != nil {
+		return err
+	}
+
+	t.u = u
+
+	return nil
+}
+
+// URLCollectionProperty contains a collection of URLs.
+type URLCollectionProperty struct {
+	urls []*URLProperty
+}
+
+// NewURLCollectionProperty returns a new URL collection property. Nil is returned if no URLs were provided.
+func NewURLCollectionProperty(urls ...*url.URL) *URLCollectionProperty {
+	if len(urls) == 0 {
+		return nil
+	}
+
+	p := &URLCollectionProperty{}
+
+	for _, u := range urls {
+		p.urls = append(p.urls, &URLProperty{u: u})
+	}
+
+	return p
+}
+
+// GetURLs returns the URLs.
+func (t *URLCollectionProperty) GetURLs() []*url.URL {
+	urls := make([]*url.URL, len(t.urls))
+
+	for i, p := range t.urls {
+		urls[i] = p.GetURL()
+	}
+
+	return urls
+}
+
+// MarshalJSON marshals the URL collection.
+func (t *URLCollectionProperty) MarshalJSON() ([]byte, error) {
+	if len(t.urls) == 1 {
+		return json.Marshal(t.urls[0])
+	}
+
+	return json.Marshal(t.urls)
+}
+
+// UnmarshalJSON unmarshals the URL collection.
+func (t *URLCollectionProperty) UnmarshalJSON(bytes []byte) error {
+	iri := &URLProperty{}
+
+	err := json.Unmarshal(bytes, &iri)
+	if err == nil {
+		t.urls = []*URLProperty{iri}
+
+		return err
+	}
+
+	var iris []*URLProperty
+
+	err = json.Unmarshal(bytes, &iris)
+	if err != nil {
+		return err
+	}
+
+	t.urls = iris
+
+	return nil
+}

--- a/pkg/activitypub/vocab/urlproperty_test.go
+++ b/pkg/activitypub/vocab/urlproperty_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vocab
+
+import (
+	"encoding/json"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestURLProperty(t *testing.T) {
+	const (
+		address = "https://example.com"
+		jsonURL = `"https://example.com"`
+	)
+
+	u, err := url.Parse(address)
+	require.NoError(t, err)
+
+	require.Nil(t, NewURLProperty(nil))
+
+	p := NewURLProperty(u)
+	require.NotNil(t, p)
+	require.Equal(t, u, p.GetURL())
+	require.Equal(t, u.String(), p.String())
+
+	bytes, err := json.Marshal(p)
+	require.NoError(t, err)
+	require.Equal(t, jsonURL, string(bytes))
+
+	p2 := &URLProperty{}
+	require.NoError(t, json.Unmarshal(bytes, p2))
+	require.Equal(t, u.String(), p2.String())
+}
+
+func TestURLCollectionProperty(t *testing.T) {
+	const (
+		address1          = "https://example1.com"
+		address2          = "https://example2.com"
+		jsonURL           = `"https://example1.com"`
+		jsonURLCollection = `["https://example1.com","https://example2.com"]`
+	)
+
+	u1, err := url.Parse(address1)
+	require.NoError(t, err)
+
+	u2, err := url.Parse(address2)
+	require.NoError(t, err)
+
+	require.Nil(t, NewURLCollectionProperty())
+
+	t.Run("Single URL", func(t *testing.T) {
+		p := NewURLCollectionProperty(u1)
+		require.NotNil(t, p)
+
+		urls := p.GetURLs()
+		require.Len(t, urls, 1)
+		require.Equal(t, u1, urls[0])
+
+		bytes, err := json.Marshal(p)
+		require.NoError(t, err)
+
+		p2 := &URLCollectionProperty{}
+		require.NoError(t, json.Unmarshal(bytes, p2))
+		require.Equal(t, jsonURL, string(bytes))
+
+		urls = p2.GetURLs()
+		require.Len(t, urls, 1)
+		require.Equal(t, u1, urls[0])
+	})
+
+	t.Run("Multiple URLs", func(t *testing.T) {
+		p := NewURLCollectionProperty(u1, u2)
+		require.NotNil(t, p)
+
+		urls := p.GetURLs()
+		require.Len(t, urls, 2)
+		require.Equal(t, u1, urls[0])
+		require.Equal(t, u2, urls[1])
+
+		bytes, err := json.Marshal(p)
+		require.NoError(t, err)
+
+		p2 := &URLCollectionProperty{}
+		require.NoError(t, json.Unmarshal(bytes, p2))
+		require.Equal(t, jsonURLCollection, string(bytes))
+
+		urls = p2.GetURLs()
+		require.Len(t, urls, 2)
+		require.Equal(t, u1, urls[0])
+		require.Equal(t, u2, urls[1])
+	})
+}

--- a/pkg/activitypub/vocab/util.go
+++ b/pkg/activitypub/vocab/util.go
@@ -1,0 +1,80 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vocab
+
+import (
+	"encoding/json"
+)
+
+// MarshalToDoc marshals the given object to a Document.
+func MarshalToDoc(obj interface{}) (Document, error) {
+	bytes, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	return UnmarshalToDoc(bytes)
+}
+
+// UnmarshalToDoc unmarshals the given bytes to a Document.
+func UnmarshalToDoc(raw []byte) (Document, error) {
+	var doc Document
+
+	err := json.Unmarshal(raw, &doc)
+	if err != nil {
+		return nil, err
+	}
+
+	return doc, nil
+}
+
+// MustUnmarshalToDoc unmarshals the given bytes to a Document.
+// If an error occurs then the function panics.
+func MustUnmarshalToDoc(raw []byte) Document {
+	doc, err := UnmarshalToDoc(raw)
+	if err != nil {
+		panic(err)
+	}
+
+	return doc
+}
+
+// MarshalJSON marshals the given objects (merging them into one document) and returns the marshalled JSON result.
+func MarshalJSON(o interface{}, others ...interface{}) ([]byte, error) {
+	doc, err := MarshalToDoc(o)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, other := range others {
+		var otherDoc Document
+		if od, ok := other.(Document); !ok {
+			otherDoc, err = MarshalToDoc(other)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			otherDoc = od
+		}
+
+		doc.MergeWith(otherDoc)
+	}
+
+	return json.Marshal(doc)
+}
+
+// UnmarshalJSON unmarshals the given bytes to the set of provided objects.
+func UnmarshalJSON(bytes []byte, objects ...interface{}) error {
+	for _, obj := range objects {
+		err := json.Unmarshal(bytes, obj)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/activitypub/vocab/util_test.go
+++ b/pkg/activitypub/vocab/util_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vocab
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarshalToDoc(t *testing.T) {
+	obj := &mockObject1{
+		Field1: "field1",
+		Field2: 2,
+	}
+
+	doc, err := MarshalToDoc(obj)
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+	require.Equal(t, "field1", doc["Field1"])
+	require.Equal(t, float64(2), doc["Field2"])
+
+	doc, err = MarshalToDoc(func() {})
+	require.Error(t, err)
+	require.Nil(t, doc)
+}
+
+func TestMustUnmarshalToDoc(t *testing.T) {
+	const (
+		jsonObj        = `{"Field1":"field1","Field2":2}`
+		jsonInvalidObj = `{"Field1":field1","Field2":2}`
+	)
+
+	doc := MustUnmarshalToDoc([]byte(jsonObj))
+	require.NotNil(t, doc)
+	require.Equal(t, "field1", doc["Field1"])
+	require.Equal(t, float64(2), doc["Field2"])
+
+	require.Panics(t, func() {
+		require.NotNil(t, MustUnmarshalToDoc([]byte(jsonInvalidObj)))
+	})
+}
+
+func TestMarshalJSON(t *testing.T) {
+	const (
+		jsonObj = `{"Field1":"field1","Field2":2,"Field3":"field3","Field4":"field4"}`
+	)
+
+	obj1 := &mockObject1{
+		Field1: "field1",
+		Field2: 2,
+	}
+
+	obj2 := &mockObject2{
+		Field1: "fieldXXX", // Should be ignored
+		Field3: "field3",
+	}
+
+	obj3 := map[string]interface{}{"Field4": "field4"}
+
+	bytes, err := MarshalJSON(obj1, obj2, obj3)
+	require.NoError(t, err)
+
+	require.Equal(t, jsonObj, string(bytes))
+}
+
+type mockObject1 struct {
+	Field1 string
+	Field2 int
+}
+
+type mockObject2 struct {
+	Field1 string
+	Field3 string
+}

--- a/pkg/activitypub/vocab/vocab.go
+++ b/pkg/activitypub/vocab/vocab.go
@@ -1,0 +1,116 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vocab
+
+// Context defines the object context.
+type Context string
+
+const (
+	// ContextActivityStreams is the ActivityStreams context.
+	ContextActivityStreams Context = "https://www.w3.org/ns/activitystreams"
+	// ContextSecurity is the security context.
+	ContextSecurity Context = "https://w3id.org/security/v1"
+	// ContextCredentials is the verifiable credential context.
+	ContextCredentials Context = "https://www.w3.org/2018/credentials/v1"
+	// ContextOrb is the Orb context.
+	ContextOrb Context = "https://trustbloc.github.io/Context/orb-v1.json"
+)
+
+const (
+	// PublicIRI indicates that the object is public, i.e. it may be viewed by anyone.
+	PublicIRI = "https://www.w3.org/ns/activitystreams#Public"
+)
+
+// Type indicates the type of the object.
+type Type string
+
+const (
+	// TypeCollection specifies the 'Collection' object type.
+	TypeCollection Type = "Collection"
+	// TypeOrderedCollection specifies the 'OrderedCollection' object type.
+	TypeOrderedCollection Type = "OrderedCollection"
+
+	// TypeService specifies the 'Service' actor type.
+	TypeService Type = "Service"
+	// TypeCreate specifies the 'Create' activity type.
+	TypeCreate Type = "Create"
+	// TypeAnnounce specifies the 'Announce' activity type.
+	TypeAnnounce Type = "Announce"
+	// TypeFollow specifies the 'Follow' activity type.
+	TypeFollow Type = "Follow"
+	// TypeAccept specifies the 'Accept' activity type.
+	TypeAccept Type = "Accept"
+	// TypeReject specifies the 'Reject' activity type.
+	TypeReject Type = "Reject"
+	// TypeLike specifies the 'Like' activity type.
+	TypeLike Type = "Like"
+
+	// TypeVerifiableCredential specifies the "VerifiableCredential" object type.
+	TypeVerifiableCredential Type = "VerifiableCredential"
+
+	// TypeCAS specifies the "Cas" object type.
+	TypeCAS Type = "Cas"
+	// TypeAnchorCredential specifies the "AnchorCredential" object type.
+	TypeAnchorCredential Type = "AnchorCredential"
+	// TypeAnchorCredentialRef specifies the "AnchorCredentialReference" object type.
+	TypeAnchorCredentialRef Type = "AnchorCredentialReference"
+	// TypeOffer specifies the "Offer" activity type.
+	TypeOffer Type = "Offer"
+)
+
+const (
+	propertyContext    = "@context"
+	propertyID         = "id"
+	propertyType       = "type"
+	propertyTo         = "to"
+	propertyPublished  = "published"
+	propertyActor      = "actor"
+	propertyCurrent    = "current"
+	propertyFirst      = "first"
+	propertyLast       = "last"
+	propertyItems      = "items"
+	propertyObject     = "object"
+	propertyResult     = "result"
+	propertyTarget     = "target"
+	propertyEndTime    = "endTime"
+	propertyStartTime  = "startTime"
+	propertyTotalItems = "totalItems"
+)
+
+func reservedProperties() []string {
+	return []string{
+		propertyContext,
+		propertyID,
+		propertyType,
+		propertyTo,
+		propertyPublished,
+		propertyActor,
+		propertyCurrent,
+		propertyFirst,
+		propertyLast,
+		propertyItems,
+		propertyObject,
+		propertyResult,
+		propertyTarget,
+		propertyEndTime,
+		propertyStartTime,
+		propertyTotalItems,
+	}
+}
+
+// Document defines a JSON document as a map.
+type Document map[string]interface{}
+
+// MergeWith merges the document with the given document. Any duplicate fields
+// in the given document are ignored.
+func (doc Document) MergeWith(other Document) {
+	for k, v := range other {
+		if _, ok := doc[k]; !ok {
+			doc[k] = v
+		}
+	}
+}

--- a/pkg/activitypub/vocab/vocab_test.go
+++ b/pkg/activitypub/vocab/vocab_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vocab
+
+import (
+	"encoding/json"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
+)
+
+func getStaticTime() time.Time {
+	loc, err := time.LoadLocation("UTC")
+	if err != nil {
+		panic(err)
+	}
+
+	return time.Date(2021, time.January, 27, 9, 30, 10, 0, loc)
+}
+
+func mustParseURL(raw string) *url.URL {
+	u, err := url.Parse(raw)
+	if err != nil {
+		panic(err)
+	}
+
+	return u
+}
+
+func getCanonical(t *testing.T, raw string) string {
+	var expectedDoc map[string]interface{}
+
+	require.NoError(t, json.Unmarshal([]byte(raw), &expectedDoc))
+
+	bytes, err := canonicalizer.MarshalCanonical(expectedDoc)
+
+	require.NoError(t, err)
+
+	return string(bytes)
+}


### PR DESCRIPTION
Defined the various types and properties for ActivityPub. Also implemented a basic Object type.

closes #26

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>