### PR TITLE
feat: Assemble witness list for Sidetree batch

### DIFF
--- a/cmd/orb-server/go.mod
+++ b/cmd/orb-server/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.6-0.20210127161542-9e174750f523
 	github.com/trustbloc/orb v0.0.0
-	github.com/trustbloc/sidetree-core-go v0.6.0
+	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210316191128-55e756ced266
 )
 
 replace github.com/trustbloc/orb => ../..

--- a/cmd/orb-server/go.sum
+++ b/cmd/orb-server/go.sum
@@ -902,8 +902,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
 github.com/trustbloc/edge-core v0.1.6-0.20210127161542-9e174750f523 h1:c4WEzovD+23hJ9cIK8Qsvg0JQ3U1Z4Z2Zlo+AEUjoI0=
 github.com/trustbloc/edge-core v0.1.6-0.20210127161542-9e174750f523/go.mod h1:/NWjplIPfzEmgoRTmUMnuHJUDKAGMWp2kQTRlUpajvE=
-github.com/trustbloc/sidetree-core-go v0.6.0 h1:fXXVcaTm5Ceq1FQYSaynmvgP4xCh4AO4paMOXTakG5E=
-github.com/trustbloc/sidetree-core-go v0.6.0/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210316191128-55e756ced266 h1:miSsIFYdUT+7jlxDfQjZgTlx52UVKDD4VvVFjNyw7Hw=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210316191128-55e756ced266/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -219,12 +219,15 @@ func startOrbServices(parameters *orbParameters) error {
 		return fmt.Errorf("failed to create vc store: %s", err.Error())
 	}
 
+	opProcessor := processor.New(parameters.didNamespace, opStore, pc)
+
 	anchorWriterProviders := &writer.Providers{
 		TxnGraph:     txnGraph,
 		DidTxns:      didTxns,
 		TxnBuilder:   vcBuilder,
 		Store:        vcStore,
 		ProofHandler: proofs.New(&proofs.Providers{}, vcCh),
+		OpProcessor:  opProcessor,
 	}
 
 	anchorWriter := writer.New("did:sidetree", anchorWriterProviders, sidetreeTxnCh, vcCh)
@@ -254,7 +257,7 @@ func startOrbServices(parameters *orbParameters) error {
 		parameters.didAliases,
 		pc,
 		batchWriter,
-		processor.New(parameters.didNamespace, opStore, pc),
+		opProcessor,
 	)
 
 	apServiceIRI, err := url.Parse(fmt.Sprintf("https://%s%s", parameters.hostURL, activityPubServicesPath))

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.6-0.20210127161542-9e174750f523
-	github.com/trustbloc/sidetree-core-go v0.6.0
+	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210316191128-55e756ced266
 )
 
 go 1.15

--- a/go.sum
+++ b/go.sum
@@ -856,8 +856,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
 github.com/trustbloc/edge-core v0.1.6-0.20210127161542-9e174750f523 h1:c4WEzovD+23hJ9cIK8Qsvg0JQ3U1Z4Z2Zlo+AEUjoI0=
 github.com/trustbloc/edge-core v0.1.6-0.20210127161542-9e174750f523/go.mod h1:/NWjplIPfzEmgoRTmUMnuHJUDKAGMWp2kQTRlUpajvE=
-github.com/trustbloc/sidetree-core-go v0.6.0 h1:fXXVcaTm5Ceq1FQYSaynmvgP4xCh4AO4paMOXTakG5E=
-github.com/trustbloc/sidetree-core-go v0.6.0/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210316191128-55e756ced266 h1:miSsIFYdUT+7jlxDfQjZgTlx52UVKDD4VvVFjNyw7Hw=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210316191128-55e756ced266/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/mr-tron/base58 v1.1.3
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.4.2
-	github.com/trustbloc/sidetree-core-go v0.6.0
+	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210316191128-55e756ced266
 )
 
 go 1.15

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -176,8 +176,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/sidetree-core-go v0.6.0 h1:fXXVcaTm5Ceq1FQYSaynmvgP4xCh4AO4paMOXTakG5E=
-github.com/trustbloc/sidetree-core-go v0.6.0/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210316191128-55e756ced266 h1:miSsIFYdUT+7jlxDfQjZgTlx52UVKDD4VvVFjNyw7Hw=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210316191128-55e756ced266/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=


### PR DESCRIPTION
This list contains anchor origins for all dids in the Sidetree batch. Create and recover operations have anchor origins referenced in operation while for update and deactivate  we have to 'resolve' did in order to figure out anchor origin.

Closes #109

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>