### PR TITLE
feat: HTTP Subscriber for Watermill

### DIFF
--- a/pkg/activitypub/service/inbox/httpsubscriber/httpsubscriber.go
+++ b/pkg/activitypub/service/inbox/httpsubscriber/httpsubscriber.go
@@ -1,0 +1,180 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package httpsubscriber
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	wmhttp "github.com/ThreeDotsLabs/watermill-http/pkg/http"
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/trustbloc/edge-core/pkg/log"
+	"github.com/trustbloc/sidetree-core-go/pkg/restapi/common"
+
+	"github.com/trustbloc/orb/pkg/activitypub/service/lifecycle"
+)
+
+var logger = log.New("activitypub_service")
+
+const (
+	defaultBufferSize = 100
+	stopTimeout       = 250 * time.Millisecond
+)
+
+// Config holds the HTTP subscriper configuration parameters.
+type Config struct {
+	ServiceEndpoint string
+	BufferSize      int
+}
+
+// Subscriber implements a subscriber for Watermill that handles HTTP requests.
+type Subscriber struct {
+	*lifecycle.Lifecycle
+	*Config
+
+	msgChan          chan *message.Message
+	stopped          chan struct{}
+	done             chan struct{}
+	unmarshalMessage wmhttp.UnmarshalMessageFunc
+}
+
+// New returns a new HTTP subscriber.
+func New(cfg *Config) *Subscriber {
+	if cfg.BufferSize == 0 {
+		cfg.BufferSize = defaultBufferSize
+	}
+
+	s := &Subscriber{
+		Config:           cfg,
+		unmarshalMessage: wmhttp.DefaultUnmarshalMessageFunc,
+		msgChan:          make(chan *message.Message, cfg.BufferSize),
+		stopped:          make(chan struct{}),
+		done:             make(chan struct{}),
+	}
+
+	s.Lifecycle = lifecycle.New("httpsubscriber-"+cfg.ServiceEndpoint, lifecycle.WithStop(s.stop))
+
+	// Start the service immediately.
+	s.Start()
+
+	return s
+}
+
+// Subscribe returns the channel over which incoming messages are sent.
+func (s *Subscriber) Subscribe(_ context.Context, _ string) (<-chan *message.Message, error) {
+	return s.msgChan, nil
+}
+
+// Close stops the subscriber.
+func (s *Subscriber) Close() error {
+	s.Stop()
+
+	return nil
+}
+
+// Path returns the base path of the target endpoint for this subscriber.
+func (s *Subscriber) Path() string {
+	return s.ServiceEndpoint
+}
+
+// Method returns the HTTP method, which is always POST.
+func (s *Subscriber) Method() string {
+	return http.MethodPost
+}
+
+// Handler returns the handler that should be invoked when an HTTP request is posted to the target endpoint.
+// This handler must be registered with an HTTP server.
+func (s *Subscriber) Handler() common.HTTPRequestHandler {
+	return s.handleMessage
+}
+
+func (s *Subscriber) handleMessage(w http.ResponseWriter, r *http.Request) {
+	msg, err := s.unmarshalMessage("", r)
+	if err != nil {
+		logger.Warnf("[%s] Error reading message: %s", s.ServiceEndpoint, err)
+
+		w.WriteHeader(http.StatusBadRequest)
+
+		return
+	}
+
+	logger.Debugf("[%s] Handling message [%s]", s.ServiceEndpoint, msg.UUID)
+
+	err = s.publish(msg)
+	if err != nil {
+		logger.Infof("[%s] Message [%s] wasn't sent: %s", s.ServiceEndpoint, msg.UUID, err)
+
+		w.WriteHeader(http.StatusServiceUnavailable)
+
+		return
+	}
+
+	s.respond(msg, w, r)
+}
+
+func (s *Subscriber) publish(msg *message.Message) error {
+	select {
+	case s.msgChan <- msg:
+		logger.Debugf("[%s] Message [%s] was delivered to subscriber", s.ServiceEndpoint, msg.UUID)
+
+		return nil
+
+	case <-s.stopped:
+		logger.Infof("[%s] Message [%s] was not published since service was stopped", s.ServiceEndpoint, msg.UUID)
+
+		s.done <- struct{}{}
+
+		return fmt.Errorf("service stopped")
+	}
+}
+
+func (s *Subscriber) respond(msg *message.Message, w http.ResponseWriter, r *http.Request) {
+	select {
+	case <-msg.Acked():
+		logger.Debugf("[%s] Ack received for message [%s]", s.ServiceEndpoint, msg.UUID)
+
+		w.WriteHeader(http.StatusOK)
+
+	case <-msg.Nacked():
+		logger.Warnf("[%s] Nack received for message [%s]", s.ServiceEndpoint, msg.UUID)
+
+		w.WriteHeader(http.StatusInternalServerError)
+
+	case <-r.Context().Done():
+		logger.Infof("[%s] Timed out waiting for ack or nack for message [%s]",
+			s.ServiceEndpoint, msg.UUID, r.Context().Err())
+
+		w.WriteHeader(http.StatusInternalServerError)
+
+	case <-s.stopped:
+		logger.Infof("[%s] Message [%s] wasn not handled since service was stopped", s.ServiceEndpoint, msg.UUID)
+
+		s.done <- struct{}{}
+
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
+}
+
+func (s *Subscriber) stop() {
+	logger.Infof("[%s] Stopping HTTP subscriber", s.ServiceEndpoint)
+
+	close(s.stopped)
+
+	// Wait for the publisher to stop so that we don't close the message channel
+	// while we're trying to publish a message to it (which would result in a panic).
+
+	select {
+	case <-s.done:
+	case <-time.After(stopTimeout):
+	}
+
+	close(s.msgChan)
+
+	logger.Infof("[%s] ... HTTP subscriber stopped.", s.ServiceEndpoint)
+}

--- a/pkg/activitypub/service/inbox/httpsubscriber/httpsubscriber_test.go
+++ b/pkg/activitypub/service/inbox/httpsubscriber/httpsubscriber_test.go
@@ -1,0 +1,193 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package httpsubscriber
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	wmhttp "github.com/ThreeDotsLabs/watermill-http/pkg/http"
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/pkg/activitypub/service/spi"
+)
+
+const endpoint = "/services/service1"
+
+func TestNew(t *testing.T) {
+	s := New(&Config{ServiceEndpoint: endpoint})
+	require.NotNil(t, s)
+
+	require.Equal(t, spi.StateStarted, s.State())
+	require.Equal(t, http.MethodPost, s.Method())
+	require.Equal(t, endpoint, s.Path())
+	require.NotNil(t, endpoint, s.Handler())
+
+	require.NoError(t, s.Close())
+
+	require.Equal(t, spi.StateStopped, s.State())
+}
+
+func TestSubscriber_HandleAck(t *testing.T) {
+	s := New(&Config{ServiceEndpoint: endpoint})
+	require.NotNil(t, s)
+
+	defer s.Stop()
+
+	msgChan, err := s.Subscribe(context.Background(), "")
+	require.NoError(t, err)
+	require.NotNil(t, msgChan)
+
+	go func() {
+		for msg := range msgChan {
+			msg.Ack()
+		}
+	}()
+
+	rw := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, endpoint, nil)
+
+	s.handleMessage(rw, req)
+
+	result := rw.Result()
+	require.Equal(t, http.StatusOK, result.StatusCode)
+	require.NoError(t, result.Body.Close())
+}
+
+func TestSubscriber_HandleNack(t *testing.T) {
+	s := New(&Config{ServiceEndpoint: endpoint})
+	require.NotNil(t, s)
+
+	defer s.Stop()
+
+	msgChan, err := s.Subscribe(context.Background(), "")
+	require.NoError(t, err)
+	require.NotNil(t, msgChan)
+
+	go func() {
+		for msg := range msgChan {
+			msg.Nack()
+		}
+	}()
+
+	rw := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, endpoint, nil)
+
+	s.handleMessage(rw, req)
+
+	result := rw.Result()
+	require.Equal(t, http.StatusInternalServerError, result.StatusCode)
+	require.NoError(t, result.Body.Close())
+}
+
+func TestSubscriber_HandleRequestTimeout(t *testing.T) {
+	s := New(&Config{ServiceEndpoint: endpoint})
+	require.NotNil(t, s)
+
+	defer s.Stop()
+
+	_, err := s.Subscribe(context.Background(), "")
+	require.NoError(t, err)
+
+	rw := httptest.NewRecorder()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	require.NotNil(t, ctx)
+	require.NotNil(t, cancel)
+
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader([]byte("data")))
+	require.NoError(t, err)
+	require.NotNil(t, req)
+
+	s.handleMessage(rw, req)
+
+	result := rw.Result()
+	require.Equal(t, http.StatusInternalServerError, result.StatusCode)
+	require.NoError(t, result.Body.Close())
+}
+
+func TestSubscriber_UnmarshalError(t *testing.T) {
+	s := New(&Config{ServiceEndpoint: endpoint})
+	require.NotNil(t, s)
+
+	defer s.Stop()
+
+	msgChan, err := s.Subscribe(context.Background(), "")
+	require.NoError(t, err)
+	require.NotNil(t, msgChan)
+
+	rw := httptest.NewRecorder()
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(nil))
+	require.NoError(t, err)
+
+	req.Header.Add(wmhttp.HeaderMetadata, "{invalid")
+
+	s.handleMessage(rw, req)
+
+	result := rw.Result()
+	require.Equal(t, http.StatusBadRequest, result.StatusCode)
+	require.NoError(t, result.Body.Close())
+}
+
+func TestSubscriber_Close(t *testing.T) {
+	t.Run("Publish when stopped", func(t *testing.T) {
+		s := New(&Config{ServiceEndpoint: endpoint})
+		require.NotNil(t, s)
+
+		_, err := s.Subscribe(context.Background(), "")
+		require.NoError(t, err)
+
+		var mutex sync.Mutex
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, endpoint, nil)
+
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+
+			mutex.Lock()
+			s.handleMessage(rw, req)
+			mutex.Unlock()
+		}()
+
+		s.stop()
+
+		mutex.Lock()
+		result := rw.Result()
+		require.Equal(t, http.StatusServiceUnavailable, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+		mutex.Unlock()
+	})
+
+	t.Run("Respond when stopped", func(t *testing.T) {
+		s := New(&Config{ServiceEndpoint: endpoint})
+		require.NotNil(t, s)
+
+		_, err := s.Subscribe(context.Background(), "")
+		require.NoError(t, err)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, endpoint, nil)
+
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			s.stop()
+		}()
+
+		s.handleMessage(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusServiceUnavailable, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+	})
+}

