### PR TITLE
feat: Implemented ActivityPub 'object' property

### DIFF
--- a/pkg/activitypub/vocab/objectproperty.go
+++ b/pkg/activitypub/vocab/objectproperty.go
@@ -1,0 +1,93 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vocab
+
+import (
+	"encoding/json"
+	"net/url"
+)
+
+// ObjectProperty defines an 'object' property. The property may be a simple IRI or
+// an embedded object such as 'Collection', 'OrderedCollection', 'Activity', etc.
+type ObjectProperty struct {
+	iri *URLProperty
+	obj *ObjectType
+}
+
+// NewObjectProperty returns a new 'object' property with the given options.
+func NewObjectProperty(opts ...Opt) *ObjectProperty {
+	options := NewOptions(opts...)
+
+	return &ObjectProperty{
+		iri: NewURLProperty(options.Iri),
+		obj: options.Object,
+	}
+}
+
+// GetType returns the type of the object property. If the property
+// is an IRI then nil is returned.
+func (p *ObjectProperty) GetType() *TypeProperty {
+	if p.obj != nil {
+		return p.obj.GetType()
+	}
+
+	return nil
+}
+
+// GetIRI returns the IRI or nil if the IRI is not set.
+func (p *ObjectProperty) GetIRI() *url.URL {
+	if p.iri == nil {
+		return nil
+	}
+
+	return p.iri.u
+}
+
+// GetObject returns the object or nil if the object is not set.
+func (p *ObjectProperty) GetObject() *ObjectType {
+	return p.obj
+}
+
+// MarshalJSON marshals the 'object' property.
+func (p *ObjectProperty) MarshalJSON() ([]byte, error) {
+	if p.iri != nil {
+		return json.Marshal(p.iri)
+	}
+
+	if p.obj != nil {
+		return json.Marshal(p.obj)
+	}
+
+	return nil, nil
+}
+
+// UnmarshalJSON unmarshals the 'object' property.
+func (p *ObjectProperty) UnmarshalJSON(bytes []byte) error {
+	if len(bytes) == 0 {
+		return nil
+	}
+
+	iri := &URLProperty{}
+
+	err := json.Unmarshal(bytes, &iri)
+	if err == nil {
+		p.iri = iri
+
+		return nil
+	}
+
+	obj := &ObjectType{}
+
+	err = json.Unmarshal(bytes, &obj)
+	if err != nil {
+		return err
+	}
+
+	p.obj = obj
+
+	return nil
+}

--- a/pkg/activitypub/vocab/objectproperty_test.go
+++ b/pkg/activitypub/vocab/objectproperty_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vocab
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewObjectProperty(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		p := NewObjectProperty()
+		require.NotNil(t, p)
+		require.Nil(t, p.GetType())
+	})
+
+	t.Run("WithIRI", func(t *testing.T) {
+		iri := mustParseURL("https://example.com/obj1")
+
+		p := NewObjectProperty(WithIRI(iri))
+		require.NotNil(t, p)
+		require.Nil(t, p.GetType())
+		require.Nil(t, p.GetObject())
+		require.Equal(t, iri, p.GetIRI())
+	})
+
+	t.Run("WithObject", func(t *testing.T) {
+		p := NewObjectProperty(WithObject(NewObject(WithType(TypeVerifiableCredential), WithID(objectPropertyID))))
+		require.NotNil(t, p)
+
+		typeProp := p.GetType()
+		require.Nil(t, p.GetIRI())
+		require.NotNil(t, typeProp)
+		require.True(t, typeProp.Is(TypeVerifiableCredential))
+	})
+}
+
+func TestObjectProperty_MarshalJSON(t *testing.T) {
+	t.Run("WithIRI", func(t *testing.T) {
+		iri := mustParseURL("https://example.com/obj1")
+
+		p := NewObjectProperty(WithIRI(iri))
+
+		bytes, err := json.Marshal(p)
+		require.NoError(t, err)
+		t.Log(string(bytes))
+
+		require.Equal(t, jsonIRIObjectProperty, string(bytes))
+	})
+
+	t.Run("WithObject", func(t *testing.T) {
+		p := NewObjectProperty(WithObject(
+			NewObject(
+				WithType(TypeVerifiableCredential),
+				WithID(objectPropertyID),
+				WithContext(ContextOrb),
+			),
+		))
+		require.NotNil(t, p)
+
+		bytes, err := json.Marshal(p)
+		require.NoError(t, err)
+		t.Log(string(bytes))
+
+		require.Equal(t, getCanonical(t, jsonEmbeddedObjectProperty), string(bytes))
+	})
+}
+
+func TestObjectProperty_UnmarshalJSON(t *testing.T) {
+	t.Run("WithIRI", func(t *testing.T) {
+		iri := mustParseURL("https://example.com/obj1")
+
+		p := NewObjectProperty()
+		require.NoError(t, json.Unmarshal([]byte(jsonIRIObjectProperty), p))
+
+		require.Nil(t, p.GetType())
+		require.Nil(t, p.GetObject())
+		require.Equal(t, iri, p.GetIRI())
+	})
+
+	t.Run("WithObject", func(t *testing.T) {
+		p := NewObjectProperty()
+		require.NoError(t, json.Unmarshal([]byte(jsonEmbeddedObjectProperty), p))
+
+		require.Nil(t, p.GetIRI())
+
+		typeProp := p.GetType()
+		require.NotNil(t, typeProp)
+		require.True(t, typeProp.Is(TypeVerifiableCredential))
+
+		obj := p.GetObject()
+		require.NotNil(t, obj)
+
+		context := obj.GetContext()
+		require.NotNil(t, context)
+		require.True(t, context.Contains(ContextOrb))
+
+		require.Equal(t, objectPropertyID, obj.GetID())
+
+		typeProp = obj.GetType()
+		require.NotNil(t, typeProp)
+		require.True(t, typeProp.Is(TypeVerifiableCredential))
+	})
+}
+
+const (
+	objectPropertyID = "some_obj_ID"
+
+	jsonIRIObjectProperty = `"https://example.com/obj1"`
+
+	jsonEmbeddedObjectProperty = `{
+  "@context": "https://trustbloc.github.io/Context/orb-v1.json",
+  "id": "some_obj_ID",
+  "type": "VerifiableCredential"
+}`
+)

