### PR TITLE
feat: Handler for the ActivityPub 'Accept' activity

### DIFF
--- a/pkg/activitypub/service/inbox/inbox_test.go
+++ b/pkg/activitypub/service/inbox/inbox_test.go
@@ -146,6 +146,8 @@ func TestInbox_Error(t *testing.T) {
 		ib.Start()
 		defer ib.Stop()
 
+		time.Sleep(50 * time.Millisecond)
+
 		// Attempt to start another inbox with the same listen address should cause
 		// the service to shut down immediately.
 		ib2.Start()

--- a/pkg/activitypub/service/service.go
+++ b/pkg/activitypub/service/service.go
@@ -9,6 +9,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/ThreeDotsLabs/watermill/message"
 
@@ -16,7 +17,6 @@ import (
 	"github.com/trustbloc/orb/pkg/activitypub/service/inbox"
 	"github.com/trustbloc/orb/pkg/activitypub/service/lifecycle"
 	"github.com/trustbloc/orb/pkg/activitypub/service/mempubsub"
-	"github.com/trustbloc/orb/pkg/activitypub/service/mocks"
 	"github.com/trustbloc/orb/pkg/activitypub/service/outbox"
 	"github.com/trustbloc/orb/pkg/activitypub/service/outbox/redelivery"
 	"github.com/trustbloc/orb/pkg/activitypub/service/spi"
@@ -40,6 +40,7 @@ type PubSubFactory func(serviceName string) PubSub
 type Config struct {
 	ServiceName               string
 	ListenAddress             string
+	ServiceIRI                *url.URL
 	RetryOpts                 *redelivery.Config
 	PubSubFactory             PubSubFactory
 	ActivityHandlerBufferSize int
@@ -74,11 +75,9 @@ func NewService(cfg *Config, activityStore store.Store, handlerOpts ...spi.Handl
 		&activityhandler.Config{
 			ServiceName: cfg.ServiceName,
 			BufferSize:  cfg.ActivityHandlerBufferSize,
+			ServiceIRI:  cfg.ServiceIRI,
 		},
-		&mocks.ActivityStore{},
-		mocks.NewOutbox(),
-		handlerOpts...,
-	)
+		activityStore, ob, handlerOpts...)
 
 	ib, err := inbox.New(
 		&inbox.Config{


### PR DESCRIPTION
Implemented a handler for the ActivityPub 'Accept' activity. The handler adds the actor to the service's 'following' list and notifies subscribers of the activity.

closes #70

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>