### PR TITLE
feat: Defined ActivityPub SPI and implemented in-memory store

### DIFF
--- a/pkg/activitypub/store/memstore/iterator.go
+++ b/pkg/activitypub/store/memstore/iterator.go
@@ -1,0 +1,37 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package memstore
+
+import (
+	"github.com/trustbloc/orb/pkg/activitypub/store/spi"
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+)
+
+type iterator struct {
+	results []*vocab.ActivityType
+	current int
+}
+
+func newIterator(results []*vocab.ActivityType) *iterator {
+	return &iterator{
+		results: results,
+		current: -1,
+	}
+}
+
+func (it *iterator) Next() (*vocab.ActivityType, error) {
+	if it.current >= len(it.results)-1 {
+		return nil, spi.ErrNotFound
+	}
+
+	it.current++
+
+	return it.results[it.current], nil
+}
+
+func (it *iterator) Close() {
+}

--- a/pkg/activitypub/store/memstore/iterator_test.go
+++ b/pkg/activitypub/store/memstore/iterator_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package memstore
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/pkg/activitypub/store/spi"
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+)
+
+func TestIterator(t *testing.T) {
+	const (
+		activityID1 = "activity1"
+		activityID2 = "activity2"
+	)
+
+	activity1 := vocab.NewAnnounceActivity(activityID1, vocab.NewObjectProperty())
+	activity2 := vocab.NewAnnounceActivity(activityID2, vocab.NewObjectProperty())
+
+	results := []*vocab.ActivityType{activity1, activity2}
+
+	it := newIterator(results)
+	require.NotNil(t, it)
+
+	for i := 0; i < 2; i++ {
+		a, err := it.Next()
+		require.NoError(t, err)
+		require.NotNil(t, a)
+		require.True(t, a.ID() == activityID1 || a.ID() == activityID2)
+	}
+
+	a, err := it.Next()
+	require.Error(t, err)
+	require.True(t, errors.Is(err, spi.ErrNotFound))
+	require.Nil(t, a)
+
+	require.NotPanics(t, it.Close)
+}

