### PR TITLE
feat: ActivityPub service

### DIFF
--- a/pkg/activitypub/service/activityhandler/activityhandler.go
+++ b/pkg/activitypub/service/activityhandler/activityhandler.go
@@ -1,0 +1,124 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package activityhandler
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/trustbloc/edge-core/pkg/log"
+
+	"github.com/trustbloc/orb/pkg/activitypub/service/lifecycle"
+	service "github.com/trustbloc/orb/pkg/activitypub/service/spi"
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+)
+
+var logger = log.New("activitypub_service")
+
+const defaultBufferSize = 100
+
+// Config holds the configuration parameters for the activity handler.
+type Config struct {
+	// ServiceName is the name of the service (used for logging).
+	ServiceName string
+
+	// BufferSize is the size of the Go channel buffer for a subscription.
+	BufferSize int
+}
+
+// Handler provides an implementation for the ActivityHandler interface.
+type Handler struct {
+	*Config
+	*lifecycle.Lifecycle
+	*service.Handlers
+
+	name        string
+	mutex       sync.RWMutex
+	subscribers []chan *vocab.ActivityType
+}
+
+// New returns a new ActivityPub activity handler.
+func New(cfg *Config, opts ...service.HandlerOpt) *Handler {
+	options := defaultOptions()
+
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	if cfg.BufferSize == 0 {
+		cfg.BufferSize = defaultBufferSize
+	}
+
+	h := &Handler{
+		Config:   cfg,
+		Handlers: options,
+	}
+
+	h.Lifecycle = lifecycle.New(cfg.ServiceName, lifecycle.WithStop(h.stop))
+
+	return h
+}
+
+func (h *Handler) stop() {
+	logger.Infof("[%s] Stopping activity handler", h.name)
+
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	for _, ch := range h.subscribers {
+		close(ch)
+	}
+
+	h.subscribers = nil
+}
+
+// Subscribe allows a client to receive published activities.
+func (h *Handler) Subscribe() <-chan *vocab.ActivityType {
+	ch := make(chan *vocab.ActivityType, h.BufferSize)
+
+	h.mutex.Lock()
+	h.subscribers = append(h.subscribers, ch)
+	h.mutex.Unlock()
+
+	return ch
+}
+
+// HandleActivity handles the ActivityPub activity.
+func (h *Handler) HandleActivity(activity *vocab.ActivityType) error {
+	typeProp := activity.Type()
+
+	switch {
+	case typeProp.Is(vocab.TypeCreate):
+		return h.handleCreateActivity(activity)
+	default:
+		return fmt.Errorf("unsupported activity type: %s", typeProp.Types())
+	}
+}
+
+func (h *Handler) handleCreateActivity(create *vocab.ActivityType) error {
+	logger.Debugf("[%s] Handling 'Create' activity: %s", h.name, create.ID())
+
+	// TODO: Announce the 'Create'.
+
+	h.notify(create)
+
+	return nil
+}
+
+func (h *Handler) notify(activity *vocab.ActivityType) {
+	h.mutex.RLock()
+	subscribers := h.subscribers
+	h.mutex.RUnlock()
+
+	for _, ch := range subscribers {
+		ch <- activity
+	}
+}
+
+func defaultOptions() *service.Handlers {
+	return &service.Handlers{}
+}

