### PR TITLE
feat: Handler for the ActivityPub 'Offer' activity

### DIFF
--- a/pkg/activitypub/service/activityhandler/activityhandler_test.go
+++ b/pkg/activitypub/service/activityhandler/activityhandler_test.go
@@ -854,6 +854,185 @@ func TestHandler_HandleAnnounceActivity(t *testing.T) {
 	})
 }
 
+func TestHandler_HandleOfferActivity(t *testing.T) {
+	service1IRI := mustParseURL("http://localhost:8301/services/service1")
+	service2IRI := mustParseURL("http://localhost:8302/services/service2")
+
+	cfg := &Config{
+		ServiceName: "service1",
+		ServiceIRI:  service1IRI,
+	}
+
+	witness := mocks.NewWitnessHandler()
+
+	h := New(cfg, memstore.New(cfg.ServiceName), &mocks.Outbox{}, spi.WithWitness(witness))
+	require.NotNil(t, h)
+
+	h.Start()
+	defer h.Stop()
+
+	activityChan := h.Subscribe()
+
+	var (
+		mutex       sync.Mutex
+		gotActivity = make(map[string]*vocab.ActivityType)
+	)
+
+	go func() {
+		for activity := range activityChan {
+			mutex.Lock()
+			gotActivity[activity.ID()] = activity
+			mutex.Unlock()
+		}
+	}()
+
+	t.Run("Success", func(t *testing.T) {
+		witness.WithProof([]byte(proof))
+
+		obj, err := vocab.NewObjectWithDocument(vocab.MustUnmarshalToDoc([]byte(anchorCredential1)))
+		require.NoError(t, err)
+
+		startTime := time.Now()
+		endTime := startTime.Add(time.Hour)
+
+		offer := vocab.NewOfferActivity(newActivityID(service1IRI),
+			vocab.NewObjectProperty(vocab.WithObject(obj)),
+			vocab.WithActor(service1IRI),
+			vocab.WithTo(service2IRI),
+			vocab.WithStartTime(&startTime),
+			vocab.WithEndTime(&endTime),
+		)
+
+		require.NoError(t, h.HandleActivity(offer))
+
+		time.Sleep(50 * time.Millisecond)
+
+		mutex.Lock()
+		require.NotNil(t, gotActivity[offer.ID()])
+		mutex.Unlock()
+		require.Len(t, witness.AnchorCreds(), 1)
+
+		liked, err := h.store.GetReferences(store.Liked, h.ServiceIRI)
+		require.NoError(t, err)
+		require.NotEmpty(t, liked)
+	})
+
+	t.Run("No response from witness -> error", func(t *testing.T) {
+		witness.WithProof(nil)
+
+		obj, err := vocab.NewObjectWithDocument(vocab.MustUnmarshalToDoc([]byte(anchorCredential1)))
+		require.NoError(t, err)
+
+		startTime := time.Now()
+		endTime := startTime.Add(time.Hour)
+
+		offer := vocab.NewOfferActivity(newActivityID(service1IRI),
+			vocab.NewObjectProperty(vocab.WithObject(obj)),
+			vocab.WithActor(service1IRI),
+			vocab.WithTo(service2IRI),
+			vocab.WithStartTime(&startTime),
+			vocab.WithEndTime(&endTime),
+		)
+
+		err = h.HandleActivity(offer)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no proof returned from witness for Offer activity")
+	})
+
+	t.Run("Witness error", func(t *testing.T) {
+		errExpected := fmt.Errorf("injected witness error")
+
+		witness.WithError(errExpected)
+		defer witness.WithError(nil)
+
+		obj, err := vocab.NewObjectWithDocument(vocab.MustUnmarshalToDoc([]byte(anchorCredential1)))
+		require.NoError(t, err)
+
+		startTime := time.Now()
+		endTime := startTime.Add(time.Hour)
+
+		offer := vocab.NewOfferActivity(newActivityID(service1IRI),
+			vocab.NewObjectProperty(vocab.WithObject(obj)),
+			vocab.WithActor(service1IRI),
+			vocab.WithTo(service2IRI),
+			vocab.WithStartTime(&startTime),
+			vocab.WithEndTime(&endTime),
+		)
+
+		require.True(t, errors.Is(h.HandleActivity(offer), errExpected))
+	})
+
+	t.Run("No start time", func(t *testing.T) {
+		obj, err := vocab.NewObjectWithDocument(vocab.MustUnmarshalToDoc([]byte(anchorCredential1)))
+		require.NoError(t, err)
+
+		endTime := time.Now().Add(time.Hour)
+
+		offer := vocab.NewOfferActivity(newActivityID(service1IRI),
+			vocab.NewObjectProperty(vocab.WithObject(obj)),
+			vocab.WithActor(service1IRI),
+			vocab.WithTo(service2IRI),
+			vocab.WithEndTime(&endTime),
+		)
+
+		err = h.HandleActivity(offer)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "startTime is required")
+	})
+
+	t.Run("No end time", func(t *testing.T) {
+		obj, err := vocab.NewObjectWithDocument(vocab.MustUnmarshalToDoc([]byte(anchorCredential1)))
+		require.NoError(t, err)
+
+		startTime := time.Now()
+
+		offer := vocab.NewOfferActivity(newActivityID(service1IRI),
+			vocab.NewObjectProperty(vocab.WithObject(obj)),
+			vocab.WithActor(service1IRI),
+			vocab.WithTo(service2IRI),
+			vocab.WithStartTime(&startTime),
+		)
+
+		err = h.HandleActivity(offer)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "endTime is required")
+	})
+
+	t.Run("Invalid object type", func(t *testing.T) {
+		startTime := time.Now()
+		endTime := startTime.Add(time.Hour)
+
+		offer := vocab.NewOfferActivity(newActivityID(service1IRI),
+			vocab.NewObjectProperty(vocab.WithObject(vocab.NewObject(vocab.WithType(vocab.TypeAnnounce)))),
+			vocab.WithActor(service1IRI),
+			vocab.WithTo(service2IRI),
+			vocab.WithStartTime(&startTime),
+			vocab.WithEndTime(&endTime),
+		)
+
+		err := h.HandleActivity(offer)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unsupported object type in Offer activity Announce")
+	})
+
+	t.Run("No object", func(t *testing.T) {
+		startTime := time.Now()
+		endTime := startTime.Add(time.Hour)
+
+		offer := vocab.NewOfferActivity(newActivityID(service1IRI),
+			vocab.NewObjectProperty(),
+			vocab.WithActor(service1IRI),
+			vocab.WithTo(service2IRI),
+			vocab.WithStartTime(&startTime),
+			vocab.WithEndTime(&endTime),
+		)
+
+		err := h.HandleActivity(offer)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "object is required")
+	})
+}
+
 func newActivityID(id fmt.Stringer) string {
 	return fmt.Sprintf("%s/%s", id, uuid.New())
 }