--- a/pkg/activitypub/store/memstore/memstore.go
+++ b/pkg/activitypub/store/memstore/memstore.go
@@ -1,0 +1,242 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package memstore
+
+import (
+	"fmt"
+	"net/url"
+	"sync"
+
+	"github.com/trustbloc/edge-core/pkg/log"
+
+	"github.com/trustbloc/orb/pkg/activitypub/store/spi"
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+)
+
+var logger = log.New("activitypub_memstore")
+
+// Store implements an in-memory ActivityPub store.
+type Store struct {
+	serviceName     string
+	activityStores  map[spi.ActivityStoreType]*activityStore
+	referenceStores map[spi.ReferenceType]*referenceStore
+	actorStore      map[string]*vocab.ActorType
+	mutex           sync.RWMutex
+}
+
+// New returns a new in-memory ActivityPub store.
+func New(serviceName string) *Store {
+	return &Store{
+		serviceName: serviceName,
+		activityStores: map[spi.ActivityStoreType]*activityStore{
+			spi.Inbox:  newActivitiesStore(),
+			spi.Outbox: newActivitiesStore(),
+		},
+		referenceStores: map[spi.ReferenceType]*referenceStore{
+			spi.Follower:   newReferenceStore(),
+			spi.Following:  newReferenceStore(),
+			spi.Witness:    newReferenceStore(),
+			spi.Witnessing: newReferenceStore(),
+			spi.Like:       newReferenceStore(),
+			spi.Liked:      newReferenceStore(),
+			spi.Share:      newReferenceStore(),
+		},
+		actorStore: make(map[string]*vocab.ActorType),
+	}
+}
+
+// PutActor stores the given actor.
+func (s *Store) PutActor(actor *vocab.ActorType) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	logger.Debugf("[%s] Storing actor [%s]", s.serviceName, actor.ID())
+
+	s.actorStore[actor.ID()] = actor
+
+	return nil
+}
+
+// GetActor returns the actor for the given IRI. Returns an ErrNoFound error if the actor is not in the store.
+func (s *Store) GetActor(iri *url.URL) (*vocab.ActorType, error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	logger.Debugf("[%s] Retrieving actor [%s]", s.serviceName, iri)
+
+	a, ok := s.actorStore[iri.String()]
+	if !ok {
+		return nil, spi.ErrNotFound
+	}
+
+	return a, nil
+}
+
+// AddActivity adds the given activity to the specified activity store.
+func (s *Store) AddActivity(storeType spi.ActivityStoreType, activity *vocab.ActivityType) error {
+	logger.Debugf("[%s] Storing activity to %s - Type: %s, ID: %s",
+		s.serviceName, storeType, activity.Type(), activity.ID())
+
+	return s.activityStores[storeType].add(activity)
+}
+
+// GetActivity returns the activity for the given ID from the given activity store
+// or ErrNotFound error if it wasn't found.
+func (s *Store) GetActivity(storeType spi.ActivityStoreType, activityID string) (*vocab.ActivityType, error) {
+	logger.Debugf("[%s] Retrieving activity from %s - ID: %s", s.serviceName, storeType, activityID)
+
+	return s.activityStores[storeType].get(activityID)
+}
+
+// QueryActivities queries the given activity store using the provided criteria
+// and returns a results iterator.
+func (s *Store) QueryActivities(storeType spi.ActivityStoreType,
+	query *spi.Criteria) (spi.ActivityResultsIterator, error) {
+	logger.Debugf("[%s] Querying activity from %s - Query: %+v", s.serviceName, storeType, query)
+
+	return s.activityStores[storeType].query(query)
+}
+
+// AddReference adds the reference of the given type to the given actor.
+func (s *Store) AddReference(referenceType spi.ReferenceType, actorIRI, referenceIRI *url.URL) error {
+	logger.Debugf("[%s] Adding reference of type %s to actor %s: %s", s.serviceName, actorIRI, referenceIRI)
+
+	return s.referenceStores[referenceType].add(actorIRI, referenceIRI)
+}
+
+// DeleteReference deletes the reference of the given type from the given actor.
+func (s *Store) DeleteReference(referenceType spi.ReferenceType, actorIRI, referenceIRI *url.URL) error {
+	logger.Debugf("[%s] Deleting reference of type %s from actor %s: %s", s.serviceName, actorIRI, referenceIRI)
+
+	return s.referenceStores[referenceType].delete(actorIRI, referenceIRI)
+}
+
+// GetReferences returns the actor's list of references of the given type.
+func (s *Store) GetReferences(referenceType spi.ReferenceType, actorIRI *url.URL) ([]*url.URL, error) {
+	logger.Debugf("[%s] Retrieving references of type %s for actor %s", s.serviceName, actorIRI)
+
+	return s.referenceStores[referenceType].get(actorIRI)
+}
+
+type activityStore struct {
+	mutex      sync.RWMutex
+	activities map[string]*vocab.ActivityType
+}
+
+func newActivitiesStore() *activityStore {
+	return &activityStore{
+		activities: make(map[string]*vocab.ActivityType),
+	}
+}
+
+func (s *activityStore) add(activity *vocab.ActivityType) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.activities[activity.ID()] = activity
+
+	return nil
+}
+
+func (s *activityStore) get(activityID string) (*vocab.ActivityType, error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	a, ok := s.activities[activityID]
+	if !ok {
+		return nil, spi.ErrNotFound
+	}
+
+	return a, nil
+}
+
+func (s *activityStore) query(query *spi.Criteria) (spi.ActivityResultsIterator, error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	return newIterator(memQueryResults(s.activities).filter(query)), nil
+}
+
+type referenceStore struct {
+	irisByActor map[string][]*url.URL
+	mutex       sync.RWMutex
+}
+
+func newReferenceStore() *referenceStore {
+	return &referenceStore{
+		irisByActor: make(map[string][]*url.URL),
+	}
+}
+
+func (s *referenceStore) add(actor fmt.Stringer, iri *url.URL) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	actorID := actor.String()
+
+	s.irisByActor[actorID] = append(s.irisByActor[actorID], iri)
+
+	return nil
+}
+
+func (s *referenceStore) delete(actor, iri fmt.Stringer) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	irisForActor := s.irisByActor[actor.String()]
+
+	for actorIRI, i := range irisForActor {
+		if i.String() == iri.String() {
+			s.irisByActor[actor.String()] = append(irisForActor[0:actorIRI], irisForActor[actorIRI+1:]...)
+
+			return nil
+		}
+	}
+
+	return spi.ErrNotFound
+}
+
+func (s *referenceStore) get(actor fmt.Stringer) ([]*url.URL, error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	return s.irisByActor[actor.String()], nil
+}
+
+type queryFilter struct {
+	*spi.Criteria
+}
+
+func newQueryFilter(query *spi.Criteria) *queryFilter {
+	return &queryFilter{
+		Criteria: query,
+	}
+}
+
+func (q *queryFilter) Accept(activity *vocab.ActivityType) bool {
+	if len(q.Types) > 0 {
+		return activity.Type().IsAny(q.Types...)
+	}
+
+	return true
+}
+
+type memQueryResults map[string]*vocab.ActivityType
+
+func (r memQueryResults) filter(query *spi.Criteria) []*vocab.ActivityType {
+	var results []*vocab.ActivityType
+
+	mq := newQueryFilter(query)
+
+	for _, a := range r {
+		if mq.Accept(a) {
+			results = append(results, a)
+		}
+	}
+
+	return results
+}

