### PR TITLE
feat: Implemented ActivityPub Outbox

### DIFF
--- a/pkg/activitypub/service/mocks/mockpubsub.go
+++ b/pkg/activitypub/service/mocks/mockpubsub.go
@@ -8,20 +8,33 @@ package mocks
 
 import (
 	"context"
+	"sync"
+	"time"
 
 	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/pkg/errors"
+
+	service "github.com/trustbloc/orb/pkg/activitypub/service/spi"
+)
+
+const (
+	maxBufferSize = 5
+	timeout       = 100 * time.Millisecond
 )
 
 // MockPubSub implements a mock publisher-subscriber.
 type MockPubSub struct {
 	Err     error
-	MsgChan chan *message.Message
+	MsgChan map[string]chan *message.Message
+	mutex   sync.RWMutex
+	Timeout time.Duration
 }
 
 // NewPubSub returns a mock publisher-subscriber.
 func NewPubSub() *MockPubSub {
 	return &MockPubSub{
-		MsgChan: make(chan *message.Message),
+		MsgChan: make(map[string]chan *message.Message, 10),
+		Timeout: timeout,
 	}
 }
 
@@ -33,12 +46,19 @@ func (m *MockPubSub) WithError(err error) *MockPubSub {
 }
 
 // Subscribe subscribes to the given topic.
-func (m *MockPubSub) Subscribe(ctx context.Context, topic string) (<-chan *message.Message, error) {
+func (m *MockPubSub) Subscribe(_ context.Context, topic string) (<-chan *message.Message, error) {
 	if m.Err != nil {
 		return nil, m.Err
 	}
 
-	return m.MsgChan, nil
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	msgChan := make(chan *message.Message, maxBufferSize)
+
+	m.MsgChan[topic] = msgChan
+
+	return msgChan, nil
 }
 
 // Publish publishes the messages to the subscribers.
@@ -47,8 +67,18 @@ func (m *MockPubSub) Publish(topic string, messages ...*message.Message) error {
 		return m.Err
 	}
 
+	m.mutex.RLock()
+	msgChan := m.MsgChan[topic]
+	m.mutex.RUnlock()
+
+	if msgChan == nil {
+		return errors.New("service is closed")
+	}
+
 	for _, msg := range messages {
-		m.MsgChan <- msg
+		msgChan <- msg
+
+		go m.check(msg)
 	}
 
 	return nil
@@ -60,7 +90,33 @@ func (m *MockPubSub) Close() error {
 		return m.Err
 	}
 
-	close(m.MsgChan)
+	m.mutex.Lock()
+
+	for _, m := range m.MsgChan {
+		close(m)
+	}
+
+	m.MsgChan = nil
+
+	m.mutex.Unlock()
 
 	return nil
+}
+
+func (m *MockPubSub) check(msg *message.Message) {
+	select {
+	case <-msg.Acked():
+	case <-msg.Nacked():
+		m.postToUndeliverable(msg)
+	case <-time.After(m.Timeout):
+		m.postToUndeliverable(msg)
+	}
+}
+
+func (m *MockPubSub) postToUndeliverable(msg *message.Message) {
+	m.mutex.RLock()
+	msgChan := m.MsgChan[service.UndeliverableTopic]
+	m.mutex.RUnlock()
+
+	msgChan <- msg
 }

--- a/pkg/activitypub/service/mocks/mockundeliverablehandler.go
+++ b/pkg/activitypub/service/mocks/mockundeliverablehandler.go
@@ -1,0 +1,52 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	"sync"
+
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+)
+
+// UndeliverableActivity holds an undeliverable activity along with the URL to which the
+// activity could not be delivered.
+type UndeliverableActivity struct {
+	Activity *vocab.ActivityType
+	ToURL    string
+}
+
+// UndeliverableHandler implements a mock undeliverable activity handler.
+type UndeliverableHandler struct {
+	mutex      sync.Mutex
+	activities map[string]*UndeliverableActivity
+}
+
+// NewUndeliverableHandler returns a mock undeliverable activity handler.
+func NewUndeliverableHandler() *UndeliverableHandler {
+	return &UndeliverableHandler{
+		activities: make(map[string]*UndeliverableActivity),
+	}
+}
+
+// HandleUndeliverableActivity adds the given undeliverable activity to a map that may be later queried by unit tests.
+func (h *UndeliverableHandler) HandleUndeliverableActivity(activity *vocab.ActivityType, toURL string) {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	h.activities[activity.ID()] = &UndeliverableActivity{
+		Activity: activity,
+		ToURL:    toURL,
+	}
+}
+
+// Activity returns an undeliverable activity.
+func (h *UndeliverableHandler) Activity(id string) *UndeliverableActivity {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	return h.activities[id]
+}

