### PR TITLE
feat:  '/liked' REST endpoint

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -309,6 +309,7 @@ func startOrbServices(parameters *orbParameters) error {
 		aphandler.NewInbox(apCfg, apStore),
 		aphandler.NewWitnesses(apCfg, apStore),
 		aphandler.NewWitnessing(apCfg, apStore),
+		aphandler.NewLiked(apCfg, apStore),
 	)
 
 	srv := &HTTPServer{

--- a/pkg/activitypub/resthandler/referencehandler_test.go
+++ b/pkg/activitypub/resthandler/referencehandler_test.go
@@ -348,6 +348,40 @@ func TestWitnessing_Handler(t *testing.T) {
 	})
 }
 
+func TestLiked_Handler(t *testing.T) {
+	serviceIRI, err := url.Parse(serviceURL)
+	require.NoError(t, err)
+
+	liked := newMockURIs(19, func(i int) string { return fmt.Sprintf("https://example.com/transactions%d", i+1) })
+
+	activityStore := memstore.New("")
+
+	for _, ref := range liked {
+		require.NoError(t, activityStore.AddReference(spi.Liked, serviceIRI, ref))
+	}
+
+	cfg := &Config{
+		BasePath:   basePath,
+		ServiceIRI: serviceIRI,
+		PageSize:   4,
+	}
+
+	h := NewLiked(cfg, activityStore)
+	require.NotNil(t, h)
+
+	t.Run("Main page -> Success", func(t *testing.T) {
+		handleRequest(t, h.handler, h.handle, "false", "", likedJSON)
+	})
+
+	t.Run("First page -> Success", func(t *testing.T) {
+		handleRequest(t, h.handler, h.handle, "true", "", likedFirstPageJSON)
+	})
+
+	t.Run("Page by num -> Success", func(t *testing.T) {
+		handleRequest(t, h.handler, h.handle, "true", "3", likedPage3JSON)
+	})
+}
+
 func handleRequest(t *testing.T, h *handler, handle http.HandlerFunc, page, pageNum, expected string) {
 	restorePaging := setPaging(h, page, pageNum)
 	defer restorePaging()
@@ -502,6 +536,44 @@ const (
     "https://example14.com/services/orb",
     "https://example15.com/services/orb",
     "https://example16.com/services/orb"
+  ]
+}`
+
+	likedJSON = `{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "id": "https://example1.com/services/orb/liked",
+  "type": "OrderedCollection",
+  "totalItems": 19,
+  "first": "https://example1.com/services/orb/liked?page=true",
+  "last": "https://example1.com/services/orb/liked?page=true&page-num=0"
+}`
+
+	likedFirstPageJSON = `{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "id": "https://example1.com/services/orb/liked?page=true&page-num=4",
+  "type": "OrderedCollectionPage",
+  "totalItems": 19,
+  "next": "https://example1.com/services/orb/liked?page=true&page-num=3",
+  "orderedItems": [
+    "https://example.com/transactions19",
+    "https://example.com/transactions18",
+    "https://example.com/transactions17",
+    "https://example.com/transactions16"
+  ]
+}`
+
+	likedPage3JSON = `{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "id": "https://example1.com/services/orb/liked?page=true&page-num=3",
+  "type": "OrderedCollectionPage",
+  "totalItems": 19,
+  "next": "https://example1.com/services/orb/liked?page=true&page-num=2",
+  "prev": "https://example1.com/services/orb/liked?page=true&page-num=4",
+  "orderedItems": [
+    "https://example.com/transactions15",
+    "https://example.com/transactions14",
+    "https://example.com/transactions13",
+    "https://example.com/transactions12"
   ]
 }`
 )

--- a/pkg/activitypub/resthandler/resthandler.go
+++ b/pkg/activitypub/resthandler/resthandler.go
@@ -34,6 +34,8 @@ const (
 	WitnessesPath = "/witnesses"
 	// WitnessingPath specifies the service's 'witnessing' endpoint.
 	WitnessingPath = "/witnessing"
+	// LikedPath specifies the service's 'liked' endpoint.
+	LikedPath = "/liked"
 )
 
 const (


### PR DESCRIPTION
Added a REST endpoint that returns the URIs of the objects that the service 'liked' as an OrderedCollection or OrderedCollectionPage type. If the request does not include a 'page' parameter then an 'OrderedCollection' is returned that specifies the first and last page of the objects that were liked. The most recent 'liked' objects are in the first page. If the request contains a 'page=true' parameter then an 'OrderedCollectionPage' is returned containing the IRI's of the liked for that page, along with the previous and next page.

closes #100

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>