### PR TITLE
feat: '/following' REST endpoint

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -304,6 +304,7 @@ func startOrbServices(parameters *orbParameters) error {
 		activityPubService.InboxHTTPHandler(),
 		aphandler.NewServices(apCfg, apStore),
 		aphandler.NewFollowers(apCfg, apStore),
+		aphandler.NewFollowing(apCfg, apStore),
 	)
 
 	srv := &HTTPServer{

--- a/pkg/activitypub/resthandler/followhandler_test.go
+++ b/pkg/activitypub/resthandler/followhandler_test.go
@@ -40,6 +40,23 @@ func TestNewFollowers(t *testing.T) {
 	require.NotNil(t, h.Handler())
 }
 
+func TestNewFollowing(t *testing.T) {
+	serviceIRI, err := url.Parse(serviceURL)
+	require.NoError(t, err)
+
+	cfg := &Config{
+		BasePath:   basePath,
+		ServiceIRI: serviceIRI,
+		PageSize:   4,
+	}
+
+	h := NewFollowing(cfg, memstore.New(""))
+	require.NotNil(t, h)
+	require.Equal(t, "/services/orb/following", h.Path())
+	require.Equal(t, http.MethodGet, h.Method())
+	require.NotNil(t, h.Handler())
+}
+
 func TestFollowers_Handler(t *testing.T) {
 	serviceIRI, err := url.Parse(serviceURL)
 	require.NoError(t, err)

--- a/pkg/activitypub/resthandler/resthandler.go
+++ b/pkg/activitypub/resthandler/resthandler.go
@@ -24,6 +24,8 @@ var logger = log.New("activitypub_resthandler")
 const (
 	// FollowersPath specifies the service's 'followers' endpoint.
 	FollowersPath = "/followers"
+	// FollowingPath specifies the service's 'following' endpoint.
+	FollowingPath = "/following"
 )
 
 const (


### PR DESCRIPTION
Added a REST endpoint that returns the URIs that a service is following as a Collection or CollectionPage type. If the request does not include a 'page' parameter then a 'Collection' is returned that specifies the first and last page of the following list. If the request contains a 'page=true' parameter then a 'CollectionPage' is returned containing the IRI's of the list of 'following' for that page, along with the URLs of the previous and next page.

closes #96

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>