--- a/pkg/activitypub/service/outbox/outbox.go
+++ b/pkg/activitypub/service/outbox/outbox.go
@@ -1,0 +1,244 @@
+package outbox
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/ThreeDotsLabs/watermill"
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/ThreeDotsLabs/watermill/message/router/middleware"
+	"github.com/ThreeDotsLabs/watermill/message/router/plugin"
+	"github.com/pkg/errors"
+	"github.com/trustbloc/edge-core/pkg/log"
+
+	"github.com/trustbloc/orb/pkg/activitypub/service/lifecycle"
+	"github.com/trustbloc/orb/pkg/activitypub/service/outbox/httppublisher"
+	"github.com/trustbloc/orb/pkg/activitypub/service/outbox/redelivery"
+	service "github.com/trustbloc/orb/pkg/activitypub/service/spi"
+	"github.com/trustbloc/orb/pkg/activitypub/service/wmlogger"
+	store "github.com/trustbloc/orb/pkg/activitypub/store/spi"
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+)
+
+var logger = log.New("activitypub_service")
+
+const (
+	metadataEventType = "event_type"
+)
+
+type redeliveryService interface {
+	service.ServiceLifecycle
+
+	Add(msg *message.Message) (time.Time, error)
+}
+
+type pubSub interface {
+	Subscribe(ctx context.Context, topic string) (<-chan *message.Message, error)
+	Publish(topic string, messages ...*message.Message) error
+	Close() error
+}
+
+// Config holds configuration parameters for the outbox.
+type Config struct {
+	ServiceName      string
+	Topic            string
+	PublishTimeout   time.Duration
+	TLSClientConfig  *tls.Config
+	RedeliveryConfig *redelivery.Config
+}
+
+// Outbox implements the ActivityPub outbox.
+type Outbox struct {
+	*Config
+	*lifecycle.Lifecycle
+
+	router               *message.Router
+	httpPublisher        message.Publisher
+	publisher            message.Publisher
+	undeliverableHandler service.UndeliverableActivityHandler
+	undeliverableChan    <-chan *message.Message
+	activityStore        store.Store
+	redeliveryService    redeliveryService
+	redeliveryChan       chan *message.Message
+	jsonMarshal          func(v interface{}) ([]byte, error)
+	jsonUnmarshal        func(data []byte, v interface{}) error
+}
+
+// New returns a new ActivityPub Outbox.
+func New(
+	cfg *Config, s store.Store, pubSub pubSub,
+	undeliverableHandler service.UndeliverableActivityHandler) (*Outbox, error) {
+	undeliverableChan, err := pubSub.Subscribe(context.Background(), service.UndeliverableTopic)
+	if err != nil {
+		return nil, err
+	}
+
+	redeliverChan := make(chan *message.Message)
+
+	h := &Outbox{
+		Config:               cfg,
+		undeliverableHandler: undeliverableHandler,
+		activityStore:        s,
+		redeliveryChan:       redeliverChan,
+		publisher:            pubSub,
+		undeliverableChan:    undeliverableChan,
+		redeliveryService:    redelivery.NewService(cfg.ServiceName, cfg.RedeliveryConfig, redeliverChan),
+		jsonMarshal:          json.Marshal,
+		jsonUnmarshal:        json.Unmarshal,
+	}
+
+	h.Lifecycle = lifecycle.New(cfg.ServiceName,
+		lifecycle.WithStart(h.start),
+		lifecycle.WithStop(h.stop),
+	)
+
+	router, err := message.NewRouter(message.RouterConfig{}, wmlogger.New())
+	if err != nil {
+		panic(err)
+	}
+
+	httpPublisher := httppublisher.New(
+		&httppublisher.Config{
+			ServiceName:     cfg.ServiceName,
+			TLSClientConfig: cfg.TLSClientConfig,
+		})
+
+	router.AddHandler(
+		"outbox-"+cfg.ServiceName, cfg.Topic,
+		pubSub, "outbox", httpPublisher,
+		func(msg *message.Message) ([]*message.Message, error) {
+			return message.Messages{msg}, nil
+		},
+	)
+
+	router.AddPlugin(plugin.SignalsHandler)
+
+	h.router = router
+	h.httpPublisher = httpPublisher
+
+	return h, nil
+}
+
+func (h *Outbox) start() {
+	// Start the redelivery message listener
+	go h.handleRedelivery()
+
+	// Start the redeliver message listener
+	go h.redeliver()
+
+	// Start the router
+	go h.route()
+
+	h.redeliveryService.Start()
+
+	// Wait for router to start
+	<-h.router.Running()
+}
+
+func (h *Outbox) stop() {
+	h.redeliveryService.Stop()
+
+	close(h.redeliveryChan)
+
+	if err := h.router.Close(); err != nil {
+		logger.Warnf("[%s] Error closing router: %s", h.ServiceName, err)
+	} else {
+		logger.Debugf("[%s] Closed router", h.ServiceName)
+	}
+}
+
+// Post posts an activity to the outbox.
+func (h *Outbox) Post(activity *vocab.ActivityType) error {
+	if h.State() != service.StateStarted {
+		return service.ErrNotStarted
+	}
+
+	activityBytes, err := h.jsonMarshal(activity)
+	if err != nil {
+		return errors.WithMessage(err, "unable to marshal")
+	}
+
+	if err := h.activityStore.AddActivity(store.Outbox, activity); err != nil {
+		return errors.WithMessage(err, "unable to store activity")
+	}
+
+	for _, to := range activity.To() {
+		if err := h.publish(activity.ID(), activityBytes, to); err != nil {
+			return errors.WithMessage(err, "unable to publish activity")
+		}
+	}
+
+	return nil
+}
+
+func (h *Outbox) publish(id string, activityBytes []byte, to fmt.Stringer) error {
+	msg := message.NewMessage(watermill.NewUUID(), activityBytes)
+	msg.Metadata.Set(metadataEventType, h.Topic)
+	msg.Metadata.Set(httppublisher.MetadataSendTo, to.String())
+
+	middleware.SetCorrelationID(id, msg)
+
+	logger.Debugf("[%s] Publishing %s", h.ServiceName, h.Topic)
+
+	return h.publisher.Publish(h.Topic, msg)
+}
+
+func (h *Outbox) route() {
+	logger.Infof("Starting router")
+
+	if err := h.router.Run(context.Background()); err != nil {
+		// This happens on startup so the best thing to do is to panic
+		panic(err)
+	}
+
+	logger.Infof("Router is shutting down")
+}
+
+func (h *Outbox) handleRedelivery() {
+	for msg := range h.undeliverableChan {
+		msg.Ack()
+
+		logger.Warnf("[%s] Got undeliverable message [%s]", h.ServiceName, msg.UUID)
+
+		h.handleUndeliverableActivity(msg)
+	}
+}
+
+func (h *Outbox) handleUndeliverableActivity(msg *message.Message) {
+	toURL := msg.Metadata[httppublisher.MetadataSendTo]
+
+	redeliveryTime, err := h.redeliveryService.Add(msg)
+	if err != nil {
+		activity := &vocab.ActivityType{}
+		if e := h.jsonUnmarshal(msg.Payload, activity); e != nil {
+			logger.Errorf("[%s] Error unmarshalling activity for message [%s]: %s", h.ServiceName, msg.UUID, e)
+
+			return
+		}
+
+		logger.Warnf("[%s] Will not attempt redelivery for message. Activity ID [%s], To: [%s]. Reason: %s",
+			h.ServiceName, activity.ID(), toURL, err)
+
+		h.undeliverableHandler.HandleUndeliverableActivity(activity, toURL)
+	} else {
+		activityID := msg.Metadata[middleware.CorrelationIDMetadataKey]
+
+		logger.Debugf("[%s] Will attempt to redeliver message at %s. Activity ID [%s], To: [%s]",
+			h.ServiceName, redeliveryTime, activityID, toURL)
+	}
+}
+
+func (h *Outbox) redeliver() {
+	for msg := range h.redeliveryChan {
+		logger.Infof("[%s] Attempting to redeliver message [%s]", h.ServiceName, msg.UUID)
+
+		if err := h.publisher.Publish(h.Topic, msg); err != nil {
+			logger.Errorf("[%s] Error redelivering message [%s]: %s", h.ServiceName, msg.UUID, err)
+		} else {
+			logger.Infof("[%s] Message was delivered: %s", h.ServiceName, msg.UUID)
+		}
+	}
+}

