### PR TITLE
feat: Implemented '/outbox' and '/inbox' REST endpoints

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -305,6 +305,8 @@ func startOrbServices(parameters *orbParameters) error {
 		aphandler.NewServices(apCfg, apStore),
 		aphandler.NewFollowers(apCfg, apStore),
 		aphandler.NewFollowing(apCfg, apStore),
+		aphandler.NewOutbox(apCfg, apStore),
+		aphandler.NewInbox(apCfg, apStore),
 	)
 
 	srv := &HTTPServer{

--- a/pkg/activitypub/resthandler/activityhandler.go
+++ b/pkg/activitypub/resthandler/activityhandler.go
@@ -1,0 +1,192 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resthandler
+
+import (
+	"net/http"
+
+	"github.com/trustbloc/orb/pkg/activitypub/store/spi"
+	"github.com/trustbloc/orb/pkg/activitypub/store/storeutil"
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+)
+
+// Outbox implements the 'outbox' REST handler that retrieves a service's outbox.
+type Outbox struct {
+	*activities
+}
+
+// NewOutbox returns a new 'outbox' REST handler.
+func NewOutbox(cfg *Config, activityStore spi.Store) *Outbox {
+	return &Outbox{
+		activities: newActivities(OutboxPath, spi.Outbox, cfg, activityStore),
+	}
+}
+
+// Inbox implements the 'inbox' REST handler that retrieves a service's inbox.
+type Inbox struct {
+	*activities
+}
+
+// NewInbox returns a new 'inbox' REST handler.
+func NewInbox(cfg *Config, activityStore spi.Store) *Outbox {
+	return &Outbox{
+		activities: newActivities(InboxPath, spi.Inbox, cfg, activityStore),
+	}
+}
+
+type activities struct {
+	*handler
+
+	storeType spi.ActivityStoreType
+}
+
+func newActivities(path string, storeType spi.ActivityStoreType, cfg *Config, activityStore spi.Store) *activities {
+	h := &activities{
+		storeType: storeType,
+	}
+
+	h.handler = newHandler(path, cfg, activityStore, h.handle, pageParam, pageNumParam)
+
+	return h
+}
+
+func (h *activities) handle(w http.ResponseWriter, req *http.Request) {
+	if h.isPaging(req) {
+		h.handleActivitiesPage(w, req)
+	} else {
+		h.handleActivities(w, req)
+	}
+}
+
+//nolint:dupl
+func (h *activities) handleActivities(rw http.ResponseWriter, _ *http.Request) {
+	activities, err := h.getActivities()
+	if err != nil {
+		logger.Errorf("[%s] Error retrieving %s for service IRI [%s]: %s",
+			h.endpoint, h.storeType, h.ServiceIRI, err)
+
+		h.writeResponse(rw, http.StatusInternalServerError, nil)
+
+		return
+	}
+
+	activitiesCollBytes, err := h.marshal(activities)
+	if err != nil {
+		logger.Errorf("[%s] Unable to marshal %s collection for service IRI [%s]: %s",
+			h.endpoint, h.storeType, h.ServiceIRI, err)
+
+		h.writeResponse(rw, http.StatusInternalServerError, nil)
+
+		return
+	}
+
+	h.writeResponse(rw, http.StatusOK, activitiesCollBytes)
+}
+
+func (h *activities) handleActivitiesPage(rw http.ResponseWriter, req *http.Request) {
+	var page *vocab.OrderedCollectionPageType
+
+	var err error
+
+	pageNum, ok := h.getPageNum(req)
+	if ok {
+		page, err = h.getPage(
+			spi.WithPageSize(h.PageSize),
+			spi.WithPageNum(pageNum),
+			spi.WithSortOrder(spi.SortDescending),
+		)
+	} else {
+		page, err = h.getPage(
+			spi.WithPageSize(h.PageSize),
+			spi.WithSortOrder(spi.SortDescending),
+		)
+	}
+
+	if err != nil {
+		logger.Errorf("[%s] Error retrieving page for service IRI [%s]: %s",
+			h.endpoint, h.ServiceIRI, err)
+
+		h.writeResponse(rw, http.StatusInternalServerError, nil)
+
+		return
+	}
+
+	pageBytes, err := h.marshal(page)
+	if err != nil {
+		logger.Errorf("[%s] Unable to marshal page for service IRI [%s]: %s",
+			h.endpoint, h.ServiceIRI, err)
+
+		h.writeResponse(rw, http.StatusInternalServerError, nil)
+
+		return
+	}
+
+	h.writeResponse(rw, http.StatusOK, pageBytes)
+}
+
+func (h *activities) getActivities() (*vocab.OrderedCollectionType, error) {
+	it, err := h.activityStore.QueryActivities(h.storeType, spi.NewCriteria())
+	if err != nil {
+		return nil, err
+	}
+
+	defer it.Close()
+
+	firstURL, err := h.getPageURL(-1)
+	if err != nil {
+		return nil, err
+	}
+
+	lastURL, err := h.getPageURL(getLastPageNum(it.TotalItems(), h.PageSize, spi.SortDescending))
+	if err != nil {
+		return nil, err
+	}
+
+	return vocab.NewOrderedCollection(nil,
+		vocab.WithContext(vocab.ContextActivityStreams),
+		vocab.WithID(h.id),
+		vocab.WithFirst(firstURL),
+		vocab.WithLast(lastURL),
+		vocab.WithTotalItems(it.TotalItems()),
+	), nil
+}
+
+//nolint:dupl
+func (h *activities) getPage(opts ...spi.QueryOpt) (*vocab.OrderedCollectionPageType, error) {
+	it, err := h.activityStore.QueryActivities(h.storeType, spi.NewCriteria(spi.WithActorIRI(h.ServiceIRI)), opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	defer it.Close()
+
+	options := storeutil.GetQueryOptions(opts...)
+
+	activities, err := storeutil.ReadActivities(it, options.PageSize)
+	if err != nil {
+		return nil, err
+	}
+
+	items := make([]*vocab.ObjectProperty, len(activities))
+
+	for i, activity := range activities {
+		items[i] = vocab.NewObjectProperty(vocab.WithActivity(activity))
+	}
+
+	id, prev, next, err := h.getIDPrevNextURL(it.TotalItems(), options)
+	if err != nil {
+		return nil, err
+	}
+
+	return vocab.NewOrderedCollectionPage(items,
+		vocab.WithContext(vocab.ContextActivityStreams),
+		vocab.WithID(id),
+		vocab.WithPrev(prev),
+		vocab.WithNext(next),
+		vocab.WithTotalItems(it.TotalItems()),
+	), nil
+}

--- a/pkg/activitypub/resthandler/activityhandler_test.go
+++ b/pkg/activitypub/resthandler/activityhandler_test.go
@@ -1,0 +1,500 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resthandler
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/pkg/activitypub/service/mocks"
+	"github.com/trustbloc/orb/pkg/activitypub/store/memstore"
+	"github.com/trustbloc/orb/pkg/activitypub/store/spi"
+)
+
+const outboxURL = "https://example.com/services/orb/outbox"
+
+func TestNewOutbox(t *testing.T) {
+	serviceIRI, err := url.Parse(serviceURL)
+	require.NoError(t, err)
+
+	cfg := &Config{
+		BasePath:   basePath,
+		ServiceIRI: serviceIRI,
+		PageSize:   4,
+	}
+
+	h := NewOutbox(cfg, memstore.New(""))
+	require.NotNil(t, h)
+	require.Equal(t, "/services/orb/outbox", h.Path())
+	require.Equal(t, http.MethodGet, h.Method())
+	require.NotNil(t, h.Handler())
+}
+
+func TestNewInbox(t *testing.T) {
+	serviceIRI, err := url.Parse(serviceURL)
+	require.NoError(t, err)
+
+	cfg := &Config{
+		BasePath:   basePath,
+		ServiceIRI: serviceIRI,
+		PageSize:   4,
+	}
+
+	h := NewInbox(cfg, memstore.New(""))
+	require.NotNil(t, h)
+	require.Equal(t, "/services/orb/inbox", h.Path())
+	require.Equal(t, http.MethodGet, h.Method())
+	require.NotNil(t, h.Handler())
+}
+
+func TestActivities_Handler(t *testing.T) {
+	serviceIRI, err := url.Parse(serviceURL)
+	require.NoError(t, err)
+
+	activityStore := memstore.New("")
+
+	for _, activity := range newMockCreateActivities(19) {
+		require.NoError(t, activityStore.AddActivity(spi.Outbox, activity))
+	}
+
+	cfg := &Config{
+		BasePath:   basePath,
+		ServiceIRI: serviceIRI,
+		PageSize:   4,
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		h := NewOutbox(cfg, activityStore)
+		require.NotNil(t, h)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, outboxURL, nil)
+
+		h.handle(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusOK, result.StatusCode)
+
+		respBytes, err := ioutil.ReadAll(result.Body)
+		require.NoError(t, err)
+
+		t.Logf("%s", respBytes)
+
+		require.Equal(t, getCanonical(t, outboxJSON), getCanonical(t, string(respBytes)))
+		require.NoError(t, result.Body.Close())
+	})
+
+	t.Run("Store error", func(t *testing.T) {
+		cfg := &Config{
+			ServiceIRI: serviceIRI,
+			PageSize:   4,
+		}
+
+		errExpected := fmt.Errorf("injected store error")
+
+		s := &mocks.ActivityStore{}
+		s.QueryActivitiesReturns(nil, errExpected)
+
+		h := NewOutbox(cfg, s)
+		require.NotNil(t, h)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, outboxURL, nil)
+
+		h.handle(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusInternalServerError, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+	})
+
+	t.Run("Marshal error", func(t *testing.T) {
+		cfg := &Config{
+			ServiceIRI: serviceIRI,
+			PageSize:   4,
+		}
+
+		h := NewOutbox(cfg, activityStore)
+		require.NotNil(t, h)
+
+		errExpected := fmt.Errorf("injected marshal error")
+
+		h.marshal = func(v interface{}) ([]byte, error) {
+			return nil, errExpected
+		}
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, outboxURL, nil)
+
+		h.handle(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusInternalServerError, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+	})
+}
+
+func TestActivities_PageHandler(t *testing.T) {
+	serviceIRI, err := url.Parse(serviceURL)
+	require.NoError(t, err)
+
+	activityStore := memstore.New("")
+
+	for _, activity := range newMockCreateActivities(19) {
+		require.NoError(t, activityStore.AddActivity(spi.Outbox, activity))
+	}
+
+	t.Run("First page -> Success", func(t *testing.T) {
+		handleActivitiesRequest(t, serviceIRI, activityStore, "true", "", outboxFirstPageJSON)
+	})
+
+	t.Run("Page by num -> Success", func(t *testing.T) {
+		handleActivitiesRequest(t, serviceIRI, activityStore, "true", "3", outboxPage3JSON)
+	})
+
+	t.Run("Page num too large -> Success", func(t *testing.T) {
+		handleActivitiesRequest(t, serviceIRI, activityStore, "true", "30", outboxPageTooLargeJSON)
+	})
+
+	t.Run("Last page -> Success", func(t *testing.T) {
+		handleActivitiesRequest(t, serviceIRI, activityStore, "true", "0", outboxLastPageJSON)
+	})
+
+	t.Run("Invalid page-num -> Success", func(t *testing.T) {
+		handleActivitiesRequest(t, serviceIRI, activityStore, "true", "invalid", outboxFirstPageJSON)
+	})
+
+	t.Run("Invalid page -> Success", func(t *testing.T) {
+		handleActivitiesRequest(t, serviceIRI, activityStore, "invalid", "3", outboxJSON)
+	})
+
+	t.Run("Store error", func(t *testing.T) {
+		errExpected := fmt.Errorf("injected store error")
+
+		s := &mocks.ActivityStore{}
+		s.QueryActivitiesReturns(nil, errExpected)
+
+		cfg := &Config{
+			ServiceIRI: serviceIRI,
+			PageSize:   4,
+		}
+
+		h := NewOutbox(cfg, s)
+		require.NotNil(t, h)
+
+		restorePaging := setPaging(h.handler, "true", "0")
+		defer restorePaging()
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, outboxURL, nil)
+
+		h.handle(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusInternalServerError, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+	})
+
+	t.Run("Marshal error", func(t *testing.T) {
+		cfg := &Config{
+			ServiceIRI: serviceIRI,
+			PageSize:   4,
+		}
+
+		h := NewOutbox(cfg, activityStore)
+		require.NotNil(t, h)
+
+		restorePaging := setPaging(h.handler, "true", "0")
+		defer restorePaging()
+
+		errExpected := fmt.Errorf("injected marshal error")
+
+		h.marshal = func(v interface{}) ([]byte, error) {
+			return nil, errExpected
+		}
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, outboxURL, nil)
+
+		h.handle(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusInternalServerError, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+	})
+}
+
+func handleActivitiesRequest(t *testing.T, serviceIRI *url.URL, as spi.Store, page, pageNum, expected string) {
+	cfg := &Config{
+		ServiceIRI: serviceIRI,
+		PageSize:   4,
+	}
+
+	h := NewOutbox(cfg, as)
+	require.NotNil(t, h)
+
+	restorePaging := setPaging(h.handler, page, pageNum)
+	defer restorePaging()
+
+	rw := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, outboxURL, nil)
+
+	h.handle(rw, req)
+
+	result := rw.Result()
+	require.Equal(t, http.StatusOK, result.StatusCode)
+
+	respBytes, err := ioutil.ReadAll(result.Body)
+	require.NoError(t, err)
+	require.NoError(t, result.Body.Close())
+
+	t.Logf("%s", respBytes)
+
+	require.Equal(t, getCanonical(t, expected), getCanonical(t, string(respBytes)))
+}
+
+const (
+	outboxJSON = `{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "id": "https://example1.com/services/orb/outbox",
+  "type": "OrderedCollection",
+  "totalItems": 19,
+  "first": "https://example1.com/services/orb/outbox?page=true",
+  "last": "https://example1.com/services/orb/outbox?page=true&page-num=0"
+}`
+
+	outboxFirstPageJSON = `{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "id": "https://example1.com/services/orb/outbox?page=true&page-num=4",
+  "next": "https://example1.com/services/orb/outbox?page=true&page-num=3",
+  "orderedItems": [
+    {
+      "@context": "https://www.w3.org/ns/activitystreams",
+      "id": "https://activity_18",
+      "object": {
+        "@context": [
+          "https://www.w3.org/ns/activitystreams",
+          "https://trustbloc.github.io/Context/orb-v1.json"
+        ],
+        "id": "https://obj_18",
+        "target": {
+          "id": "bafkd34G7hD6gbj94fnKm5D",
+          "type": "Cas"
+        },
+        "type": "AnchorCredentialReference"
+      },
+      "type": "Create"
+    },
+    {
+      "@context": "https://www.w3.org/ns/activitystreams",
+      "id": "https://activity_17",
+      "object": {
+        "@context": [
+          "https://www.w3.org/ns/activitystreams",
+          "https://trustbloc.github.io/Context/orb-v1.json"
+        ],
+        "id": "https://obj_17",
+        "target": {
+          "id": "bafkd34G7hD6gbj94fnKm5D",
+          "type": "Cas"
+        },
+        "type": "AnchorCredentialReference"
+      },
+      "type": "Create"
+    },
+    {
+      "@context": "https://www.w3.org/ns/activitystreams",
+      "id": "https://activity_16",
+      "object": {
+        "@context": [
+          "https://www.w3.org/ns/activitystreams",
+          "https://trustbloc.github.io/Context/orb-v1.json"
+        ],
+        "id": "https://obj_16",
+        "target": {
+          "id": "bafkd34G7hD6gbj94fnKm5D",
+          "type": "Cas"
+        },
+        "type": "AnchorCredentialReference"
+      },
+      "type": "Create"
+    },
+    {
+      "@context": "https://www.w3.org/ns/activitystreams",
+      "id": "https://activity_15",
+      "object": {
+        "@context": [
+          "https://www.w3.org/ns/activitystreams",
+          "https://trustbloc.github.io/Context/orb-v1.json"
+        ],
+        "id": "https://obj_15",
+        "target": {
+          "id": "bafkd34G7hD6gbj94fnKm5D",
+          "type": "Cas"
+        },
+        "type": "AnchorCredentialReference"
+      },
+      "type": "Create"
+    }
+  ],
+  "totalItems": 19,
+  "type": "OrderedCollectionPage"
+}`
+
+	outboxLastPageJSON = `{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "id": "https://example1.com/services/orb/outbox?page=true&page-num=0",
+  "orderedItems": [
+    {
+      "@context": "https://www.w3.org/ns/activitystreams",
+      "id": "https://activity_2",
+      "object": {
+        "@context": [
+          "https://www.w3.org/ns/activitystreams",
+          "https://trustbloc.github.io/Context/orb-v1.json"
+        ],
+        "id": "https://obj_2",
+        "target": {
+          "id": "bafkd34G7hD6gbj94fnKm5D",
+          "type": "Cas"
+        },
+        "type": "AnchorCredentialReference"
+      },
+      "type": "Create"
+    },
+    {
+      "@context": "https://www.w3.org/ns/activitystreams",
+      "id": "https://activity_1",
+      "object": {
+        "@context": [
+          "https://www.w3.org/ns/activitystreams",
+          "https://trustbloc.github.io/Context/orb-v1.json"
+        ],
+        "id": "https://obj_1",
+        "target": {
+          "id": "bafkd34G7hD6gbj94fnKm5D",
+          "type": "Cas"
+        },
+        "type": "AnchorCredentialReference"
+      },
+      "type": "Create"
+    },
+    {
+      "@context": "https://www.w3.org/ns/activitystreams",
+      "id": "https://activity_0",
+      "object": {
+        "@context": [
+          "https://www.w3.org/ns/activitystreams",
+          "https://trustbloc.github.io/Context/orb-v1.json"
+        ],
+        "id": "https://obj_0",
+        "target": {
+          "id": "bafkd34G7hD6gbj94fnKm5D",
+          "type": "Cas"
+        },
+        "type": "AnchorCredentialReference"
+      },
+      "type": "Create"
+    }
+  ],
+  "prev": "https://example1.com/services/orb/outbox?page=true&page-num=1",
+  "totalItems": 19,
+  "type": "OrderedCollectionPage"
+}`
+
+	outboxPage3JSON = `{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "id": "https://example1.com/services/orb/outbox?page=true&page-num=3",
+  "next": "https://example1.com/services/orb/outbox?page=true&page-num=2",
+  "orderedItems": [
+    {
+      "@context": "https://www.w3.org/ns/activitystreams",
+      "id": "https://activity_14",
+      "object": {
+        "@context": [
+          "https://www.w3.org/ns/activitystreams",
+          "https://trustbloc.github.io/Context/orb-v1.json"
+        ],
+        "id": "https://obj_14",
+        "target": {
+          "id": "bafkd34G7hD6gbj94fnKm5D",
+          "type": "Cas"
+        },
+        "type": "AnchorCredentialReference"
+      },
+      "type": "Create"
+    },
+    {
+      "@context": "https://www.w3.org/ns/activitystreams",
+      "id": "https://activity_13",
+      "object": {
+        "@context": [
+          "https://www.w3.org/ns/activitystreams",
+          "https://trustbloc.github.io/Context/orb-v1.json"
+        ],
+        "id": "https://obj_13",
+        "target": {
+          "id": "bafkd34G7hD6gbj94fnKm5D",
+          "type": "Cas"
+        },
+        "type": "AnchorCredentialReference"
+      },
+      "type": "Create"
+    },
+    {
+      "@context": "https://www.w3.org/ns/activitystreams",
+      "id": "https://activity_12",
+      "object": {
+        "@context": [
+          "https://www.w3.org/ns/activitystreams",
+          "https://trustbloc.github.io/Context/orb-v1.json"
+        ],
+        "id": "https://obj_12",
+        "target": {
+          "id": "bafkd34G7hD6gbj94fnKm5D",
+          "type": "Cas"
+        },
+        "type": "AnchorCredentialReference"
+      },
+      "type": "Create"
+    },
+    {
+      "@context": "https://www.w3.org/ns/activitystreams",
+      "id": "https://activity_11",
+      "object": {
+        "@context": [
+          "https://www.w3.org/ns/activitystreams",
+          "https://trustbloc.github.io/Context/orb-v1.json"
+        ],
+        "id": "https://obj_11",
+        "target": {
+          "id": "bafkd34G7hD6gbj94fnKm5D",
+          "type": "Cas"
+        },
+        "type": "AnchorCredentialReference"
+      },
+      "type": "Create"
+    }
+  ],
+  "prev": "https://example1.com/services/orb/outbox?page=true&page-num=4",
+  "totalItems": 19,
+  "type": "OrderedCollectionPage"
+}`
+	outboxPageTooLargeJSON = `{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "id": "https://example1.com/services/orb/outbox?page=true&page-num=30",
+  "next": "https://example1.com/services/orb/outbox?page=true&page-num=4",
+  "totalItems": 19,
+  "type": "OrderedCollectionPage"
+}`
+)

