### PR TITLE
feat: Listener for witnessed anchored credential

### DIFF
--- a/pkg/anchor/graph/graph.go
+++ b/pkg/anchor/graph/graph.go
@@ -68,6 +68,10 @@ func (g *Graph) GetDidTransactions(cid, did string) ([]string, error) {
 
 		cur, ok = previousTxns[did]
 		if ok {
+			if cur == "" { // create
+				return refs, nil
+			}
+
 			refs = append(refs, cur)
 		}
 	}

--- a/pkg/anchor/graph/graph_test.go
+++ b/pkg/anchor/graph/graph_test.go
@@ -107,7 +107,7 @@ func TestGraph_GetDidTransactions(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, txn1CID)
 
-		testDID := "did:method:abc"
+		testDID := "did:method:123"
 
 		previousDIDTxns := make(map[string]string)
 		previousDIDTxns[testDID] = txn1CID
@@ -127,6 +127,30 @@ func TestGraph_GetDidTransactions(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, len(didTxns))
 		require.Equal(t, txn1CID, didTxns[0])
+	})
+
+	t.Run("success - cid referenced in previous transaction empty (create)", func(t *testing.T) {
+		graph := New(mocks.NewMockCasClient(nil), pubKeyFetcherFnc)
+
+		testDID := "did:method:abc"
+
+		previousDIDTxns := make(map[string]string)
+		previousDIDTxns[testDID] = ""
+
+		payload := txn.Payload{
+			AnchorString:         "anchor-3",
+			Namespace:            "namespace",
+			Version:              1,
+			PreviousTransactions: previousDIDTxns,
+		}
+
+		txnCID, err := graph.Add(buildCredential(payload))
+		require.NoError(t, err)
+		require.NotNil(t, txnCID)
+
+		didTxns, err := graph.GetDidTransactions(txnCID, testDID)
+		require.NoError(t, err)
+		require.Nil(t, didTxns)
 	})
 
 	t.Run("error - cid referenced in previous transaction not found", func(t *testing.T) {

--- a/pkg/anchor/proofs/proofs.go
+++ b/pkg/anchor/proofs/proofs.go
@@ -1,0 +1,55 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package proofs
+
+import (
+	"fmt"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+	"github.com/trustbloc/edge-core/pkg/log"
+)
+
+var logger = log.New("proof-handler")
+
+// Handler implements proof handler (responsible for collecting/managing proofs).
+type Handler struct {
+	*Providers
+	vcCh chan *verifiable.Credential
+}
+
+// Providers contains all of the providers required by proof handler.
+type Providers struct {
+	// TODO: proof store
+}
+
+// New returns a new proof handler.
+func New(providers *Providers, vcCh chan *verifiable.Credential) *Handler {
+	return &Handler{
+		Providers: providers,
+		vcCh:      vcCh,
+	}
+}
+
+// RequestProofs requests proofs from witnesses.
+func (h *Handler) RequestProofs(vc *verifiable.Credential, witnesses []string) error {
+	logger.Debugf("sending anchor credential[%s] to witnesses: %s", vc.ID, witnesses)
+
+	vcBytes, err := vc.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("failed to marshal anchor credential: %s", err.Error())
+	}
+
+	retVC, err := verifiable.ParseCredential(vcBytes, verifiable.WithDisabledProofCheck())
+	if err != nil {
+		return fmt.Errorf("failed to parse anchor credential: %s", err.Error())
+	}
+
+	// TODO: create an offer for witnesses and wait for witness proofs
+	h.vcCh <- retVC
+
+	return nil
+}

--- a/pkg/anchor/proofs/proofs_test.go
+++ b/pkg/anchor/proofs/proofs_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package proofs
+
+import (
+	"testing"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	var vcChan chan *verifiable.Credential
+
+	providers := &Providers{}
+
+	c := New(providers, vcChan)
+	require.NotNil(t, c)
+}
+
+func TestClient_GetProofs(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		vcCh := make(chan *verifiable.Credential, 100)
+
+		providers := &Providers{}
+
+		c := New(providers, vcCh)
+
+		anchorVC, err := verifiable.ParseCredential([]byte(anchorCred), verifiable.WithDisabledProofCheck())
+		require.NoError(t, err)
+
+		err = c.RequestProofs(anchorVC, nil)
+		require.NoError(t, err)
+	})
+}
+
+//nolint:gochecknoglobals,lll
+var anchorCred = `
+{
+	"@context": [
+		"https://www.w3.org/2018/credentials/v1"
+	],
+	"credentialSubject": {
+		"anchorString": "1.QmaevShHgc5s7bNnGKkQ98BdaKDNrsCTUV6rcwHr522tQB",
+		"namespace": "did:sidetree",
+		"previousTransactions": {
+		"EiBAnjPBzHqAA-yONCU1HbGln-I0T-ZUPSIkkYAM6EwKKQ": "QmPEVPudBXM5XCoxoNUQiV466e7vD4XowohU8nRAhKJZ6f"
+		},
+		"version": 0
+	},
+	"id": "http://peer1.com/vc/85ef42f6-1019-40cc-ab3a-2b477681f5d8",
+	"issuanceDate": "2021-03-10T16:34:17.9767297Z",
+	"issuer": "http://peer1.com",
+	"proof": {
+		"created": "2021-03-10T16:34:17.9799878Z",
+		"domain": "domain.com",
+		"jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..yRt-VlWPDRq0jX-5iMYSfugJspbtmXZn3a9L011w8LI22WzpFZ5YQCTz6B09Stonywg_Xe6fwygG3IPQ5jreBg",
+		"proofPurpose": "assertionMethod",
+		"type": "Ed25519Signature2018",
+		"verificationMethod": "did:web:abc#vaK33R-2ssibOOf2CS0RceLeT61Z2hpskHuEvDW7Hq0"
+	},
+	"type": "VerifiableCredential"
+}`

