### PR TITLE
feat: '/followers' REST endpoint

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -288,6 +288,12 @@ func startOrbServices(parameters *orbParameters) error {
 		return fmt.Errorf("failed to create ActivityPub service: %s", err.Error())
 	}
 
+	apCfg := &aphandler.Config{
+		BasePath:   activityPubServicesPath,
+		ServiceIRI: apServiceIRI,
+		PageSize:   100, // TODO: Make configurable
+	}
+
 	httpServer := httpserver.New(
 		parameters.hostURL,
 		parameters.tlsCertificate,
@@ -296,7 +302,8 @@ func startOrbServices(parameters *orbParameters) error {
 		diddochandler.NewUpdateHandler(baseUpdatePath, didDocHandler, pc),
 		diddochandler.NewResolveHandler(baseResolvePath, didDocHandler),
 		activityPubService.InboxHTTPHandler(),
-		aphandler.NewServices(activityPubServicesPath, apServiceIRI, apStore),
+		aphandler.NewServices(apCfg, apStore),
+		aphandler.NewFollowers(apCfg, apStore),
 	)
 
 	srv := &HTTPServer{

--- a/pkg/activitypub/resthandler/followershandler.go
+++ b/pkg/activitypub/resthandler/followershandler.go
@@ -1,0 +1,165 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resthandler
+
+import (
+	"net/http"
+
+	"github.com/trustbloc/orb/pkg/activitypub/store/spi"
+	"github.com/trustbloc/orb/pkg/activitypub/store/storeutil"
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+)
+
+// Followers implements the 'followers' REST handler that retrieves a service's list of followers.
+type Followers struct {
+	*handler
+}
+
+// NewFollowers returns a new 'followers' REST handler.
+func NewFollowers(cfg *Config, activityStore spi.Store) *Followers {
+	h := &Followers{}
+
+	h.handler = newHandler(FollowersPath, cfg, activityStore, h.handle, pageParam, pageNumParam)
+
+	return h
+}
+
+func (h *Followers) handle(w http.ResponseWriter, req *http.Request) {
+	if h.isPaging(req) {
+		h.handleFollowersPage(w, req)
+	} else {
+		h.handleFollowers(w, req)
+	}
+}
+
+func (h *Followers) handleFollowers(rw http.ResponseWriter, _ *http.Request) {
+	followers, err := h.getFollowers()
+	if err != nil {
+		logger.Errorf("[%s] Error retrieving followers for service IRI [%s]: %s",
+			h.endpoint, h.ServiceIRI, err)
+
+		h.writeResponse(rw, http.StatusInternalServerError, nil)
+
+		return
+	}
+
+	followersCollBytes, err := h.marshal(followers)
+	if err != nil {
+		logger.Errorf("[%s] Unable to marshal followers collection for service IRI [%s]: %s",
+			h.endpoint, h.ServiceIRI, err)
+
+		h.writeResponse(rw, http.StatusInternalServerError, nil)
+
+		return
+	}
+
+	h.writeResponse(rw, http.StatusOK, followersCollBytes)
+}
+
+func (h *Followers) handleFollowersPage(rw http.ResponseWriter, req *http.Request) {
+	var page *vocab.CollectionPageType
+
+	var err error
+
+	pageNum, ok := h.getPageNum(req)
+	if ok {
+		page, err = h.getFollowersPage(spi.WithPageSize(h.PageSize), spi.WithPageNum(pageNum))
+	} else {
+		page, err = h.getFollowersPage(spi.WithPageSize(h.PageSize))
+	}
+
+	if err != nil {
+		logger.Errorf("[%s] Error retrieving page for service IRI [%s]: %s",
+			h.endpoint, h.ServiceIRI, err)
+
+		h.writeResponse(rw, http.StatusInternalServerError, nil)
+
+		return
+	}
+
+	pageBytes, err := h.marshal(page)
+	if err != nil {
+		logger.Errorf("[%s] Unable to marshal followers page for service IRI [%s]: %s",
+			h.endpoint, h.ServiceIRI, err)
+
+		h.writeResponse(rw, http.StatusInternalServerError, nil)
+
+		return
+	}
+
+	h.writeResponse(rw, http.StatusOK, pageBytes)
+}
+
+func (h *Followers) getFollowers() (*vocab.CollectionType, error) {
+	it, err := h.activityStore.QueryReferences(spi.Follower,
+		spi.NewCriteria(
+			spi.WithActorIRI(h.ServiceIRI),
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	defer it.Close()
+
+	firstURL, err := h.getPageURL(-1)
+	if err != nil {
+		return nil, err
+	}
+
+	lastURL, err := h.getPageURL(getLastPageNum(it.TotalItems(), h.PageSize, spi.SortAscending))
+	if err != nil {
+		return nil, err
+	}
+
+	return vocab.NewCollection(nil,
+		vocab.WithContext(vocab.ContextActivityStreams),
+		vocab.WithID(h.id),
+		vocab.WithFirst(firstURL),
+		vocab.WithLast(lastURL),
+		vocab.WithTotalItems(it.TotalItems()),
+	), nil
+}
+
+func (h *Followers) getFollowersPage(opts ...spi.QueryOpt) (*vocab.CollectionPageType, error) {
+	it, err := h.activityStore.QueryReferences(
+		spi.Follower,
+		spi.NewCriteria(spi.WithActorIRI(h.ServiceIRI)),
+		opts...,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	defer it.Close()
+
+	options := storeutil.GetQueryOptions(opts...)
+
+	refs, err := storeutil.ReadReferences(it, options.PageSize)
+	if err != nil {
+		return nil, err
+	}
+
+	items := make([]*vocab.ObjectProperty, len(refs))
+
+	for i, ref := range refs {
+		items[i] = vocab.NewObjectProperty(vocab.WithIRI(ref))
+	}
+
+	id, prev, next, err := h.getIDPrevNextURL(it.TotalItems(), options)
+	if err != nil {
+		return nil, err
+	}
+
+	return vocab.NewCollectionPage(items,
+		vocab.WithContext(vocab.ContextActivityStreams),
+		vocab.WithID(id),
+		vocab.WithPrev(prev),
+		vocab.WithNext(next),
+		vocab.WithTotalItems(it.TotalItems()),
+	), nil
+}

--- a/pkg/activitypub/resthandler/followershandler_test.go
+++ b/pkg/activitypub/resthandler/followershandler_test.go
@@ -1,0 +1,311 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resthandler
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/pkg/activitypub/service/mocks"
+	"github.com/trustbloc/orb/pkg/activitypub/store/memstore"
+	"github.com/trustbloc/orb/pkg/activitypub/store/spi"
+)
+
+const followersURL = "https://example.com/services/orb/followers"
+
+func TestNewFollowers(t *testing.T) {
+	serviceIRI, err := url.Parse(serviceURL)
+	require.NoError(t, err)
+
+	cfg := &Config{
+		BasePath:   basePath,
+		ServiceIRI: serviceIRI,
+		PageSize:   4,
+	}
+
+	h := NewFollowers(cfg, memstore.New(""))
+	require.NotNil(t, h)
+	require.Equal(t, "/services/orb/followers", h.Path())
+	require.Equal(t, http.MethodGet, h.Method())
+	require.NotNil(t, h.Handler())
+}
+
+func TestFollowers_Handler(t *testing.T) {
+	serviceIRI, err := url.Parse(serviceURL)
+	require.NoError(t, err)
+
+	followers := newMockURIs(19, func(i int) string { return fmt.Sprintf("https://example%d.com/services/orb", i) })
+
+	activityStore := memstore.New("")
+
+	for _, ref := range followers {
+		require.NoError(t, activityStore.AddReference(spi.Follower, serviceIRI, ref))
+	}
+
+	cfg := &Config{
+		BasePath:   basePath,
+		ServiceIRI: serviceIRI,
+		PageSize:   4,
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		h := NewFollowers(cfg, activityStore)
+		require.NotNil(t, h)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, followersURL, nil)
+
+		h.handle(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusOK, result.StatusCode)
+
+		respBytes, err := ioutil.ReadAll(result.Body)
+		require.NoError(t, err)
+
+		t.Logf("%s", respBytes)
+
+		require.Equal(t, getCanonical(t, followersJSON), getCanonical(t, string(respBytes)))
+		require.NoError(t, result.Body.Close())
+	})
+
+	t.Run("Store error", func(t *testing.T) {
+		cfg := &Config{
+			ServiceIRI: serviceIRI,
+			PageSize:   4,
+		}
+
+		errExpected := fmt.Errorf("injected store error")
+
+		s := &mocks.ActivityStore{}
+		s.QueryReferencesReturns(nil, errExpected)
+
+		h := NewFollowers(cfg, s)
+		require.NotNil(t, h)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, followersURL, nil)
+
+		h.handle(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusInternalServerError, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+	})
+
+	t.Run("Marshal error", func(t *testing.T) {
+		cfg := &Config{
+			ServiceIRI: serviceIRI,
+			PageSize:   4,
+		}
+
+		h := NewFollowers(cfg, activityStore)
+		require.NotNil(t, h)
+
+		errExpected := fmt.Errorf("injected marshal error")
+
+		h.marshal = func(v interface{}) ([]byte, error) {
+			return nil, errExpected
+		}
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, followersURL, nil)
+
+		h.handle(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusInternalServerError, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+	})
+}
+
+func TestFollowers_PageHandler(t *testing.T) {
+	serviceIRI, err := url.Parse(serviceURL)
+	require.NoError(t, err)
+
+	followers := newMockURIs(19, func(i int) string { return fmt.Sprintf("https://example%d.com/services/orb", i+1) })
+
+	activityStore := memstore.New("")
+
+	for _, ref := range followers {
+		require.NoError(t, activityStore.AddReference(spi.Follower, serviceIRI, ref))
+	}
+
+	t.Run("First page -> Success", func(t *testing.T) {
+		handleFollowersRequest(t, serviceIRI, activityStore, "true", "", followersFirstPageJSON)
+	})
+
+	t.Run("Page by num -> Success", func(t *testing.T) {
+		handleFollowersRequest(t, serviceIRI, activityStore, "true", "3", followersPage3JSON)
+	})
+
+	t.Run("Page num too large -> Success", func(t *testing.T) {
+		handleFollowersRequest(t, serviceIRI, activityStore, "true", "30", followersPageTooLargeJSON)
+	})
+
+	t.Run("Last page -> Success", func(t *testing.T) {
+		handleFollowersRequest(t, serviceIRI, activityStore, "true", "4", followersLastPageJSON)
+	})
+
+	t.Run("Invalid page-num -> Success", func(t *testing.T) {
+		handleFollowersRequest(t, serviceIRI, activityStore, "true", "invalid", followersFirstPageJSON)
+	})
+
+	t.Run("Invalid page -> Success", func(t *testing.T) {
+		handleFollowersRequest(t, serviceIRI, activityStore, "invalid", "3", followersJSON)
+	})
+
+	t.Run("Store error", func(t *testing.T) {
+		errExpected := fmt.Errorf("injected store error")
+
+		s := &mocks.ActivityStore{}
+		s.QueryReferencesReturns(nil, errExpected)
+
+		cfg := &Config{
+			ServiceIRI: serviceIRI,
+			PageSize:   4,
+		}
+
+		h := NewFollowers(cfg, s)
+		require.NotNil(t, h)
+
+		restorePaging := setPaging(h.handler, "true", "0")
+		defer restorePaging()
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, followersURL, nil)
+
+		h.handle(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusInternalServerError, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+	})
+
+	t.Run("Marshal error", func(t *testing.T) {
+		cfg := &Config{
+			ServiceIRI: serviceIRI,
+			PageSize:   4,
+		}
+
+		h := NewFollowers(cfg, activityStore)
+		require.NotNil(t, h)
+
+		restorePaging := setPaging(h.handler, "true", "0")
+		defer restorePaging()
+
+		errExpected := fmt.Errorf("injected marshal error")
+
+		h.marshal = func(v interface{}) ([]byte, error) {
+			return nil, errExpected
+		}
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, followersURL, nil)
+
+		h.handle(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusInternalServerError, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+	})
+}
+
+func handleFollowersRequest(t *testing.T, serviceIRI *url.URL, as spi.Store, page, pageNum, expected string) {
+	cfg := &Config{
+		ServiceIRI: serviceIRI,
+		PageSize:   4,
+	}
+
+	h := NewFollowers(cfg, as)
+	require.NotNil(t, h)
+
+	restorePaging := setPaging(h.handler, page, pageNum)
+	defer restorePaging()
+
+	rw := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, followersURL, nil)
+
+	h.handle(rw, req)
+
+	result := rw.Result()
+	require.Equal(t, http.StatusOK, result.StatusCode)
+
+	respBytes, err := ioutil.ReadAll(result.Body)
+	require.NoError(t, err)
+	require.NoError(t, result.Body.Close())
+
+	t.Logf("%s", respBytes)
+
+	require.Equal(t, getCanonical(t, expected), getCanonical(t, string(respBytes)))
+}
+
+const (
+	followersJSON = `{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "id": "https://example1.com/services/orb/followers",
+  "type": "Collection",
+  "totalItems": 19,
+  "first": "https://example1.com/services/orb/followers?page=true",
+  "last": "https://example1.com/services/orb/followers?page=true&page-num=4"
+}`
+
+	followersFirstPageJSON = `{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "id": "https://example1.com/services/orb/followers?page=true&page-num=0",
+  "type": "CollectionPage",
+  "totalItems": 19,
+  "next": "https://example1.com/services/orb/followers?page=true&page-num=1",
+  "items": [
+    "https://example1.com/services/orb",
+    "https://example2.com/services/orb",
+    "https://example3.com/services/orb",
+    "https://example4.com/services/orb"
+  ]
+}`
+
+	followersLastPageJSON = `{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "id": "https://example1.com/services/orb/followers?page=true&page-num=4",
+  "type": "CollectionPage",
+  "totalItems": 19,
+  "prev": "https://example1.com/services/orb/followers?page=true&page-num=3",
+  "items": [
+    "https://example17.com/services/orb",
+    "https://example18.com/services/orb",
+    "https://example19.com/services/orb"
+  ]
+}`
+
+	followersPage3JSON = `{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "id": "https://example1.com/services/orb/followers?page=true&page-num=3",
+  "type": "CollectionPage",
+  "totalItems": 19,
+  "next": "https://example1.com/services/orb/followers?page=true&page-num=4",
+  "prev": "https://example1.com/services/orb/followers?page=true&page-num=2",
+  "items": [
+    "https://example13.com/services/orb",
+    "https://example14.com/services/orb",
+    "https://example15.com/services/orb",
+    "https://example16.com/services/orb"
+  ]
+}`
+	followersPageTooLargeJSON = `{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "id": "https://example1.com/services/orb/followers?page=true&page-num=30",
+  "type": "CollectionPage",
+  "totalItems": 19,
+  "prev": "https://example1.com/services/orb/followers?page=true&page-num=4"
+}`
+)

--- a/pkg/activitypub/resthandler/resthandler.go
+++ b/pkg/activitypub/resthandler/resthandler.go
@@ -8,8 +8,10 @@ package resthandler
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 
 	"github.com/trustbloc/edge-core/pkg/log"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/common"
@@ -19,22 +21,50 @@ import (
 
 var logger = log.New("activitypub_resthandler")
 
+const (
+	// FollowersPath specifies the service's 'followers' endpoint.
+	FollowersPath = "/followers"
+)
+
+const (
+	pageParam    = "page"
+	pageNumParam = "page-num"
+)
+
+// Config contains configuration parameters for the handler.
+type Config struct {
+	BasePath   string
+	ServiceIRI *url.URL
+	PageSize   int
+}
+
 type handler struct {
+	*Config
+
+	id            string
 	endpoint      string
+	params        map[string]string
 	activityStore spi.Store
-	serviceIRI    *url.URL
 	handler       common.HTTPRequestHandler
 	marshal       func(v interface{}) ([]byte, error)
 	writeResponse func(w http.ResponseWriter, status int, body []byte)
+	getParams     func(req *http.Request) map[string][]string
 }
 
-func newHandler(endpoint string, serviceIRI *url.URL, s spi.Store, h common.HTTPRequestHandler) *handler {
+func newHandler(endpoint string, cfg *Config, s spi.Store, h common.HTTPRequestHandler, params ...string) *handler {
+	id := fmt.Sprintf("%s%s", cfg.ServiceIRI, endpoint)
+
 	return &handler{
-		endpoint:      endpoint,
+		Config:        cfg,
+		id:            id,
+		endpoint:      fmt.Sprintf("%s%s", cfg.BasePath, endpoint),
+		params:        paramsBuilder(params).build(),
 		activityStore: s,
-		serviceIRI:    serviceIRI,
 		handler:       h,
 		marshal:       json.Marshal,
+		getParams: func(req *http.Request) map[string][]string {
+			return req.URL.Query()
+		},
 		writeResponse: func(w http.ResponseWriter, status int, body []byte) {
 			if len(body) > 0 {
 				if _, err := w.Write(body); err != nil {
@@ -56,6 +86,11 @@ func (h *handler) Path() string {
 	return h.endpoint
 }
 
+// Params returns the accepted parameters.
+func (h *handler) Params() map[string]string {
+	return h.params
+}
+
 // Method returns the HTTP method, which is always GET.
 func (h *handler) Method() string {
 	return http.MethodGet
@@ -65,4 +100,189 @@ func (h *handler) Method() string {
 // This handler must be registered with an HTTP server.
 func (h *handler) Handler() common.HTTPRequestHandler {
 	return h.handler
+}
+
+func (h *handler) getPageID(pageNum int) string {
+	if pageNum >= 0 {
+		return fmt.Sprintf("%s?%s=true&%s=%d", h.id, pageParam, pageNumParam, pageNum)
+	}
+
+	return fmt.Sprintf("%s?%s=true", h.id, pageParam)
+}
+
+func (h *handler) getPageURL(pageNum int) (*url.URL, error) {
+	pageID := h.getPageID(pageNum)
+
+	pageURL, err := url.Parse(pageID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid 'page' URL [%s]: %w", pageID, err)
+	}
+
+	return pageURL, nil
+}
+
+func (h *handler) getCurrentPrevNext(totalItems int, options *spi.QueryOptions) (int, int, int) {
+	first := getFirstPageNum(totalItems, options.PageSize, options.SortOrder)
+	last := getLastPageNum(totalItems, options.PageSize, options.SortOrder)
+
+	var current int
+	if options.PageNumber >= 0 {
+		current = options.PageNumber
+	} else {
+		current = first
+	}
+
+	var prev, next int
+
+	if options.SortOrder == spi.SortDescending {
+		prev, next = getPrevNextDescending(current, first, last)
+	} else {
+		prev, next = getPrevNextAscending(current, first, last)
+	}
+
+	return current, prev, next
+}
+
+func (h *handler) getIDPrevNextURL(totalItems int, options *spi.QueryOptions) (string, *url.URL, *url.URL, error) {
+	current, prev, next := h.getCurrentPrevNext(totalItems, options)
+
+	var err error
+
+	var nextURL *url.URL
+
+	var prevURL *url.URL
+
+	if prev >= 0 {
+		prevURL, err = h.getPageURL(prev)
+		if err != nil {
+			return "", nil, nil, err
+		}
+	}
+
+	if next >= 0 {
+		nextURL, err = h.getPageURL(next)
+		if err != nil {
+			return "", nil, nil, err
+		}
+	}
+
+	return h.getPageID(current), prevURL, nextURL, nil
+}
+
+func (h *handler) isPaging(req *http.Request) bool {
+	return h.paramAsBool(req, pageParam)
+}
+
+func (h *handler) getPageNum(req *http.Request) (int, bool) {
+	return h.paramAsInt(req, pageNumParam)
+}
+
+func (h *handler) paramAsInt(req *http.Request, param string) (int, bool) {
+	params := h.getParams(req)
+
+	values := params[param]
+	if len(values) == 0 || values[0] == "" {
+		return 0, false
+	}
+
+	size, err := strconv.Atoi(values[0])
+	if err != nil {
+		logger.Debugf("Invalid value for parameter [%s]: %s", param, err)
+
+		return 0, false
+	}
+
+	return size, true
+}
+
+func (h *handler) paramAsBool(req *http.Request, param string) bool {
+	params := h.getParams(req)
+
+	values := params[param]
+	if len(values) == 0 || values[0] == "" {
+		return false
+	}
+
+	b, err := strconv.ParseBool(values[0])
+	if err != nil {
+		logger.Debugf("Invalid value for parameter [%s]: %s", param, err)
+
+		return false
+	}
+
+	return b
+}
+
+func getPrevNextAscending(current, first, last int) (int, int) {
+	prev := -1
+	next := -1
+
+	if current < last {
+		next = current + 1
+	}
+
+	if current > first {
+		if current > last {
+			prev = last
+		} else {
+			prev = current - 1
+		}
+	}
+
+	return prev, next
+}
+
+func getPrevNextDescending(current, first, last int) (int, int) {
+	prev := -1
+	next := -1
+
+	if current > last {
+		if current > first {
+			next = first
+		} else {
+			next = current - 1
+		}
+	}
+
+	if current < first {
+		prev = current + 1
+	}
+
+	return prev, next
+}
+
+func getFirstPageNum(totalItems, pageSize int, sortOrder spi.SortOrder) int {
+	if sortOrder == spi.SortAscending {
+		return 0
+	}
+
+	if totalItems%pageSize > 0 {
+		return totalItems / pageSize
+	}
+
+	return totalItems/pageSize - 1
+}
+
+func getLastPageNum(totalItems, pageSize int, sortOrder spi.SortOrder) int {
+	if sortOrder == spi.SortDescending {
+		return 0
+	}
+
+	if totalItems%pageSize > 0 {
+		return totalItems / pageSize
+	}
+
+	return totalItems/pageSize - 1
+}
+
+type paramsBuilder []string
+
+func (p paramsBuilder) build() map[string]string {
+	m := make(map[string]string)
+
+	for _, p := range p {
+		m[p] = fmt.Sprintf("{%s}", p)
+	}
+
+	return m
 }

--- a/pkg/activitypub/resthandler/resthandler_test.go
+++ b/pkg/activitypub/resthandler/resthandler_test.go
@@ -16,22 +16,258 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
 
 	"github.com/trustbloc/orb/pkg/activitypub/store/memstore"
+	"github.com/trustbloc/orb/pkg/activitypub/store/spi"
 )
 
 func TestNewHandler(t *testing.T) {
-	const endpoint = "/services/orb"
-
 	serviceIRI, err := url.Parse(serviceURL)
 	require.NoError(t, err)
 
-	h := newHandler(endpoint, serviceIRI, memstore.New(""),
+	cfg := &Config{
+		BasePath:   basePath,
+		ServiceIRI: serviceIRI,
+		PageSize:   4,
+	}
+
+	h := newHandler("", cfg, memstore.New(""),
 		func(writer http.ResponseWriter, request *http.Request) {},
+		pageNumParam, pageParam,
 	)
 
 	require.NotNil(t, h)
-	require.Equal(t, endpoint, h.Path())
+	require.Equal(t, basePath, h.Path())
 	require.Equal(t, http.MethodGet, h.Method())
 	require.NotNil(t, h.Handler())
+	require.Equal(t, "{page}", h.Params()[pageParam])
+	require.Equal(t, "{page-num}", h.Params()[pageNumParam])
+}
+
+func TestGetFirstPageNum(t *testing.T) {
+	t.Run("Sort ascending", func(t *testing.T) {
+		require.Equal(t, 0, getFirstPageNum(10, 3, spi.SortAscending))
+	})
+
+	t.Run("Sort descending", func(t *testing.T) {
+		require.Equal(t, 0, getFirstPageNum(9, 20, spi.SortDescending))
+		require.Equal(t, 2, getFirstPageNum(9, 3, spi.SortDescending))
+		require.Equal(t, 3, getFirstPageNum(10, 3, spi.SortDescending))
+	})
+}
+
+func TestGetLastPageNum(t *testing.T) {
+	t.Run("Sort ascending", func(t *testing.T) {
+		require.Equal(t, 3, getLastPageNum(10, 3, spi.SortAscending))
+		require.Equal(t, 2, getLastPageNum(9, 3, spi.SortAscending))
+	})
+
+	t.Run("Sort descending", func(t *testing.T) {
+		require.Equal(t, 0, getLastPageNum(9, 20, spi.SortDescending))
+		require.Equal(t, 0, getLastPageNum(10, 3, spi.SortDescending))
+	})
+}
+
+func TestGetCurrentPrevNext(t *testing.T) {
+	serviceIRI, err := url.Parse(serviceURL)
+	require.NoError(t, err)
+
+	cfg := &Config{
+		BasePath:   basePath,
+		ServiceIRI: serviceIRI,
+		PageSize:   4,
+	}
+
+	h := newHandler("", cfg, memstore.New(""), nil)
+
+	t.Run("Sort ascending", func(t *testing.T) {
+		t.Run("No page-num", func(t *testing.T) {
+			current, prev, next := h.getCurrentPrevNext(10,
+				&spi.QueryOptions{
+					PageNumber: -1,
+					PageSize:   4,
+					SortOrder:  spi.SortAscending,
+				},
+			)
+			require.Equal(t, 0, current)
+			require.Equal(t, -1, prev)
+			require.Equal(t, 1, next)
+		})
+
+		t.Run("Page-num specified", func(t *testing.T) {
+			current, prev, next := h.getCurrentPrevNext(10,
+				&spi.QueryOptions{
+					PageNumber: 1,
+					PageSize:   4,
+					SortOrder:  spi.SortAscending,
+				},
+			)
+			require.Equal(t, 1, current)
+			require.Equal(t, 0, prev)
+			require.Equal(t, 2, next)
+		})
+
+		t.Run("Page-num too large", func(t *testing.T) {
+			current, prev, next := h.getCurrentPrevNext(10,
+				&spi.QueryOptions{
+					PageNumber: 10,
+					PageSize:   4,
+					SortOrder:  spi.SortAscending,
+				},
+			)
+			require.Equal(t, 10, current)
+			require.Equal(t, 2, prev)
+			require.Equal(t, -1, next)
+		})
+	})
+
+	t.Run("Sort descending", func(t *testing.T) {
+		t.Run("No page-num", func(t *testing.T) {
+			current, prev, next := h.getCurrentPrevNext(10,
+				&spi.QueryOptions{
+					PageNumber: -1,
+					PageSize:   4,
+					SortOrder:  spi.SortDescending,
+				},
+			)
+			require.Equal(t, 2, current)
+			require.Equal(t, -1, prev)
+			require.Equal(t, 1, next)
+		})
+
+		t.Run("Page-num specified", func(t *testing.T) {
+			current, prev, next := h.getCurrentPrevNext(10,
+				&spi.QueryOptions{
+					PageNumber: 1,
+					PageSize:   4,
+					SortOrder:  spi.SortDescending,
+				},
+			)
+			require.Equal(t, 1, current)
+			require.Equal(t, 2, prev)
+			require.Equal(t, 0, next)
+		})
+
+		t.Run("Page-num too large", func(t *testing.T) {
+			current, prev, next := h.getCurrentPrevNext(10,
+				&spi.QueryOptions{
+					PageNumber: 10,
+					PageSize:   4,
+					SortOrder:  spi.SortDescending,
+				},
+			)
+			require.Equal(t, 10, current)
+			require.Equal(t, -1, prev)
+			require.Equal(t, 2, next)
+		})
+	})
+}
+
+func TestGetIDPrevNextURL(t *testing.T) {
+	serviceIRI, err := url.Parse(serviceURL)
+	require.NoError(t, err)
+
+	cfg := &Config{
+		BasePath:   basePath,
+		ServiceIRI: serviceIRI,
+		PageSize:   4,
+	}
+
+	h := newHandler("", cfg, memstore.New(""), nil)
+
+	t.Run("Sort ascending", func(t *testing.T) {
+		t.Run("No page-num", func(t *testing.T) {
+			id, prev, next, err := h.getIDPrevNextURL(10,
+				&spi.QueryOptions{
+					PageNumber: -1,
+					PageSize:   4,
+					SortOrder:  spi.SortAscending,
+				},
+			)
+			require.NoError(t, err)
+			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=0", id)
+			require.Nil(t, prev)
+			require.NotNil(t, next)
+			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=1", next.String())
+		})
+
+		t.Run("Page-num specified", func(t *testing.T) {
+			id, prev, next, err := h.getIDPrevNextURL(10,
+				&spi.QueryOptions{
+					PageNumber: 1,
+					PageSize:   4,
+					SortOrder:  spi.SortAscending,
+				},
+			)
+			require.NoError(t, err)
+			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=1", id)
+			require.NotNil(t, prev)
+			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=0", prev.String())
+			require.NotNil(t, next)
+			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=2", next.String())
+		})
+
+		t.Run("Page-num too large", func(t *testing.T) {
+			id, prev, next, err := h.getIDPrevNextURL(10,
+				&spi.QueryOptions{
+					PageNumber: 10,
+					PageSize:   4,
+					SortOrder:  spi.SortAscending,
+				},
+			)
+			require.NoError(t, err)
+			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=10", id)
+			require.NotNil(t, prev)
+			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=2", prev.String())
+			require.Nil(t, next)
+		})
+	})
+
+	t.Run("Sort descending", func(t *testing.T) {
+		t.Run("No page-num", func(t *testing.T) {
+			id, prev, next, err := h.getIDPrevNextURL(10,
+				&spi.QueryOptions{
+					PageNumber: -1,
+					PageSize:   4,
+					SortOrder:  spi.SortDescending,
+				},
+			)
+			require.NoError(t, err)
+			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=2", id)
+			require.Nil(t, prev)
+			require.NotNil(t, next)
+			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=1", next.String())
+		})
+
+		t.Run("Page-num specified", func(t *testing.T) {
+			id, prev, next, err := h.getIDPrevNextURL(10,
+				&spi.QueryOptions{
+					PageNumber: 1,
+					PageSize:   4,
+					SortOrder:  spi.SortDescending,
+				},
+			)
+			require.NoError(t, err)
+			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=1", id)
+			require.NotNil(t, prev)
+			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=2", prev.String())
+			require.NotNil(t, next)
+			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=0", next.String())
+		})
+
+		t.Run("Page-num too large", func(t *testing.T) {
+			id, prev, next, err := h.getIDPrevNextURL(10,
+				&spi.QueryOptions{
+					PageNumber: 10,
+					PageSize:   4,
+					SortOrder:  spi.SortDescending,
+				},
+			)
+			require.NoError(t, err)
+			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=10", id)
+			require.Nil(t, prev)
+			require.NotNil(t, next)
+			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=2", next.String())
+		})
+	})
 }
 
 func getCanonical(t *testing.T, raw string) string {
@@ -53,4 +289,29 @@ func mustParseURL(raw string) *url.URL {
 	}
 
 	return u
+}
+
+func newMockURIs(num int, getURI func(i int) string) []*url.URL {
+	results := make([]*url.URL, num)
+
+	for i := 0; i < num; i++ {
+		results[i] = mustParseURL(getURI(i))
+	}
+
+	return results
+}
+
+func setPaging(h *handler, page, pageNum string) func() {
+	getParamsRestore := h.getParams
+
+	h.getParams = func(req *http.Request) map[string][]string {
+		return map[string][]string{
+			pageParam:    {page},
+			pageNumParam: {pageNum},
+		}
+	}
+
+	return func() {
+		h.getParams = getParamsRestore
+	}
 }

--- a/pkg/activitypub/resthandler/serviceshandler.go
+++ b/pkg/activitypub/resthandler/serviceshandler.go
@@ -8,7 +8,6 @@ package resthandler
 
 import (
 	"net/http"
-	"net/url"
 
 	"github.com/trustbloc/orb/pkg/activitypub/store/spi"
 )
@@ -19,18 +18,18 @@ type Services struct {
 }
 
 // NewServices returns a new 'services' REST handler.
-func NewServices(basePath string, serviceIRI *url.URL, activityStore spi.Store) *Services {
+func NewServices(cfg *Config, activityStore spi.Store) *Services {
 	h := &Services{}
 
-	h.handler = newHandler(basePath, serviceIRI, activityStore, h.handle)
+	h.handler = newHandler("", cfg, activityStore, h.handle)
 
 	return h
 }
 
 func (h *Services) handle(w http.ResponseWriter, _ *http.Request) {
-	service, err := h.activityStore.GetActor(h.serviceIRI)
+	service, err := h.activityStore.GetActor(h.ServiceIRI)
 	if err != nil {
-		logger.Errorf("[%s] Error retrieving service [%s]: %s", h.endpoint, h.serviceIRI, err)
+		logger.Errorf("[%s] Error retrieving service [%s]: %s", h.endpoint, h.ServiceIRI, err)
 
 		h.writeResponse(w, http.StatusInternalServerError, nil)
 
@@ -39,7 +38,7 @@ func (h *Services) handle(w http.ResponseWriter, _ *http.Request) {
 
 	serviceBytes, err := h.marshal(service)
 	if err != nil {
-		logger.Errorf("[%s] Unable to marshal service [%s]: %s", h.endpoint, h.serviceIRI, err)
+		logger.Errorf("[%s] Unable to marshal service [%s]: %s", h.endpoint, h.ServiceIRI, err)
 
 		h.writeResponse(w, http.StatusInternalServerError, nil)
 


### PR DESCRIPTION
Added a REST endpoint that returns a service's followers as a Collection or CollectionPage type. If the request does not include a 'page' parameter then a 'Collection' is returned that specifies the first and last page of the followers. If the request contains a 'page=true' parameter then a 'CollectionPage' is returned containing the IRI's of the followers for that page, along with the URLs of the previous and next page.

closes #95

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>