### PR TITLE
chore: Redefine/rename anchor credential subject fields

### DIFF
--- a/pkg/activitypub/service/activityhandler/activityhandler_test.go
+++ b/pkg/activitypub/service/activityhandler/activityhandler_test.go
@@ -1262,10 +1262,11 @@ const anchorCredential1 = `{
   "issuer": "https://sally.example.com/services/orb",
   "issuanceDate": "2021-01-27T09:30:10Z",
   "credentialSubject": {
-	"anchorString": "bafkreihwsn",
+	"operationCount": 2,
+	"coreIndex": "bafkreihwsn",
 	"namespace": "did:orb",
 	"version": "1",
-	"previousTransactions": {
+	"previousAnchors": {
 	  "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
 	  "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w"
 	}

--- a/pkg/activitypub/service/service_test.go
+++ b/pkg/activitypub/service/service_test.go
@@ -842,10 +842,11 @@ const anchorCredential1 = `{
   "issuer": "https://sally.example.com/services/orb",
   "issuanceDate": "2021-01-27T09:30:10Z",
   "credentialSubject": {
-	"anchorString": "bafkreihwsn",
+	"operationCount": 2,
+	"coreIndex": "bafkreihwsn",
 	"namespace": "did:orb",
 	"version": "1",
-	"previousTransactions": {
+	"previousAnchors": {
 	  "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
 	  "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w"
 	}

--- a/pkg/activitypub/vocab/activitytype_test.go
+++ b/pkg/activitypub/vocab/activitytype_test.go
@@ -832,9 +832,10 @@ const (
         "https://trustbloc.github.io/Context/orb-v1.json"
       ],
       "credentialSubject": {
-        "anchorString": "bafkreihwsn",
+	"operationCount": 2,
+	"coreIndex": "bafkreihwsn",
         "namespace": "did:orb",
-        "previousTransactions": {
+        "previousAnchors": {
           "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
           "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w"
         },
@@ -956,9 +957,10 @@ const (
           "issuer": "https://sally.example.com/services/orb",
           "issuanceDate": "2021-01-27T09:30:10Z",
           "credentialSubject": {
-            "anchorString": "bafkreihwsn",
+            "operationCount": 2,
+            "coreIndex": "bafkreihwsn",
             "namespace": "did:orb",
-            "previousTransactions": {
+            "previousAnchors": {
               "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
               "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w"
             },
@@ -1023,10 +1025,11 @@ const (
   "issuer": "https://sally.example.com/services/orb",
   "issuanceDate": "2021-01-27T09:30:10Z",
   "credentialSubject": {
-	"anchorString": "bafkreihwsn",
+	"operationCount": 2,
+	"coreIndex": "bafkreihwsn",
 	"namespace": "did:orb",
 	"version": "1",
-	"previousTransactions": {
+	"previousAnchors": {
 	  "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
 	  "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w"
 	}
@@ -1088,9 +1091,10 @@ const (
       "https://trustbloc.github.io/Context/orb-v1.json"
     ],
     "credentialSubject": {
-      "anchorString": "bafkreihwsn",
+      "operationCount": 2,
+      "coreIndex": "bafkreihwsn",
       "namespace": "did:orb",
-      "previousTransactions": {
+      "previousAnchors": {
         "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
         "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w"
       },
@@ -1167,9 +1171,10 @@ const (
     "issuer": "https://sally.example.com/services/orb",
     "issuanceDate": "2021-01-27T09:30:10Z",
     "credentialSubject": {
-      "anchorString": "bafkreihwsn",
+      "operationCount": 2,
+      "coreIndex": "bafkreihwsn",
       "namespace": "did:orb",
-      "previousTransactions": {
+      "previousAnchors": {
         "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
         "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w"
       },

--- a/pkg/activitypub/vocab/anchorcredreftype_test.go
+++ b/pkg/activitypub/vocab/anchorcredreftype_test.go
@@ -222,10 +222,11 @@ const (
   "issuer": "https://sally.example.com/services/orb",
   "issuanceDate": "2021-01-27T09:30:10Z",
   "credentialSubject": {
-	"anchorString": "bafkreihwsn",
+	"operationCount": 2,
+	"coreIndex": "bafkreihwsn",
 	"namespace": "did:orb",
 	"version": "1",
-	"previousTransactions": {
+	"previousAnchors": {
 	  "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
 	  "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w"
 	}
@@ -256,9 +257,10 @@ const (
       "https://trustbloc.github.io/Context/orb-v1.json"
     ],
     "credentialSubject": {
-      "anchorString": "bafkreihwsn",
+      "operationCount": 2,
+      "coreIndex": "bafkreihwsn",
       "namespace": "did:orb",
-      "previousTransactions": {
+      "previousAnchors": {
         "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
         "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w"
       },

--- a/pkg/activitypub/vocab/objecttype_test.go
+++ b/pkg/activitypub/vocab/objecttype_test.go
@@ -110,9 +110,10 @@ func TestObjectType_WithDocument(t *testing.T) {
 		obj, err := NewObjectWithDocument(
 			Document{
 				"credentialSubject": Document{
-					"anchorString": "bafkreihwsn",
-					"namespace":    "did:orb",
-					"previousTransactions": Document{
+					"operationCount": 2,
+					"coreIndex":      "bafkreihwsn",
+					"namespace":      "did:orb",
+					"previousAnchors": Document{
 						"EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
 						"EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w",
 					},
@@ -192,9 +193,10 @@ const (
     "https://to2"
   ],
   "credentialSubject": {
-    "anchorString": "bafkreihwsn",
+    "operationCount": 2,
+    "coreIndex": "bafkreihwsn",
     "namespace": "did:orb",
-    "previousTransactions": {
+    "previousAnchors": {
       "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
       "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w"
     },

--- a/pkg/anchor/graph/graph.go
+++ b/pkg/anchor/graph/graph.go
@@ -64,9 +64,9 @@ func (g *Graph) GetDidTransactions(cid, did string) ([]string, error) {
 			return nil, err
 		}
 
-		previousTxns := payload.PreviousTransactions
+		previousAnchors := payload.PreviousAnchors
 
-		cur, ok = previousTxns[did]
+		cur, ok = previousAnchors[did]
 		if ok {
 			if cur == "" { // create
 				return refs, nil

--- a/pkg/anchor/graph/graph_test.go
+++ b/pkg/anchor/graph/graph_test.go
@@ -32,9 +32,10 @@ func TestGraph_Add(t *testing.T) {
 		graph := New(mocks.NewMockCasClient(nil), pubKeyFetcherFnc)
 
 		payload := txn.Payload{
-			AnchorString: "anchor",
-			Namespace:    "namespace",
-			Version:      1,
+			OperationCount: 1,
+			CoreIndex:      "coreIndex",
+			Namespace:      "namespace",
+			Version:        1,
 		}
 
 		cid, err := graph.Add(buildCredential(payload))
@@ -48,9 +49,10 @@ func TestGraph_Read(t *testing.T) {
 		graph := New(mocks.NewMockCasClient(nil), pubKeyFetcherFnc)
 
 		payload := txn.Payload{
-			AnchorString: "anchor",
-			Namespace:    "namespace",
-			Version:      1,
+			OperationCount: 2,
+			CoreIndex:      "coreIndex",
+			Namespace:      "namespace",
+			Version:        1,
 		}
 
 		txnCID, err := graph.Add(buildCredential(payload))
@@ -80,9 +82,10 @@ func TestGraph_GetDidTransactions(t *testing.T) {
 		graph := New(mocks.NewMockCasClient(nil), pubKeyFetcherFnc)
 
 		payload := txn.Payload{
-			AnchorString: "anchor",
-			Namespace:    "namespace",
-			Version:      1,
+			OperationCount: 1,
+			CoreIndex:      "coreIndex",
+			Namespace:      "namespace",
+			Version:        1,
 		}
 
 		txnCID, err := graph.Add(buildCredential(payload))
@@ -98,9 +101,10 @@ func TestGraph_GetDidTransactions(t *testing.T) {
 		graph := New(mocks.NewMockCasClient(nil), pubKeyFetcherFnc)
 
 		payload := txn.Payload{
-			AnchorString: "anchor-1",
-			Namespace:    "namespace",
-			Version:      1,
+			OperationCount: 1,
+			CoreIndex:      "coreIndex-1",
+			Namespace:      "namespace",
+			Version:        1,
 		}
 
 		txn1CID, err := graph.Add(buildCredential(payload))
@@ -113,10 +117,11 @@ func TestGraph_GetDidTransactions(t *testing.T) {
 		previousDIDTxns[testDID] = txn1CID
 
 		payload = txn.Payload{
-			AnchorString:         "anchor-2",
-			Namespace:            "namespace",
-			Version:              1,
-			PreviousTransactions: previousDIDTxns,
+			OperationCount:  1,
+			CoreIndex:       "coreIndex-2",
+			Namespace:       "namespace",
+			Version:         1,
+			PreviousAnchors: previousDIDTxns,
 		}
 
 		txnCID, err := graph.Add(buildCredential(payload))
@@ -138,10 +143,11 @@ func TestGraph_GetDidTransactions(t *testing.T) {
 		previousDIDTxns[testDID] = ""
 
 		payload := txn.Payload{
-			AnchorString:         "anchor-3",
-			Namespace:            "namespace",
-			Version:              1,
-			PreviousTransactions: previousDIDTxns,
+			OperationCount:  1,
+			CoreIndex:       "coreIndex-3",
+			Namespace:       "namespace",
+			Version:         1,
+			PreviousAnchors: previousDIDTxns,
 		}
 
 		txnCID, err := graph.Add(buildCredential(payload))
@@ -162,10 +168,10 @@ func TestGraph_GetDidTransactions(t *testing.T) {
 		previousDIDTxns[testDID] = "non-existent"
 
 		payload := txn.Payload{
-			AnchorString:         "anchor-2",
-			Namespace:            "namespace",
-			Version:              1,
-			PreviousTransactions: previousDIDTxns,
+			CoreIndex:       "coreIndex-2",
+			Namespace:       "namespace",
+			Version:         1,
+			PreviousAnchors: previousDIDTxns,
 		}
 
 		txnCID, err := graph.Add(buildCredential(payload))

--- a/pkg/anchor/proofs/proofs_test.go
+++ b/pkg/anchor/proofs/proofs_test.go
@@ -50,27 +50,28 @@ func TestClient_GetProofs(t *testing.T) {
 //nolint:gochecknoglobals,lll
 var anchorCred = `
 {
-	"@context": [
-		"https://www.w3.org/2018/credentials/v1"
-	],
-	"credentialSubject": {
-		"anchorString": "1.QmaevShHgc5s7bNnGKkQ98BdaKDNrsCTUV6rcwHr522tQB",
-		"namespace": "did:sidetree",
-		"previousTransactions": {
-		"EiBAnjPBzHqAA-yONCU1HbGln-I0T-ZUPSIkkYAM6EwKKQ": "QmPEVPudBXM5XCoxoNUQiV466e7vD4XowohU8nRAhKJZ6f"
-		},
-		"version": 0
-	},
-	"id": "http://peer1.com/vc/85ef42f6-1019-40cc-ab3a-2b477681f5d8",
-	"issuanceDate": "2021-03-10T16:34:17.9767297Z",
-	"issuer": "http://peer1.com",
-	"proof": {
-		"created": "2021-03-10T16:34:17.9799878Z",
-		"domain": "domain.com",
-		"jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..yRt-VlWPDRq0jX-5iMYSfugJspbtmXZn3a9L011w8LI22WzpFZ5YQCTz6B09Stonywg_Xe6fwygG3IPQ5jreBg",
-		"proofPurpose": "assertionMethod",
-		"type": "Ed25519Signature2018",
-		"verificationMethod": "did:web:abc#vaK33R-2ssibOOf2CS0RceLeT61Z2hpskHuEvDW7Hq0"
-	},
-	"type": "VerifiableCredential"
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1"
+  ],
+  "credentialSubject": {
+    "coreIndex": "QmeKVo2aASdByo5eEtHsQ53Edizu8LsYRs4DMQcqytEBv8",
+    "namespace": "did:sidetree",
+    "operationCount": 1,
+    "previousAnchors": {
+      "EiBOAYRI3yUpwuZ_wYcJB57S3Pk0JMiK0_T9_dr1Maa4JQ": "QmeahiopyNSmCwEyGFmEQrtCaQSr67sP7aTiU8tfezMKb6"
+    },
+    "version": 0
+  },
+  "id": "http://peer1.com/vc/bd832ff3-446d-4a64-b11d-52bc3b59a922",
+  "issuanceDate": "2021-03-17T20:01:09.3303708Z",
+  "issuer": "http://peer1.com",
+  "proof": {
+    "created": "2021-03-17T20:01:09.3323119Z",
+    "domain": "domain.com",
+    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..81HnKImSkOGFw9Uzux38FwYkUBnvbhLaD3rexlIu-n-MEOIIAgJ_CnI6mekB1_cJVo5H_agzFwFjN50wJmrhBQ",
+    "proofPurpose": "assertionMethod",
+    "type": "Ed25519Signature2018",
+    "verificationMethod": "did:web:abc#CvSyX0VxMCbg-UiYpAVd9OmhaFBXBr5ISpv2RZ2c9DY"
+  },
+  "type": "VerifiableCredential"
 }`

--- a/pkg/anchor/txn/model.go
+++ b/pkg/anchor/txn/model.go
@@ -8,8 +8,9 @@ package txn
 
 // Payload defines orb transaction details.
 type Payload struct {
-	AnchorString         string            `json:"anchorString"`
-	Namespace            string            `json:"namespace"`
-	Version              uint64            `json:"version"`
-	PreviousTransactions map[string]string `json:"previousTransactions,omitempty"`
+	OperationCount  uint64            `json:"operationCount"`
+	CoreIndex       string            `json:"coreIndex"`
+	Namespace       string            `json:"namespace"`
+	Version         uint64            `json:"version"`
+	PreviousAnchors map[string]string `json:"previousAnchors,omitempty"`
 }

--- a/pkg/anchor/util/anchordata.go
+++ b/pkg/anchor/util/anchordata.go
@@ -1,0 +1,60 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package util
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	delimiter    = "."
+	allowedParts = 2
+)
+
+// nolint:gochecknoglobals
+var (
+	integerRegex = regexp.MustCompile(`^[1-9]\d*$`)
+)
+
+// AnchorData holds anchored data.
+type AnchorData struct {
+	OperationCount   uint64
+	CoreIndexFileURI string
+}
+
+// ParseAnchorString will parse anchor string into anchor data model.
+func ParseAnchorString(anchor string) (*AnchorData, error) {
+	parts := strings.Split(anchor, delimiter)
+
+	if len(parts) != allowedParts {
+		return nil, fmt.Errorf("parse anchor data[%s] failed: expecting [%d] parts, got [%d] parts",
+			anchor, allowedParts, len(parts))
+	}
+
+	ok := integerRegex.MatchString(parts[0])
+	if !ok {
+		return nil, fmt.Errorf("parse anchor data[%s] failed: number of operations must be positive integer", anchor)
+	}
+
+	opsNum, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("parse anchor data[%s] failed: %s", anchor, err.Error())
+	}
+
+	return &AnchorData{
+		OperationCount:   opsNum,
+		CoreIndexFileURI: parts[1],
+	}, nil
+}
+
+// GetAnchorString will create anchor string from anchor data.
+func (ad *AnchorData) GetAnchorString() string {
+	return fmt.Sprintf("%d", ad.OperationCount) + delimiter + ad.CoreIndexFileURI
+}

--- a/pkg/anchor/util/anchordata_test.go
+++ b/pkg/anchor/util/anchordata_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAnchorData(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		ad, err := ParseAnchorString("101.coreIndexURI")
+		require.NoError(t, err)
+		require.NotNil(t, ad)
+
+		require.Equal(t, ad.OperationCount, uint64(101))
+		require.Equal(t, ad.CoreIndexFileURI, "coreIndexURI")
+
+		require.Equal(t, "101.coreIndexURI", ad.GetAnchorString())
+	})
+
+	t.Run("error - invalid number of parts", func(t *testing.T) {
+		ad, err := ParseAnchorString("1.coreIndexURI.other")
+		require.Error(t, err)
+		require.Nil(t, ad)
+
+		require.Contains(t, err.Error(), "expecting [2] parts, got [3] parts")
+	})
+
+	t.Run("error - invalid number of operations", func(t *testing.T) {
+		ad, err := ParseAnchorString("abc.coreIndexURI")
+		require.Error(t, err)
+		require.Nil(t, ad)
+
+		require.Contains(t, err.Error(), "number of operations must be positive integer")
+	})
+
+	t.Run("error - invalid number of operations starts with 0", func(t *testing.T) {
+		ad, err := ParseAnchorString("01.coreIndexURI")
+		require.Error(t, err)
+		require.Nil(t, ad)
+
+		require.Contains(t, err.Error(), "number of operations must be positive integer")
+	})
+
+	t.Run("error - number of operations is negative", func(t *testing.T) {
+		ad, err := ParseAnchorString("-1.coreIndexURI")
+		require.Error(t, err)
+		require.Nil(t, ad)
+
+		require.Contains(t, err.Error(), "number of operations must be positive integer")
+	})
+}

--- a/pkg/anchor/util/util_test.go
+++ b/pkg/anchor/util/util_test.go
@@ -22,9 +22,10 @@ const defVCContext = "https://www.w3.org/2018/credentials/v1"
 func TestGetTransactionPayload(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		txnInfo := &txn.Payload{
-			AnchorString: "anchor",
-			Namespace:    "namespace",
-			Version:      1,
+			OperationCount: 1,
+			CoreIndex:      "coreIndex",
+			Namespace:      "namespace",
+			Version:        1,
 		}
 
 		vc := &verifiable.Credential{
@@ -48,9 +49,10 @@ func TestGetTransactionPayload(t *testing.T) {
 		require.NotNil(t, txnInfoFromVC)
 
 		require.Equal(t, txnInfo.Namespace, txnInfoFromVC.Namespace)
-		require.Equal(t, txnInfo.AnchorString, txnInfoFromVC.AnchorString)
+		require.Equal(t, txnInfo.OperationCount, txnInfoFromVC.OperationCount)
+		require.Equal(t, txnInfo.CoreIndex, txnInfoFromVC.CoreIndex)
 		require.Equal(t, txnInfo.Version, txnInfoFromVC.Version)
-		require.Equal(t, txnInfo.PreviousTransactions, txnInfoFromVC.PreviousTransactions)
+		require.Equal(t, txnInfo.PreviousAnchors, txnInfoFromVC.PreviousAnchors)
 	})
 
 	t.Run("error - no credential subject", func(t *testing.T) {

--- a/pkg/anchor/writer/writer_test.go
+++ b/pkg/anchor/writer/writer_test.go
@@ -83,7 +83,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			},
 		}
 
-		err = c.WriteAnchor("anchor", opRefs, 1)
+		err = c.WriteAnchor("1.anchor", opRefs, 1)
 		require.NoError(t, err)
 
 		anchorVC, err := verifiable.ParseCredential([]byte(anchorCred), verifiable.WithDisabledProofCheck())
@@ -118,7 +118,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			},
 		}
 
-		err = c.WriteAnchor("anchor", opRefs, 1)
+		err = c.WriteAnchor("1.anchor", opRefs, 1)
 		require.Error(t, err)
 		require.Equal(t, err.Error(), "failed to create witness list: operation processor error")
 	})
@@ -136,7 +136,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 
 		c := New(namespace, providersWithErr, txnCh, vcCh)
 
-		err := c.WriteAnchor("anchor", []*operation.Reference{{UniqueSuffix: testDID, Type: operation.TypeCreate}}, 1)
+		err := c.WriteAnchor("1.anchor", []*operation.Reference{{UniqueSuffix: testDID, Type: operation.TypeCreate}}, 1)
 		require.Contains(t, err.Error(), "failed to build anchor credential: sign error")
 	})
 
@@ -162,7 +162,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 
 		c := New(namespace, providersWithErr, txnCh, vcCh)
 
-		err = c.WriteAnchor("anchor", []*operation.Reference{{UniqueSuffix: testDID, Type: operation.TypeCreate}}, 1)
+		err = c.WriteAnchor("1.anchor", []*operation.Reference{{UniqueSuffix: testDID, Type: operation.TypeCreate}}, 1)
 		require.Contains(t, err.Error(), "error put")
 	})
 
@@ -487,27 +487,28 @@ func (m *mockOpProcessor) Resolve(uniqueSuffix string) (*protocol.ResolutionMode
 //nolint:gochecknoglobals,lll
 var anchorCred = `
 {
-	"@context": [
-		"https://www.w3.org/2018/credentials/v1"
-	],
-	"credentialSubject": {
-		"anchorString": "1.QmaevShHgc5s7bNnGKkQ98BdaKDNrsCTUV6rcwHr522tQB",
-		"namespace": "did:sidetree",
-		"previousTransactions": {
-		"EiBAnjPBzHqAA-yONCU1HbGln-I0T-ZUPSIkkYAM6EwKKQ": "QmPEVPudBXM5XCoxoNUQiV466e7vD4XowohU8nRAhKJZ6f"
-		},
-		"version": 0
-	},
-	"id": "http://peer1.com/vc/85ef42f6-1019-40cc-ab3a-2b477681f5d8",
-	"issuanceDate": "2021-03-10T16:34:17.9767297Z",
-	"issuer": "http://peer1.com",
-	"proof": {
-		"created": "2021-03-10T16:34:17.9799878Z",
-		"domain": "domain.com",
-		"jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..yRt-VlWPDRq0jX-5iMYSfugJspbtmXZn3a9L011w8LI22WzpFZ5YQCTz6B09Stonywg_Xe6fwygG3IPQ5jreBg",
-		"proofPurpose": "assertionMethod",
-		"type": "Ed25519Signature2018",
-		"verificationMethod": "did:web:abc#vaK33R-2ssibOOf2CS0RceLeT61Z2hpskHuEvDW7Hq0"
-	},
-	"type": "VerifiableCredential"
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1"
+  ],
+  "credentialSubject": {
+    "coreIndex": "QmZzPwGc3JEMQDiJu21YZcdpEPam7qCoXPLEUQXn34sMhB",
+    "namespace": "did:sidetree",
+    "operationCount": 1,
+    "previousAnchors": {
+      "EiBjG9z921eyj8wI4j-LAqsJBRC_GalIUWPJeXGekxFQ-w": ""
+    },
+    "version": 0
+  },
+  "id": "http://peer1.com/vc/62c153d1-a6be-400e-a6a6-5b700b596d9d",
+  "issuanceDate": "2021-03-17T20:01:10.4002903Z",
+  "issuer": "http://peer1.com",
+  "proof": {
+    "created": "2021-03-17T20:01:10.4024292Z",
+    "domain": "domain.com",
+    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..pHA1rMSsHBJLbDwRpNY0FrgSgoLzBw4S7VP7d5bkYW-JwU8qc_4CmPfQctR8kycQHSa2Jh8LNBqNKMeVWsAwDA",
+    "proofPurpose": "assertionMethod",
+    "type": "Ed25519Signature2018",
+    "verificationMethod": "did:web:abc#CvSyX0VxMCbg-UiYpAVd9OmhaFBXBr5ISpv2RZ2c9DY"
+  },
+  "type": "VerifiableCredential"
 }`

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -120,9 +120,11 @@ func (o *Observer) process(txns []string) {
 			continue
 		}
 
+		ad := &util.AnchorData{OperationCount: txnPayload.OperationCount, CoreIndexFileURI: txnPayload.CoreIndex}
+
 		sidetreeTxn := txnapi.SidetreeTxn{
 			TransactionTime:     uint64(txnNode.Issued.Unix()),
-			AnchorString:        txnPayload.AnchorString,
+			AnchorString:        ad.GetAnchorString(),
 			Namespace:           txnPayload.Namespace,
 			ProtocolGenesisTime: txnPayload.Version,
 			Reference:           txn,
@@ -130,11 +132,11 @@ func (o *Observer) process(txns []string) {
 
 		err = v.TransactionProcessor().Process(sidetreeTxn)
 		if err != nil {
-			logger.Warnf("failed to process anchor[%s]: %s", txnPayload.AnchorString, err.Error())
+			logger.Warnf("failed to process anchor[%s]: %s", txnPayload.CoreIndex, err.Error())
 
 			continue
 		}
 
-		logger.Debugf("successfully processed anchor[%s]", txnPayload.AnchorString)
+		logger.Debugf("successfully processed anchor[%s]", txnPayload.CoreIndex)
 	}
 }

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -60,13 +60,13 @@ func TestStartObserver(t *testing.T) {
 		var txns []string
 		txnGraph := graph.New(mocks.NewMockCasClient(nil), pubKeyFetcherFnc)
 
-		payload1 := orbtxn.Payload{Namespace: namespace1, Version: 1, AnchorString: "1.address"}
+		payload1 := orbtxn.Payload{Namespace: namespace1, Version: 1, CoreIndex: "1.address"}
 
 		cid, err := txnGraph.Add(buildCredential(payload1))
 		require.NoError(t, err)
 		txns = append(txns, cid)
 
-		payload2 := orbtxn.Payload{Namespace: namespace2, Version: 1, AnchorString: "2.address"}
+		payload2 := orbtxn.Payload{Namespace: namespace2, Version: 1, CoreIndex: "2.address"}
 
 		cid, err = txnGraph.Add(buildCredential(payload2))
 		require.NoError(t, err)

--- a/pkg/store/verifiable/store.go
+++ b/pkg/store/verifiable/store.go
@@ -11,9 +11,12 @@ import (
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	"github.com/hyperledger/aries-framework-go/spi/storage"
+	"github.com/trustbloc/edge-core/pkg/log"
 )
 
 const nameSpace = "verifiable"
+
+var logger = log.New("orb-txn-processor")
 
 // New returns new instance of verifiable credentials store.
 func New(provider storage.Provider) (*Store, error) {
@@ -42,6 +45,8 @@ func (s *Store) Put(vc *verifiable.Credential) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal vc: %w", err)
 	}
+
+	logger.Infof(string(vcBytes))
 
 	if e := s.store.Put(vc.ID, vcBytes); e != nil {
 		return fmt.Errorf("failed to put vc: %w", e)

--- a/pkg/store/verifiable/store_test.go
+++ b/pkg/store/verifiable/store_test.go
@@ -77,29 +77,30 @@ var udCredentialWithoutID = `
 //nolint:gochecknoglobals,lll
 var anchorCred = `
 {
-	"@context": [
-		"https://www.w3.org/2018/credentials/v1"
-	],
-	"credentialSubject": {
-		"anchorString": "1.QmaevShHgc5s7bNnGKkQ98BdaKDNrsCTUV6rcwHr522tQB",
-		"namespace": "did:sidetree",
-		"previousTransactions": {
-		"EiBAnjPBzHqAA-yONCU1HbGln-I0T-ZUPSIkkYAM6EwKKQ": "QmPEVPudBXM5XCoxoNUQiV466e7vD4XowohU8nRAhKJZ6f"
-		},
-		"version": 0
-	},
-	"id": "http://peer1.com/vc/85ef42f6-1019-40cc-ab3a-2b477681f5d8",
-	"issuanceDate": "2021-03-10T16:34:17.9767297Z",
-	"issuer": "http://peer1.com",
-	"proof": {
-		"created": "2021-03-10T16:34:17.9799878Z",
-		"domain": "domain.com",
-		"jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..yRt-VlWPDRq0jX-5iMYSfugJspbtmXZn3a9L011w8LI22WzpFZ5YQCTz6B09Stonywg_Xe6fwygG3IPQ5jreBg",
-		"proofPurpose": "assertionMethod",
-		"type": "Ed25519Signature2018",
-		"verificationMethod": "did:web:abc#vaK33R-2ssibOOf2CS0RceLeT61Z2hpskHuEvDW7Hq0"
-	},
-	"type": "VerifiableCredential"
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1"
+  ],
+  "credentialSubject": {
+    "coreIndex": "QmZzPwGc3JEMQDiJu21YZcdpEPam7qCoXPLEUQXn34sMhB",
+    "namespace": "did:sidetree",
+    "operationCount": 1,
+    "previousAnchors": {
+      "EiBjG9z921eyj8wI4j-LAqsJBRC_GalIUWPJeXGekxFQ-w": ""
+    },
+    "version": 0
+  },
+  "id": "http://peer1.com/vc/62c153d1-a6be-400e-a6a6-5b700b596d9d",
+  "issuanceDate": "2021-03-17T20:01:10.4002903Z",
+  "issuer": "http://peer1.com",
+  "proof": {
+    "created": "2021-03-17T20:01:10.4024292Z",
+    "domain": "domain.com",
+    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..pHA1rMSsHBJLbDwRpNY0FrgSgoLzBw4S7VP7d5bkYW-JwU8qc_4CmPfQctR8kycQHSa2Jh8LNBqNKMeVWsAwDA",
+    "proofPurpose": "assertionMethod",
+    "type": "Ed25519Signature2018",
+    "verificationMethod": "did:web:abc#CvSyX0VxMCbg-UiYpAVd9OmhaFBXBr5ISpv2RZ2c9DY"
+  },
+  "type": "VerifiableCredential"
 }`
 
 func TestNew(t *testing.T) {
@@ -172,7 +173,7 @@ func TestStore_Get(t *testing.T) {
 
 		vc, err := s.Get(anchorVC.ID)
 		require.NoError(t, err)
-		require.Equal(t, vc.ID, "http://peer1.com/vc/85ef42f6-1019-40cc-ab3a-2b477681f5d8")
+		require.Equal(t, vc.ID, "http://peer1.com/vc/62c153d1-a6be-400e-a6a6-5b700b596d9d")
 	})
 
 	t.Run("error - vc without ID", func(t *testing.T) {


### PR DESCRIPTION
- "anchorString" will be split into "coreIndex" and "operationCount"
- "previousTransactions" will be renamed to "previousAnchors"

Closes #122

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>