--- a/pkg/activitypub/service/outbox/outbox_test.go
+++ b/pkg/activitypub/service/outbox/outbox_test.go
@@ -1,0 +1,359 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package outbox
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/edge-core/pkg/log"
+	"github.com/trustbloc/sidetree-core-go/pkg/restapi/common"
+
+	"github.com/trustbloc/orb/pkg/activitypub/service/mocks"
+	"github.com/trustbloc/orb/pkg/activitypub/service/outbox/redelivery"
+	"github.com/trustbloc/orb/pkg/activitypub/service/spi"
+	"github.com/trustbloc/orb/pkg/activitypub/store/memstore"
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+	"github.com/trustbloc/orb/pkg/httpserver"
+)
+
+func TestNewOutbox(t *testing.T) {
+	undeliverableHandler := mocks.NewUndeliverableHandler()
+	activityStore := memstore.New("service1")
+
+	t.Run("Success", func(t *testing.T) {
+		cfg := &Config{
+			ServiceName:    "service1",
+			Topic:          "activities",
+			PublishTimeout: 50 * time.Millisecond,
+		}
+
+		ob, err := New(cfg, activityStore, mocks.NewPubSub(), undeliverableHandler)
+		require.NoError(t, err)
+		require.NotNil(t, ob)
+	})
+
+	t.Run("Tls HTTP client -> Success", func(t *testing.T) {
+		cfg := &Config{
+			ServiceName:    "service1",
+			Topic:          "activities",
+			PublishTimeout: 50 * time.Millisecond,
+			TLSClientConfig: &tls.Config{
+				MinVersion: tls.VersionTLS12,
+			},
+		}
+
+		ob, err := New(cfg, activityStore, mocks.NewPubSub(), undeliverableHandler)
+		require.NoError(t, err)
+		require.NotNil(t, ob)
+	})
+
+	t.Run("PubSub Subscribe error", func(t *testing.T) {
+		cfg := &Config{
+			ServiceName:    "service1",
+			Topic:          "activities",
+			PublishTimeout: 50 * time.Millisecond,
+		}
+
+		errExpected := errors.New("injected PubSub error")
+
+		ob, err := New(cfg, activityStore, mocks.NewPubSub().WithError(errExpected), undeliverableHandler)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, errExpected))
+		require.Nil(t, ob)
+	})
+}
+
+func TestOutbox_StartStop(t *testing.T) {
+	undeliverableHandler := mocks.NewUndeliverableHandler()
+	activityStore := memstore.New("service1")
+	pubSub := mocks.NewPubSub()
+
+	cfg := &Config{
+		ServiceName:    "service1",
+		Topic:          "activities",
+		PublishTimeout: 50 * time.Millisecond,
+	}
+
+	ob, err := New(cfg, activityStore, pubSub, undeliverableHandler)
+	require.NoError(t, err)
+	require.NotNil(t, ob)
+
+	ob.Start()
+
+	time.Sleep(50 * time.Millisecond)
+
+	require.Equal(t, spi.StateStarted, ob.State())
+
+	ob.Stop()
+
+	require.Equal(t, spi.StateStopped, ob.State())
+}
+
+func TestOutbox_Post(t *testing.T) {
+	log.SetLevel("activitypub_service", log.DEBUG)
+
+	var mutex sync.RWMutex
+
+	activitiesReceived := make(map[string]*vocab.ActivityType)
+
+	httpServer := httpserver.New(":8002", "", "", "",
+		newTestHandler("/services/service1", func(w http.ResponseWriter, req *http.Request) {
+			bytes, err := ioutil.ReadAll(req.Body)
+			require.NoError(t, err)
+
+			fmt.Printf("Got HTTP message: %s\n", bytes)
+
+			activity := &vocab.ActivityType{}
+			require.NoError(t, json.Unmarshal(bytes, activity))
+
+			mutex.Lock()
+			activitiesReceived[activity.ID()] = activity
+			mutex.Unlock()
+
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	require.NoError(t, httpServer.Start())
+
+	defer func() {
+		require.NoError(t, httpServer.Stop(context.Background()))
+	}()
+
+	undeliverableHandler := mocks.NewUndeliverableHandler()
+	activityStore := memstore.New("service1")
+	pubSub := mocks.NewPubSub()
+
+	cfg := &Config{
+		ServiceName:    "service1",
+		Topic:          "activities",
+		PublishTimeout: 100 * time.Millisecond,
+		RedeliveryConfig: &redelivery.Config{
+			MaxRetries:     5,
+			InitialBackoff: 100 * time.Millisecond,
+			MaxBackoff:     time.Second,
+			BackoffFactor:  1.5,
+			MaxMessages:    20,
+		},
+	}
+
+	ob, err := New(cfg, activityStore, pubSub, undeliverableHandler)
+	require.NoError(t, err)
+	require.NotNil(t, ob)
+
+	ob.Start()
+
+	objIRI, err := url.Parse("http://example.com/transactions/txn1")
+	require.NoError(t, err)
+
+	toURL, err := url.Parse("http://localhost:8002/services/service1")
+	require.NoError(t, err)
+
+	activity := vocab.NewCreateActivity(newActivityID(cfg.ServiceName),
+		vocab.NewObjectProperty(
+			vocab.WithObject(
+				vocab.NewObject(
+					vocab.WithIRI(objIRI),
+				),
+			),
+		),
+		vocab.WithTo(toURL),
+	)
+
+	require.NoError(t, ob.Post(activity))
+
+	time.Sleep(250 * time.Millisecond)
+
+	mutex.RLock()
+	_, ok := activitiesReceived[activity.ID()]
+	mutex.RUnlock()
+	require.True(t, ok)
+
+	time.Sleep(100 * time.Millisecond)
+
+	ob.Stop()
+}
+
+func TestOutbox_PostError(t *testing.T) {
+	log.SetLevel("activitypub_service", log.DEBUG)
+
+	activityStore := memstore.New("service1")
+
+	cfg := &Config{
+		ServiceName:    "service1",
+		Topic:          "activities",
+		PublishTimeout: 100 * time.Millisecond,
+		RedeliveryConfig: &redelivery.Config{
+			MaxRetries:     1,
+			InitialBackoff: 10 * time.Millisecond,
+			MaxBackoff:     time.Second,
+			BackoffFactor:  1.5,
+			MaxMessages:    20,
+		},
+	}
+
+	objIRI, err := url.Parse("http://example.com/transactions/txn1")
+	require.NoError(t, err)
+
+	toURL, err := url.Parse("http://localhost:8002/services/service1")
+	require.NoError(t, err)
+
+	t.Run("Not started", func(t *testing.T) {
+		ob, err := New(cfg, activityStore, mocks.NewPubSub(), mocks.NewUndeliverableHandler())
+		require.NoError(t, err)
+		require.NotNil(t, ob)
+
+		activity := vocab.NewCreateActivity(newActivityID(cfg.ServiceName), nil)
+
+		require.True(t, errors.Is(ob.Post(activity), spi.ErrNotStarted))
+	})
+
+	t.Run("Store error", func(t *testing.T) {
+		errExpected := errors.New("injected store error")
+
+		activityStore := &mocks.ActivityStore{}
+		activityStore.AddActivityReturns(errExpected)
+
+		ob, err := New(cfg, activityStore, mocks.NewPubSub(), mocks.NewUndeliverableHandler())
+		require.NoError(t, err)
+		require.NotNil(t, ob)
+
+		ob.Start()
+
+		activity := vocab.NewCreateActivity(newActivityID(cfg.ServiceName), nil)
+
+		require.True(t, errors.Is(ob.Post(activity), errExpected))
+
+		time.Sleep(100 * time.Millisecond)
+
+		ob.Stop()
+	})
+
+	t.Run("Marshal error", func(t *testing.T) {
+		ob, err := New(cfg, activityStore, mocks.NewPubSub(), mocks.NewUndeliverableHandler())
+		require.NoError(t, err)
+		require.NotNil(t, ob)
+
+		ob.Start()
+
+		errExpected := errors.New("injected marshal error")
+
+		ob.jsonMarshal = func(v interface{}) ([]byte, error) { return nil, errExpected }
+
+		activity := vocab.NewCreateActivity(newActivityID(cfg.ServiceName), nil)
+
+		require.True(t, errors.Is(ob.Post(activity), errExpected))
+
+		time.Sleep(100 * time.Millisecond)
+
+		ob.Stop()
+	})
+
+	t.Run("Redelivery max retries reached", func(t *testing.T) {
+		undeliverableHandler := mocks.NewUndeliverableHandler()
+
+		ob, err := New(cfg, activityStore, mocks.NewPubSub(), undeliverableHandler)
+		require.NoError(t, err)
+		require.NotNil(t, ob)
+
+		ob.Start()
+
+		activity := vocab.NewCreateActivity(newActivityID(cfg.ServiceName),
+			vocab.NewObjectProperty(
+				vocab.WithObject(
+					vocab.NewObject(
+						vocab.WithIRI(objIRI),
+					),
+				),
+			),
+			vocab.WithTo(toURL),
+		)
+
+		require.NoError(t, ob.Post(activity))
+
+		time.Sleep(1000 * time.Millisecond)
+
+		undeliverableActivity := undeliverableHandler.Activity(activity.ID())
+		require.NotNil(t, undeliverableActivity)
+
+		time.Sleep(100 * time.Millisecond)
+
+		ob.Stop()
+	})
+
+	t.Run("Redelivery unmarshal error", func(t *testing.T) {
+		undeliverableHandler := mocks.NewUndeliverableHandler()
+		pubSub := mocks.NewPubSub()
+
+		ob, err := New(cfg, activityStore, pubSub, undeliverableHandler)
+		require.NoError(t, err)
+		require.NotNil(t, ob)
+
+		ob.Start()
+
+		errExpected := errors.New("injected unmarshal error")
+
+		ob.jsonUnmarshal = func(data []byte, v interface{}) error { return errExpected }
+
+		activity := vocab.NewCreateActivity(newActivityID(cfg.ServiceName),
+			vocab.NewObjectProperty(
+				vocab.WithObject(
+					vocab.NewObject(
+						vocab.WithIRI(objIRI),
+					),
+				),
+			),
+			vocab.WithTo(toURL),
+		)
+
+		require.NoError(t, ob.Post(activity))
+
+		time.Sleep(100 * time.Millisecond)
+
+		ob.Stop()
+	})
+}
+
+func newActivityID(serviceName string) string {
+	return fmt.Sprintf("%s/%s", serviceName, uuid.New())
+}
+
+type testHandler struct {
+	path    string
+	handler common.HTTPRequestHandler
+}
+
+func newTestHandler(path string, handler common.HTTPRequestHandler) *testHandler {
+	return &testHandler{
+		path:    path,
+		handler: handler,
+	}
+}
+
+func (m *testHandler) Path() string {
+	return m.path
+}
+
+func (m *testHandler) Method() string {
+	return http.MethodPost
+}
+
+func (m *testHandler) Handler() common.HTTPRequestHandler {
+	return m.handler
+}

--- a/pkg/activitypub/service/outbox/redelivery/redelivery.go
+++ b/pkg/activitypub/service/outbox/redelivery/redelivery.go
@@ -1,0 +1,197 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package redelivery
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/pkg/errors"
+	"github.com/trustbloc/edge-core/pkg/log"
+
+	"github.com/trustbloc/orb/pkg/activitypub/service/lifecycle"
+	service "github.com/trustbloc/orb/pkg/activitypub/service/spi"
+)
+
+var logger = log.New("activitypub_service")
+
+const (
+	metadataRedeliveryAttempts = "redelivery_attempts"
+
+	defaultMaxRetries     = 5
+	defaultInitialBackoff = 100 * time.Millisecond
+	defaultMaxBackoff     = time.Second
+	defaultBackoffFactor  = 1.5
+	defaultMaxMessages    = 20
+)
+
+type entry struct {
+	msg   *message.Message
+	delay time.Duration
+}
+
+// Config holds the configuration parameters for the redelivery service.
+type Config struct {
+	// MaxRetries is maximum number of times a retry will be attempted.
+	MaxRetries int
+
+	// InitialBackoff is the first interval between retries. Subsequent intervals will be scaled by BackoffFactor.
+	InitialBackoff time.Duration
+
+	// MaxBackoff sets the limit for the exponential backoff of retries. The interval will not be
+	// increased beyond MaxBackoff.
+	MaxBackoff time.Duration
+
+	// BackoffFactor is the factor by which the waiting interval will be multiplied between retries.
+	BackoffFactor float64
+
+	// MaxMessages is the maximum number of messages that can be concurrently managed by the redelivery service.
+	MaxMessages int
+}
+
+// DefaultConfig returns the default configuration parameters for the redelivery service.
+func DefaultConfig() *Config {
+	return &Config{
+		MaxRetries:     defaultMaxRetries,
+		InitialBackoff: defaultInitialBackoff,
+		MaxBackoff:     defaultMaxBackoff,
+		BackoffFactor:  defaultBackoffFactor,
+		MaxMessages:    defaultMaxMessages,
+	}
+}
+
+// Service manages redelivery of messages that failed delivery. The messages are published after a delay which is
+// calculated according to the provided config, which includes an initial backoff and a backoff factor.
+type Service struct {
+	*Config
+	*lifecycle.Lifecycle
+
+	serviceName string
+	notifyChan  chan<- *message.Message
+	entryChan   chan *entry
+	done        chan struct{}
+}
+
+// NewService returns a new redelivery service.
+func NewService(serviceName string, cfg *Config, notifyChan chan<- *message.Message) *Service {
+	if cfg == nil {
+		cfg = DefaultConfig()
+	}
+
+	m := &Service{
+		serviceName: serviceName,
+		Config:      cfg,
+		notifyChan:  notifyChan,
+		entryChan:   make(chan *entry, cfg.MaxMessages),
+		done:        make(chan struct{}),
+	}
+
+	m.Lifecycle = lifecycle.New(serviceName+"-redelivery",
+		lifecycle.WithStart(m.start),
+		lifecycle.WithStop(m.stop),
+	)
+
+	return m
+}
+
+// Add adds a message for redelivery. The time when the redelivery attempt will occur is returned, or an error
+// is returned if the message cannot be redelivered. This function generally returns immediately, although if
+// the number of messages already being redelivered has reached the MaxMessages limit then this function will
+// block until a previously added message has been processed.
+func (m *Service) Add(msg *message.Message) (time.Time, error) {
+	if m.State() != service.StateStarted {
+		return time.Time{}, service.ErrNotStarted
+	}
+
+	redeliveryAttempts := 0
+
+	redeliverAttemptsStr, ok := msg.Metadata[metadataRedeliveryAttempts]
+	if ok {
+		ra, err := strconv.Atoi(redeliverAttemptsStr)
+		if err != nil {
+			return time.Time{},
+				errors.WithMessagef(
+					err, "error converting redelivery attempts metadata to number for message [%s]", msg.UUID,
+				)
+		}
+
+		redeliveryAttempts = ra
+	}
+
+	if redeliveryAttempts >= m.MaxRetries {
+		return time.Time{},
+			errors.Errorf("unable to redeliver message after %d redelivery attempts", redeliveryAttempts)
+	}
+
+	newMsg := msg.Copy()
+
+	newMsg.Metadata[metadataRedeliveryAttempts] = strconv.Itoa(redeliveryAttempts + 1)
+
+	backoff := m.backoff(redeliveryAttempts)
+
+	m.entryChan <- &entry{
+		msg:   newMsg,
+		delay: backoff,
+	}
+
+	logger.Debugf("[%s] Adding message for redelivery: ID [%s], Delay [%s], Redelivery Attempts: %d",
+		m.serviceName, msg.UUID, backoff, redeliveryAttempts)
+
+	return time.Now().Add(backoff), nil
+}
+
+func (m *Service) start() {
+	logger.Infof("[%s] Redelivery service started.", m.serviceName)
+
+	go m.monitor()
+}
+
+func (m *Service) stop() {
+	close(m.done)
+	close(m.entryChan)
+
+	logger.Infof("[%s] Redelivery service stopped", m.serviceName)
+}
+
+func (m *Service) monitor() {
+	for entry := range m.entryChan {
+		go m.redeliver(entry)
+	}
+}
+
+func (m *Service) redeliver(entry *entry) {
+	logger.Debugf("[%s] Waiting %s to redeliver message %s", m.serviceName, entry.delay, entry.msg.UUID)
+
+	select {
+	case <-time.After(entry.delay):
+		logger.Debugf("[%s] Submitting message %s after waiting %s ...",
+			m.serviceName, entry.msg.UUID, entry.delay)
+
+		m.notifyChan <- entry.msg
+
+		logger.Debugf("[%s] ... submitted message %s after waiting %s",
+			m.serviceName, entry.msg.UUID, entry.delay)
+	case <-m.done:
+		logger.Debugf("[%s] Not redelivering message [%s] since redelivery manager has been closed",
+			m.serviceName, entry.msg.UUID)
+	}
+}
+
+func (m *Service) backoff(retries int) time.Duration {
+	backoff, max := float64(m.InitialBackoff), float64(m.MaxBackoff)
+
+	for i := 0; i < retries && backoff < max; i++ {
+		backoff *= m.BackoffFactor
+	}
+
+	if backoff > max {
+		backoff = max
+	}
+
+	return time.Duration(backoff)
+}

--- a/pkg/activitypub/service/outbox/redelivery/redelivery_test.go
+++ b/pkg/activitypub/service/outbox/redelivery/redelivery_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package redelivery
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ThreeDotsLabs/watermill"
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewService(t *testing.T) {
+	s := NewService("service1", nil, nil)
+	require.NotNil(t, s)
+	require.Equalf(t, DefaultConfig(), s.Config, "should have used default config if nil config was passed as an arg")
+}
+
+func TestService(t *testing.T) {
+	notifyChan := make(chan *message.Message)
+
+	cfg := &Config{
+		MaxRetries:     2,
+		InitialBackoff: 50 * time.Millisecond,
+		MaxBackoff:     time.Second,
+		BackoffFactor:  1.5,
+		MaxMessages:    20,
+	}
+
+	s := NewService("service1", cfg, notifyChan)
+	require.NotNil(t, s)
+
+	s.Start()
+
+	payload := []byte("payload")
+
+	t.Run("Success", func(t *testing.T) {
+		msg := message.NewMessage(watermill.NewUUID(), payload)
+
+		now := time.Now()
+
+		deliveryTime, err := s.Add(msg)
+		require.NoError(t, err)
+		require.True(t, deliveryTime.After(now.Add(cfg.InitialBackoff)))
+
+		var undeliverableMsg *message.Message
+
+		select {
+		case m := <-notifyChan:
+			undeliverableMsg = m
+		case <-time.After(100 * time.Millisecond):
+		}
+
+		require.NotNil(t, undeliverableMsg)
+	})
+
+	t.Run("Invalid metadata -> Error", func(t *testing.T) {
+		msg := message.NewMessage(watermill.NewUUID(), payload)
+		msg.Metadata[metadataRedeliveryAttempts] = "invalid"
+
+		_, err := s.Add(msg)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error converting redelivery attempts metadata to number")
+	})
+
+	t.Run("Max attempts reached -> Error", func(t *testing.T) {
+		msg := message.NewMessage(watermill.NewUUID(), payload)
+		msg.Metadata[metadataRedeliveryAttempts] = "2"
+
+		_, err := s.Add(msg)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unable to redeliver message after 2 redelivery attempts")
+	})
+
+	// Add a message and immediately shut down to ensure we don't panic.
+	_, err := s.Add(message.NewMessage(watermill.NewUUID(), payload))
+	require.NoError(t, err)
+
+	s.Stop()
+}
+
+func TestBackoff(t *testing.T) {
+	cfg := &Config{
+		MaxRetries:     2,
+		InitialBackoff: 50 * time.Millisecond,
+		MaxBackoff:     time.Second,
+		BackoffFactor:  1.5,
+		MaxMessages:    20,
+	}
+
+	s := NewService("service1", cfg, nil)
+	require.NotNil(t, s)
+
+	require.Equal(t, cfg.InitialBackoff, s.backoff(0))
+	require.True(t, s.backoff(1) > cfg.InitialBackoff)
+	require.Equal(t, cfg.MaxBackoff, s.backoff(10))
+}

--- a/pkg/activitypub/service/spi/spi.go
+++ b/pkg/activitypub/service/spi/spi.go
@@ -7,8 +7,17 @@ SPDX-License-Identifier: Apache-2.0
 package spi
 
 import (
+	"errors"
+
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
 )
+
+// UndeliverableTopic is the topic to which to post undeliverable messages.
+const UndeliverableTopic = "undeliverable"
+
+// ErrNotStarted indicates that an attempt was made to invoke a service that has not been started
+// or is still in the process of starting.
+var ErrNotStarted = errors.New("service has not started")
 
 // State is the state of the service.
 type State = uint32
@@ -38,4 +47,9 @@ type ServiceLifecycle interface {
 type ActivityHandler interface {
 	// HandleActivity handles the ActivityPub activity.
 	HandleActivity(activity *vocab.ActivityType) error
+}
+
+// UndeliverableActivityHandler handles undeliverable activities.
+type UndeliverableActivityHandler interface {
+	HandleUndeliverableActivity(activity *vocab.ActivityType, toURL string)
 }


### PR DESCRIPTION
Implemented an outbox for ActivityPub messages. The outbox sends an HTTP message with an activity and monitors whether or not the message was sent. If an error occurs then it attempts to redeliver the message (according to redelivery config).

closes #55

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>