### PR TITLE
feat: ActivityPub handler for 'Create' activity

### DIFF
--- a/pkg/activitypub/service/mocks/mockanchorcredhandler.go
+++ b/pkg/activitypub/service/mocks/mockanchorcredhandler.go
@@ -1,0 +1,54 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	"sync"
+)
+
+// AnchorCredentialHandler is a mock anchor credential handler.
+type AnchorCredentialHandler struct {
+	mutex       sync.Mutex
+	anchorCreds map[string][]byte
+	err         error
+}
+
+// NewAnchorCredentialHandler returns a mock anchor credential handler.
+func NewAnchorCredentialHandler() *AnchorCredentialHandler {
+	return &AnchorCredentialHandler{
+		anchorCreds: make(map[string][]byte),
+	}
+}
+
+// WithError injects an error into the mock handler.
+func (m *AnchorCredentialHandler) WithError(err error) *AnchorCredentialHandler {
+	m.err = err
+
+	return m
+}
+
+// HandlerAnchorCredential stores the anchor credential or returns an error if it was set.
+func (m *AnchorCredentialHandler) HandlerAnchorCredential(cid string, anchorCred []byte) error {
+	if m.err != nil {
+		return m.err
+	}
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	m.anchorCreds[cid] = anchorCred
+
+	return nil
+}
+
+// AnchorCred returns the anchor credential by ID or nil if it doesn't exist.
+func (m *AnchorCredentialHandler) AnchorCred(cid string) []byte {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	return m.anchorCreds[cid]
+}

--- a/pkg/activitypub/service/mocks/mocksubscriber.go
+++ b/pkg/activitypub/service/mocks/mocksubscriber.go
@@ -12,18 +12,18 @@ import (
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
 )
 
