### PR TITLE
feat: Handler for 'Follow' activity

### DIFF
--- a/pkg/activitypub/service/mocks/activities.go
+++ b/pkg/activitypub/service/mocks/activities.go
@@ -1,0 +1,27 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+)
+
+// Activities contains a slice of ActivityType.
+type Activities []*vocab.ActivityType
+
+// QueryByType returns the activities that match the given types.
+func (a Activities) QueryByType(types ...vocab.Type) Activities {
+	var result Activities
+
+	for _, activity := range a {
+		if activity.Type().Is(types...) {
+			result = append(result, activity)
+		}
+	}
+
+	return result
+}

--- a/pkg/activitypub/service/mocks/mockfollowerauth.go
+++ b/pkg/activitypub/service/mocks/mockfollowerauth.go
@@ -1,0 +1,48 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+)
+
+// FollowerAuth implements a mock follower authorization.
+type FollowerAuth struct {
+	accept bool
+	err    error
+}
+
+// NewFollowerAuth returns a mock follower authorization.
+func NewFollowerAuth() *FollowerAuth {
+	return &FollowerAuth{}
+}
+
+// WithAccept ensures that the request to follow is accepted.
+func (m *FollowerAuth) WithAccept() *FollowerAuth {
+	m.accept = true
+
+	return m
+}
+
+// WithReject ensures that the request to follow is rejected.
+func (m *FollowerAuth) WithReject() *FollowerAuth {
+	m.accept = false
+
+	return m
+}
+
+// WithError injects an error into the handler.
+func (m *FollowerAuth) WithError(err error) *FollowerAuth {
+	m.err = err
+
+	return m
+}
+
+// AuthorizeFollower is a mock implementation that returns the injected values.
+func (m *FollowerAuth) AuthorizeFollower(follower *vocab.ActorType) (bool, error) {
+	return m.accept, m.err
+}

--- a/pkg/activitypub/service/mocks/mockoutbox.go
+++ b/pkg/activitypub/service/mocks/mockoutbox.go
@@ -1,0 +1,69 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	"sync"
+
+	"github.com/trustbloc/orb/pkg/activitypub/service/spi"
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+)
+
+// Outbox implements a mock Outbox.
+type Outbox struct {
+	mutex      sync.RWMutex
+	activities Activities
+	err        error
+}
+
+// NewOutbox returns a mock outbox.
+func NewOutbox() *Outbox {
+	return &Outbox{}
+}
+
+// WithError injects an error into the mock outbox.
+func (m *Outbox) WithError(err error) *Outbox {
+	m.err = err
+
+	return m
+}
+
+// Activities returns the activities that were posted to the outbox.
+func (m *Outbox) Activities() Activities {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	return m.activities
+}
+
+// Post post an activity to the outbox. The activity is simply stored
+// so that it may be retrieved by the Activies function.
+func (m *Outbox) Post(activity *vocab.ActivityType) error {
+	if m.err != nil {
+		return m.err
+	}
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	m.activities = append(m.activities, activity)
+
+	return nil
+}
+
+// Start does nothing.
+func (m *Outbox) Start() {
+}
+
+// Stop does nothing.
+func (m *Outbox) Stop() {
+}
+
+// State always returns StateStarted.
+func (m *Outbox) State() spi.State {
+	return spi.StateStarted
+}

