### PR TITLE
feat: Handler for the ActivityPub 'Announce' activity

### DIFF
--- a/pkg/activitypub/service/inbox/inbox_test.go
+++ b/pkg/activitypub/service/inbox/inbox_test.go
@@ -283,7 +283,7 @@ func TestInbox_Error(t *testing.T) {
 		ib.Start()
 		defer ib.Stop()
 
-		time.Sleep(200 * time.Millisecond)
+		time.Sleep(300 * time.Millisecond)
 
 		activityHandler.HandleActivityReturns(errors.New("injected handler error"))
 

--- a/pkg/activitypub/service/service_test.go
+++ b/pkg/activitypub/service/service_test.go
@@ -133,7 +133,7 @@ func TestService_Create(t *testing.T) {
 
 	unavailableServiceIRI := mustParseURL("http://localhost:8304/services/service4")
 
-	create := vocab.NewCreateActivity(newActivityID(service1IRI.String()),
+	create := vocab.NewCreateActivity(newActivityID(service1IRI),
 		vocab.NewObjectProperty(vocab.WithObject(obj)),
 		vocab.WithActor(service1IRI),
 		vocab.WithTarget(targetProperty),
@@ -237,7 +237,7 @@ func TestService_Follow(t *testing.T) {
 		actorIRI := service1IRI
 		targetIRI := service2IRI
 
-		follow := vocab.NewFollowActivity(newActivityID(actorIRI.String()),
+		follow := vocab.NewFollowActivity(newActivityID(actorIRI),
 			vocab.NewObjectProperty(vocab.WithIRI(targetIRI)),
 			vocab.WithActor(actorIRI),
 			vocab.WithTo(targetIRI),
@@ -291,7 +291,7 @@ func TestService_Follow(t *testing.T) {
 		actorIRI := service2IRI
 		targetIRI := service1IRI
 
-		follow := vocab.NewFollowActivity(newActivityID(actorIRI.String()),
+		follow := vocab.NewFollowActivity(newActivityID(actorIRI),
 			vocab.NewObjectProperty(vocab.WithIRI(targetIRI)),
 			vocab.WithActor(actorIRI),
 			vocab.WithTo(targetIRI),
@@ -350,7 +350,255 @@ func TestService_Follow(t *testing.T) {
 	})
 }
 
-func newActivityID(serviceName string) string {
+func TestService_Announce(t *testing.T) {
+	log.SetLevel(wmlogger.Module, log.WARNING)
+
+	service1IRI := mustParseURL("http://localhost:8301/services/service1")
+	service2IRI := mustParseURL("http://localhost:8302/services/service2")
+	service3IRI := mustParseURL("http://localhost:8303/services/service3")
+
+	cfg1 := &Config{
+		ServiceName:   "/services/service1",
+		ServiceIRI:    service1IRI,
+		ListenAddress: ":8301",
+		RetryOpts:     redelivery.DefaultConfig(),
+	}
+
+	store1 := memstore.New(cfg1.ServiceName)
+	anchorCredHandler1 := mocks.NewAnchorCredentialHandler()
+	followerAuth1 := mocks.NewFollowerAuth()
+	undeliverableHandler1 := mocks.NewUndeliverableHandler()
+
+	service1, err := NewService(cfg1, store1,
+		service.WithUndeliverableHandler(undeliverableHandler1),
+		service.WithAnchorCredentialHandler(anchorCredHandler1),
+		service.WithFollowerAuth(followerAuth1),
+	)
+	require.NoError(t, err)
+
+	cfg2 := &Config{
+		ServiceName:   "/services/service2",
+		ServiceIRI:    service2IRI,
+		ListenAddress: ":8302",
+		RetryOpts: &redelivery.Config{
+			MaxRetries:     5,
+			InitialBackoff: 10 * time.Millisecond,
+			MaxBackoff:     time.Second,
+			BackoffFactor:  1.2,
+			MaxMessages:    20,
+		},
+	}
+
+	store2 := memstore.New(cfg2.ServiceName)
+	anchorCredHandler2 := mocks.NewAnchorCredentialHandler()
+	followerAuth2 := mocks.NewFollowerAuth()
+	undeliverableHandler2 := mocks.NewUndeliverableHandler()
+
+	service2, err := NewService(cfg2, store2,
+		service.WithUndeliverableHandler(undeliverableHandler2),
+		service.WithAnchorCredentialHandler(anchorCredHandler2),
+		service.WithFollowerAuth(followerAuth2),
+	)
+	require.NoError(t, err)
+
+	subscriber2 := mocks.NewSubscriber(service2.Subscribe())
+
+	cfg3 := &Config{
+		ServiceName:   "/services/service3",
+		ServiceIRI:    service3IRI,
+		ListenAddress: ":8303",
+	}
+
+	store3 := memstore.New(cfg3.ServiceName)
+	anchorCredHandler3 := mocks.NewAnchorCredentialHandler()
+	followerAuth3 := mocks.NewFollowerAuth()
+	undeliverableHandler3 := mocks.NewUndeliverableHandler()
+
+	service3, err := NewService(cfg3, store3,
+		service.WithUndeliverableHandler(undeliverableHandler3),
+		service.WithAnchorCredentialHandler(anchorCredHandler3),
+		service.WithFollowerAuth(followerAuth3),
+	)
+	require.NoError(t, err)
+
+	subscriber3 := mocks.NewSubscriber(service3.Subscribe())
+
+	service1.Start()
+	service2.Start()
+	service3.Start()
+
+	defer service1.Stop()
+	defer service2.Stop()
+	defer service3.Stop()
+
+	t.Run("Announce - anchor credential ref (no embedded object)", func(t *testing.T) {
+		const cid = "bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y"
+
+		ref := vocab.NewAnchorCredentialReference(newActivityID(service2IRI), cid)
+
+		items := []*vocab.ObjectProperty{
+			vocab.NewObjectProperty(
+				vocab.WithAnchorCredentialReference(ref),
+			),
+		}
+
+		published := time.Now()
+
+		announce := vocab.NewAnnounceActivity(newActivityID(service2IRI),
+			vocab.NewObjectProperty(
+				vocab.WithCollection(
+					vocab.NewCollection(items),
+				),
+			),
+			vocab.WithActor(service2IRI),
+			vocab.WithTo(service3IRI),
+			vocab.WithPublishedTime(&published),
+		)
+
+		require.NoError(t, service2.Outbox().Post(announce))
+
+		time.Sleep(1000 * time.Millisecond)
+
+		activity, err := store2.GetActivity(spi.Outbox, announce.ID())
+		require.NoError(t, err)
+		require.NotNil(t, activity)
+		require.Equal(t, announce.ID(), activity.ID())
+
+		activity, err = store3.GetActivity(spi.Inbox, announce.ID())
+		require.NoError(t, err)
+		require.NotNil(t, activity)
+		require.Equal(t, announce.ID(), activity.ID())
+
+		require.NotEmpty(t, subscriber3.Activities())
+
+		require.NotEmpty(t, anchorCredHandler3.AnchorCred(cid))
+	})
+
+	t.Run("Announce - anchor credential ref (with embedded object)", func(t *testing.T) {
+		const cid = "bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y"
+
+		ref, err := vocab.NewAnchorCredentialReferenceWithDocument(newTransactionID(service2IRI),
+			cid, vocab.MustUnmarshalToDoc([]byte(anchorCredential1)),
+		)
+		require.NoError(t, err)
+
+		items := []*vocab.ObjectProperty{
+			vocab.NewObjectProperty(
+				vocab.WithAnchorCredentialReference(ref),
+			),
+		}
+
+		published := time.Now()
+
+		announce := vocab.NewAnnounceActivity(newActivityID(service2IRI),
+			vocab.NewObjectProperty(
+				vocab.WithCollection(
+					vocab.NewCollection(items),
+				),
+			),
+			vocab.WithActor(service2IRI),
+			vocab.WithTo(service3IRI),
+			vocab.WithPublishedTime(&published),
+		)
+
+		require.NoError(t, service2.Outbox().Post(announce))
+
+		time.Sleep(1000 * time.Millisecond)
+
+		activity, err := store2.GetActivity(spi.Outbox, announce.ID())
+		require.NoError(t, err)
+		require.NotNil(t, activity)
+		require.Equal(t, announce.ID(), activity.ID())
+
+		activity, err = store3.GetActivity(spi.Inbox, announce.ID())
+		require.NoError(t, err)
+		require.NotNil(t, activity)
+		require.Equal(t, announce.ID(), activity.ID())
+
+		require.NotEmpty(t, subscriber3.Activities())
+
+		require.NotEmpty(t, anchorCredHandler3.AnchorCred(cid))
+	})
+
+	t.Run("Create and announce", func(t *testing.T) {
+		// Service3 requests to follow Service2
+
+		// Add Service3 to Service2's store since we haven't implemented actor resolution yet and
+		// Service2 needs to retrieve the requesting actor.
+		require.NoError(t, store2.PutActor(vocab.NewService(service3IRI.String())))
+
+		followerAuth2.WithAccept()
+
+		follow := vocab.NewFollowActivity(newActivityID(service3IRI),
+			vocab.NewObjectProperty(vocab.WithIRI(service2IRI)),
+			vocab.WithActor(service3IRI),
+			vocab.WithTo(service2IRI),
+		)
+
+		require.NoError(t, service1.Outbox().Post(follow))
+
+		time.Sleep(1000 * time.Millisecond)
+
+		followers, err := store2.GetReferences(spi.Follower, service2IRI)
+		require.NoError(t, err)
+		require.NotEmpty(t, followers)
+		require.Truef(t, containsIRI(followers, service3IRI), "expecting %s to have %s as a follower",
+			service2IRI, service3IRI)
+
+		const cid = "bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3z"
+
+		targetProperty := vocab.NewObjectProperty(vocab.WithObject(
+			vocab.NewObject(
+				vocab.WithID(cid),
+				vocab.WithType(vocab.TypeCAS),
+			),
+		))
+
+		obj, err := vocab.NewObjectWithDocument(vocab.MustUnmarshalToDoc([]byte(anchorCredential1)))
+		if err != nil {
+			panic(err)
+		}
+
+		// Service1 posts a 'Create' to Service2
+		create := vocab.NewCreateActivity(newActivityID(service1IRI),
+			vocab.NewObjectProperty(vocab.WithObject(obj)),
+			vocab.WithTarget(targetProperty),
+			vocab.WithContext(vocab.ContextOrb),
+			vocab.WithTo(service2IRI),
+		)
+
+		require.NoError(t, service1.Outbox().Post(create))
+
+		time.Sleep(500 * time.Millisecond)
+
+		activity, err := store1.GetActivity(spi.Outbox, create.ID())
+		require.NoError(t, err)
+		require.NotNil(t, activity)
+		require.Equal(t, create.ID(), activity.ID())
+
+		activity, err = store2.GetActivity(spi.Inbox, create.ID())
+		require.NoError(t, err)
+		require.NotNil(t, activity)
+		require.Equal(t, create.ID(), activity.ID())
+		require.NotEmpty(t, subscriber2.Activities())
+		require.NotEmpty(t, anchorCredHandler2.AnchorCred(cid))
+
+		// Service3 should have received an 'Announce' activity from Service2
+		it, err := store3.QueryActivities(spi.Inbox, spi.NewCriteria(spi.WithType(vocab.TypeAnnounce)))
+		require.NoError(t, err)
+
+		announce, err := it.Next()
+		require.NoError(t, err)
+		require.NotNil(t, announce)
+		require.Equal(t, service2IRI.String(), announce.Actor().String())
+	})
+}
+
+func newActivityID(serviceName fmt.Stringer) string {
+	return fmt.Sprintf("%s/%s", serviceName, uuid.New())
+}
+
+func newTransactionID(serviceName fmt.Stringer) string {
 	return fmt.Sprintf("%s/%s", serviceName, uuid.New())
 }
 


### PR DESCRIPTION
Implemented a handler for the ActivityPub 'Announce' activity. The handler for the 'Create' activity posts an 'Announce' activity to the service's followers. The 'Announce' handler invokes the registered 'AnchorCredentialHandler' with the announced anchor credential.

closes #67

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>