@@ -893,4 +1072,19 @@ const anchorCredential1 = `{
 	}
   },
   "proofChain": [{}]
+}`
+
+const proof = `{
+  "@context": [
+    "https://w3id.org/security/v1",
+    "https://w3c-ccg.github.io/lds-jws2020/contexts/lds-jws2020-v1.json"
+  ],
+  "proof": {
+    "type": "JsonWebSignature2020",
+    "proofPurpose": "assertionMethod",
+    "created": "2021-01-27T09:30:15Z",
+    "verificationMethod": "did:example:abcd#key",
+    "domain": "https://witness1.example.com/ledgers/maple2021",
+    "jws": "eyJ..."
+  }
 }`

--- a/pkg/activitypub/service/inbox/inbox_test.go
+++ b/pkg/activitypub/service/inbox/inbox_test.go
@@ -229,7 +229,7 @@ func TestInbox_Error(t *testing.T) {
 		ib.Start()
 		defer ib.Stop()
 
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(500 * time.Millisecond)
 
 		activityStore.AddActivityReturns(errors.New("injected store error"))
 

--- a/pkg/activitypub/service/mocks/mockwitnesspub.go
+++ b/pkg/activitypub/service/mocks/mockwitnesspub.go
@@ -1,0 +1,58 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	"sync"
+	"time"
+)
+
+// WitnessHandler implements a mock witness handler.
+type WitnessHandler struct {
+	mutex       sync.Mutex
+	err         error
+	proof       []byte
+	anchorCreds [][]byte
+}
+
+// NewWitnessHandler returns a mock witness handler.
+func NewWitnessHandler() *WitnessHandler {
+	return &WitnessHandler{}
+}
+
+// WithProof sets the proof to be returned from the witness handler.
+func (m *WitnessHandler) WithProof(proof []byte) *WitnessHandler {
+	m.proof = proof
+
+	return m
+}
+
+// WithError injects an error.
+func (m *WitnessHandler) WithError(err error) *WitnessHandler {
+	m.err = err
+
+	return m
+}
+
+// Witness adds the anchor credential to a list that can be inspected using the AnchorCreds function
+// and returns the injected proof/error.
+func (m *WitnessHandler) Witness(startTime, endTime time.Time, anchorCred []byte) ([]byte, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	m.anchorCreds = append(m.anchorCreds, anchorCred)
+
+	return m.proof, m.err
+}
+
+// AnchorCreds returns all of the anchor credentials that were witnessed by this mock.
+func (m *WitnessHandler) AnchorCreds() [][]byte {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	return m.anchorCreds
+}

--- a/pkg/activitypub/service/spi/spi.go
+++ b/pkg/activitypub/service/spi/spi.go
@@ -8,6 +8,7 @@ package spi
 
 import (
 	"errors"
+	"time"
 
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
 )
@@ -66,6 +67,11 @@ type FollowerAuth interface {
 	AuthorizeFollower(follower *vocab.ActorType) (bool, error)
 }
 
+// WitnessHandler is a handler that witnesses an anchor credential.
+type WitnessHandler interface {
+	Witness(startTime, endTime time.Time, anchorCred []byte) ([]byte, error)
+}
+
 // ActivityHandler defines the functions of an Activity handler.
 type ActivityHandler interface {
 	ServiceLifecycle
@@ -87,6 +93,7 @@ type Handlers struct {
 	UndeliverableHandler    UndeliverableActivityHandler
 	AnchorCredentialHandler AnchorCredentialHandler
 	FollowerAuth            FollowerAuth
+	Witness                 WitnessHandler
 }
 
 // HandlerOpt sets a specific handler.
@@ -110,5 +117,12 @@ func WithAnchorCredentialHandler(handler AnchorCredentialHandler) HandlerOpt {
 func WithFollowerAuth(handler FollowerAuth) HandlerOpt {
 	return func(options *Handlers) {
 		options.FollowerAuth = handler
+	}
+}
+
+// WithWitness sets the witness handler.
+func WithWitness(handler WitnessHandler) HandlerOpt {
+	return func(options *Handlers) {
+		options.Witness = handler
 	}
 }


### PR DESCRIPTION
Implemented a handler for the ActivityPub 'Offer' activity. The handler invokes a 'witness' handler with the embedded anchor credential so that it may generate a proof. If successful, the handler posts a 'Like' activity with the proofs back to the actor (requestor). The handler also adds the activity to the service's 'liked' list.

closes #72

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>