-// MockSubscriber implements a mock activity subscriber.
-type MockSubscriber struct {
+// Subscriber implements a mock activity subscriber.
+type Subscriber struct {
 	serviceName  string
 	activityChan <-chan *vocab.ActivityType
 	mutex        sync.Mutex
 	activities   []*vocab.ActivityType
 }
 
-// NewMockSubscriber returns a new mock activity subscriber.
-func NewMockSubscriber(
-	serviceName string, activityChan <-chan *vocab.ActivityType) *MockSubscriber {
-	s := &MockSubscriber{
+// NewSubscriber returns a new mock activity subscriber.
+func NewSubscriber(
+	serviceName string, activityChan <-chan *vocab.ActivityType) *Subscriber {
+	s := &Subscriber{
 		serviceName:  serviceName,
 		activityChan: activityChan,
 	}
@@ -34,20 +34,20 @@ func NewMockSubscriber(
 }
 
 // Activities returns the activities that were received by the subscriber.
-func (m *MockSubscriber) Activities() []*vocab.ActivityType {
+func (m *Subscriber) Activities() []*vocab.ActivityType {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
 	return m.activities
 }
 
-func (m *MockSubscriber) listen() {
+func (m *Subscriber) listen() {
 	for activity := range m.activityChan {
 		m.add(activity)
 	}
 }
 
-func (m *MockSubscriber) add(activity *vocab.ActivityType) {
+func (m *Subscriber) add(activity *vocab.ActivityType) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 

--- a/pkg/activitypub/service/service_test.go
+++ b/pkg/activitypub/service/service_test.go
@@ -83,16 +83,18 @@ func TestService(t *testing.T) {
 	}
 
 	store2 := memstore.New(cfg2.ServiceName)
+	anchorCredHandler2 := mocks.NewAnchorCredentialHandler()
 	undeliverableHandler2 := mocks.NewUndeliverableHandler()
 
 	service2, err := NewService(cfg2, store2,
 		service.WithUndeliverableHandler(undeliverableHandler2),
+		service.WithAnchorCredentialHandler(anchorCredHandler2),
 	)
 	require.NoError(t, err)
 
 	defer service2.Stop()
 
-	subscriber2 := mocks.NewMockSubscriber(cfg2.ServiceName, service2.Subscribe())
+	subscriber2 := mocks.NewSubscriber(cfg2.ServiceName, service2.Subscribe())
 
 	service1.Start()
 
@@ -141,6 +143,7 @@ func TestService(t *testing.T) {
 		require.NotNil(t, activity)
 		require.Equal(t, create.ID(), activity.ID())
 		require.NotEmpty(t, subscriber2.Activities())
+		require.NotEmpty(t, anchorCredHandler2.AnchorCred(cid))
 
 		ua := undeliverableHandler1.Activities()
 		require.Len(t, ua, 1)

--- a/pkg/activitypub/service/spi/spi.go
+++ b/pkg/activitypub/service/spi/spi.go
@@ -55,6 +55,11 @@ type Inbox interface {
 	ServiceLifecycle
 }
 
+// AnchorCredentialHandler handles a new, published anchor credential.
+type AnchorCredentialHandler interface {
+	HandlerAnchorCredential(cid string, anchorCred []byte) error
+}
+
 // ActivityHandler defines the functions of an Activity handler.
 type ActivityHandler interface {
 	ServiceLifecycle
@@ -73,7 +78,8 @@ type UndeliverableActivityHandler interface {
 
 // Handlers contains handlers for various activity events, including undeliverable activities.
 type Handlers struct {
-	UndeliverableHandler UndeliverableActivityHandler
+	UndeliverableHandler    UndeliverableActivityHandler
+	AnchorCredentialHandler AnchorCredentialHandler
 }
 
 // HandlerOpt sets a specific handler.
@@ -83,5 +89,12 @@ type HandlerOpt func(options *Handlers)
 func WithUndeliverableHandler(handler UndeliverableActivityHandler) HandlerOpt {
 	return func(options *Handlers) {
 		options.UndeliverableHandler = handler
+	}
+}
+
+// WithAnchorCredentialHandler sets the handler for published anchor credentials.
+func WithAnchorCredentialHandler(handler AnchorCredentialHandler) HandlerOpt {
+	return func(options *Handlers) {
+		options.AnchorCredentialHandler = handler
 	}
 }

--- a/pkg/activitypub/vocab/contextproperty.go
+++ b/pkg/activitypub/vocab/contextproperty.go
@@ -8,6 +8,7 @@ package vocab
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // ContextProperty holds one or more contexts.
@@ -22,6 +23,19 @@ func NewContextProperty(context ...Context) *ContextProperty {
 	}
 
 	return &ContextProperty{contexts: context}
+}
+
+// String returns the string representation of the context property.
+func (p *ContextProperty) String() string {
+	if p == nil || len(p.contexts) == 0 {
+		return ""
+	}
+
+	if len(p.contexts) == 1 {
+		return string(p.contexts[0])
+	}
+
+	return fmt.Sprintf("%s", p.contexts)
 }
 
 // Contexts returns all of the contexts defined in the property.

--- a/pkg/activitypub/vocab/contextproperty_test.go
+++ b/pkg/activitypub/vocab/contextproperty_test.go
@@ -25,6 +25,7 @@ func TestContextProperty(t *testing.T) {
 		require.Empty(t, p.Contexts())
 		require.False(t, p.Contains(ContextOrb))
 		require.False(t, p.ContainsAny(ContextOrb))
+		require.Equal(t, "", p.String())
 	})
 
 	t.Run("Single context", func(t *testing.T) {
@@ -43,6 +44,7 @@ func TestContextProperty(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(jsonContext), p2))
 		require.True(t, p2.Contains(ContextCredentials))
 		require.False(t, p2.ContainsAny(ContextSecurity))
+		require.Equal(t, "https://www.w3.org/2018/credentials/v1", p.String())
 	})
 
 	t.Run("Multiple contexts", func(t *testing.T) {
@@ -63,5 +65,6 @@ func TestContextProperty(t *testing.T) {
 		require.True(t, p2.Contains(ContextCredentials, ContextSecurity))
 		require.False(t, p2.Contains(ContextCredentials, ContextOrb))
 		require.True(t, p2.ContainsAny(ContextSecurity))
+		require.Equal(t, "[https://www.w3.org/2018/credentials/v1 https://w3id.org/security/v1]", p.String())
 	})
 }

--- a/pkg/activitypub/vocab/typeproperty.go
+++ b/pkg/activitypub/vocab/typeproperty.go
@@ -8,6 +8,7 @@ package vocab
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // TypeProperty defines a 'type' property on an abject which
@@ -55,6 +56,19 @@ func (p *TypeProperty) UnmarshalJSON(bytes []byte) error {
 	p.types = types
 
 	return nil
+}
+
+// String returns the string representation of the type property.
+func (p *TypeProperty) String() string {
+	if p == nil || len(p.types) == 0 {
+		return ""
+	}
+
+	if len(p.types) == 1 {
+		return string(p.types[0])
+	}
+
+	return fmt.Sprintf("%s", p.types)
 }
 
 // Types returns all types.

--- a/pkg/activitypub/vocab/typeproperty_test.go
+++ b/pkg/activitypub/vocab/typeproperty_test.go
@@ -25,6 +25,7 @@ func TestTypeProperty(t *testing.T) {
 		require.False(t, p.Is(TypeCreate))
 		require.False(t, p.IsAny(TypeCreate))
 		require.Empty(t, p.Types())
+		require.Equal(t, "", p.String())
 	})
 
 	t.Run("Single type", func(t *testing.T) {
@@ -43,6 +44,7 @@ func TestTypeProperty(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(jsonType), p2))
 		require.True(t, p2.Is(TypeCreate))
 		require.False(t, p2.IsAny(TypeAnchorCredential))
+		require.Equal(t, "Create", p2.String())
 	})
 
 	t.Run("Multiple types", func(t *testing.T) {
@@ -63,5 +65,6 @@ func TestTypeProperty(t *testing.T) {
 		require.True(t, p2.Is(TypeCreate, TypeAnchorCredential))
 		require.False(t, p2.Is(TypeCreate, TypeFollow))
 		require.True(t, p2.IsAny(TypeAnchorCredential))
+		require.Equal(t, "[Create AnchorCredential]", p2.String())
 	})
 }


### PR DESCRIPTION
Implemented a handler for the 'Create' activity which invokes an 'anchor credential handler' to handle the new anchor credential.

Also implemented the String() function on ContextProperty and TypeProperty to make logs more readable.

closes #68

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>