### PR TITLE
feat: Implemented '/witnesses' and '/witnessing' REST endpoints

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -307,6 +307,8 @@ func startOrbServices(parameters *orbParameters) error {
 		aphandler.NewFollowing(apCfg, apStore),
 		aphandler.NewOutbox(apCfg, apStore),
 		aphandler.NewInbox(apCfg, apStore),
+		aphandler.NewWitnesses(apCfg, apStore),
+		aphandler.NewWitnessing(apCfg, apStore),
 	)
 
 	srv := &HTTPServer{

--- a/pkg/activitypub/resthandler/resthandler.go
+++ b/pkg/activitypub/resthandler/resthandler.go
@@ -30,6 +30,10 @@ const (
 	OutboxPath = "/outbox"
 	// InboxPath specifies the service's 'inbox' endpoint.
 	InboxPath = "/inbox"
+	// WitnessesPath specifies the service's 'witnesses' endpoint.
+	WitnessesPath = "/witnesses"
+	// WitnessingPath specifies the service's 'witnessing' endpoint.
+	WitnessingPath = "/witnessing"
 )
 
 const (

--- a/pkg/activitypub/resthandler/resthandler_test.go
+++ b/pkg/activitypub/resthandler/resthandler_test.go
@@ -293,6 +293,7 @@ func mustParseURL(raw string) *url.URL {
 	return u
 }
 
+//nolint:unparam
 func newMockURIs(num int, getURI func(i int) string) []*url.URL {
 	results := make([]*url.URL, num)
 


### PR DESCRIPTION
Added REST endpoints that return a service's witnesses as well as the URIs that the local service is witnessing. If the request does not include a 'page' parameter then a 'Collection' is returned that specifies the first and last page of the witnesses/witnessing. If the request contains a 'page=true' parameter then a 'CollectionPage' is returned containing the witnesses/witnessing URIs for that page, along with the URIs of the previous and next page.

closes #97
closes #98

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>