--- a/pkg/activitypub/resthandler/followhandler.go
+++ b/pkg/activitypub/resthandler/followhandler.go
@@ -62,6 +62,7 @@ func (h *follow) handle(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
+//nolint:dupl
 func (h *follow) handleFollow(rw http.ResponseWriter, _ *http.Request) {
 	following, err := h.getFollow()
 	if err != nil {
@@ -151,6 +152,7 @@ func (h *follow) getFollow() (*vocab.CollectionType, error) {
 	), nil
 }
 
+//nolint:dupl
 func (h *follow) getPage(opts ...spi.QueryOpt) (*vocab.CollectionPageType, error) {
 	it, err := h.activityStore.QueryReferences(
 		h.refType,

--- a/pkg/activitypub/resthandler/resthandler.go
+++ b/pkg/activitypub/resthandler/resthandler.go
@@ -26,6 +26,10 @@ const (
 	FollowersPath = "/followers"
 	// FollowingPath specifies the service's 'following' endpoint.
 	FollowingPath = "/following"
+	// OutboxPath specifies the service's 'outbox' endpoint.
+	OutboxPath = "/outbox"
+	// InboxPath specifies the service's 'inbox' endpoint.
+	InboxPath = "/inbox"
 )
 
 const (

--- a/pkg/activitypub/resthandler/resthandler_test.go
+++ b/pkg/activitypub/resthandler/resthandler_test.go
@@ -8,6 +8,7 @@ package resthandler
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/trustbloc/orb/pkg/activitypub/store/memstore"
 	"github.com/trustbloc/orb/pkg/activitypub/store/spi"
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
 )
 
 func TestNewHandler(t *testing.T) {
@@ -299,6 +301,25 @@ func newMockURIs(num int, getURI func(i int) string) []*url.URL {
 	}
 
 	return results
+}
+
+func newMockCreateActivities(num int) []*vocab.ActivityType {
+	activities := make([]*vocab.ActivityType, num)
+
+	for i := 0; i < num; i++ {
+		activities[i] = newMockCreateActivity(fmt.Sprintf("https://activity_%d", i), fmt.Sprintf("https://obj_%d", i))
+	}
+
+	return activities
+}
+
+func newMockCreateActivity(id, objID string) *vocab.ActivityType {
+	return vocab.NewCreateActivity(id, vocab.NewObjectProperty(
+		vocab.WithAnchorCredentialReference(
+			vocab.NewAnchorCredentialReference(objID, "bafkd34G7hD6gbj94fnKm5D"),
+		),
+	),
+	)
 }
 
 func setPaging(h *handler, page, pageNum string) func() {

--- a/pkg/activitypub/store/storeutil/storeutil.go
+++ b/pkg/activitypub/store/storeutil/storeutil.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 
 	store "github.com/trustbloc/orb/pkg/activitypub/store/spi"
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
 )
 
 // GetQueryOptions populates and returns the QueryOptions struct with the given options.
@@ -45,4 +46,25 @@ func ReadReferences(it store.ReferenceIterator, maxItems int) ([]*url.URL, error
 	}
 
 	return refs, nil
+}
+
+// ReadActivities returns all of the activities resulting from iterating over the given iterator,
+// up to the given maximum number of activities. If maxItems is <=0 then all items are read.
+func ReadActivities(it store.ActivityIterator, maxItems int) ([]*vocab.ActivityType, error) {
+	var activities []*vocab.ActivityType
+
+	for i := 0; maxItems <= 0 || i < maxItems; i++ {
+		ref, err := it.Next()
+		if err != nil {
+			if err == store.ErrNotFound {
+				break
+			}
+
+			return nil, err
+		}
+
+		activities = append(activities, ref)
+	}
+
+	return activities, nil
 }

--- a/pkg/activitypub/vocab/collection.go
+++ b/pkg/activitypub/vocab/collection.go
@@ -123,7 +123,7 @@ func NewOrderedCollection(items []*ObjectProperty, opts ...Opt) *OrderedCollecti
 }
 
 type orderedCollectionType struct {
-	OrderedItems []*ObjectProperty `json:"orderedItems"`
+	OrderedItems []*ObjectProperty `json:"orderedItems,omitempty"`
 }
 
 // Items returns the items in the ordered collection.


### PR DESCRIPTION
Added REST endpoints that return the activities in the service's inbox and outbox as an OrderedCollection or OrderedCollectionPage type. If the request does not include a 'page' parameter then an 'OrderedCollection' is returned that specifies the first and last page of the inbox or outbox. The first page contains the most recent activities. If the request contains a 'page=true' parameter then an 'OrderedCollectionPage' is returned containing the activities for that page, along with the URLs of the previous and next page.

closes #93
closes #94

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>