### PR TITLE
chore: Add system witness list

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -221,12 +221,19 @@ func startOrbServices(parameters *orbParameters) error {
 
 	opProcessor := processor.New(parameters.didNamespace, opStore, pc)
 
+	apServiceIRI, err := url.Parse(fmt.Sprintf("https://%s%s", parameters.hostURL, activityPubServicesPath))
+	if err != nil {
+		return fmt.Errorf("invalid service IRI: %s", err.Error())
+	}
+
+	proofHandler := proofs.New(&proofs.Providers{}, vcCh, apServiceIRI)
+
 	anchorWriterProviders := &writer.Providers{
 		TxnGraph:     txnGraph,
 		DidTxns:      didTxns,
 		TxnBuilder:   vcBuilder,
 		Store:        vcStore,
-		ProofHandler: proofs.New(&proofs.Providers{}, vcCh),
+		ProofHandler: proofHandler,
 		OpProcessor:  opProcessor,
 	}
 
@@ -259,11 +266,6 @@ func startOrbServices(parameters *orbParameters) error {
 		batchWriter,
 		opProcessor,
 	)
-
-	apServiceIRI, err := url.Parse(fmt.Sprintf("https://%s%s", parameters.hostURL, activityPubServicesPath))
-	if err != nil {
-		return fmt.Errorf("invalid service IRI: %s", err.Error())
-	}
 
 	apConfig := &apservice.Config{
 		ServiceEndpoint: activityPubServicesPath,

--- a/pkg/anchor/proofs/proofs_test.go
+++ b/pkg/anchor/proofs/proofs_test.go
@@ -7,18 +7,24 @@ SPDX-License-Identifier: Apache-2.0
 package proofs
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	"github.com/stretchr/testify/require"
 )
 
+const activityPubURL = "http://localhost/activityPubURL"
+
 func TestNew(t *testing.T) {
 	var vcChan chan *verifiable.Credential
 
 	providers := &Providers{}
 
-	c := New(providers, vcChan)
+	apServiceIRI, err := url.Parse(activityPubURL)
+	require.NoError(t, err)
+
+	c := New(providers, vcChan, apServiceIRI)
 	require.NotNil(t, c)
 }
 
@@ -28,7 +34,10 @@ func TestClient_GetProofs(t *testing.T) {
 
 		providers := &Providers{}
 
-		c := New(providers, vcCh)
+		apServiceIRI, err := url.Parse(activityPubURL)
+		require.NoError(t, err)
+
+		c := New(providers, vcCh, apServiceIRI)
 
 		anchorVC, err := verifiable.ParseCredential([]byte(anchorCred), verifiable.WithDisabledProofCheck())
 		require.NoError(t, err)


### PR DESCRIPTION
There is no need for additional server configuration parameter. System witness list is an activity pub collection that is configured as activityPubURL + "/server/orb/witnesses". Add this 'system' witness list to the list of witnesses collected from Sidetree batch before creating an ActivityPub offer.

Closes #114

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>