### PR TITLE
chore: Changed object type 'Cas' to 'ContentAddressedStorage' and added 'cid' property to target

### DIFF
--- a/pkg/activitypub/resthandler/activityhandler_test.go
+++ b/pkg/activitypub/resthandler/activityhandler_test.go
@@ -288,8 +288,9 @@ const (
         ],
         "id": "https://obj_18",
         "target": {
-          "id": "bafkd34G7hD6gbj94fnKm5D",
-          "type": "Cas"
+          "id": "https://example.com/cas/bafkd34G7hD6gbj94fnKm5D",
+          "cid": "bafkd34G7hD6gbj94fnKm5D",
+          "type": "ContentAddressedStorage"
         },
         "type": "AnchorCredentialReference"
       },
@@ -305,8 +306,9 @@ const (
         ],
         "id": "https://obj_17",
         "target": {
-          "id": "bafkd34G7hD6gbj94fnKm5D",
-          "type": "Cas"
+          "id": "https://example.com/cas/bafkd34G7hD6gbj94fnKm5D",
+          "cid": "bafkd34G7hD6gbj94fnKm5D",
+          "type": "ContentAddressedStorage"
         },
         "type": "AnchorCredentialReference"
       },
@@ -322,8 +324,9 @@ const (
         ],
         "id": "https://obj_16",
         "target": {
-          "id": "bafkd34G7hD6gbj94fnKm5D",
-          "type": "Cas"
+          "id": "https://example.com/cas/bafkd34G7hD6gbj94fnKm5D",
+          "cid": "bafkd34G7hD6gbj94fnKm5D",
+          "type": "ContentAddressedStorage"
         },
         "type": "AnchorCredentialReference"
       },
@@ -339,8 +342,9 @@ const (
         ],
         "id": "https://obj_15",
         "target": {
-          "id": "bafkd34G7hD6gbj94fnKm5D",
-          "type": "Cas"
+          "id": "https://example.com/cas/bafkd34G7hD6gbj94fnKm5D",
+          "cid": "bafkd34G7hD6gbj94fnKm5D",
+          "type": "ContentAddressedStorage"
         },
         "type": "AnchorCredentialReference"
       },
@@ -365,8 +369,9 @@ const (
         ],
         "id": "https://obj_2",
         "target": {
-          "id": "bafkd34G7hD6gbj94fnKm5D",
-          "type": "Cas"
+          "id": "https://example.com/cas/bafkd34G7hD6gbj94fnKm5D",
+          "cid": "bafkd34G7hD6gbj94fnKm5D",
+          "type": "ContentAddressedStorage"
         },
         "type": "AnchorCredentialReference"
       },
@@ -382,8 +387,9 @@ const (
         ],
         "id": "https://obj_1",
         "target": {
-          "id": "bafkd34G7hD6gbj94fnKm5D",
-          "type": "Cas"
+          "id": "https://example.com/cas/bafkd34G7hD6gbj94fnKm5D",
+          "cid": "bafkd34G7hD6gbj94fnKm5D",
+          "type": "ContentAddressedStorage"
         },
         "type": "AnchorCredentialReference"
       },
@@ -399,8 +405,9 @@ const (
         ],
         "id": "https://obj_0",
         "target": {
-          "id": "bafkd34G7hD6gbj94fnKm5D",
-          "type": "Cas"
+          "id": "https://example.com/cas/bafkd34G7hD6gbj94fnKm5D",
+          "cid": "bafkd34G7hD6gbj94fnKm5D",
+          "type": "ContentAddressedStorage"
         },
         "type": "AnchorCredentialReference"
       },
@@ -427,8 +434,9 @@ const (
         ],
         "id": "https://obj_14",
         "target": {
-          "id": "bafkd34G7hD6gbj94fnKm5D",
-          "type": "Cas"
+          "id": "https://example.com/cas/bafkd34G7hD6gbj94fnKm5D",
+          "cid": "bafkd34G7hD6gbj94fnKm5D",
+          "type": "ContentAddressedStorage"
         },
         "type": "AnchorCredentialReference"
       },
@@ -444,8 +452,9 @@ const (
         ],
         "id": "https://obj_13",
         "target": {
-          "id": "bafkd34G7hD6gbj94fnKm5D",
-          "type": "Cas"
+          "id": "https://example.com/cas/bafkd34G7hD6gbj94fnKm5D",
+          "cid": "bafkd34G7hD6gbj94fnKm5D",
+          "type": "ContentAddressedStorage"
         },
         "type": "AnchorCredentialReference"
       },