--- a/pkg/activitypub/service/activityhandler/activityhandler_test.go
+++ b/pkg/activitypub/service/activityhandler/activityhandler_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package activityhandler
+
+import (
+	"fmt"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/pkg/activitypub/service/mocks"
+	"github.com/trustbloc/orb/pkg/activitypub/service/spi"
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+)
+
+func TestNew(t *testing.T) {
+	cfg := &Config{
+		ServiceName: "service1",
+		BufferSize:  100,
+	}
+
+	h := New(cfg, spi.WithUndeliverableHandler(mocks.NewUndeliverableHandler()))
+	require.NotNil(t, h)
+
+	require.Equal(t, spi.StateNotStarted, h.State())
+
+	h.Start()
+
+	require.Equal(t, spi.StateStarted, h.State())
+
+	h.Stop()
+
+	require.Equal(t, spi.StateStopped, h.State())
+}
+
+func TestHandler_HandleCreateActivity(t *testing.T) {
+	cfg := &Config{
+		ServiceName: "service1",
+	}
+
+	h := New(cfg, spi.WithUndeliverableHandler(mocks.NewUndeliverableHandler()))
+	require.NotNil(t, h)
+
+	h.Start()
+	defer h.Stop()
+
+	activityChan := h.Subscribe()
+
+	var (
+		mutex       sync.Mutex
+		gotActivity *vocab.ActivityType
+	)
+
+	go func() {
+		for activity := range activityChan {
+			mutex.Lock()
+			gotActivity = activity
+			mutex.Unlock()
+		}
+	}()
+
+	t.Run("Success", func(t *testing.T) {
+		const cid = "bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y"
+
+		targetProperty := vocab.NewObjectProperty(vocab.WithObject(
+			vocab.NewObject(
+				vocab.WithID(cid),
+				vocab.WithType(vocab.TypeCAS),
+			),
+		))
+
+		obj, err := vocab.NewObjectWithDocument(vocab.MustUnmarshalToDoc([]byte(anchorCredential1)))
+		if err != nil {
+			panic(err)
+		}
+
+		service1IRI := mustParseURL("http://localhost:8301/services/service1")
+		service2IRI := mustParseURL("http://localhost:8302/services/service2")
+
+		create := vocab.NewCreateActivity(newActivityID(service1IRI.String()),
+			vocab.NewObjectProperty(vocab.WithObject(obj)),
+			vocab.WithTarget(targetProperty),
+			vocab.WithContext(vocab.ContextOrb),
+			vocab.WithTo(service2IRI),
+		)
+
+		require.NoError(t, h.HandleActivity(create))
+
+		time.Sleep(50 * time.Millisecond)
+
+		mutex.Lock()
+		require.Equal(t, create, gotActivity)
+		mutex.Unlock()
+	})
+
+	t.Run("Unsupported activity", func(t *testing.T) {
+		activity := &vocab.ActivityType{
+			ObjectType: vocab.NewObject(vocab.WithType(vocab.Type("unsupported_type"))),
+		}
+		err := h.HandleActivity(activity)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unsupported activity type")
+	})
+}
+
+func newActivityID(serviceName string) string {
+	return fmt.Sprintf("%s/%s", serviceName, uuid.New())
+}
+
+func mustParseURL(raw string) *url.URL {
+	u, err := url.Parse(raw)
+	if err != nil {
+		panic(err)
+	}
+
+	return u
+}
+
+const anchorCredential1 = `{
+  "@context": [
+	"https://www.w3.org/2018/credentials/v1",
+	"https://trustbloc.github.io/Context/orb-v1.json"
+  ],
+  "id": "http://sally.example.com/transactions/bafkreihwsn",
+  "type": [
+	"VerifiableCredential",
+	"AnchorCredential"
+  ],
+  "issuer": "https://sally.example.com/services/orb",
+  "issuanceDate": "2021-01-27T09:30:10Z",
+  "credentialSubject": {
+	"anchorString": "bafkreihwsn",
+	"namespace": "did:orb",
+	"version": "1",
+	"previousTransactions": {
+	  "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
+	  "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w"
+	}
+  },
+  "proofChain": [{}]
+}`

