### PR TITLE
feat: Handler for 'Like' activity

### DIFF
--- a/pkg/activitypub/service/mocks/mockproofhandler.go
+++ b/pkg/activitypub/service/mocks/mockproofhandler.go
@@ -1,0 +1,51 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	"sync"
+	"time"
+)
+
+// ProofHandler implements a mock proof handler.
+type ProofHandler struct {
+	mutex  sync.Mutex
+	proofs map[string][]byte
+	err    error
+}
+
+// NewProofHandler returns a mock proof handler.
+func NewProofHandler() *ProofHandler {
+	return &ProofHandler{
+		proofs: make(map[string][]byte),
+	}
+}
+
+// WithError injects an error.
+func (m *ProofHandler) WithError(err error) *ProofHandler {
+	m.err = err
+
+	return m
+}
+
+// HandleProof store the proof and returns any injected error.
+func (m *ProofHandler) HandleProof(anchorCredID string, startTime, endTime time.Time, proof []byte) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	m.proofs[anchorCredID] = proof
+
+	return m.err
+}
+
+// Proof returns the stored proof for the givin ID.
+func (m *ProofHandler) Proof(objID string) []byte {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	return m.proofs[objID]
+}

--- a/pkg/activitypub/service/spi/spi.go
+++ b/pkg/activitypub/service/spi/spi.go
@@ -8,6 +8,7 @@ package spi
 
 import (
 	"errors"
+	"time"
 
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
 )
@@ -71,6 +72,11 @@ type WitnessHandler interface {
 	Witness(anchorCred []byte) ([]byte, error)
 }
 
+// ProofHandler handles the given proof for the anchor credential.
+type ProofHandler interface {
+	HandleProof(anchorCredID string, startTime time.Time, endTime time.Time, proof []byte) error
+}
+
 // ActivityHandler defines the functions of an Activity handler.
 type ActivityHandler interface {
 	ServiceLifecycle
@@ -93,6 +99,7 @@ type Handlers struct {
 	AnchorCredentialHandler AnchorCredentialHandler
 	FollowerAuth            FollowerAuth
 	Witness                 WitnessHandler
+	ProofHandler            ProofHandler
 }
 
 // HandlerOpt sets a specific handler.
@@ -123,5 +130,12 @@ func WithFollowerAuth(handler FollowerAuth) HandlerOpt {
 func WithWitness(handler WitnessHandler) HandlerOpt {
 	return func(options *Handlers) {
 		options.Witness = handler
+	}
+}
+
+// WithProofHandler sets the proof handler.
+func WithProofHandler(handler ProofHandler) HandlerOpt {
+	return func(options *Handlers) {
+		options.ProofHandler = handler
 	}
 }


### PR DESCRIPTION
Implemented a handler for the ActivityPub 'Like' (endorse) activity. The handler invokes a 'proof' handler with the embedded proof so that it may handle the endorsed transaction. The handler also adds the 'Like' activity to the service's 'likes' list.

closes #73

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>