### PR TITLE
feat: Handler for the ActivityPub 'Reject' activity

### DIFF
--- a/pkg/activitypub/service/activityhandler/activityhandler_test.go
+++ b/pkg/activitypub/service/activityhandler/activityhandler_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-	"github.com/trustbloc/edge-core/pkg/log"
 
 	"github.com/trustbloc/orb/pkg/activitypub/service/mocks"
 	"github.com/trustbloc/orb/pkg/activitypub/service/spi"
@@ -374,9 +373,6 @@ func TestHandler_HandleFollowActivity(t *testing.T) {
 }
 
 func TestHandler_HandleAcceptActivity(t *testing.T) {
-	log.SetLevel("activitypub_service", log.DEBUG)
-	log.SetLevel("activitypub_memstore", log.DEBUG)
-
 	service1IRI := mustParseURL("http://localhost:8301/services/service1")
 	service2IRI := mustParseURL("http://localhost:8302/services/service2")
 
@@ -508,6 +504,142 @@ func TestHandler_HandleAcceptActivity(t *testing.T) {
 
 		require.NoError(t, h.HandleActivity(accept),
 			"should have ignored 'Accept' since actor in the 'Follow' does not match the target service",
+		)
+	})
+}
+
+func TestHandler_HandleRejectActivity(t *testing.T) {
+	service1IRI := mustParseURL("http://localhost:8301/services/service1")
+	service2IRI := mustParseURL("http://localhost:8302/services/service2")
+
+	cfg := &Config{
+		ServiceName: "service2",
+		ServiceIRI:  service2IRI,
+	}
+
+	ob := mocks.NewOutbox()
+	as := memstore.New(cfg.ServiceName)
+
+	h := New(cfg, as, ob)
+	require.NotNil(t, h)
+
+	h.Start()
+	defer h.Stop()
+
+	activityChan := h.Subscribe()
+
+	var (
+		mutex       sync.Mutex
+		gotActivity = make(map[string]*vocab.ActivityType)
+	)
+
+	go func() {
+		for activity := range activityChan {
+			mutex.Lock()
+			gotActivity[activity.ID()] = activity
+			mutex.Unlock()
+		}
+	}()
+
+	t.Run("Success", func(t *testing.T) {
+		follow := vocab.NewFollowActivity(newActivityID(service2IRI),
+			vocab.NewObjectProperty(vocab.WithIRI(service1IRI)),
+			vocab.WithActor(service2IRI),
+			vocab.WithTo(service1IRI),
+		)
+
+		reject := vocab.NewRejectActivity(newActivityID(service1IRI),
+			vocab.NewObjectProperty(vocab.WithActivity(follow)),
+			vocab.WithActor(service1IRI),
+			vocab.WithTo(service2IRI),
+		)
+
+		require.NoError(t, h.HandleActivity(reject))
+
+		time.Sleep(50 * time.Millisecond)
+
+		mutex.Lock()
+		require.NotNil(t, gotActivity[reject.ID()])
+		mutex.Unlock()
+
+		following, err := h.store.GetReferences(store.Following, h.ServiceIRI)
+		require.NoError(t, err)
+		require.True(t, !containsIRI(following, service1IRI))
+	})
+
+	t.Run("No actor in Reject activity", func(t *testing.T) {
+		follow := vocab.NewFollowActivity(newActivityID(service2IRI),
+			vocab.NewObjectProperty(vocab.WithIRI(service1IRI)),
+			vocab.WithActor(service2IRI),
+			vocab.WithTo(service1IRI),
+		)
+
+		reject := vocab.NewRejectActivity(newActivityID(service1IRI),
+			vocab.NewObjectProperty(vocab.WithActivity(follow)),
+			vocab.WithTo(service2IRI),
+		)
+
+		require.EqualError(t, h.HandleActivity(reject), "no actor specified in 'Reject' activity")
+	})
+
+	t.Run("No Follow activity specified in 'object' field", func(t *testing.T) {
+		reject := vocab.NewRejectActivity(newActivityID(service1IRI),
+			vocab.NewObjectProperty(),
+			vocab.WithActor(service1IRI),
+			vocab.WithTo(service2IRI),
+		)
+
+		require.EqualError(t, h.HandleActivity(reject),
+			"no 'Follow' activity specified in the 'object' field of the 'Reject' activity")
+	})
+
+	t.Run("Object is not a Follow activity", func(t *testing.T) {
+		follow := vocab.NewAnnounceActivity(newActivityID(service2IRI),
+			vocab.NewObjectProperty(vocab.WithIRI(service1IRI)),
+			vocab.WithTo(service1IRI),
+		)
+
+		reject := vocab.NewRejectActivity(newActivityID(service1IRI),
+			vocab.NewObjectProperty(vocab.WithActivity(follow)),
+			vocab.WithActor(service1IRI),
+			vocab.WithTo(service2IRI),
+		)
+
+		require.EqualError(t, h.HandleActivity(reject),
+			"the 'object' field of the 'Reject' activity must be a 'Follow' type")
+	})
+
+	t.Run("No actor specified in the Follow activity", func(t *testing.T) {
+		follow := vocab.NewFollowActivity(newActivityID(service2IRI),
+			vocab.NewObjectProperty(vocab.WithIRI(service1IRI)),
+			vocab.WithTo(service1IRI),
+		)
+
+		reject := vocab.NewRejectActivity(newActivityID(service1IRI),
+			vocab.NewObjectProperty(vocab.WithActivity(follow)),
+			vocab.WithActor(service1IRI),
+			vocab.WithTo(service2IRI),
+		)
+
+		require.EqualError(t, h.HandleActivity(reject),
+			"no actor specified in the original 'Follow' activity of the 'Reject' activity")
+	})
+
+	t.Run("Follow actor does not match target service IRI in Reject activity", func(t *testing.T) {
+		follow := vocab.NewFollowActivity(newActivityID(service2IRI),
+			vocab.NewObjectProperty(vocab.WithIRI(service1IRI)),
+			vocab.WithActor(service1IRI),
+			vocab.WithTo(service1IRI),
+		)
+
+		reject := vocab.NewRejectActivity(newActivityID(service1IRI),
+			vocab.NewObjectProperty(vocab.WithActivity(follow)),
+			vocab.WithActor(service1IRI),
+			vocab.WithTo(service2IRI),
+		)
+
+		require.NoError(t, h.HandleActivity(reject),
+			"should have ignored 'Reject' since actor in the 'Follow' does not match the target service",
 		)
 	})
 }


### PR DESCRIPTION
Implemented a handler for the ActivityPub 'Reject' activity. The handler should notify subscribers of the activity.

closes #71

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>