### PR TITLE
fix: Offer handler responds with incorrect start and end time in Like activity

### DIFF
--- a/pkg/activitypub/service/activityhandler/activityhandler_test.go
+++ b/pkg/activitypub/service/activityhandler/activityhandler_test.go
@@ -936,7 +936,7 @@ func TestHandler_HandleOfferActivity(t *testing.T) {
 
 		err = h.HandleActivity(offer)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "no proof returned from witness for Offer activity")
+		require.Contains(t, err.Error(), "unable to unmarshal proof")
 	})
 
 	t.Run("Witness error", func(t *testing.T) {

--- a/pkg/activitypub/service/mocks/mockwitnesshandler.go
+++ b/pkg/activitypub/service/mocks/mockwitnesshandler.go
@@ -8,7 +8,6 @@ package mocks
 
 import (
 	"sync"
-	"time"
 )
 
 // WitnessHandler implements a mock witness handler.
@@ -40,7 +39,7 @@ func (m *WitnessHandler) WithError(err error) *WitnessHandler {
 
 // Witness adds the anchor credential to a list that can be inspected using the AnchorCreds function
 // and returns the injected proof/error.
-func (m *WitnessHandler) Witness(startTime, endTime time.Time, anchorCred []byte) ([]byte, error) {
+func (m *WitnessHandler) Witness(anchorCred []byte) ([]byte, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 

--- a/pkg/activitypub/service/service.go
+++ b/pkg/activitypub/service/service.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"time"
 
 	"github.com/ThreeDotsLabs/watermill/message"
 
@@ -44,6 +45,9 @@ type Config struct {
 	RetryOpts                 *redelivery.Config
 	PubSubFactory             PubSubFactory
 	ActivityHandlerBufferSize int
+
+	// MaxWitnessDelay is the maximum delay that the witnessed transaction becomes included into the ledger.
+	MaxWitnessDelay time.Duration
 }
 
 // Service implements an ActivityPub service which has an inbox, outbox, and
@@ -73,9 +77,10 @@ func NewService(cfg *Config, activityStore store.Store, handlerOpts ...spi.Handl
 
 	handler := activityhandler.New(
 		&activityhandler.Config{
-			ServiceName: cfg.ServiceName,
-			BufferSize:  cfg.ActivityHandlerBufferSize,
-			ServiceIRI:  cfg.ServiceIRI,
+			ServiceName:     cfg.ServiceName,
+			BufferSize:      cfg.ActivityHandlerBufferSize,
+			ServiceIRI:      cfg.ServiceIRI,
+			MaxWitnessDelay: cfg.MaxWitnessDelay,
 		},
 		activityStore, ob, handlerOpts...)
 

--- a/pkg/activitypub/service/spi/spi.go
+++ b/pkg/activitypub/service/spi/spi.go
@@ -8,7 +8,6 @@ package spi
 
 import (
 	"errors"
-	"time"
 
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
 )
@@ -69,7 +68,7 @@ type FollowerAuth interface {
 
 // WitnessHandler is a handler that witnesses an anchor credential.
 type WitnessHandler interface {
-	Witness(startTime, endTime time.Time, anchorCred []byte) ([]byte, error)
+	Witness(anchorCred []byte) ([]byte, error)
 }
 
 // ActivityHandler defines the functions of an Activity handler.


### PR DESCRIPTION
The Offer handler responds with a 'Like' activity and the start and end times were set incorrectly. This commit changes the end time to be the current server time plus a configurable delay.

Also, the Offer activity is rejected if the offer has already expired (according to the endTime in the Offer activity).

closes #81

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>