--- a/pkg/activitypub/store/memstore/memstore_test.go
+++ b/pkg/activitypub/store/memstore/memstore_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package memstore
+
+import (
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/pkg/activitypub/store/spi"
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+)
+
+func TestStore_Activity(t *testing.T) {
+	s := New("service1")
+	require.NotNil(t, s)
+
+	const (
+		activityID1 = "activity1"
+		activityID2 = "activity2"
+		activityID3 = "activity3"
+		activityID4 = "activity4"
+	)
+
+	a, err := s.GetActivity(spi.Inbox, activityID1)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, spi.ErrNotFound))
+	require.Nil(t, a)
+
+	activity1 := vocab.NewCreateActivity(activityID1, vocab.NewObjectProperty())
+	require.NoError(t, s.AddActivity(spi.Inbox, activity1))
+
+	a, err = s.GetActivity(spi.Inbox, activityID1)
+	require.NoError(t, err)
+	require.NotNil(t, a)
+	require.Equal(t, activity1, a)
+
+	activity2 := vocab.NewAnnounceActivity(activityID2, vocab.NewObjectProperty())
+	require.NoError(t, s.AddActivity(spi.Inbox, activity2))
+
+	activity3 := vocab.NewCreateActivity(activityID3, vocab.NewObjectProperty())
+	require.NoError(t, s.AddActivity(spi.Inbox, activity3))
+
+	activity4 := vocab.NewAcceptActivity(activityID4, vocab.NewObjectProperty())
+	require.NoError(t, s.AddActivity(spi.Outbox, activity4))
+
+	t.Run("Query all", func(t *testing.T) {
+		it, err := s.QueryActivities(spi.Inbox, spi.NewCriteria())
+		require.NoError(t, err)
+		require.NotNil(t, it)
+
+		checkQueryResults(t, it, activityID1, activityID2, activityID3)
+
+		it, err = s.QueryActivities(spi.Outbox, spi.NewCriteria())
+		require.NoError(t, err)
+		require.NotNil(t, it)
+
+		checkQueryResults(t, it, activityID4)
+	})
+
+	t.Run("Query by type", func(t *testing.T) {
+		it, err := s.QueryActivities(spi.Inbox, spi.NewCriteria(spi.WithType(vocab.TypeCreate)))
+		require.NoError(t, err)
+		require.NotNil(t, it)
+
+		checkQueryResults(t, it, activityID1, activityID3)
+	})
+}
+
+func TestStore_Reference(t *testing.T) {
+	s := New("service1")
+	require.NotNil(t, s)
+
+	actor1 := mustParseURL("https://actor1")
+	actor2 := mustParseURL("https://actor2")
+	actor3 := mustParseURL("https://actor3")
+
+	followers, err := s.GetReferences(spi.Follower, actor1)
+	require.NoError(t, err)
+	require.Empty(t, followers)
+
+	require.NoError(t, s.AddReference(spi.Follower, actor1, actor2))
+	require.NoError(t, s.AddReference(spi.Follower, actor1, actor3))
+
+	followers, err = s.GetReferences(spi.Follower, actor1)
+	require.NoError(t, err)
+	require.Len(t, followers, 2)
+	require.Equal(t, actor2.String(), followers[0].String())
+	require.Equal(t, actor3.String(), followers[1].String())
+
+	following, err := s.GetReferences(spi.Following, actor1)
+	require.NoError(t, err)
+	require.Empty(t, following)
+
+	require.NoError(t, s.AddReference(spi.Following, actor1, actor2))
+
+	following, err = s.GetReferences(spi.Following, actor1)
+	require.NoError(t, err)
+	require.Len(t, following, 1)
+	require.Equal(t, actor2.String(), following[0].String())
+
+	require.NoError(t, s.DeleteReference(spi.Follower, actor1, actor2))
+
+	followers, err = s.GetReferences(spi.Follower, actor1)
+	require.NoError(t, err)
+	require.Len(t, followers, 1)
+	require.Equal(t, actor3.String(), followers[0].String())
+
+	followers, err = s.GetReferences(spi.Follower, actor2)
+	require.NoError(t, err)
+	require.Empty(t, followers)
+
+	require.NoError(t, s.AddReference(spi.Follower, actor2, actor3))
+	require.EqualError(t, s.DeleteReference(spi.Follower, actor2, actor1), spi.ErrNotFound.Error())
+
+	followers, err = s.GetReferences(spi.Follower, actor2)
+	require.NoError(t, err)
+	require.Len(t, followers, 1)
+	require.Equal(t, actor3.String(), followers[0].String())
+}
+
+func TestStore_Actors(t *testing.T) {
+	s := New("service1")
+	require.NotNil(t, s)
+
+	actor1IRI := mustParseURL("https://actor1")
+	actor2IRI := mustParseURL("https://actor2")
+
+	a, err := s.GetActor(actor1IRI)
+	require.EqualError(t, err, spi.ErrNotFound.Error())
+	require.Nil(t, a)
+
+	actor1 := vocab.NewService(actor1IRI.String())
+	actor2 := vocab.NewService(actor2IRI.String())
+
+	require.NoError(t, s.PutActor(actor1))
+	require.NoError(t, s.PutActor(actor2))
+
+	a, err = s.GetActor(actor1IRI)
+	require.NoError(t, err)
+	require.Equal(t, actor1, a)
+
+	a, err = s.GetActor(actor2IRI)
+	require.NoError(t, err)
+	require.Equal(t, actor2, a)
+}
+
+func checkQueryResults(t *testing.T, it spi.ActivityResultsIterator, expectedTypes ...string) {
+	for i := 0; i < len(expectedTypes); i++ {
+		a, err := it.Next()
+		require.NoError(t, err)
+		require.NotNil(t, a)
+		require.True(t, contains(a.ID(), expectedTypes))
+	}
+
+	a, err := it.Next()
+	require.Error(t, err)
+	require.True(t, errors.Is(err, spi.ErrNotFound))
+	require.Nil(t, a)
+}
+
+func contains(activityType string, types []string) bool {
+	for _, t := range types {
+		if t == activityType {
+			return true
+		}
+	}
+
+	return false
+}
+
+func mustParseURL(raw string) *url.URL {
+	u, err := url.Parse(raw)
+	if err != nil {
+		panic(err)
+	}
+
+	return u
+}