--- a/pkg/activitypub/service/inbox/inbox_test.go
+++ b/pkg/activitypub/service/inbox/inbox_test.go
@@ -281,7 +281,7 @@ func TestInbox_Error(t *testing.T) {
 		ib.Start()
 		defer ib.Stop()
 
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(200 * time.Millisecond)
 
 		activityHandler.HandleActivityReturns(errors.New("injected handler error"))
 

--- a/pkg/activitypub/service/mocks/activityhandler.gen.go
+++ b/pkg/activitypub/service/mocks/activityhandler.gen.go
@@ -9,6 +9,21 @@ import (
 )
 
 type ActivityHandler struct {
+	StartStub        func()
+	startMutex       sync.RWMutex
+	startArgsForCall []struct{}
+	StopStub         func()
+	stopMutex        sync.RWMutex
+	stopArgsForCall  []struct{}
+	StateStub        func() spi.State
+	stateMutex       sync.RWMutex
+	stateArgsForCall []struct{}
+	stateReturns     struct {
+		result1 spi.State
+	}
+	stateReturnsOnCall map[int]struct {
+		result1 spi.State
+	}
 	HandleActivityStub        func(activity *vocab.ActivityType) error
 	handleActivityMutex       sync.RWMutex
 	handleActivityArgsForCall []struct {
@@ -20,9 +35,6 @@ type ActivityHandler struct {
 	handleActivityReturnsOnCall map[int]struct {
 		result1 error
 	}
-	CloseStub            func()
-	closeMutex           sync.RWMutex
-	closeArgsForCall     []struct{}
 	SubscribeStub        func() <-chan *vocab.ActivityType
 	subscribeMutex       sync.RWMutex
 	subscribeArgsForCall []struct{}
@@ -34,6 +46,78 @@ type ActivityHandler struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *ActivityHandler) Start() {
+	fake.startMutex.Lock()
+	fake.startArgsForCall = append(fake.startArgsForCall, struct{}{})
+	fake.recordInvocation("Start", []interface{}{})
+	fake.startMutex.Unlock()
+	if fake.StartStub != nil {
+		fake.StartStub()
+	}
+}
+
+func (fake *ActivityHandler) StartCallCount() int {
+	fake.startMutex.RLock()
+	defer fake.startMutex.RUnlock()
+	return len(fake.startArgsForCall)
+}
+
+func (fake *ActivityHandler) Stop() {
+	fake.stopMutex.Lock()
+	fake.stopArgsForCall = append(fake.stopArgsForCall, struct{}{})
+	fake.recordInvocation("Stop", []interface{}{})
+	fake.stopMutex.Unlock()
+	if fake.StopStub != nil {
+		fake.StopStub()
+	}
+}
+
+func (fake *ActivityHandler) StopCallCount() int {
+	fake.stopMutex.RLock()
+	defer fake.stopMutex.RUnlock()
+	return len(fake.stopArgsForCall)
+}
+
+func (fake *ActivityHandler) State() spi.State {
+	fake.stateMutex.Lock()
+	ret, specificReturn := fake.stateReturnsOnCall[len(fake.stateArgsForCall)]
+	fake.stateArgsForCall = append(fake.stateArgsForCall, struct{}{})
+	fake.recordInvocation("State", []interface{}{})
+	fake.stateMutex.Unlock()
+	if fake.StateStub != nil {
+		return fake.StateStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fake.stateReturns.result1
+}
+
+func (fake *ActivityHandler) StateCallCount() int {
+	fake.stateMutex.RLock()
+	defer fake.stateMutex.RUnlock()
+	return len(fake.stateArgsForCall)
+}
+
+func (fake *ActivityHandler) StateReturns(result1 spi.State) {
+	fake.StateStub = nil
+	fake.stateReturns = struct {
+		result1 spi.State
+	}{result1}
+}
+
+func (fake *ActivityHandler) StateReturnsOnCall(i int, result1 spi.State) {
+	fake.StateStub = nil
+	if fake.stateReturnsOnCall == nil {
+		fake.stateReturnsOnCall = make(map[int]struct {
+			result1 spi.State
+		})
+	}
+	fake.stateReturnsOnCall[i] = struct {
+		result1 spi.State
+	}{result1}
 }
 
 func (fake *ActivityHandler) HandleActivity(activity *vocab.ActivityType) error {
@@ -84,22 +168,6 @@ func (fake *ActivityHandler) HandleActivityReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *ActivityHandler) Close() {
-	fake.closeMutex.Lock()
-	fake.closeArgsForCall = append(fake.closeArgsForCall, struct{}{})
-	fake.recordInvocation("Close", []interface{}{})
-	fake.closeMutex.Unlock()
-	if fake.CloseStub != nil {
-		fake.CloseStub()
-	}
-}
-
-func (fake *ActivityHandler) CloseCallCount() int {
-	fake.closeMutex.RLock()
-	defer fake.closeMutex.RUnlock()
-	return len(fake.closeArgsForCall)
-}
-
 func (fake *ActivityHandler) Subscribe() <-chan *vocab.ActivityType {
 	fake.subscribeMutex.Lock()
 	ret, specificReturn := fake.subscribeReturnsOnCall[len(fake.subscribeArgsForCall)]
@@ -143,10 +211,14 @@ func (fake *ActivityHandler) SubscribeReturnsOnCall(i int, result1 <-chan *vocab
 func (fake *ActivityHandler) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.startMutex.RLock()
+	defer fake.startMutex.RUnlock()
+	fake.stopMutex.RLock()
+	defer fake.stopMutex.RUnlock()
+	fake.stateMutex.RLock()
+	defer fake.stateMutex.RUnlock()
 	fake.handleActivityMutex.RLock()
 	defer fake.handleActivityMutex.RUnlock()
-	fake.closeMutex.RLock()
-	defer fake.closeMutex.RUnlock()
 	fake.subscribeMutex.RLock()
 	defer fake.subscribeMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/pkg/activitypub/service/mocks/mocksubscriber.go
+++ b/pkg/activitypub/service/mocks/mocksubscriber.go
@@ -1,0 +1,55 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	"sync"
+
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+)
+
+// MockSubscriber implements a mock activity subscriber.
+type MockSubscriber struct {
+	serviceName  string
+	activityChan <-chan *vocab.ActivityType
+	mutex        sync.Mutex
+	activities   []*vocab.ActivityType
+}
+
+// NewMockSubscriber returns a new mock activity subscriber.
+func NewMockSubscriber(
+	serviceName string, activityChan <-chan *vocab.ActivityType) *MockSubscriber {
+	s := &MockSubscriber{
+		serviceName:  serviceName,
+		activityChan: activityChan,
+	}
+
+	go s.listen()
+
+	return s
+}
+
+// Activities returns the activities that were received by the subscriber.
+func (m *MockSubscriber) Activities() []*vocab.ActivityType {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	return m.activities
+}
+
+func (m *MockSubscriber) listen() {
+	for activity := range m.activityChan {
+		m.add(activity)
+	}
+}
+
+func (m *MockSubscriber) add(activity *vocab.ActivityType) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	m.activities = append(m.activities, activity)
+}

--- a/pkg/activitypub/service/mocks/mockundeliverablehandler.go
+++ b/pkg/activitypub/service/mocks/mockundeliverablehandler.go
@@ -22,14 +22,12 @@ type UndeliverableActivity struct {
 // UndeliverableHandler implements a mock undeliverable activity handler.
 type UndeliverableHandler struct {
 	mutex      sync.Mutex
-	activities map[string]*UndeliverableActivity
+	activities []*UndeliverableActivity
 }
 
 // NewUndeliverableHandler returns a mock undeliverable activity handler.
 func NewUndeliverableHandler() *UndeliverableHandler {
-	return &UndeliverableHandler{
-		activities: make(map[string]*UndeliverableActivity),
-	}
+	return &UndeliverableHandler{}
 }
 
 // HandleUndeliverableActivity adds the given undeliverable activity to a map that may be later queried by unit tests.
@@ -37,16 +35,16 @@ func (h *UndeliverableHandler) HandleUndeliverableActivity(activity *vocab.Activ
 	h.mutex.Lock()
 	defer h.mutex.Unlock()
 
-	h.activities[activity.ID()] = &UndeliverableActivity{
+	h.activities = append(h.activities, &UndeliverableActivity{
 		Activity: activity,
 		ToURL:    toURL,
-	}
+	})
 }
 
-// Activity returns an undeliverable activity.
-func (h *UndeliverableHandler) Activity(id string) *UndeliverableActivity {
+// Activities returns the undeliverable activities.
+func (h *UndeliverableHandler) Activities() []*UndeliverableActivity {
 	h.mutex.Lock()
 	defer h.mutex.Unlock()
 
-	return h.activities[id]
+	return h.activities
 }

--- a/pkg/activitypub/service/service.go
+++ b/pkg/activitypub/service/service.go
@@ -1,0 +1,135 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+
+	"github.com/trustbloc/orb/pkg/activitypub/service/activityhandler"
+	"github.com/trustbloc/orb/pkg/activitypub/service/inbox"
+	"github.com/trustbloc/orb/pkg/activitypub/service/lifecycle"
+	"github.com/trustbloc/orb/pkg/activitypub/service/mempubsub"
+	"github.com/trustbloc/orb/pkg/activitypub/service/outbox"
+	"github.com/trustbloc/orb/pkg/activitypub/service/outbox/redelivery"
+	"github.com/trustbloc/orb/pkg/activitypub/service/spi"
+	store "github.com/trustbloc/orb/pkg/activitypub/store/spi"
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+)
+
+const activitiesTopic = "activities"
+
+// PubSub defines the functions for a publisher/subscriber.
+type PubSub interface {
+	Subscribe(ctx context.Context, topic string) (<-chan *message.Message, error)
+	Publish(topic string, messages ...*message.Message) error
+	Close() error
+}
+
+// PubSubFactory creates a publisher/subscriber.
+type PubSubFactory func(serviceName string) PubSub
+
+// Config holds the configuration parameters for an ActivityPub service.
+type Config struct {
+	ServiceName               string
+	ListenAddress             string
+	RetryOpts                 *redelivery.Config
+	PubSubFactory             PubSubFactory
+	ActivityHandlerBufferSize int
+}
+
+// Service implements an ActivityPub service which has an inbox, outbox, and
+// handlers for the various ActivityPub activities.
+type Service struct {
+	*lifecycle.Lifecycle
+
+	inbox           *inbox.Inbox
+	outbox          *outbox.Outbox
+	activityHandler spi.ActivityHandler
+}
+
+// NewService returns a new ActivityPub service.
+func NewService(cfg *Config, activityStore store.Store, handlerOpts ...spi.HandlerOpt) (*Service, error) {
+	ob, err := outbox.New(
+		&outbox.Config{
+			ServiceName:      cfg.ServiceName,
+			Topic:            activitiesTopic,
+			RedeliveryConfig: cfg.RetryOpts,
+		},
+		activityStore, newPubSub(cfg, "outbox-"+cfg.ServiceName),
+		handlerOpts...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create outbox failed: %w", err)
+	}
+
+	handler := activityhandler.New(
+		&activityhandler.Config{
+			ServiceName: cfg.ServiceName,
+			BufferSize:  cfg.ActivityHandlerBufferSize,
+		}, handlerOpts...,
+	)
+
+	ib, err := inbox.New(
+		&inbox.Config{
+			ServiceName:   cfg.ServiceName,
+			Topic:         activitiesTopic,
+			ListenAddress: cfg.ListenAddress,
+		},
+		activityStore,
+		newPubSub(cfg, "inbox-"+cfg.ServiceName),
+		handler,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create inbox failed: %w", err)
+	}
+
+	s := &Service{
+		inbox:           ib,
+		outbox:          ob,
+		activityHandler: handler,
+	}
+
+	s.Lifecycle = lifecycle.New(cfg.ServiceName,
+		lifecycle.WithStart(s.start),
+		lifecycle.WithStop(s.stop),
+	)
+
+	return s, nil
+}
+
+func (s *Service) start() {
+	s.activityHandler.Start()
+	s.inbox.Start()
+	s.outbox.Start()
+}
+
+func (s *Service) stop() {
+	s.outbox.Stop()
+	s.inbox.Stop()
+	s.activityHandler.Stop()
+}
+
+// Outbox returns the outbox, which allows clients to post activities.
+func (s *Service) Outbox() spi.Outbox {
+	return s.outbox
+}
+
+// Subscribe allows a client to receive published activities.
+func (s *Service) Subscribe() <-chan *vocab.ActivityType {
+	return s.activityHandler.Subscribe()
+}
+
+func newPubSub(cfg *Config, serviceName string) PubSub {
+	if cfg.PubSubFactory != nil {
+		return cfg.PubSubFactory(serviceName)
+	}
+
+	return mempubsub.New(serviceName, mempubsub.DefaultConfig())
+}

--- a/pkg/activitypub/service/service_test.go
+++ b/pkg/activitypub/service/service_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package service
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/edge-core/pkg/log"
+
+	"github.com/trustbloc/orb/pkg/activitypub/service/mocks"
+	"github.com/trustbloc/orb/pkg/activitypub/service/outbox/redelivery"
+	service "github.com/trustbloc/orb/pkg/activitypub/service/spi"
+	"github.com/trustbloc/orb/pkg/activitypub/service/wmlogger"
+	"github.com/trustbloc/orb/pkg/activitypub/store/memstore"
+	"github.com/trustbloc/orb/pkg/activitypub/store/spi"
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+)
+
+func TestNewService(t *testing.T) {
+	cfg1 := &Config{
+		ServiceName:   "/services/service1",
+		ListenAddress: ":8311",
+		PubSubFactory: func(serviceName string) PubSub {
+			return mocks.NewPubSub()
+		},
+	}
+
+	store1 := memstore.New(cfg1.ServiceName)
+	undeliverableHandler1 := mocks.NewUndeliverableHandler()
+
+	service1, err := NewService(cfg1, store1, service.WithUndeliverableHandler(undeliverableHandler1))
+	require.NoError(t, err)
+
+	service1.Start()
+
+	require.Equal(t, service.StateStarted, service1.State())
+
+	service1.Stop()
+
+	require.Equal(t, service.StateStopped, service1.State())
+}
+
+func TestService(t *testing.T) {
+	log.SetLevel(wmlogger.Module, log.WARNING)
+
+	service1IRI := mustParseURL("http://localhost:8301/services/service1")
+	service2IRI := mustParseURL("http://localhost:8302/services/service2")
+
+	cfg1 := &Config{
+		ServiceName:   "/services/service1",
+		ListenAddress: ":8301",
+	}
+
+	store1 := memstore.New(cfg1.ServiceName)
+	undeliverableHandler1 := mocks.NewUndeliverableHandler()
+
+	service1, err := NewService(cfg1, store1,
+		service.WithUndeliverableHandler(undeliverableHandler1),
+	)
+	require.NoError(t, err)
+
+	defer service1.Stop()
+
+	cfg2 := &Config{
+		ServiceName:   "/services/service2",
+		ListenAddress: ":8302",
+		RetryOpts: &redelivery.Config{
+			MaxRetries:     5,
+			InitialBackoff: 10 * time.Millisecond,
+			MaxBackoff:     time.Second,
+			BackoffFactor:  1.2,
+			MaxMessages:    20,
+		},
+	}
+
+	store2 := memstore.New(cfg2.ServiceName)
+	undeliverableHandler2 := mocks.NewUndeliverableHandler()
+
+	service2, err := NewService(cfg2, store2,
+		service.WithUndeliverableHandler(undeliverableHandler2),
+	)
+	require.NoError(t, err)
+
+	defer service2.Stop()
+
+	subscriber2 := mocks.NewMockSubscriber(cfg2.ServiceName, service2.Subscribe())
+
+	service1.Start()
+
+	// delay the start of Service2 to test redelivery
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		service2.Start()
+	}()
+
+	t.Run("Create", func(t *testing.T) {
+		const cid = "bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y"
+
+		targetProperty := vocab.NewObjectProperty(vocab.WithObject(
+			vocab.NewObject(
+				vocab.WithID(cid),
+				vocab.WithType(vocab.TypeCAS),
+			),
+		))
+
+		obj, err := vocab.NewObjectWithDocument(vocab.MustUnmarshalToDoc([]byte(anchorCredential1)))
+		if err != nil {
+			panic(err)
+		}
+
+		unavailableServiceIRI := mustParseURL("http://localhost:8304/services/service4")
+
+		create := vocab.NewCreateActivity(newActivityID(service1IRI.String()),
+			vocab.NewObjectProperty(vocab.WithObject(obj)),
+			vocab.WithActor(service1IRI),
+			vocab.WithTarget(targetProperty),
+			vocab.WithContext(vocab.ContextOrb),
+			vocab.WithTo(service2IRI, unavailableServiceIRI),
+		)
+
+		require.NoError(t, service1.Outbox().Post(create))
+
+		time.Sleep(1500 * time.Millisecond)
+
+		activity, err := store1.GetActivity(spi.Outbox, create.ID())
+		require.NoError(t, err)
+		require.NotNil(t, activity)
+		require.Equal(t, create.ID(), activity.ID())
+
+		activity, err = store2.GetActivity(spi.Inbox, create.ID())
+		require.NoError(t, err)
+		require.NotNil(t, activity)
+		require.Equal(t, create.ID(), activity.ID())
+		require.NotEmpty(t, subscriber2.Activities())
+
+		ua := undeliverableHandler1.Activities()
+		require.Len(t, ua, 1)
+		require.Equal(t, unavailableServiceIRI.String(), ua[0].ToURL)
+	})
+}
+
+func newActivityID(serviceName string) string {
+	return fmt.Sprintf("%s/%s", serviceName, uuid.New())
+}
+
+func mustParseURL(raw string) *url.URL {
+	u, err := url.Parse(raw)
+	if err != nil {
+		panic(err)
+	}
+
+	return u
+}
+
+const anchorCredential1 = `{
+  "@context": [
+	"https://www.w3.org/2018/credentials/v1",
+	"https://trustbloc.github.io/Context/orb-v1.json"
+  ],
+  "id": "http://sally.example.com/transactions/bafkreihwsn",
+  "type": [
+	"VerifiableCredential",
+	"AnchorCredential"
+  ],
+  "issuer": "https://sally.example.com/services/orb",
+  "issuanceDate": "2021-01-27T09:30:10Z",
+  "credentialSubject": {
+	"anchorString": "bafkreihwsn",
+	"namespace": "did:orb",
+	"version": "1",
+	"previousTransactions": {
+	  "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
+	  "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w"
+	}
+  },
+  "proofChain": [{}]
+}`

--- a/pkg/activitypub/service/spi/spi.go
+++ b/pkg/activitypub/service/spi/spi.go
@@ -43,13 +43,45 @@ type ServiceLifecycle interface {
 	State() State
 }
 
+// Outbox defines the functions for an ActivityPub outbox.
+type Outbox interface {
+	ServiceLifecycle
+
+	Post(activity *vocab.ActivityType) error
+}
+
+// Inbox defines the functions for an ActivityPub inbox.
+type Inbox interface {
+	ServiceLifecycle
+}
+
 // ActivityHandler defines the functions of an Activity handler.
 type ActivityHandler interface {
+	ServiceLifecycle
+
 	// HandleActivity handles the ActivityPub activity.
 	HandleActivity(activity *vocab.ActivityType) error
+
+	// Subscribe allows a client to receive published activities.
+	Subscribe() <-chan *vocab.ActivityType
 }
 
 // UndeliverableActivityHandler handles undeliverable activities.
 type UndeliverableActivityHandler interface {
 	HandleUndeliverableActivity(activity *vocab.ActivityType, toURL string)
+}
+
+// Handlers contains handlers for various activity events, including undeliverable activities.
+type Handlers struct {
+	UndeliverableHandler UndeliverableActivityHandler
+}
+
+// HandlerOpt sets a specific handler.
+type HandlerOpt func(options *Handlers)
+
+// WithUndeliverableHandler sets the handler that's called when an activity can't be delivered.
+func WithUndeliverableHandler(handler UndeliverableActivityHandler) HandlerOpt {
+	return func(options *Handlers) {
+		options.UndeliverableHandler = handler
+	}
 }


### PR DESCRIPTION
Implemented an ActivityPub service that encapsulates an inbox and outbox. The service allow clients to post messages to the outbox and register for notifications of inbound activities. The service provides an activity handler to process the activities. Currently only a skeleton implementation is provided for the 'Create' activity. Future commits will provide implementations for all activities.

closes #56

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>