@@ -461,8 +470,9 @@ const (
         ],
         "id": "https://obj_12",
         "target": {
-          "id": "bafkd34G7hD6gbj94fnKm5D",
-          "type": "Cas"
+          "id": "https://example.com/cas/bafkd34G7hD6gbj94fnKm5D",
+          "cid": "bafkd34G7hD6gbj94fnKm5D",
+          "type": "ContentAddressedStorage"
         },
         "type": "AnchorCredentialReference"
       },
@@ -478,8 +488,9 @@ const (
         ],
         "id": "https://obj_11",
         "target": {
-          "id": "bafkd34G7hD6gbj94fnKm5D",
-          "type": "Cas"
+          "id": "https://example.com/cas/bafkd34G7hD6gbj94fnKm5D",
+          "cid": "bafkd34G7hD6gbj94fnKm5D",
+          "type": "ContentAddressedStorage"
         },
         "type": "AnchorCredentialReference"
       },

--- a/pkg/activitypub/resthandler/resthandler_test.go
+++ b/pkg/activitypub/resthandler/resthandler_test.go
@@ -317,7 +317,8 @@ func newMockCreateActivities(num int) []*vocab.ActivityType {
 func newMockCreateActivity(id, objID string) *vocab.ActivityType {
 	return vocab.NewCreateActivity(id, vocab.NewObjectProperty(
 		vocab.WithAnchorCredentialReference(
-			vocab.NewAnchorCredentialReference(objID, "bafkd34G7hD6gbj94fnKm5D"),
+			vocab.NewAnchorCredentialReference(objID, "https://example.com/cas/bafkd34G7hD6gbj94fnKm5D",
+				"bafkd34G7hD6gbj94fnKm5D"),
 		),
 	),
 	)

--- a/pkg/activitypub/service/activityhandler/activityhandler.go
+++ b/pkg/activitypub/service/activityhandler/activityhandler.go
@@ -481,7 +481,7 @@ func (h *Handler) handleLikeActivity(like *vocab.ActivityType) error {
 }
 
 func (h *Handler) handleAnchorCredential(target *vocab.ObjectProperty, obj *vocab.ObjectType) error {
-	if !target.Type().Is(vocab.TypeCAS) {
+	if !target.Type().Is(vocab.TypeContentAddressedStorage) {
 		return fmt.Errorf("unsupported target type %s", target.Type().Types())
 	}
 
@@ -543,9 +543,10 @@ func (h *Handler) announceAnchorCredential(create *vocab.ActivityType) error {
 		return fmt.Errorf("unable to unmarshal anchor credential: %w", err)
 	}
 
+	targetObj := create.Target().Object()
+
 	ref, err := vocab.NewAnchorCredentialReferenceWithDocument(anchorCredential.ID(),
-		create.Target().Object().ID(), anchorCredDoc,
-	)
+		targetObj.ID(), targetObj.CID(), anchorCredDoc)
 	if err != nil {
 		return err
 	}

--- a/pkg/activitypub/service/activityhandler/activityhandler_test.go
+++ b/pkg/activitypub/service/activityhandler/activityhandler_test.go
@@ -111,7 +111,7 @@ func TestHandler_HandleCreateActivity(t *testing.T) {
 		targetProperty := vocab.NewObjectProperty(vocab.WithObject(
 			vocab.NewObject(
 				vocab.WithID(cid),
-				vocab.WithType(vocab.TypeCAS),
+				vocab.WithType(vocab.TypeContentAddressedStorage),
 			),
 		))
 
@@ -156,8 +156,9 @@ func TestHandler_HandleCreateActivity(t *testing.T) {
 
 	t.Run("Anchor credential reference", func(t *testing.T) {
 		const (
-			cid   = "bafkreiarkubvukdidicmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y"
-			refID = "http://sally.example.com/transactions/bafkreihwsnuregceqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
+			anchorCredID = "https://sally.example.com/cas/bafkreiarkubvukdidicmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y"
+			cid          = "bafkreiarkubvukdidicmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y"
+			refID        = "https://sally.example.com/transactions/bafkreihwsnuregceqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
 		)
 
 		published := time.Now()
@@ -165,7 +166,7 @@ func TestHandler_HandleCreateActivity(t *testing.T) {
 		create := vocab.NewCreateActivity(newActivityID(service1IRI),
 			vocab.NewObjectProperty(
 				vocab.WithAnchorCredentialReference(
-					vocab.NewAnchorCredentialReference(refID, cid),
+					vocab.NewAnchorCredentialReference(refID, anchorCredID, cid),
 				),
 			),
 			vocab.WithActor(service1IRI),
@@ -701,9 +702,12 @@ func TestHandler_HandleAnnounceActivity(t *testing.T) {
 	}()
 
 	t.Run("Anchor credential ref - collection (no embedded object)", func(t *testing.T) {
-		const cid = "bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y"
+		const (
+			anchorCredID = "https://sally.example.com/cas/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
+			cid          = "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
+		)
 
-		ref := vocab.NewAnchorCredentialReference(newTransactionID(service1IRI), cid)
+		ref := vocab.NewAnchorCredentialReference(newTransactionID(service1IRI), anchorCredID, cid)
 
 		items := []*vocab.ObjectProperty{
 			vocab.NewObjectProperty(
@@ -734,9 +738,12 @@ func TestHandler_HandleAnnounceActivity(t *testing.T) {
 	})
 
 	t.Run("Anchor credential ref - ordered collection (no embedded object)", func(t *testing.T) {
-		const cid = "bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y"
+		const (
+			anchorCredID = "https://sally.example.com/cas/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
+			cid          = "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
+		)
 
-		ref := vocab.NewAnchorCredentialReference(newTransactionID(service1IRI), cid)
+		ref := vocab.NewAnchorCredentialReference(newTransactionID(service1IRI), anchorCredID, cid)
 
 		items := []*vocab.ObjectProperty{
 			vocab.NewObjectProperty(
@@ -767,10 +774,13 @@ func TestHandler_HandleAnnounceActivity(t *testing.T) {
 	})
 
 	t.Run("Anchor credential ref (with embedded object)", func(t *testing.T) {
-		const cid = "bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y"
+		const (
+			anchorCredID = "https://sally.example.com/cas/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
+			cid          = "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
+		)
 
 		ref, err := vocab.NewAnchorCredentialReferenceWithDocument(newTransactionID(service1IRI),
-			cid, vocab.MustUnmarshalToDoc([]byte(anchorCredential1)),
+			anchorCredID, cid, vocab.MustUnmarshalToDoc([]byte(anchorCredential1)),
 		)
 		require.NoError(t, err)
 

--- a/pkg/activitypub/service/service_test.go
+++ b/pkg/activitypub/service/service_test.go
@@ -127,12 +127,12 @@ func TestService_Create(t *testing.T) {
 	defer service1.Stop()
 	defer service2.Stop()
 
-	const cid = "bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y"
+	const cid = "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
 
 	targetProperty := vocab.NewObjectProperty(vocab.WithObject(
 		vocab.NewObject(
 			vocab.WithID(cid),
-			vocab.WithType(vocab.TypeCAS),
+			vocab.WithType(vocab.TypeContentAddressedStorage),
 		),
 	))
 
@@ -481,9 +481,10 @@ func TestService_Announce(t *testing.T) {
 	defer service3.Stop()
 
 	t.Run("Announce - anchor credential ref (no embedded object)", func(t *testing.T) {
-		const cid = "bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y"
+		const anchorCredID = "https://sally.example.com/cas/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
+		const cid = "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
 
-		ref := vocab.NewAnchorCredentialReference(newActivityID(service2IRI), cid)
+		ref := vocab.NewAnchorCredentialReference(newActivityID(service2IRI), anchorCredID, cid)
 
 		items := []*vocab.ObjectProperty{
 			vocab.NewObjectProperty(
@@ -520,13 +521,14 @@ func TestService_Announce(t *testing.T) {
 
 		require.NotEmpty(t, subscriber3.Activities())
 
-		require.NotEmpty(t, anchorCredHandler3.AnchorCred(cid))
+		require.NotEmpty(t, anchorCredHandler3.AnchorCred(anchorCredID))
 	})
 
 	t.Run("Announce - anchor credential ref (with embedded object)", func(t *testing.T) {
-		const cid = "bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y"
+		const anchorCredID = "https://sally.example.com/cas/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
+		const cid = "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
 
-		ref, err := vocab.NewAnchorCredentialReferenceWithDocument(newTransactionID(service2IRI),
+		ref, err := vocab.NewAnchorCredentialReferenceWithDocument(newTransactionID(service2IRI), anchorCredID,
 			cid, vocab.MustUnmarshalToDoc([]byte(anchorCredential1)),
 		)
 		require.NoError(t, err)
@@ -566,7 +568,7 @@ func TestService_Announce(t *testing.T) {
 
 		require.NotEmpty(t, subscriber3.Activities())
 
-		require.NotEmpty(t, anchorCredHandler3.AnchorCred(cid))
+		require.NotEmpty(t, anchorCredHandler3.AnchorCred(anchorCredID))
 	})
 
 	t.Run("Create and announce", func(t *testing.T) {
@@ -602,7 +604,7 @@ func TestService_Announce(t *testing.T) {
 		targetProperty := vocab.NewObjectProperty(vocab.WithObject(
 			vocab.NewObject(
 				vocab.WithID(cid),
-				vocab.WithType(vocab.TypeCAS),
+				vocab.WithType(vocab.TypeContentAddressedStorage),
 			),
 		))
 

--- a/pkg/activitypub/vocab/activitytype_test.go
+++ b/pkg/activitypub/vocab/activitytype_test.go
@@ -36,7 +36,7 @@ func TestCreateTypeMarshal(t *testing.T) {
 		targetProperty := NewObjectProperty(WithObject(
 			NewObject(
 				WithID(cid),
-				WithType(TypeCAS),
+				WithType(TypeContentAddressedStorage),
 			),
 		))
 
@@ -87,7 +87,7 @@ func TestCreateTypeMarshal(t *testing.T) {
 		require.NotNil(t, targetProp)
 		require.NotNil(t, targetProp.Object())
 		require.Equal(t, cid, targetProp.Object().ID())
-		require.True(t, targetProp.Object().Type().Is(TypeCAS))
+		require.True(t, targetProp.Object().Type().Is(TypeContentAddressedStorage))
 
 		objProp := a.Object()
 		require.NotNil(t, objProp)
@@ -99,15 +99,16 @@ func TestCreateTypeMarshal(t *testing.T) {
 
 	t.Run("With AnchorCredentialReference", func(t *testing.T) {
 		const (
-			refID = "http://sally.example.com/transactions/bafkreihwsnuregceqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
-			cid   = "bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y"
+			refID         = "https://sally.example.com/transactions/bafkreihwsnuregceqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
+			cid           = "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
+			anchorCredIRI = "https://sally.example.com/cas/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
 		)
 
 		t.Run("Marshal", func(t *testing.T) {
 			create := NewCreateActivity(createActivityID,
 				NewObjectProperty(
 					WithAnchorCredentialReference(
-						NewAnchorCredentialReference(refID, cid),
+						NewAnchorCredentialReference(refID, anchorCredIRI, cid),
 					),
 				),
 				WithActor(actor),
@@ -159,16 +160,20 @@ func TestCreateTypeMarshal(t *testing.T) {
 
 			refTargetObj := refTarget.Object()
 			require.NotNil(t, refTargetObj)
-			require.Equal(t, cid, refTargetObj.ID())
+			require.Equal(t, anchorCredIRI, refTargetObj.ID())
+			require.Equal(t, cid, refTargetObj.CID())
 
 			refTargetObjType := refTargetObj.Type()
 			require.NotNil(t, refTargetObjType)
-			require.True(t, refTargetObjType.Is(TypeCAS))
+			require.True(t, refTargetObjType.Is(TypeContentAddressedStorage))
 		})
 	})
 
 	t.Run("With embedded AnchorCredential", func(t *testing.T) {
-		cid = "bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y"
+		const (
+			cid           = "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
+			anchorCredIRI = "https://sally.example.com/cas/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
+		)
 
 		t.Run("Marshal", func(t *testing.T) {
 			anchorCredential, err := NewObjectWithDocument(MustUnmarshalToDoc([]byte(anchorCredential)))
@@ -181,7 +186,7 @@ func TestCreateTypeMarshal(t *testing.T) {
 				WithTarget(
 					NewObjectProperty(
 						WithObject(
-							NewObject(WithID(cid), WithType(TypeCAS)),
+							NewObject(WithID(anchorCredIRI), WithCID(cid), WithType(TypeContentAddressedStorage)),
 						),
 					),
 				),
@@ -224,15 +229,16 @@ func TestCreateTypeMarshal(t *testing.T) {
 
 			targetProp := a.Target()
 			require.NotNil(t, targetProp)
-			require.True(t, targetProp.Type().Is(TypeCAS))
+			require.True(t, targetProp.Type().Is(TypeContentAddressedStorage))
 
 			targetObj := targetProp.Object()
 			require.NotNil(t, targetObj)
-			require.Equal(t, cid, targetObj.ID())
+			require.Equal(t, anchorCredIRI, targetObj.ID())
+			require.Equal(t, cid, targetObj.CID())
 
 			targetObjType := targetObj.Type()
 			require.NotNil(t, targetObjType)
-			require.True(t, targetObjType.Is(TypeCAS))
+			require.True(t, targetObjType.Is(TypeContentAddressedStorage))
 
 			objProp := a.Object()
 			require.NotNil(t, objProp)
@@ -302,11 +308,13 @@ func TestAnnounceTypeMarshal(t *testing.T) {
 
 	t.Run("With AnchorCredentialReferences", func(t *testing.T) {
 		const (
-			cid1 = "bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y"
-			cid2 = "bafkreiatkubvbkdedscmqwnkyls3iqawdqvthi7e6mbky2amuw3inxsi3y"
+			anchorCredIRI1 = "https://sally.example.com/cas/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
+			cid1           = "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
+			refID1         = "https://sally.example.com/transactions/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
 
-			refID1 = "http://sally.example.com/transactions/bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y"
-			refID2 = "http://sally.example.com/transactions/bafkreiatkubvbkdedscmqwnkyls3iqawdqvthi7e6mbky2amuw3inxsi3y"
+			anchorCredIRI2 = "https://sally.example.com/cas/bafkreiatkubvbkdedscmqwnkyls3iqawdqvthi7e6mbky2amuw3inxsi3y"
+			cid2           = "bafkreiatkubvbkdedscmqwnkyls3iqawdqvthi7e6mbky2amuw3inxsi3y"
+			refID2         = "https://sally.example.com/transactions/bafkreiatkubvbkdedscmqwnkyls3iqawdqvthi7e6mbky2amuw3inxsi3y"
 		)
 
 		published := getStaticTime()
@@ -315,12 +323,12 @@ func TestAnnounceTypeMarshal(t *testing.T) {
 			items := []*ObjectProperty{
 				NewObjectProperty(
 					WithAnchorCredentialReference(
-						NewAnchorCredentialReference(refID1, cid1),
+						NewAnchorCredentialReference(refID1, anchorCredIRI1, cid1),
 					),
 				),
 				NewObjectProperty(
 					WithAnchorCredentialReference(
-						NewAnchorCredentialReference(refID2, cid2),
+						NewAnchorCredentialReference(refID2, anchorCredIRI2, cid2),
 					),
 				),
 			}
@@ -385,7 +393,8 @@ func TestAnnounceTypeMarshal(t *testing.T) {
 
 			refTargetObj := refTargetProp.Object()
 			require.NotNil(t, refTargetObj)
-			require.Equal(t, cid1, refTargetObj.ID())
+			require.Equal(t, anchorCredIRI1, refTargetObj.ID())
+			require.Equal(t, cid1, refTargetObj.CID())
 
 			item = items[1]
 
@@ -398,20 +407,22 @@ func TestAnnounceTypeMarshal(t *testing.T) {
 
 			refTargetObj = refTargetProp.Object()
 			require.NotNil(t, refTargetObj)
-			require.Equal(t, cid2, refTargetObj.ID())
+			require.Equal(t, anchorCredIRI2, refTargetObj.ID())
+			require.Equal(t, cid2, refTargetObj.CID())
 		})
 	})
 
 	t.Run("With AnchorCredentialReference and embedded object", func(t *testing.T) {
 		const (
-			cid   = "bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y"
-			refID = "http://sally.example.com/transactions/bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y"
+			cid           = "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
+			anchorCredIRI = "https://sally.example.com/cas/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
+			refID         = "https://sally.example.com/transactions/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
 		)
 
 		published := getStaticTime()
 
 		t.Run("Marshal", func(t *testing.T) {
-			ref, err := NewAnchorCredentialReferenceWithDocument(refID, cid,
+			ref, err := NewAnchorCredentialReferenceWithDocument(refID, anchorCredIRI, cid,
 				MustUnmarshalToDoc([]byte(anchorCredential)),
 			)
 			require.NoError(t, err)
@@ -483,7 +494,8 @@ func TestAnnounceTypeMarshal(t *testing.T) {
 
 			refTargetObj := refTargetProp.Object()
 			require.NotNil(t, refTargetObj)
-			require.Equal(t, cid, refTargetObj.ID())
+			require.Equal(t, anchorCredIRI, refTargetObj.ID())
+			require.Equal(t, cid, refTargetObj.CID())
 
 			refObjProp := ref.Object()
 			require.NotNil(t, refObjProp)
@@ -855,7 +867,7 @@ const (
     "published": "2021-01-27T09:30:10Z",
     "target": {
       "id": "97bcd005-abb6-423d-a889-18bc1ce84988",
-      "type": "Cas"
+      "type": "ContentAddressedStorage"
     },
     "to": [
       "https://sally.example.com/services/orb/followers",
@@ -896,11 +908,12 @@ const (
           "https://www.w3.org/ns/activitystreams",
           "https://trustbloc.github.io/Context/orb-v1.json"
         ],
-        "id": "http://sally.example.com/transactions/bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y",
+        "id": "https://sally.example.com/transactions/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
         "type": "AnchorCredentialReference",
         "target": {
-          "id": "bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y",
-          "type": "Cas"
+          "id": "https://sally.example.com/cas/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
+          "cid": "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
+          "type": "ContentAddressedStorage"
         }
       },
       {
@@ -908,11 +921,12 @@ const (
           "https://www.w3.org/ns/activitystreams",
           "https://trustbloc.github.io/Context/orb-v1.json"
         ],
-        "id": "http://sally.example.com/transactions/bafkreiatkubvbkdedscmqwnkyls3iqawdqvthi7e6mbky2amuw3inxsi3y",
+        "id": "https://sally.example.com/transactions/bafkreiatkubvbkdedscmqwnkyls3iqawdqvthi7e6mbky2amuw3inxsi3y",
         "type": "AnchorCredentialReference",
         "target": {
-          "id": "bafkreiatkubvbkdedscmqwnkyls3iqawdqvthi7e6mbky2amuw3inxsi3y",
-          "type": "Cas"
+          "id": "https://sally.example.com/cas/bafkreiatkubvbkdedscmqwnkyls3iqawdqvthi7e6mbky2amuw3inxsi3y",
+          "cid": "bafkreiatkubvbkdedscmqwnkyls3iqawdqvthi7e6mbky2amuw3inxsi3y",
+          "type": "ContentAddressedStorage"
         }
       }
     ]
@@ -938,11 +952,12 @@ const (
           "https://www.w3.org/ns/activitystreams",
           "https://trustbloc.github.io/Context/orb-v1.json"
         ],
-        "id": "http://sally.example.com/transactions/bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y",
+        "id": "https://sally.example.com/transactions/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
         "type": "AnchorCredentialReference",
         "target": {
-          "id": "bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y",
-          "type": "Cas"
+          "id": "https://sally.example.com/cas/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
+          "cid": "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
+          "type": "ContentAddressedStorage"
         },
         "object": {
           "@context": [
@@ -1132,11 +1147,12 @@ const (
       "https://www.w3.org/ns/activitystreams",
       "https://trustbloc.github.io/Context/orb-v1.json"
     ],
-    "id": "http://sally.example.com/transactions/bafkreihwsnuregceqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
+    "id": "https://sally.example.com/transactions/bafkreihwsnuregceqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
     "type": "AnchorCredentialReference",
     "target": {
-      "type": "Cas",
-      "id": "bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y"
+      "type": "ContentAddressedStorage",
+      "id": "https://sally.example.com/cas/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
+      "cid": "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
     }
   }
 }`
@@ -1155,8 +1171,9 @@ const (
   ],
   "published": "2021-01-27T09:30:10Z",
   "target": {
-    "id": "bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y",
-    "type": "Cas"
+    "id": "https://sally.example.com/cas/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
+    "cid": "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
+    "type": "ContentAddressedStorage"
   },
   "object": {
     "@context": [

--- a/pkg/activitypub/vocab/anchorcredreftype.go
+++ b/pkg/activitypub/vocab/anchorcredreftype.go
@@ -19,7 +19,7 @@ type anchorCredentialReferenceType struct {
 }
 
 // NewAnchorCredentialReference returns a new "AnchorCredentialReference".
-func NewAnchorCredentialReference(id, cid string, opts ...Opt) *AnchorCredentialReferenceType {
+func NewAnchorCredentialReference(id, anchorCredIRI, cid string, opts ...Opt) *AnchorCredentialReferenceType {
 	options := NewOptions(opts...)
 
 	return &AnchorCredentialReferenceType{
@@ -32,7 +32,7 @@ func NewAnchorCredentialReference(id, cid string, opts ...Opt) *AnchorCredential
 			Target: NewObjectProperty(
 				WithObject(
 					NewObject(
-						WithID(cid), WithType(TypeCAS),
+						WithID(anchorCredIRI), WithCID(cid), WithType(TypeContentAddressedStorage),
 					),
 				),
 			),
@@ -42,7 +42,7 @@ func NewAnchorCredentialReference(id, cid string, opts ...Opt) *AnchorCredential
 
 // NewAnchorCredentialReferenceWithDocument returns a new "AnchorCredentialReference" with the given document embedded.
 func NewAnchorCredentialReferenceWithDocument(
-	id, cid string, doc Document, opts ...Opt) (*AnchorCredentialReferenceType, error) {
+	id, anchorCredIRI, cid string, doc Document, opts ...Opt) (*AnchorCredentialReferenceType, error) {
 	options := NewOptions(opts...)
 
 	obj, err := NewObjectWithDocument(doc)
@@ -60,7 +60,7 @@ func NewAnchorCredentialReferenceWithDocument(
 			Target: NewObjectProperty(
 				WithObject(
 					NewObject(
-						WithID(cid), WithType(TypeCAS),
+						WithID(anchorCredIRI), WithCID(cid), WithType(TypeContentAddressedStorage),
 					),
 				),
 			),

--- a/pkg/activitypub/vocab/anchorcredreftype_test.go
+++ b/pkg/activitypub/vocab/anchorcredreftype_test.go
@@ -14,18 +14,19 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
 )
 
-func TestNewAnchorCredentialReference(t *testing.T) {
-	const (
-		txID = "https://org1.com/transactions/tx1"
-		cid  = "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
-	)
+const (
+	txID          = "https://org1.com/transactions/tx1"
+	cid           = "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
+	anchorCredIRI = "https://sally.example.com/cas/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
+)
 
+func TestNewAnchorCredentialReference(t *testing.T) {
 	t.Run("No document", func(t *testing.T) {
-		ref := NewAnchorCredentialReference(txID, cid,
+		ref := NewAnchorCredentialReference(txID, anchorCredIRI, cid,
 			WithTarget(
 				NewObjectProperty(
 					WithObject(
-						NewObject(WithID(cid), WithType(TypeCAS)),
+						NewObject(WithID(cid), WithType(TypeContentAddressedStorage)),
 					),
 				),
 			),
@@ -47,20 +48,21 @@ func TestNewAnchorCredentialReference(t *testing.T) {
 
 		targetObjProp := targetProp.Object()
 		require.NotNil(t, targetObjProp)
-		require.Equal(t, cid, targetObjProp.ID())
+		require.Equal(t, anchorCredIRI, targetObjProp.ID())
+		require.Equal(t, cid, targetObjProp.CID())
 
 		targetTypeProp := targetObjProp.Type()
 		require.NotNil(t, targetTypeProp)
-		require.True(t, targetTypeProp.Is(TypeCAS))
+		require.True(t, targetTypeProp.Is(TypeContentAddressedStorage))
 	})
 
 	t.Run("With document", func(t *testing.T) {
-		ref, err := NewAnchorCredentialReferenceWithDocument(txID, cid, nil)
+		ref, err := NewAnchorCredentialReferenceWithDocument(txID, anchorCredIRI, cid, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "nil document")
 		require.Nil(t, ref)
 
-		ref, err = NewAnchorCredentialReferenceWithDocument(txID, cid,
+		ref, err = NewAnchorCredentialReferenceWithDocument(txID, anchorCredIRI, cid,
 			MustUnmarshalToDoc([]byte(anchorCredential)),
 		)
 		require.NoError(t, err)
@@ -81,11 +83,12 @@ func TestNewAnchorCredentialReference(t *testing.T) {
 
 		targetObjProp := targetProp.Object()
 		require.NotNil(t, targetObjProp)
-		require.Equal(t, cid, targetObjProp.ID())
+		require.Equal(t, anchorCredIRI, targetObjProp.ID())
+		require.Equal(t, cid, targetObjProp.CID())
 
 		targetTypeProp := targetObjProp.Type()
 		require.NotNil(t, targetTypeProp)
-		require.True(t, targetTypeProp.Is(TypeCAS))
+		require.True(t, targetTypeProp.Is(TypeContentAddressedStorage))
 
 		refObjProp := ref.Object()
 		require.NotNil(t, refObjProp)
@@ -104,17 +107,12 @@ func TestNewAnchorCredentialReference(t *testing.T) {
 }
 
 func TestAnchorCredentialReferenceMarshal(t *testing.T) {
-	const (
-		txID = "https://org1.com/transactions/tx1"
-		cid  = "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
-	)
-
 	t.Run("Marshal", func(t *testing.T) {
-		ref := NewAnchorCredentialReference(txID, cid,
+		ref := NewAnchorCredentialReference(txID, anchorCredIRI, cid,
 			WithTarget(
 				NewObjectProperty(
 					WithObject(
-						NewObject(WithID(cid), WithType(TypeCAS)),
+						NewObject(WithID(cid), WithType(TypeContentAddressedStorage)),
 					),
 				),
 			),
@@ -146,15 +144,16 @@ func TestAnchorCredentialReferenceMarshal(t *testing.T) {
 
 		targetObjProp := targetProp.Object()
 		require.NotNil(t, targetObjProp)
-		require.Equal(t, cid, targetObjProp.ID())
+		require.Equal(t, anchorCredIRI, targetObjProp.ID())
+		require.Equal(t, cid, targetObjProp.CID())
 
 		targetTypeProp := targetObjProp.Type()
 		require.NotNil(t, targetTypeProp)
-		require.True(t, targetTypeProp.Is(TypeCAS))
+		require.True(t, targetTypeProp.Is(TypeContentAddressedStorage))
 	})
 
 	t.Run("Marshal with document", func(t *testing.T) {
-		ref, err := NewAnchorCredentialReferenceWithDocument(txID, cid,
+		ref, err := NewAnchorCredentialReferenceWithDocument(txID, anchorCredIRI, cid,
 			MustUnmarshalToDoc([]byte(anchorCredential)),
 		)
 		require.NoError(t, err)
@@ -186,11 +185,12 @@ func TestAnchorCredentialReferenceMarshal(t *testing.T) {
 
 		targetObjProp := targetProp.Object()
 		require.NotNil(t, targetObjProp)
-		require.Equal(t, cid, targetObjProp.ID())
+		require.Equal(t, anchorCredIRI, targetObjProp.ID())
+		require.Equal(t, cid, targetObjProp.CID())
 
 		targetTypeProp := targetObjProp.Type()
 		require.NotNil(t, targetTypeProp)
-		require.True(t, targetTypeProp.Is(TypeCAS))
+		require.True(t, targetTypeProp.Is(TypeContentAddressedStorage))
 
 		refObjProp := ref.Object()
 		require.NotNil(t, refObjProp)
@@ -240,8 +240,9 @@ const (
   ],
   "id": "https://org1.com/transactions/tx1",
   "target": {
-    "id": "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
-    "type": "Cas"
+    "id": "https://sally.example.com/cas/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
+    "cid": "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
+    "type": "ContentAddressedStorage"
   },
   "type": "AnchorCredentialReference"
 }`
@@ -276,8 +277,9 @@ const (
     ]
   },
   "target": {
-    "id": "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
-    "type": "Cas"
+    "id": "https://sally.example.com/cas/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
+    "type": "ContentAddressedStorage",
+    "cid":  "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
   },
   "type": "AnchorCredentialReference"
 }`

--- a/pkg/activitypub/vocab/objecttype.go
+++ b/pkg/activitypub/vocab/objecttype.go
@@ -29,6 +29,7 @@ func NewObject(opts ...Opt) *ObjectType {
 		object: &objectType{
 			Context:   NewContextProperty(options.Context...),
 			ID:        options.ID,
+			CID:       options.CID,
 			Type:      NewTypeProperty(options.Types...),
 			To:        NewURLCollectionProperty(options.To...),
 			Published: options.Published,
@@ -67,6 +68,7 @@ type objectType struct {
 	Published *time.Time             `json:"published,omitempty"`
 	StartTime *time.Time             `json:"startTime,omitempty"`
 	EndTime   *time.Time             `json:"endTime,omitempty"`
+	CID       string                 `json:"cid,omitempty"`
 }
 
 // Context returns the context property.
@@ -112,6 +114,11 @@ func (t *ObjectType) To() []*url.URL {
 	}
 
 	return urls
+}
+
+// CID returns the object's content ID.
+func (t *ObjectType) CID() string {
+	return t.object.CID
 }
 
 // Value returns the value of a property.

--- a/pkg/activitypub/vocab/options.go
+++ b/pkg/activitypub/vocab/options.go
@@ -20,6 +20,7 @@ type Options struct {
 	StartTime *time.Time
 	EndTime   *time.Time
 	Types     []Type
+	CID       string
 
 	ObjectPropertyOptions
 	CollectionOptions
@@ -52,6 +53,13 @@ func WithContext(context ...Context) Opt {
 func WithID(id string) Opt {
 	return func(opts *Options) {
 		opts.ID = id
+	}
+}
+
+// WithCID sets the 'cid' property on the object.
+func WithCID(cid string) Opt {
+	return func(opts *Options) {
+		opts.CID = cid
 	}
 }
 

--- a/pkg/activitypub/vocab/options_test.go
+++ b/pkg/activitypub/vocab/options_test.go
@@ -60,7 +60,7 @@ func TestNewOptions(t *testing.T) {
 		iri: NewURLProperty(mustParseURL("https://property_result")),
 	}
 
-	anchorRef := NewAnchorCredentialReference("anchor_cred_ref_id", "cid")
+	anchorRef := NewAnchorCredentialReference("anchor_cred_ref_id", "anchor_cred_iri", "cid")
 
 	opts := NewOptions(
 		WithID(id),

--- a/pkg/activitypub/vocab/vocab.go
+++ b/pkg/activitypub/vocab/vocab.go
@@ -56,8 +56,8 @@ const (
 	// TypeVerifiableCredential specifies the "VerifiableCredential" object type.
 	TypeVerifiableCredential Type = "VerifiableCredential"
 
-	// TypeCAS specifies the "Cas" object type.
-	TypeCAS Type = "Cas"
+	// TypeContentAddressedStorage specifies the "ContentAddressedStorage" object type.
+	TypeContentAddressedStorage Type = "ContentAddressedStorage"
 	// TypeAnchorCredential specifies the "AnchorCredential" object type.
 	TypeAnchorCredential Type = "AnchorCredential"
 	// TypeAnchorCredentialRef specifies the "AnchorCredentialReference" object type.


### PR DESCRIPTION
The CAS object type has been renamed to 'ContentAddressedStorage' and the anchor credential reference target now has a resolvable 'id' as well as a 'cid' property.

closes #125

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>