--- a/pkg/activitypub/service/inbox/inbox.go
+++ b/pkg/activitypub/service/inbox/inbox.go
@@ -9,15 +9,15 @@ package inbox
 import (
 	"context"
 	"encoding/json"
-	"net/http"
 
-	wmhttp "github.com/ThreeDotsLabs/watermill-http/pkg/http"
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/ThreeDotsLabs/watermill/message/router/middleware"
 	"github.com/ThreeDotsLabs/watermill/message/router/plugin"
 	"github.com/pkg/errors"
 	"github.com/trustbloc/edge-core/pkg/log"
+	"github.com/trustbloc/sidetree-core-go/pkg/restapi/common"
 
+	"github.com/trustbloc/orb/pkg/activitypub/service/inbox/httpsubscriber"
 	"github.com/trustbloc/orb/pkg/activitypub/service/lifecycle"
 	service "github.com/trustbloc/orb/pkg/activitypub/service/spi"
 	"github.com/trustbloc/orb/pkg/activitypub/service/wmlogger"
@@ -35,9 +35,8 @@ type pubSub interface {
 
 // Config holds configuration parameters for the Inbox.
 type Config struct {
-	ServiceName   string
-	ListenAddress string
-	Topic         string
+	ServiceEndpoint string
+	Topic           string
 }
 
 // Inbox implements the ActivityPub inbox.
@@ -46,7 +45,7 @@ type Inbox struct {
 	*lifecycle.Lifecycle
 
 	router          *message.Router
-	httpSubscriber  *wmhttp.Subscriber
+	httpSubscriber  *httpsubscriber.Subscriber
 	msgChannel      <-chan *message.Message
 	activityHandler service.ActivityHandler
 	activityStore   store.Store
@@ -62,7 +61,7 @@ func New(cfg *Config, s store.Store, pubSub pubSub, activityHandler service.Acti
 		jsonUnmarshal:   json.Unmarshal,
 	}
 
-	h.Lifecycle = lifecycle.New(cfg.ServiceName,
+	h.Lifecycle = lifecycle.New(cfg.ServiceEndpoint,
 		lifecycle.WithStart(h.start),
 		lifecycle.WithStop(h.stop),
 	)
@@ -72,10 +71,11 @@ func New(cfg *Config, s store.Store, pubSub pubSub, activityHandler service.Acti
 		return nil, errors.WithMessagef(err, "unable to subscribe to topic [%s]", cfg.Topic)
 	}
 
-	httpSubscriber, err := wmhttp.NewSubscriber(cfg.ListenAddress, wmhttp.SubscriberConfig{}, wmlogger.New())
-	if err != nil {
-		return nil, errors.WithMessagef(err, "unable to create HTTP subscriber")
-	}
+	httpSubscriber := httpsubscriber.New(
+		&httpsubscriber.Config{
+			ServiceEndpoint: cfg.ServiceEndpoint,
+		},
+	)
 
 	router, err := message.NewRouter(message.RouterConfig{}, wmlogger.New())
 	if err != nil {
@@ -87,7 +87,7 @@ func New(cfg *Config, s store.Store, pubSub pubSub, activityHandler service.Acti
 	router.AddPlugin(plugin.SignalsHandler)
 
 	router.AddHandler(
-		"inbox-"+cfg.ServiceName, cfg.ServiceName,
+		"inbox-"+cfg.ServiceEndpoint, cfg.ServiceEndpoint,
 		httpSubscriber, cfg.Topic, pubSub,
 		func(msg *message.Message) ([]*message.Message, error) {
 			// Simply forward the message.
@@ -102,6 +102,12 @@ func New(cfg *Config, s store.Store, pubSub pubSub, activityHandler service.Acti
 	return h, nil
 }
 
+// HTTPHandler returns the HTTP handler which is invoked by the HTTP server.
+// This handler must be registered with an HTTP server.
+func (h *Inbox) HTTPHandler() common.HTTPHandler {
+	return h.httpSubscriber
+}
+
 func (h *Inbox) start() {
 	// Start the router
 	go h.route()
@@ -111,68 +117,47 @@ func (h *Inbox) start() {
 
 	// HTTP server needs to be started after router is ready.
 	<-h.router.Running()
-
-	// Start the HTTP server
-	go h.serveHTTP()
 }
 
 func (h *Inbox) stop() {
-	if err := h.httpSubscriber.Close(); err != nil {
-		logger.Warnf("Error closing inbox: %s", err)
-	}
-
 	if err := h.router.Close(); err != nil {
-		logger.Warnf("[%s] Error closing router: %s", h.ServiceName, err)
+		logger.Warnf("[%s] Error closing router: %s", h.ServiceEndpoint, err)
 	} else {
-		logger.Debugf("[%s] Closed router", h.ServiceName)
+		logger.Debugf("[%s] Closed router", h.ServiceEndpoint)
 	}
 }
 
 func (h *Inbox) route() {
-	logger.Debugf("[%s] Starting router", h.ServiceName)
+	logger.Debugf("[%s] Starting router", h.ServiceEndpoint)
 
 	if err := h.router.Run(context.Background()); err != nil {
 		// This happens on startup so the best thing to do is to panic
 		panic(err)
 	}
 
-	logger.Debugf("[%s] Router stopped", h.ServiceName)
+	logger.Debugf("[%s] Router stopped", h.ServiceEndpoint)
 }
 
 func (h *Inbox) listen() {
-	logger.Debugf("[%s] Starting message listener", h.ServiceName)
+	logger.Debugf("[%s] Starting message listener", h.ServiceEndpoint)
 
 	for msg := range h.msgChannel {
-		logger.Debugf("[%s] Got new message: %s: %s", h.ServiceName, msg.UUID, msg.Payload)
+		logger.Debugf("[%s] Got new message: %s: %s", h.ServiceEndpoint, msg.UUID, msg.Payload)
 
 		h.handle(msg)
 	}
 
-	logger.Debugf("[%s] Message listener stopped", h.ServiceName)
-}
-
-func (h *Inbox) serveHTTP() {
-	logger.Debugf("[%s] Starting HTTP server", h.ServiceName)
-
-	if err := h.httpSubscriber.StartHTTPServer(); err != nil {
-		if err == http.ErrServerClosed {
-			logger.Debugf("[%s] HTTP server stopped", h.ServiceName)
-		} else {
-			logger.Errorf("[%s] Error starting HTTP server: %s", h.ServiceName, err)
-
-			h.Stop()
-		}
-	}
+	logger.Debugf("[%s] Message listener stopped", h.ServiceEndpoint)
 }
 
 func (h *Inbox) handle(msg *message.Message) {
-	logger.Debugf("[%s] Handling activities message [%s]: %s", h.ServiceName, msg.UUID, msg.Payload)
+	logger.Debugf("[%s] Handling activities message [%s]: %s", h.ServiceEndpoint, msg.UUID, msg.Payload)
 
 	activity := &vocab.ActivityType{}
 
 	err := h.jsonUnmarshal(msg.Payload, activity)
 	if err != nil {
-		logger.Errorf("[%s] Error unmarshalling activity message: %s", h.ServiceName, err)
+		logger.Errorf("[%s] Error unmarshalling activity message: %s", h.ServiceEndpoint, err)
 
 		msg.Nack()
 
@@ -180,7 +165,7 @@ func (h *Inbox) handle(msg *message.Message) {
 	}
 
 	if err := h.activityStore.AddActivity(store.Inbox, activity); err != nil {
-		logger.Errorf("[%s] Error storing activity [%s]: %s", h.ServiceName, activity.ID(), err)
+		logger.Errorf("[%s] Error storing activity [%s]: %s", h.ServiceEndpoint, activity.ID(), err)
 
 		msg.Nack()
 
@@ -188,11 +173,11 @@ func (h *Inbox) handle(msg *message.Message) {
 	}
 
 	if err := h.activityHandler.HandleActivity(activity); err != nil {
-		logger.Warnf("[%s] Error handling message [%s]: %s", h.ServiceName, msg.UUID, err)
+		logger.Warnf("[%s] Error handling message [%s]: %s", h.ServiceEndpoint, msg.UUID, err)
 
 		msg.Nack()
 	} else {
-		logger.Warnf("[%s] Successfully handled message [%s]", h.ServiceName, msg.UUID)
+		logger.Warnf("[%s] Successfully handled message [%s]", h.ServiceEndpoint, msg.UUID)
 
 		msg.Ack()
 	}


### PR DESCRIPTION
Implemented a Watermill HTTP subscriber that may integrate with an existing HTTP server. This HTTP subscriber exposes a handler that can be registered with Orb's existing HTTP server. All REST endpoints may now be served from the same address/port.

closes #84

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>