--- a/pkg/activitypub/vocab/options.go
+++ b/pkg/activitypub/vocab/options.go
@@ -20,6 +20,8 @@ type Options struct {
 	StartTime *time.Time
 	EndTime   *time.Time
 	Types     []Type
+
+	ObjectPropertyOptions
 }
 
 // Opt is an for an object, activity, etc.
@@ -82,5 +84,25 @@ func WithStartTime(t *time.Time) Opt {
 func WithEndTime(t *time.Time) Opt {
 	return func(opts *Options) {
 		opts.EndTime = t
+	}
+}
+
+// ObjectPropertyOptions holds options for an 'object' property.
+type ObjectPropertyOptions struct {
+	Iri    *url.URL
+	Object *ObjectType
+}
+
+// WithIRI sets the 'object' property to an IRI.
+func WithIRI(iri *url.URL) Opt {
+	return func(opts *Options) {
+		opts.Iri = iri
+	}
+}
+
+// WithObject sets the 'object' property to an embedded object.
+func WithObject(obj *ObjectType) Opt {
+	return func(opts *Options) {
+		opts.Object = obj
 	}
 }

--- a/pkg/activitypub/vocab/options_test.go
+++ b/pkg/activitypub/vocab/options_test.go
@@ -19,6 +19,9 @@ func TestNewOptions(t *testing.T) {
 	to1 := mustParseURL("https://to1")
 	to2 := mustParseURL("https://to2")
 
+	obj := &ObjectType{}
+	iri := mustParseURL("https://iri")
+
 	publishedTime := time.Now()
 	startTime := time.Now()
 	endTime := time.Now()
@@ -31,6 +34,8 @@ func TestNewOptions(t *testing.T) {
 		WithPublishedTime(&publishedTime),
 		WithStartTime(&startTime),
 		WithEndTime(&endTime),
+		WithObject(obj),
+		WithIRI(iri),
 	)
 
 	require.NotNil(t, opts)
@@ -51,4 +56,8 @@ func TestNewOptions(t *testing.T) {
 	require.Equal(t, &publishedTime, opts.Published)
 	require.Equal(t, &startTime, opts.StartTime)
 	require.Equal(t, &endTime, opts.EndTime)
+
+	require.Equal(t, obj, opts.Object)
+
+	require.Equal(t, iri.String(), opts.Iri.String())
 }

--- a/pkg/activitypub/vocab/util_test.go
+++ b/pkg/activitypub/vocab/util_test.go
@@ -45,27 +45,42 @@ func TestMustUnmarshalToDoc(t *testing.T) {
 	})
 }
 
-func TestMarshalJSON(t *testing.T) {
+func TestMarshalUnmarshalJSON(t *testing.T) {
 	const (
 		jsonObj = `{"Field1":"field1","Field2":2,"Field3":"field3","Field4":"field4"}`
 	)
 
-	obj1 := &mockObject1{
-		Field1: "field1",
-		Field2: 2,
-	}
+	t.Run("MarshalJSON", func(t *testing.T) {
+		obj1 := &mockObject1{
+			Field1: "field1",
+			Field2: 2,
+		}
 
-	obj2 := &mockObject2{
-		Field1: "fieldXXX", // Should be ignored
-		Field3: "field3",
-	}
+		obj2 := &mockObject2{
+			Field1: "fieldXXX", // Should be ignored
+			Field3: "field3",
+		}
 
-	obj3 := map[string]interface{}{"Field4": "field4"}
+		obj3 := Document{"Field4": "field4"}
 
-	bytes, err := MarshalJSON(obj1, obj2, obj3)
-	require.NoError(t, err)
+		bytes, err := MarshalJSON(obj1, obj2, obj3)
+		require.NoError(t, err)
 
-	require.Equal(t, jsonObj, string(bytes))
+		require.Equal(t, jsonObj, string(bytes))
+	})
+
+	t.Run("UnmarshalJSON", func(t *testing.T) {
+		obj1 := mockObject1{}
+		obj2 := mockObject2{}
+		obj3 := Document{}
+
+		require.NoError(t, UnmarshalJSON([]byte(jsonObj), &obj1, &obj2, &obj3))
+		require.Equal(t, "field1", obj1.Field1)
+		require.Equal(t, 2, obj1.Field2)
+		require.Equal(t, "field1", obj2.Field1)
+		require.Equal(t, "field3", obj2.Field3)
+		require.Equal(t, "field4", obj3["Field4"])
+	})
 }
 
 type mockObject1 struct {


### PR DESCRIPTION
The value of the 'object' property can be an IRI (URL) or another embedded ActivityPub object.

closes #29

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>