--- a/pkg/activitypub/service/mocks/mocksubscriber.go
+++ b/pkg/activitypub/service/mocks/mocksubscriber.go
@@ -14,17 +14,14 @@ import (
 
 // Subscriber implements a mock activity subscriber.
 type Subscriber struct {
-	serviceName  string
 	activityChan <-chan *vocab.ActivityType
 	mutex        sync.Mutex
 	activities   []*vocab.ActivityType
 }
 
 // NewSubscriber returns a new mock activity subscriber.
-func NewSubscriber(
-	serviceName string, activityChan <-chan *vocab.ActivityType) *Subscriber {
+func NewSubscriber(activityChan <-chan *vocab.ActivityType) *Subscriber {
 	s := &Subscriber{
-		serviceName:  serviceName,
 		activityChan: activityChan,
 	}
 

--- a/pkg/activitypub/service/service.go
+++ b/pkg/activitypub/service/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/trustbloc/orb/pkg/activitypub/service/inbox"
 	"github.com/trustbloc/orb/pkg/activitypub/service/lifecycle"
 	"github.com/trustbloc/orb/pkg/activitypub/service/mempubsub"
+	"github.com/trustbloc/orb/pkg/activitypub/service/mocks"
 	"github.com/trustbloc/orb/pkg/activitypub/service/outbox"
 	"github.com/trustbloc/orb/pkg/activitypub/service/outbox/redelivery"
 	"github.com/trustbloc/orb/pkg/activitypub/service/spi"
@@ -73,7 +74,10 @@ func NewService(cfg *Config, activityStore store.Store, handlerOpts ...spi.Handl
 		&activityhandler.Config{
 			ServiceName: cfg.ServiceName,
 			BufferSize:  cfg.ActivityHandlerBufferSize,
-		}, handlerOpts...,
+		},
+		&mocks.ActivityStore{},
+		mocks.NewOutbox(),
+		handlerOpts...,
 	)
 
 	ib, err := inbox.New(

--- a/pkg/activitypub/service/service_test.go
+++ b/pkg/activitypub/service/service_test.go
@@ -94,7 +94,7 @@ func TestService(t *testing.T) {
 
 	defer service2.Stop()
 
-	subscriber2 := mocks.NewSubscriber(cfg2.ServiceName, service2.Subscribe())
+	subscriber2 := mocks.NewSubscriber(service2.Subscribe())
 
 	service1.Start()
 

--- a/pkg/activitypub/service/spi/spi.go
+++ b/pkg/activitypub/service/spi/spi.go
@@ -60,6 +60,12 @@ type AnchorCredentialHandler interface {
 	HandlerAnchorCredential(cid string, anchorCred []byte) error
 }
 
+// FollowerAuth makes the decision of whether or not a request by the given
+// follower should be accepted.
+type FollowerAuth interface {
+	AuthorizeFollower(follower *vocab.ActorType) (bool, error)
+}
+
 // ActivityHandler defines the functions of an Activity handler.
 type ActivityHandler interface {
 	ServiceLifecycle
@@ -80,6 +86,7 @@ type UndeliverableActivityHandler interface {
 type Handlers struct {
 	UndeliverableHandler    UndeliverableActivityHandler
 	AnchorCredentialHandler AnchorCredentialHandler
+	FollowerAuth            FollowerAuth
 }
 
 // HandlerOpt sets a specific handler.
@@ -92,9 +99,16 @@ func WithUndeliverableHandler(handler UndeliverableActivityHandler) HandlerOpt {
 	}
 }
 
-// WithAnchorCredentialHandler sets the handler for published anchor credentials.
+// WithAnchorCredentialHandler sets the handler for the published anchor credentials.
 func WithAnchorCredentialHandler(handler AnchorCredentialHandler) HandlerOpt {
 	return func(options *Handlers) {
 		options.AnchorCredentialHandler = handler
+	}
+}
+
+// WithFollowerAuth sets the handler that decides whether or not to accept a 'Follow' request.
+func WithFollowerAuth(handler FollowerAuth) HandlerOpt {
+	return func(options *Handlers) {
+		options.FollowerAuth = handler
 	}
 }

--- a/pkg/activitypub/store/memstore/memstore.go
+++ b/pkg/activitypub/store/memstore/memstore.go
@@ -103,21 +103,23 @@ func (s *Store) QueryActivities(storeType spi.ActivityStoreType,
 
 // AddReference adds the reference of the given type to the given actor.
 func (s *Store) AddReference(referenceType spi.ReferenceType, actorIRI, referenceIRI *url.URL) error {
-	logger.Debugf("[%s] Adding reference of type %s to actor %s: %s", s.serviceName, actorIRI, referenceIRI)
+	logger.Debugf("[%s] Adding reference of type %s to actor %s: %s",
+		s.serviceName, referenceType, actorIRI, referenceIRI)
 
 	return s.referenceStores[referenceType].add(actorIRI, referenceIRI)
 }
 
 // DeleteReference deletes the reference of the given type from the given actor.
 func (s *Store) DeleteReference(referenceType spi.ReferenceType, actorIRI, referenceIRI *url.URL) error {
-	logger.Debugf("[%s] Deleting reference of type %s from actor %s: %s", s.serviceName, actorIRI, referenceIRI)
+	logger.Debugf("[%s] Deleting reference of type %s from actor %s: %s",
+		s.serviceName, referenceType, actorIRI, referenceIRI)
 
 	return s.referenceStores[referenceType].delete(actorIRI, referenceIRI)
 }
 
 // GetReferences returns the actor's list of references of the given type.
 func (s *Store) GetReferences(referenceType spi.ReferenceType, actorIRI *url.URL) ([]*url.URL, error) {
-	logger.Debugf("[%s] Retrieving references of type %s for actor %s", s.serviceName, actorIRI)
+	logger.Debugf("[%s] Retrieving references of type %s for actor %s", s.serviceName, referenceType, actorIRI)
 
 	return s.referenceStores[referenceType].get(actorIRI)
 }


### PR DESCRIPTION
Implemented a handler for the ActivityPub 'Follow' activity. An authorization handler is 'asked' if the service should accept or reject the follow request. If accepted, the handler posts an 'Accept' activity to the requesting actor and adds the actor to the list of followers; otherwise a 'Reject' activity is posted.

closes #69

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>