--- a/pkg/anchor/writer/writer.go
+++ b/pkg/anchor/writer/writer.go
@@ -15,24 +15,27 @@ import (
 	txnapi "github.com/trustbloc/sidetree-core-go/pkg/api/txn"
 
 	"github.com/trustbloc/orb/pkg/anchor/txn"
+	"github.com/trustbloc/orb/pkg/anchor/util"
 	"github.com/trustbloc/orb/pkg/didtxnref"
 )
 
-var logger = log.New("txn-client")
+var logger = log.New("anchor-writer")
 
 // Writer implements writing orb transactions.
 type Writer struct {
 	*Providers
 	namespace string
+	vcCh      <-chan *verifiable.Credential
 	txnCh     chan []string
 }
 
 // Providers contains all of the providers required by the client.
 type Providers struct {
-	TxnGraph   txnGraph
-	DidTxns    didTxns
-	TxnBuilder txnBuilder
-	Store      vcStore
+	TxnGraph     txnGraph
+	DidTxns      didTxns
+	TxnBuilder   txnBuilder
+	ProofHandler proofHandler
+	Store        vcStore
 }
 
 type txnGraph interface {
@@ -44,7 +47,7 @@ type txnBuilder interface {
 }
 
 type didTxns interface {
-	Add(did, cid string) error
+	Add(dids []string, cid string) error
 	Last(did string) (string, error)
 }
 
@@ -53,13 +56,22 @@ type vcStore interface {
 	Get(id string) (*verifiable.Credential, error)
 }
 
+type proofHandler interface {
+	RequestProofs(vc *verifiable.Credential, witnesses []string) error
+}
+
 // New returns a new orb transaction client.
-func New(namespace string, providers *Providers, txnCh chan []string) *Writer {
-	return &Writer{
+func New(namespace string, providers *Providers, txnCh chan []string, vcCh chan *verifiable.Credential) *Writer {
+	w := &Writer{
 		Providers: providers,
 		txnCh:     txnCh,
+		vcCh:      vcCh,
 		namespace: namespace,
 	}
+
+	go w.listenForWitnessedAnchorCredentials()
+
+	return w
 }
 
 // WriteAnchor writes anchor string to orb transaction.
@@ -70,34 +82,21 @@ func (c *Writer) WriteAnchor(anchor string, refs []*operation.Reference, version
 		return err
 	}
 
-	logger.Debugf("created anchor credential for anchor: %s", anchor)
-
 	// store anchor credential
 	err = c.Store.Put(vc)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to store anchor credential: %s", err.Error())
 	}
 
-	// TODO: create an offer for witnesses and wait for witness proofs
+	logger.Debugf("stored anchor credential[%s] for anchor: %s", vc.ID, anchor)
 
-	// TODO: Add proofs to stored anchor credential
+	// TODO: Figure out witness list for this anchor file
 
-	cid, err := c.TxnGraph.Add(vc)
+	// request proofs from witnesses
+	err = c.ProofHandler.RequestProofs(vc, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to request proofs from witnesses: %s", err.Error())
 	}
-
-	// update global did/txn references
-	for _, ref := range refs {
-		addErr := c.DidTxns.Add(ref.UniqueSuffix, cid)
-		if addErr != nil {
-			return addErr
-		}
-	}
-
-	// TODO: announce txn to followers and node observer (if running in observer node)
-
-	c.txnCh <- []string{cid}
 
 	return nil
 }
@@ -119,7 +118,13 @@ func (c *Writer) getPreviousTransactions(refs []*operation.Reference) (map[strin
 		last, err := c.DidTxns.Last(ref.UniqueSuffix)
 		if err != nil {
 			if err == didtxnref.ErrDidTransactionsNotFound {
-				// TODO: it is ok for transaction references not to be there for create; handle other types here
+				if ref.Type != operation.TypeCreate {
+					return nil, fmt.Errorf("previous did transaction reference not found for %s operation for did[%s]", ref.Type, ref.UniqueSuffix) //nolint:lll
+				}
+
+				// create doesn't have previous transaction references
+				previousDidTxns[ref.UniqueSuffix] = ""
+
 				continue
 			} else {
 				return nil, err
@@ -153,4 +158,67 @@ func (c *Writer) buildCredential(anchor string, refs []*operation.Reference, ver
 	}
 
 	return vc, nil
+}
+
+func (c *Writer) listenForWitnessedAnchorCredentials() {
+	logger.Debugf("starting witnessed anchored credentials listener")
+
+	for vc := range c.vcCh {
+		logger.Debugf("got witnessed anchor credential: %s: %s", vc.ID)
+
+		c.handle(vc)
+	}
+
+	logger.Debugf("[%s] witnessed anchor credential listener stopped")
+}
+
+func (c *Writer) handle(vc *verifiable.Credential) {
+	logger.Debugf("handling witnessed anchored credential: %s", vc.ID)
+
+	// store anchor credential with witness proofs
+	err := c.Store.Put(vc)
+	if err != nil {
+		logger.Warnf("failed to store witnessed anchor credential[%s]: %s", vc.ID, err.Error())
+
+		// TODO: How to handle recovery after this and all other errors in this handler
+
+		return
+	}
+
+	cid, err := c.TxnGraph.Add(vc)
+	if err != nil {
+		logger.Errorf("failed to add witnessed anchor credential[%s] to anchor graph: %s", vc.ID, err.Error())
+
+		return
+	}
+
+	txnPayload, err := util.GetTransactionPayload(vc)
+	if err != nil {
+		logger.Errorf("failed to extract txn payload from witnessed anchor credential[%s]: %s", vc.ID, err.Error())
+
+		return
+	}
+
+	// update global did/txn references
+	suffixes := getKeys(txnPayload.PreviousTransactions)
+
+	err = c.DidTxns.Add(suffixes, cid)
+	if err != nil {
+		logger.Errorf("failed updating did transaction references for anchor credential[%s]: %s", vc.ID, err.Error())
+
+		return
+	}
+
+	// TODO: announce txn to followers and node observer (if running in observer node)
+
+	c.txnCh <- []string{cid}
+}
+
+func getKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+
+	return keys
 }

--- a/pkg/anchor/writer/writer_test.go
+++ b/pkg/anchor/writer/writer_test.go
@@ -8,6 +8,7 @@ package writer
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
@@ -25,97 +26,223 @@ import (
 
 const (
 	namespace = "did:sidetree"
+
+	testDID = "did:method:abc"
 )
 
 func TestNew(t *testing.T) {
 	var txnCh chan []string
 
+	var vcCh chan *verifiable.Credential
+
 	vcStore, err := vcstore.New(mockstore.NewMockStoreProvider())
 	require.NoError(t, err)
 
 	providers := &Providers{
-		TxnGraph:   graph.New(nil, pubKeyFetcherFnc),
-		DidTxns:    memdidtxnref.New(),
-		TxnBuilder: &mockTxnBuilder{},
-		Store:      vcStore,
+		TxnGraph:     graph.New(nil, pubKeyFetcherFnc),
+		DidTxns:      memdidtxnref.New(),
+		TxnBuilder:   &mockTxnBuilder{},
+		ProofHandler: &mockProofHandler{vcCh: make(chan *verifiable.Credential, 100)},
+		Store:        vcStore,
 	}
 
-	c := New(namespace, providers, txnCh)
+	c := New(namespace, providers, txnCh, vcCh)
 	require.NotNil(t, c)
 }
 
-func TestClient_WriteAnchor(t *testing.T) {
-	vcStore, err := vcstore.New(mockstore.NewMockStoreProvider())
-	require.NoError(t, err)
-
-	providers := &Providers{
-		TxnGraph:   graph.New(mocks.NewMockCasClient(nil), pubKeyFetcherFnc),
-		DidTxns:    memdidtxnref.New(),
-		TxnBuilder: &mockTxnBuilder{},
-		Store:      vcStore,
-	}
-
+func TestWriter_WriteAnchor(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		txnCh := make(chan []string, 100)
+		vcCh := make(chan *verifiable.Credential, 100)
 
-		const testDID = "did:method:abc"
-
-		didTxns := memdidtxnref.New()
-		err := didTxns.Add(testDID, "cid")
+		vcStore, err := vcstore.New(mockstore.NewMockStoreProvider())
 		require.NoError(t, err)
 
-		c := New(namespace, providers, txnCh)
-
-		err = c.WriteAnchor("anchor", []*operation.Reference{{UniqueSuffix: testDID}}, 1)
-		require.NoError(t, err)
-	})
-
-	t.Run("error - cas error", func(t *testing.T) {
-		txnCh := make(chan []string, 100)
-
-		const testDID = "did:method:abc"
-
-		didTxns := memdidtxnref.New()
-		err := didTxns.Add(testDID, "cid")
-		require.NoError(t, err)
-
-		casErr := errors.New("CAS Error")
-		providersWithErr := &Providers{
-			TxnGraph:   graph.New(mocks.NewMockCasClient(casErr), pubKeyFetcherFnc),
-			DidTxns:    memdidtxnref.New(),
-			TxnBuilder: &mockTxnBuilder{},
-			Store:      vcStore,
+		providers := &Providers{
+			TxnGraph:     graph.New(mocks.NewMockCasClient(nil), pubKeyFetcherFnc),
+			DidTxns:      memdidtxnref.New(),
+			TxnBuilder:   &mockTxnBuilder{},
+			ProofHandler: &mockProofHandler{vcCh: make(chan *verifiable.Credential, 100)},
+			Store:        vcStore,
 		}
 
-		c := New(namespace, providersWithErr, txnCh)
+		c := New(namespace, providers, txnCh, vcCh)
 
-		err = c.WriteAnchor("anchor", []*operation.Reference{{UniqueSuffix: testDID}}, 1)
-		require.Equal(t, err, casErr)
-	})
-
-	t.Run("error - build error", func(t *testing.T) {
-		txnCh := make(chan []string, 100)
-
-		const testDID = "did:method:abc"
-
-		didTxns := memdidtxnref.New()
-		err := didTxns.Add(testDID, "cid")
+		err = c.WriteAnchor("anchor", []*operation.Reference{{UniqueSuffix: testDID, Type: operation.TypeCreate}}, 1)
 		require.NoError(t, err)
 
+		anchorVC, err := verifiable.ParseCredential([]byte(anchorCred), verifiable.WithDisabledProofCheck())
+		require.NoError(t, err)
+
+		vcCh <- anchorVC
+	})
+
+	t.Run("error - build anchor credential error", func(t *testing.T) {
+		txnCh := make(chan []string, 100)
+		vcCh := make(chan *verifiable.Credential, 100)
+
 		providersWithErr := &Providers{
-			TxnGraph:   graph.New(mocks.NewMockCasClient(nil), pubKeyFetcherFnc),
-			DidTxns:    memdidtxnref.New(),
-			TxnBuilder: &mockTxnBuilder{Err: errors.New("sign error")},
+			TxnGraph:     graph.New(mocks.NewMockCasClient(nil), pubKeyFetcherFnc),
+			DidTxns:      memdidtxnref.New(),
+			TxnBuilder:   &mockTxnBuilder{Err: errors.New("sign error")},
+			ProofHandler: &mockProofHandler{vcCh: vcCh},
 		}
 
-		c := New(namespace, providersWithErr, txnCh)
+		c := New(namespace, providersWithErr, txnCh, vcCh)
 
-		err = c.WriteAnchor("anchor", []*operation.Reference{{UniqueSuffix: testDID}}, 1)
+		err := c.WriteAnchor("anchor", []*operation.Reference{{UniqueSuffix: testDID, Type: operation.TypeCreate}}, 1)
 		require.Contains(t, err.Error(), "failed to build anchor credential: sign error")
+	})
+
+	t.Run("error - store anchor credential error", func(t *testing.T) {
+		txnCh := make(chan []string, 100)
+		vcCh := make(chan *verifiable.Credential, 100)
+
+		storeProviderWithErr := mockstore.NewCustomMockStoreProvider(&mockstore.MockStore{
+			Store:  make(map[string]mockstore.DBEntry),
+			ErrPut: fmt.Errorf("error put"),
+		})
+
+		vcStoreWithErr, err := vcstore.New(storeProviderWithErr)
+		require.NoError(t, err)
+
+		providersWithErr := &Providers{
+			TxnGraph:     graph.New(mocks.NewMockCasClient(nil), pubKeyFetcherFnc),
+			DidTxns:      memdidtxnref.New(),
+			TxnBuilder:   &mockTxnBuilder{},
+			ProofHandler: &mockProofHandler{vcCh: vcCh},
+			Store:        vcStoreWithErr,
+		}
+
+		c := New(namespace, providersWithErr, txnCh, vcCh)
+
+		err = c.WriteAnchor("anchor", []*operation.Reference{{UniqueSuffix: testDID, Type: operation.TypeCreate}}, 1)
+		require.Contains(t, err.Error(), "error put")
+	})
+
+	t.Run("error - previous did transaction reference not found for non-create operations", func(t *testing.T) {
+		txnCh := make(chan []string, 100)
+		vcCh := make(chan *verifiable.Credential, 100)
+
+		vcStore, err := vcstore.New(mockstore.NewMockStoreProvider())
+		require.NoError(t, err)
+
+		providers := &Providers{
+			TxnGraph:     graph.New(mocks.NewMockCasClient(nil), pubKeyFetcherFnc),
+			DidTxns:      memdidtxnref.New(),
+			TxnBuilder:   &mockTxnBuilder{},
+			ProofHandler: &mockProofHandler{vcCh: vcCh},
+			Store:        vcStore,
+		}
+
+		c := New(namespace, providers, txnCh, vcCh)
+
+		err = c.WriteAnchor("anchor", []*operation.Reference{{UniqueSuffix: testDID, Type: operation.TypeUpdate}}, 1)
+		require.Contains(t, err.Error(),
+			"previous did transaction reference not found for update operation for did[did:method:abc]")
 	})
 }
 
-func TestClient_Read(t *testing.T) {
+func TestWriter_handle(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		vcStore, err := vcstore.New(mockstore.NewMockStoreProvider())
+		require.NoError(t, err)
+
+		providers := &Providers{
+			TxnGraph:     graph.New(mocks.NewMockCasClient(nil), pubKeyFetcherFnc),
+			DidTxns:      memdidtxnref.New(),
+			TxnBuilder:   &mockTxnBuilder{},
+			ProofHandler: &mockProofHandler{vcCh: make(chan *verifiable.Credential, 100)},
+			Store:        vcStore,
+		}
+
+		txnCh := make(chan []string, 100)
+		vcCh := make(chan *verifiable.Credential, 100)
+
+		c := New(namespace, providers, txnCh, vcCh)
+
+		anchorVC, err := verifiable.ParseCredential([]byte(anchorCred), verifiable.WithDisabledProofCheck())
+		require.NoError(t, err)
+
+		c.handle(anchorVC)
+	})
+
+	t.Run("error - save anchor credential to store error", func(t *testing.T) {
+		txnCh := make(chan []string, 100)
+		vcCh := make(chan *verifiable.Credential, 100)
+
+		storeProviderWithErr := mockstore.NewCustomMockStoreProvider(&mockstore.MockStore{
+			Store:  make(map[string]mockstore.DBEntry),
+			ErrPut: fmt.Errorf("error put"),
+		})
+
+		vcStoreWithErr, err := vcstore.New(storeProviderWithErr)
+		require.NoError(t, err)
+
+		providersWithErr := &Providers{
+			TxnGraph:     graph.New(mocks.NewMockCasClient(nil), pubKeyFetcherFnc),
+			DidTxns:      memdidtxnref.New(),
+			TxnBuilder:   &mockTxnBuilder{},
+			ProofHandler: &mockProofHandler{vcCh: vcCh},
+			Store:        vcStoreWithErr,
+		}
+
+		c := New(namespace, providersWithErr, txnCh, vcCh)
+
+		anchorVC, err := verifiable.ParseCredential([]byte(anchorCred), verifiable.WithDisabledProofCheck())
+		require.NoError(t, err)
+
+		c.handle(anchorVC)
+	})
+
+	t.Run("error - add anchor credential to txn graph error", func(t *testing.T) {
+		txnCh := make(chan []string, 100)
+		vcCh := make(chan *verifiable.Credential, 100)
+
+		vcStore, err := vcstore.New(mockstore.NewMockStoreProvider())
+		require.NoError(t, err)
+
+		providersWithErr := &Providers{
+			TxnGraph:     &mockTxnGraph{Err: errors.New("txn graph error")},
+			DidTxns:      memdidtxnref.New(),
+			TxnBuilder:   &mockTxnBuilder{},
+			ProofHandler: &mockProofHandler{vcCh: vcCh},
+			Store:        vcStore,
+		}
+
+		c := New(namespace, providersWithErr, txnCh, vcCh)
+
+		anchorVC, err := verifiable.ParseCredential([]byte(anchorCred), verifiable.WithDisabledProofCheck())
+		require.NoError(t, err)
+
+		c.handle(anchorVC)
+	})
+
+	t.Run("error - add anchor credential cid to did transactions error", func(t *testing.T) {
+		txnCh := make(chan []string, 100)
+		vcCh := make(chan *verifiable.Credential, 100)
+
+		vcStore, err := vcstore.New(mockstore.NewMockStoreProvider())
+		require.NoError(t, err)
+
+		providersWithErr := &Providers{
+			TxnGraph:     graph.New(mocks.NewMockCasClient(nil), pubKeyFetcherFnc),
+			DidTxns:      &mockDidTxns{Err: errors.New("did references error")},
+			TxnBuilder:   &mockTxnBuilder{},
+			ProofHandler: &mockProofHandler{vcCh: vcCh},
+			Store:        vcStore,
+		}
+
+		c := New(namespace, providersWithErr, txnCh, vcCh)
+
+		anchorVC, err := verifiable.ParseCredential([]byte(anchorCred), verifiable.WithDisabledProofCheck())
+		require.NoError(t, err)
+
+		c.handle(anchorVC)
+	})
+}
+
+func TestWriter_Read(t *testing.T) {
 	providers := &Providers{
 		TxnGraph: graph.New(nil, pubKeyFetcherFnc),
 		DidTxns:  memdidtxnref.New(),
@@ -123,8 +250,9 @@ func TestClient_Read(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		txnCh := make(chan []string, 100)
+		vcCh := make(chan *verifiable.Credential, 100)
 
-		c := New(namespace, providers, txnCh)
+		c := New(namespace, providers, txnCh, vcCh)
 
 		more, entries := c.Read(-1)
 		require.False(t, more)
@@ -147,3 +275,69 @@ func (m *mockTxnBuilder) Build(subject *txn.Payload) (*verifiable.Credential, er
 var pubKeyFetcherFnc = func(issuerID, keyID string) (*verifier.PublicKey, error) {
 	return nil, nil
 }
+
+type mockProofHandler struct {
+	vcCh chan *verifiable.Credential
+}
+
+func (m *mockProofHandler) RequestProofs(vc *verifiable.Credential, _ []string) error {
+	m.vcCh <- vc
+
+	return nil
+}
+
+type mockTxnGraph struct {
+	Err error
+}
+
+func (m *mockTxnGraph) Add(vc *verifiable.Credential) (string, error) {
+	if m.Err != nil {
+		return "", m.Err
+	}
+
+	return "cid", nil
+}
+
+type mockDidTxns struct {
+	Err error
+}
+
+func (m *mockDidTxns) Add(_ []string, _ string) error {
+	if m.Err != nil {
+		return m.Err
+	}
+
+	return nil
+}
+
+func (m *mockDidTxns) Last(did string) (string, error) {
+	return "cid", nil
+}
+
+//nolint:gochecknoglobals,lll
+var anchorCred = `
+{
+	"@context": [
+		"https://www.w3.org/2018/credentials/v1"
+	],
+	"credentialSubject": {
+		"anchorString": "1.QmaevShHgc5s7bNnGKkQ98BdaKDNrsCTUV6rcwHr522tQB",
+		"namespace": "did:sidetree",
+		"previousTransactions": {
+		"EiBAnjPBzHqAA-yONCU1HbGln-I0T-ZUPSIkkYAM6EwKKQ": "QmPEVPudBXM5XCoxoNUQiV466e7vD4XowohU8nRAhKJZ6f"
+		},
+		"version": 0
+	},
+	"id": "http://peer1.com/vc/85ef42f6-1019-40cc-ab3a-2b477681f5d8",
+	"issuanceDate": "2021-03-10T16:34:17.9767297Z",
+	"issuer": "http://peer1.com",
+	"proof": {
+		"created": "2021-03-10T16:34:17.9799878Z",
+		"domain": "domain.com",
+		"jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..yRt-VlWPDRq0jX-5iMYSfugJspbtmXZn3a9L011w8LI22WzpFZ5YQCTz6B09Stonywg_Xe6fwygG3IPQ5jreBg",
+		"proofPurpose": "assertionMethod",
+		"type": "Ed25519Signature2018",
+		"verificationMethod": "did:web:abc#vaK33R-2ssibOOf2CS0RceLeT61Z2hpskHuEvDW7Hq0"
+	},
+	"type": "VerifiableCredential"
+}`

--- a/pkg/didtxnref/memdidtxnref/refs.go
+++ b/pkg/didtxnref/memdidtxnref/refs.go
@@ -24,11 +24,14 @@ func New() *MemDidTxnRef {
 }
 
 // Add adds cid (transaction reference) to the list of transaction references that have been seen for this did.
-func (ref *MemDidTxnRef) Add(suffix, cid string) error {
+func (ref *MemDidTxnRef) Add(suffixes []string, cid string) error {
 	ref.Lock()
 	defer ref.Unlock()
 
-	ref.m[suffix] = append(ref.m[suffix], cid)
+	// update global did/txn references
+	for _, suffix := range suffixes {
+		ref.m[suffix] = append(ref.m[suffix], cid)
+	}
 
 	return nil
 }

--- a/pkg/didtxnref/memdidtxnref/refs_test.go
+++ b/pkg/didtxnref/memdidtxnref/refs_test.go
@@ -15,7 +15,7 @@ import (
 func TestMemDidTxnRef_Add(t *testing.T) {
 	refs := New()
 
-	err := refs.Add("did", "cid")
+	err := refs.Add([]string{"did"}, "cid")
 	require.NoError(t, err)
 }
 
@@ -23,7 +23,7 @@ func TestMemDidTxnRef_Get(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		refs := New()
 
-		err := refs.Add("did", "cid")
+		err := refs.Add([]string{"did"}, "cid")
 		require.NoError(t, err)
 
 		didTxnRefs, err := refs.Get("did")
@@ -37,5 +37,26 @@ func TestMemDidTxnRef_Get(t *testing.T) {
 		didTxnRefs, err := refs.Get("non-existent")
 		require.Error(t, err)
 		require.Nil(t, didTxnRefs)
+	})
+}
+
+func TestMemDidTxnRef_Last(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		refs := New()
+
+		err := refs.Add([]string{"did"}, "cid")
+		require.NoError(t, err)
+
+		last, err := refs.Last("did")
+		require.NoError(t, err)
+		require.Equal(t, last, "cid")
+	})
+
+	t.Run("error - did transaction references not found", func(t *testing.T) {
+		refs := New()
+
+		last, err := refs.Last("non-existent")
+		require.Error(t, err)
+		require.Empty(t, last)
 	})
 }

--- a/pkg/versions/1_0/txnprocessor/txnprocessor.go
+++ b/pkg/versions/1_0/txnprocessor/txnprocessor.go
@@ -92,7 +92,7 @@ func (p *TxnProcessor) processTxnOperations(txnOps []*operation.AnchoredOperatio
 			// TODO: This should not happen if we actively 'observe' batch writers
 			// however if can happen if observer starts starts observing new system and it is not done in order
 			// for now reject this case
-			return fmt.Errorf("discrepancy between transactions in the graph and anchored operations for did: %s", op.UniqueSuffix) //nolint:lll
+			return fmt.Errorf("discrepancy between transactions in the graph[%d] and anchored operations[%d] for did: %s", len(didRefs), len(opsSoFar), op.UniqueSuffix) //nolint:lll
 		}
 
 		// TODO: Should we check that anchored operation reference matches anchored graph

--- a/pkg/versions/1_0/txnprocessor/txnprocessor_test.go
+++ b/pkg/versions/1_0/txnprocessor/txnprocessor_test.go
@@ -81,7 +81,8 @@ func TestProcessTxnOperations(t *testing.T) {
 		err := p.processTxnOperations([]*operation.AnchoredOperation{{UniqueSuffix: "abc"}},
 			txn.SidetreeTxn{AnchorString: anchorString})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "discrepancy between transactions in the graph and anchored operations for did: abc")
+		require.Contains(t, err.Error(),
+			"discrepancy between transactions in the graph[2] and anchored operations[0] for did: abc")
 	})
 
 	t.Run("test success", func(t *testing.T) {


### PR DESCRIPTION
Anchor Writer must:
- request proofs for anchored credential from proof handler
- listen for witnessed anchored credential
- save witnessed anchored credentials to anchored credentials store

Also, add reference for create operation to previous transactions in anchor credential (it will be empty string)

Closes #107

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>