--- a/pkg/activitypub/store/spi/spi.go
+++ b/pkg/activitypub/store/spi/spi.go
@@ -1,0 +1,109 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package spi
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+)
+
+// ErrNotFound is returned from various store functions when a requested
+// object is not found in the store.
+var ErrNotFound = fmt.Errorf("not found in ActivityPub store")
+
+// ActivityStoreType indicates the type of activities store, i.e. inbox, outbox.
+type ActivityStoreType string
+
+const (
+	// Inbox indicates that the activity store is the inbox.
+	Inbox ActivityStoreType = "INBOX"
+	// Outbox indicates that the activity store is the outbox.
+	Outbox ActivityStoreType = "OUTBOX"
+)
+
+// ReferenceType defines the type of reference, e.g. follower, witness, etc.
+type ReferenceType string
+
+const (
+	// Follower indicates that the reference is an actor that's following the local service.
+	Follower ReferenceType = "FOLLOWER"
+	// Following indicates that the reference is an actor that the local service is following.
+	Following ReferenceType = "FOLLOWING"
+	// Witness indicates that the reference is an actor to which the local service sends
+	// anchor credentials to witness.
+	Witness ReferenceType = "WITNESS"
+	// Witnessing indicates that the reference is a service from which the local service
+	// receives anchor credentials to witness.
+	Witnessing ReferenceType = "WITNESSING"
+	// Like indicates that the reference is an object created by the local service that was
+	// liked (endorsed) by a witness.
+	Like ReferenceType = "LIKE"
+	// Liked indicates that the reference is an object that the local service witnessed
+	// and liked (endorsed).
+	Liked ReferenceType = "LIKED"
+	// Share indicates that the reference is an object that the local service shared with
+	// (announced to) its followers.
+	Share ReferenceType = "SHARE"
+)
+
+// Store defines the functions of an ActivityPub store.
+type Store interface {
+	// PutActor stores the given actor.
+	PutActor(actor *vocab.ActorType) error
+	// GetActor returns the actor for the given IRI. Returns an ErrNotFound error if the actor is not in the store.
+	GetActor(actorIRI *url.URL) (*vocab.ActorType, error)
+	// AddActivity adds the given activity to the specified activity store.
+	AddActivity(storeType ActivityStoreType, activity *vocab.ActivityType) error
+	// GetActivity returns the activity for the given ID from the given activity store
+	// or an ErrNotFound error if it wasn't found.
+	GetActivity(storeType ActivityStoreType, activityID string) (*vocab.ActivityType, error)
+	// QueryActivities queries the given activity store using the provided criteria
+	// and returns a results iterator.
+	QueryActivities(storeType ActivityStoreType, query *Criteria) (ActivityResultsIterator, error)
+	// AddReference adds the reference of the given type to the given actor.
+	AddReference(refType ReferenceType, actorIRI *url.URL, referenceIRI *url.URL) error
+	// DeleteReference deletes the reference of the given type from the given actor.
+	DeleteReference(refType ReferenceType, actorIRI *url.URL, referenceIRI *url.URL) error
+	// GetReferences returns the actor's list of references of the given type.
+	GetReferences(refType ReferenceType, actorIRI *url.URL) ([]*url.URL, error)
+}
+
+// Criteria holds the search criteria for a query.
+type Criteria struct {
+	Types []vocab.Type
+}
+
+// CriteriaOpt sets a Criteria option.
+type CriteriaOpt func(q *Criteria)
+
+// NewCriteria returns new Criteria which may be used to perform a query.
+func NewCriteria(opts ...CriteriaOpt) *Criteria {
+	q := &Criteria{}
+
+	for _, opt := range opts {
+		opt(q)
+	}
+
+	return q
+}
+
+// WithType sets the object Type on the criteria.
+func WithType(t ...vocab.Type) CriteriaOpt {
+	return func(query *Criteria) {
+		query.Types = append(query.Types, t...)
+	}
+}
+
+// ActivityResultsIterator defines the query results iterator for activity queries.
+type ActivityResultsIterator interface {
+	// Next returns the next activity or an ErrNotFound error if there are no more items.
+	Next() (*vocab.ActivityType, error)
+	// Close closes the iterator.
+	Close()
+}

--- a/pkg/activitypub/store/spi/spi_test.go
+++ b/pkg/activitypub/store/spi/spi_test.go
@@ -1,0 +1,23 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package spi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+)
+
+func TestCriteria(t *testing.T) {
+	c := NewCriteria(WithType(vocab.TypeCreate, vocab.TypeAnnounce))
+	require.NotNil(t, c)
+	require.Len(t, c.Types, 2)
+	require.Equal(t, vocab.TypeCreate, c.Types[0])
+	require.Equal(t, vocab.TypeAnnounce, c.Types[1])
+}


### PR DESCRIPTION
This commit defines the ActivityPub store service provider interface and also implements an in-memory store.

closes #52

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>