### PR TITLE
feat: Don't require check for nil on ActivityPub properties

### DIFF
--- a/pkg/activitypub/vocab/activitytype_test.go
+++ b/pkg/activitypub/vocab/activitytype_test.go
@@ -375,6 +375,7 @@ func TestAnnounceTypeMarshal(t *testing.T) {
 
 			item := items[0]
 
+			require.True(t, item.Type().Is(TypeAnchorCredentialRef))
 			ref := item.AnchorCredentialReference()
 			require.NotNil(t, ref)
 			require.Equal(t, refID1, ref.ID())

--- a/pkg/activitypub/vocab/contextproperty.go
+++ b/pkg/activitypub/vocab/contextproperty.go
@@ -26,12 +26,16 @@ func NewContextProperty(context ...Context) *ContextProperty {
 
 // Contexts returns all of the contexts defined in the property.
 func (p *ContextProperty) Contexts() []Context {
+	if p == nil {
+		return nil
+	}
+
 	return p.contexts
 }
 
 // Contains returns true if the property contains all of the given contexts.
 func (p *ContextProperty) Contains(contexts ...Context) bool {
-	if len(contexts) == 0 {
+	if p == nil || len(contexts) == 0 {
 		return false
 	}
 
@@ -46,6 +50,10 @@ func (p *ContextProperty) Contains(contexts ...Context) bool {
 
 // ContainsAny returns true if the property contains any of the given contexts.
 func (p *ContextProperty) ContainsAny(contexts ...Context) bool {
+	if p == nil || len(contexts) == 0 {
+		return false
+	}
+
 	for _, t := range contexts {
 		if p.contains(t) {
 			return true

--- a/pkg/activitypub/vocab/contextproperty_test.go
+++ b/pkg/activitypub/vocab/contextproperty_test.go
@@ -19,7 +19,13 @@ func TestContextProperty(t *testing.T) {
 		jsonMultiContext = `["https://www.w3.org/2018/credentials/v1","https://w3id.org/security/v1"]`
 	)
 
-	require.Nil(t, NewContextProperty())
+	t.Run("Nil context", func(t *testing.T) {
+		p := NewContextProperty()
+		require.Nil(t, p)
+		require.Empty(t, p.Contexts())
+		require.False(t, p.Contains(ContextOrb))
+		require.False(t, p.ContainsAny(ContextOrb))
+	})
 
 	t.Run("Single context", func(t *testing.T) {
 		p := NewContextProperty(ContextCredentials)

--- a/pkg/activitypub/vocab/objectproperty.go
+++ b/pkg/activitypub/vocab/objectproperty.go
@@ -40,6 +40,10 @@ func NewObjectProperty(opts ...Opt) *ObjectProperty {
 // Type returns the type of the object property. If the property
 // is an IRI then nil is returned.
 func (p *ObjectProperty) Type() *TypeProperty {
+	if p == nil {
+		return nil
+	}
+
 	if p.obj != nil {
 		return p.obj.Type()
 	}
@@ -65,7 +69,7 @@ func (p *ObjectProperty) Type() *TypeProperty {
 
 // IRI returns the IRI or nil if the IRI is not set.
 func (p *ObjectProperty) IRI() *url.URL {
-	if p.iri == nil {
+	if p == nil || p.iri == nil {
 		return nil
 	}
 
@@ -74,27 +78,47 @@ func (p *ObjectProperty) IRI() *url.URL {
 
 // Object returns the object or nil if the object is not set.
 func (p *ObjectProperty) Object() *ObjectType {
+	if p == nil {
+		return nil
+	}
+
 	return p.obj
 }
 
 // Collection returns the collection or nil if the collection is not set.
 func (p *ObjectProperty) Collection() *CollectionType {
+	if p == nil {
+		return nil
+	}
+
 	return p.coll
 }
 
 // OrderedCollection returns the ordered collection or nil if the ordered collection is not set.
 func (p *ObjectProperty) OrderedCollection() *OrderedCollectionType {
+	if p == nil {
+		return nil
+	}
+
 	return p.orderedColl
 }
 
 // Activity returns the activity or nil if the activity is not set.
 func (p *ObjectProperty) Activity() *ActivityType {
+	if p == nil {
+		return nil
+	}
+
 	return p.activity
 }
 
 // AnchorCredentialReference returns the anchored credential reference or nil if
 // the anchored credential reference is not set.
 func (p *ObjectProperty) AnchorCredentialReference() *AnchorCredentialReferenceType {
+	if p == nil {
+		return nil
+	}
+
 	return p.anchorCredRef
 }
 

--- a/pkg/activitypub/vocab/objectproperty_test.go
+++ b/pkg/activitypub/vocab/objectproperty_test.go
@@ -24,10 +24,26 @@ var (
 )
 
 func TestNewObjectProperty(t *testing.T) {
+	t.Run("Nil", func(t *testing.T) {
+		var p *ObjectProperty
+		require.Nil(t, p.Type())
+		require.Nil(t, p.Object())
+		require.Nil(t, p.IRI())
+		require.Nil(t, p.Collection())
+		require.Nil(t, p.OrderedCollection())
+		require.Nil(t, p.Activity())
+		require.Nil(t, p.AnchorCredentialReference())
+	})
+
 	t.Run("Empty", func(t *testing.T) {
 		p := NewObjectProperty()
-		require.NotNil(t, p)
 		require.Nil(t, p.Type())
+		require.Nil(t, p.Object())
+		require.Nil(t, p.IRI())
+		require.Nil(t, p.Collection())
+		require.Nil(t, p.OrderedCollection())
+		require.Nil(t, p.Activity())
+		require.Nil(t, p.AnchorCredentialReference())
 	})
 
 	t.Run("WithIRI", func(t *testing.T) {

--- a/pkg/activitypub/vocab/typeproperty.go
+++ b/pkg/activitypub/vocab/typeproperty.go
@@ -59,12 +59,16 @@ func (p *TypeProperty) UnmarshalJSON(bytes []byte) error {
 
 // Types returns all types.
 func (p *TypeProperty) Types() []Type {
+	if p == nil {
+		return nil
+	}
+
 	return p.types
 }
 
 // Is returns true if the property has all of the given types.
 func (p *TypeProperty) Is(types ...Type) bool {
-	if len(types) == 0 {
+	if p == nil || len(types) == 0 {
 		return false
 	}
 
@@ -79,6 +83,10 @@ func (p *TypeProperty) Is(types ...Type) bool {
 
 // IsAny returns true if the property has any of the given types.
 func (p *TypeProperty) IsAny(types ...Type) bool {
+	if p == nil || len(types) == 0 {
+		return false
+	}
+
 	for _, t := range types {
 		if p.Is(t) {
 			return true

--- a/pkg/activitypub/vocab/typeproperty_test.go
+++ b/pkg/activitypub/vocab/typeproperty_test.go
@@ -19,7 +19,13 @@ func TestTypeProperty(t *testing.T) {
 		jsonMultiType = `["Create","AnchorCredential"]`
 	)
 
-	require.Nil(t, NewTypeProperty())
+	t.Run("Nil type", func(t *testing.T) {
+		p := NewTypeProperty()
+		require.Nil(t, p)
+		require.False(t, p.Is(TypeCreate))
+		require.False(t, p.IsAny(TypeCreate))
+		require.Empty(t, p.Types())
+	})
 
 	t.Run("Single type", func(t *testing.T) {
 		p := NewTypeProperty(TypeCreate)

--- a/pkg/activitypub/vocab/urlproperty.go
+++ b/pkg/activitypub/vocab/urlproperty.go
@@ -26,26 +26,30 @@ func NewURLProperty(u *url.URL) *URLProperty {
 }
 
 // String returns the string representation of the URL.
-func (t *URLProperty) String() string {
-	if t.u == nil {
+func (p *URLProperty) String() string {
+	if p == nil || p.u == nil {
 		return ""
 	}
 
-	return t.u.String()
+	return p.u.String()
 }
 
 // URL returns the contained URL.
-func (t *URLProperty) URL() *url.URL {
-	return t.u
+func (p *URLProperty) URL() *url.URL {
+	if p == nil {
+		return nil
+	}
+
+	return p.u
 }
 
 // MarshalJSON marshals the URL property.
-func (t *URLProperty) MarshalJSON() ([]byte, error) {
-	return json.Marshal(t.u.String())
+func (p *URLProperty) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.u.String())
 }
 
 // UnmarshalJSON unmarshals the URL property.
-func (t *URLProperty) UnmarshalJSON(bytes []byte) error {
+func (p *URLProperty) UnmarshalJSON(bytes []byte) error {
 	var iri string
 
 	err := json.Unmarshal(bytes, &iri)
@@ -58,7 +62,7 @@ func (t *URLProperty) UnmarshalJSON(bytes []byte) error {
 		return err
 	}
 
-	t.u = u
+	p.u = u
 
 	return nil
 }
@@ -84,10 +88,14 @@ func NewURLCollectionProperty(urls ...*url.URL) *URLCollectionProperty {
 }
 
 // URLs returns the URLs.
-func (t *URLCollectionProperty) URLs() []*url.URL {
-	urls := make([]*url.URL, len(t.urls))
+func (p *URLCollectionProperty) URLs() []*url.URL {
+	if p == nil || len(p.urls) == 0 {
+		return nil
+	}
 
-	for i, p := range t.urls {
+	urls := make([]*url.URL, len(p.urls))
+
+	for i, p := range p.urls {
 		urls[i] = p.URL()
 	}
 
@@ -95,21 +103,21 @@ func (t *URLCollectionProperty) URLs() []*url.URL {
 }
 
 // MarshalJSON marshals the URL collection.
-func (t *URLCollectionProperty) MarshalJSON() ([]byte, error) {
-	if len(t.urls) == 1 {
-		return json.Marshal(t.urls[0])
+func (p *URLCollectionProperty) MarshalJSON() ([]byte, error) {
+	if len(p.urls) == 1 {
+		return json.Marshal(p.urls[0])
 	}
 
-	return json.Marshal(t.urls)
+	return json.Marshal(p.urls)
 }
 
 // UnmarshalJSON unmarshals the URL collection.
-func (t *URLCollectionProperty) UnmarshalJSON(bytes []byte) error {
+func (p *URLCollectionProperty) UnmarshalJSON(bytes []byte) error {
 	iri := &URLProperty{}
 
 	err := json.Unmarshal(bytes, &iri)
 	if err == nil {
-		t.urls = []*URLProperty{iri}
+		p.urls = []*URLProperty{iri}
 
 		return err
 	}
@@ -121,7 +129,7 @@ func (t *URLCollectionProperty) UnmarshalJSON(bytes []byte) error {
 		return err
 	}
 
-	t.urls = iris
+	p.urls = iris
 
 	return nil
 }

--- a/pkg/activitypub/vocab/urlproperty_test.go
+++ b/pkg/activitypub/vocab/urlproperty_test.go
@@ -20,13 +20,17 @@ func TestURLProperty(t *testing.T) {
 		jsonURL = `"https://example.com"`
 	)
 
+	t.Run("Nil", func(t *testing.T) {
+		p := NewURLProperty(nil)
+		require.Nil(t, p)
+		require.Nil(t, p.URL())
+		require.Empty(t, p.String())
+	})
+
 	u, err := url.Parse(address)
 	require.NoError(t, err)
 
-	require.Nil(t, NewURLProperty(nil))
-
 	p := NewURLProperty(u)
-	require.NotNil(t, p)
 	require.Equal(t, u, p.URL())
 	require.Equal(t, u.String(), p.String())
 
@@ -53,7 +57,11 @@ func TestURLCollectionProperty(t *testing.T) {
 	u2, err := url.Parse(address2)
 	require.NoError(t, err)
 
-	require.Nil(t, NewURLCollectionProperty())
+	t.Run("Nil", func(t *testing.T) {
+		p := NewURLCollectionProperty()
+		require.Nil(t, p)
+		require.Empty(t, p.URLs())
+	})
 
 	t.Run("Single URL", func(t *testing.T) {
 		p := NewURLCollectionProperty(u1)


### PR DESCRIPTION
ActivityPub properties may now be accessed without a check for nil. For example:

    isCreate := activity.Type().Is(TypeCreate)

Even if activity.Type() returns nil, the above will return false without a panic.

closes #46

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>