### PR TITLE
refactor: Change ActivityPub object ID to URL

### DIFF
--- a/pkg/activitypub/resthandler/activityhandler_test.go
+++ b/pkg/activitypub/resthandler/activityhandler_test.go
@@ -24,9 +24,6 @@ import (
 const outboxURL = "https://example.com/services/orb/outbox"
 
 func TestNewOutbox(t *testing.T) {
-	serviceIRI, err := url.Parse(serviceURL)
-	require.NoError(t, err)
-
 	cfg := &Config{
 		BasePath:   basePath,
 		ServiceIRI: serviceIRI,
@@ -41,9 +38,6 @@ func TestNewOutbox(t *testing.T) {
 }
 
 func TestNewInbox(t *testing.T) {
-	serviceIRI, err := url.Parse(serviceURL)
-	require.NoError(t, err)
-
 	cfg := &Config{
 		BasePath:   basePath,
 		ServiceIRI: serviceIRI,
@@ -58,9 +52,6 @@ func TestNewInbox(t *testing.T) {
 }
 
 func TestActivities_Handler(t *testing.T) {
-	serviceIRI, err := url.Parse(serviceURL)
-	require.NoError(t, err)
-
 	activityStore := memstore.New("")
 
 	for _, activity := range newMockCreateActivities(19) {
@@ -145,9 +136,6 @@ func TestActivities_Handler(t *testing.T) {
 }
 
 func TestActivities_PageHandler(t *testing.T) {
-	serviceIRI, err := url.Parse(serviceURL)
-	require.NoError(t, err)
-
 	activityStore := memstore.New("")
 
 	for _, activity := range newMockCreateActivities(19) {

--- a/pkg/activitypub/resthandler/referencehandler_test.go
+++ b/pkg/activitypub/resthandler/referencehandler_test.go
@@ -11,7 +11,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,9 +23,6 @@ import (
 const followersURL = "https://example.com/services/orb/followers"
 
 func TestNewFollowers(t *testing.T) {
-	serviceIRI, err := url.Parse(serviceURL)
-	require.NoError(t, err)
-
 	cfg := &Config{
 		BasePath:   basePath,
 		ServiceIRI: serviceIRI,
@@ -41,9 +37,6 @@ func TestNewFollowers(t *testing.T) {
 }
 
 func TestNewFollowing(t *testing.T) {
-	serviceIRI, err := url.Parse(serviceURL)
-	require.NoError(t, err)
-
 	cfg := &Config{
 		BasePath:   basePath,
 		ServiceIRI: serviceIRI,
@@ -58,9 +51,6 @@ func TestNewFollowing(t *testing.T) {
 }
 
 func TestNewWitnesses(t *testing.T) {
-	serviceIRI, err := url.Parse(serviceURL)
-	require.NoError(t, err)
-
 	cfg := &Config{
 		BasePath:   basePath,
 		ServiceIRI: serviceIRI,
@@ -75,9 +65,6 @@ func TestNewWitnesses(t *testing.T) {
 }
 
 func TestNewWitnessing(t *testing.T) {
-	serviceIRI, err := url.Parse(serviceURL)
-	require.NoError(t, err)
-
 	cfg := &Config{
 		BasePath:   basePath,
 		ServiceIRI: serviceIRI,
@@ -92,9 +79,6 @@ func TestNewWitnessing(t *testing.T) {
 }
 
 func TestFollowers_Handler(t *testing.T) {
-	serviceIRI, err := url.Parse(serviceURL)
-	require.NoError(t, err)
-
 	followers := newMockURIs(19, func(i int) string { return fmt.Sprintf("https://example%d.com/services/orb", i) })
 
 	activityStore := memstore.New("")
@@ -181,9 +165,6 @@ func TestFollowers_Handler(t *testing.T) {
 }
 
 func TestFollowers_PageHandler(t *testing.T) {
-	serviceIRI, err := url.Parse(serviceURL)
-	require.NoError(t, err)
-
 	followers := newMockURIs(19, func(i int) string { return fmt.Sprintf("https://example%d.com/services/orb", i+1) })
 
 	activityStore := memstore.New("")
@@ -281,9 +262,6 @@ func TestFollowers_PageHandler(t *testing.T) {
 }
 
 func TestWitnesses_Handler(t *testing.T) {
-	serviceIRI, err := url.Parse(serviceURL)
-	require.NoError(t, err)
-
 	witnesses := newMockURIs(19, func(i int) string { return fmt.Sprintf("https://example%d.com/services/orb", i+1) })
 
 	activityStore := memstore.New("")
@@ -315,9 +293,6 @@ func TestWitnesses_Handler(t *testing.T) {
 }
 
 func TestWitnessing_Handler(t *testing.T) {
-	serviceIRI, err := url.Parse(serviceURL)
-	require.NoError(t, err)
-
 	witnessing := newMockURIs(19, func(i int) string { return fmt.Sprintf("https://example%d.com/services/orb", i+1) })
 
 	activityStore := memstore.New("")
@@ -349,9 +324,6 @@ func TestWitnessing_Handler(t *testing.T) {
 }
 
 func TestLiked_Handler(t *testing.T) {
-	serviceIRI, err := url.Parse(serviceURL)
-	require.NoError(t, err)
-
 	liked := newMockURIs(19, func(i int) string { return fmt.Sprintf("https://example.com/transactions%d", i+1) })
 
 	activityStore := memstore.New("")

--- a/pkg/activitypub/resthandler/resthandler_test.go
+++ b/pkg/activitypub/resthandler/resthandler_test.go
@@ -22,9 +22,6 @@ import (
 )
 
 func TestNewHandler(t *testing.T) {
-	serviceIRI, err := url.Parse(serviceURL)
-	require.NoError(t, err)
-
 	cfg := &Config{
 		BasePath:   basePath,
 		ServiceIRI: serviceIRI,
@@ -69,9 +66,6 @@ func TestGetLastPageNum(t *testing.T) {
 }
 
 func TestGetCurrentPrevNext(t *testing.T) {
-	serviceIRI, err := url.Parse(serviceURL)
-	require.NoError(t, err)
-
 	cfg := &Config{
 		BasePath:   basePath,
 		ServiceIRI: serviceIRI,
@@ -164,9 +158,6 @@ func TestGetCurrentPrevNext(t *testing.T) {
 }
 
 func TestGetIDPrevNextURL(t *testing.T) {
-	serviceIRI, err := url.Parse(serviceURL)
-	require.NoError(t, err)
-
 	cfg := &Config{
 		BasePath:   basePath,
 		ServiceIRI: serviceIRI,
@@ -185,7 +176,7 @@ func TestGetIDPrevNextURL(t *testing.T) {
 				},
 			)
 			require.NoError(t, err)
-			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=0", id)
+			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=0", id.String())
 			require.Nil(t, prev)
 			require.NotNil(t, next)
 			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=1", next.String())
@@ -200,7 +191,7 @@ func TestGetIDPrevNextURL(t *testing.T) {
 				},
 			)
 			require.NoError(t, err)
-			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=1", id)
+			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=1", id.String())
 			require.NotNil(t, prev)
 			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=0", prev.String())
 			require.NotNil(t, next)
@@ -216,7 +207,7 @@ func TestGetIDPrevNextURL(t *testing.T) {
 				},
 			)
 			require.NoError(t, err)
-			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=10", id)
+			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=10", id.String())
 			require.NotNil(t, prev)
 			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=2", prev.String())
 			require.Nil(t, next)
@@ -233,7 +224,7 @@ func TestGetIDPrevNextURL(t *testing.T) {
 				},
 			)
 			require.NoError(t, err)
-			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=2", id)
+			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=2", id.String())
 			require.Nil(t, prev)
 			require.NotNil(t, next)
 			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=1", next.String())
@@ -248,7 +239,7 @@ func TestGetIDPrevNextURL(t *testing.T) {
 				},
 			)
 			require.NoError(t, err)
-			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=1", id)
+			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=1", id.String())
 			require.NotNil(t, prev)
 			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=2", prev.String())
 			require.NotNil(t, next)
@@ -264,7 +255,7 @@ func TestGetIDPrevNextURL(t *testing.T) {
 				},
 			)
 			require.NoError(t, err)
-			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=10", id)
+			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=10", id.String())
 			require.Nil(t, prev)
 			require.NotNil(t, next)
 			require.Equal(t, "https://example1.com/services/orb?page=true&page-num=2", next.String())
@@ -315,9 +306,11 @@ func newMockCreateActivities(num int) []*vocab.ActivityType {
 }
 
 func newMockCreateActivity(id, objID string) *vocab.ActivityType {
-	return vocab.NewCreateActivity(id, vocab.NewObjectProperty(
+	return vocab.NewCreateActivity(mustParseURL(id), vocab.NewObjectProperty(
 		vocab.WithAnchorCredentialReference(
-			vocab.NewAnchorCredentialReference(objID, "https://example.com/cas/bafkd34G7hD6gbj94fnKm5D",
+			vocab.NewAnchorCredentialReference(
+				mustParseURL(objID),
+				mustParseURL("https://example.com/cas/bafkd34G7hD6gbj94fnKm5D"),
 				"bafkd34G7hD6gbj94fnKm5D"),
 		),
 	),

--- a/pkg/activitypub/resthandler/serviceshandler_test.go
+++ b/pkg/activitypub/resthandler/serviceshandler_test.go
@@ -11,7 +11,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -21,15 +20,11 @@ import (
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
 )
 
-const (
-	serviceURL = "https://example1.com/services/orb"
-	basePath   = "/services/orb"
-)
+const basePath = "/services/orb"
+
+var serviceIRI = mustParseURL("https://example1.com/services/orb")
 
 func TestNewServices(t *testing.T) {
-	serviceIRI, err := url.Parse(serviceURL)
-	require.NoError(t, err)
-
 	cfg := &Config{
 		BasePath:   basePath,
 		ServiceIRI: serviceIRI,
@@ -44,9 +39,6 @@ func TestNewServices(t *testing.T) {
 }
 
 func TestServices_Handler(t *testing.T) {
-	serviceIRI, err := url.Parse(serviceURL)
-	require.NoError(t, err)
-
 	cfg := &Config{
 		BasePath:   basePath,
 		ServiceIRI: serviceIRI,
@@ -62,7 +54,7 @@ func TestServices_Handler(t *testing.T) {
 		require.NotNil(t, h)
 
 		rw := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodGet, serviceURL, nil)
+		req := httptest.NewRequest(http.MethodGet, serviceIRI.String(), nil)
 
 		h.handle(rw, req)
 
@@ -88,7 +80,7 @@ func TestServices_Handler(t *testing.T) {
 		require.NotNil(t, h)
 
 		rw := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodGet, serviceURL, nil)
+		req := httptest.NewRequest(http.MethodGet, serviceIRI.String(), nil)
 
 		h.handle(rw, req)
 
@@ -108,7 +100,7 @@ func TestServices_Handler(t *testing.T) {
 		}
 
 		rw := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodGet, serviceURL, nil)
+		req := httptest.NewRequest(http.MethodGet, serviceIRI.String(), nil)
 
 		h.handle(rw, req)
 
@@ -141,7 +133,7 @@ func newMockService() *vocab.ActorType {
 		PublicKeyPem: keyPem,
 	}
 
-	return vocab.NewService(serviceURL,
+	return vocab.NewService(serviceIRI,
 		vocab.WithPublicKey(publicKey),
 		vocab.WithInbox(inbox),
 		vocab.WithOutbox(outbox),

--- a/pkg/activitypub/service/inbox/inbox_test.go
+++ b/pkg/activitypub/service/inbox/inbox_test.go
@@ -115,7 +115,7 @@ func TestInbox_Handle(t *testing.T) {
 		// Wait for the activity to be handled
 		time.Sleep(50 * time.Millisecond)
 
-		a, err := activityStore.GetActivity(store.Inbox, activity.ID())
+		a, err := activityStore.GetActivity(store.Inbox, activity.ID().URL())
 		require.NoError(t, err)
 		require.NotNil(t, a)
 		require.Equalf(t, activity.ID(), a.ID(), "The activity should have been stored in the inbox")
@@ -330,8 +330,8 @@ func newHTTPRequest(u string, activity *vocab.ActivityType) (*http.Request, erro
 	return req, nil
 }
 
-func newActivityID(serviceName string) string {
-	return fmt.Sprintf("%s/%s", serviceName, uuid.New())
+func newActivityID(serviceName string) *url.URL {
+	return mustParseURL(fmt.Sprintf("%s/%s", serviceName, uuid.New()))
 }
 
 func startHTTPServer(t *testing.T, listenAddress string, handlers ...common.HTTPHandler) func() {
@@ -342,4 +342,13 @@ func startHTTPServer(t *testing.T, listenAddress string, handlers ...common.HTTP
 	return func() {
 		require.NoError(t, httpServer.Stop(context.Background()))
 	}
+}
+
+func mustParseURL(raw string) *url.URL {
+	u, err := url.Parse(raw)
+	if err != nil {
+		panic(err)
+	}
+
+	return u
 }

--- a/pkg/activitypub/service/mocks/activitystore.gen.go
+++ b/pkg/activitypub/service/mocks/activitystore.gen.go
@@ -46,11 +46,11 @@ type ActivityStore struct {
 	addActivityReturnsOnCall map[int]struct {
 		result1 error
 	}
-	GetActivityStub        func(storeType spi.ActivityStoreType, activityID string) (*vocab.ActivityType, error)
+	GetActivityStub        func(storeType spi.ActivityStoreType, activityID *url.URL) (*vocab.ActivityType, error)
 	getActivityMutex       sync.RWMutex
 	getActivityArgsForCall []struct {
 		storeType  spi.ActivityStoreType
-		activityID string
+		activityID *url.URL
 	}
 	getActivityReturns struct {
 		result1 *vocab.ActivityType
@@ -268,12 +268,12 @@ func (fake *ActivityStore) AddActivityReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *ActivityStore) GetActivity(storeType spi.ActivityStoreType, activityID string) (*vocab.ActivityType, error) {
+func (fake *ActivityStore) GetActivity(storeType spi.ActivityStoreType, activityID *url.URL) (*vocab.ActivityType, error) {
 	fake.getActivityMutex.Lock()
 	ret, specificReturn := fake.getActivityReturnsOnCall[len(fake.getActivityArgsForCall)]
 	fake.getActivityArgsForCall = append(fake.getActivityArgsForCall, struct {
 		storeType  spi.ActivityStoreType
-		activityID string
+		activityID *url.URL
 	}{storeType, activityID})
 	fake.recordInvocation("GetActivity", []interface{}{storeType, activityID})
 	fake.getActivityMutex.Unlock()
@@ -292,7 +292,7 @@ func (fake *ActivityStore) GetActivityCallCount() int {
 	return len(fake.getActivityArgsForCall)
 }
 
-func (fake *ActivityStore) GetActivityArgsForCall(i int) (spi.ActivityStoreType, string) {
+func (fake *ActivityStore) GetActivityArgsForCall(i int) (spi.ActivityStoreType, *url.URL) {
 	fake.getActivityMutex.RLock()
 	defer fake.getActivityMutex.RUnlock()
 	return fake.getActivityArgsForCall[i].storeType, fake.getActivityArgsForCall[i].activityID

--- a/pkg/activitypub/service/mocks/mockanchorcredhandler.go
+++ b/pkg/activitypub/service/mocks/mockanchorcredhandler.go
@@ -32,7 +32,7 @@ func (m *AnchorCredentialHandler) WithError(err error) *AnchorCredentialHandler 
 }
 
 // HandlerAnchorCredential stores the anchor credential or returns an error if it was set.
-func (m *AnchorCredentialHandler) HandlerAnchorCredential(cid string, anchorCred []byte) error {
+func (m *AnchorCredentialHandler) HandlerAnchorCredential(id string, anchorCred []byte) error {
 	if m.err != nil {
 		return m.err
 	}
@@ -40,15 +40,15 @@ func (m *AnchorCredentialHandler) HandlerAnchorCredential(cid string, anchorCred
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	m.anchorCreds[cid] = anchorCred
+	m.anchorCreds[id] = anchorCred
 
 	return nil
 }
 
 // AnchorCred returns the anchor credential by ID or nil if it doesn't exist.
-func (m *AnchorCredentialHandler) AnchorCred(cid string) []byte {
+func (m *AnchorCredentialHandler) AnchorCred(id string) []byte {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	return m.anchorCreds[cid]
+	return m.anchorCreds[id]
 }

--- a/pkg/activitypub/service/outbox/outbox.go
+++ b/pkg/activitypub/service/outbox/outbox.go
@@ -169,7 +169,7 @@ func (h *Outbox) Post(activity *vocab.ActivityType) error {
 	}
 
 	for _, to := range activity.To() {
-		if err := h.publish(activity.ID(), activityBytes, to); err != nil {
+		if err := h.publish(activity.ID().String(), activityBytes, to); err != nil {
 			return errors.WithMessage(err, "unable to publish activity")
 		}
 	}

--- a/pkg/activitypub/service/outbox/outbox_test.go
+++ b/pkg/activitypub/service/outbox/outbox_test.go
@@ -121,7 +121,7 @@ func TestOutbox_Post(t *testing.T) {
 			require.NoError(t, json.Unmarshal(bytes, activity))
 
 			mutex.Lock()
-			activitiesReceived[activity.ID()] = activity
+			activitiesReceived[activity.ID().String()] = activity
 			mutex.Unlock()
 
 			w.WriteHeader(http.StatusOK)
@@ -178,7 +178,7 @@ func TestOutbox_Post(t *testing.T) {
 	time.Sleep(250 * time.Millisecond)
 
 	mutex.RLock()
-	_, ok := activitiesReceived[activity.ID()]
+	_, ok := activitiesReceived[activity.ID().String()]
 	mutex.RUnlock()
 	require.True(t, ok)
 
@@ -329,8 +329,8 @@ func TestOutbox_PostError(t *testing.T) {
 	})
 }
 
-func newActivityID(serviceName string) string {
-	return fmt.Sprintf("%s/%s", serviceName, uuid.New())
+func newActivityID(serviceName string) *url.URL {
+	return mustParseURL(fmt.Sprintf("%s/%s", serviceName, uuid.New()))
 }
 
 type testHandler struct {
@@ -355,4 +355,13 @@ func (m *testHandler) Method() string {
 
 func (m *testHandler) Handler() common.HTTPRequestHandler {
 	return m.handler
+}
+
+func mustParseURL(raw string) *url.URL {
+	u, err := url.Parse(raw)
+	if err != nil {
+		panic(err)
+	}
+
+	return u
 }

--- a/pkg/activitypub/service/spi/spi.go
+++ b/pkg/activitypub/service/spi/spi.go
@@ -58,7 +58,7 @@ type Inbox interface {
 
 // AnchorCredentialHandler handles a new, published anchor credential.
 type AnchorCredentialHandler interface {
-	HandlerAnchorCredential(cid string, anchorCred []byte) error
+	HandlerAnchorCredential(id string, anchorCred []byte) error
 }
 
 // FollowerAuth makes the decision of whether or not a request by the given

--- a/pkg/activitypub/store/memstore/iterator_test.go
+++ b/pkg/activitypub/store/memstore/iterator_test.go
@@ -18,9 +18,9 @@ import (
 )
 
 func TestActivityIterator(t *testing.T) {
-	const (
-		activityID1 = "activity1"
-		activityID2 = "activity2"
+	var (
+		activityID1 = mustParseURL("https://example.com/activities/activity1")
+		activityID2 = mustParseURL("https://example.com/activities/activity2")
 	)
 
 	activity1 := vocab.NewAnnounceActivity(activityID1, vocab.NewObjectProperty())
@@ -35,12 +35,12 @@ func TestActivityIterator(t *testing.T) {
 	a, err := it.Next()
 	require.NoError(t, err)
 	require.NotNil(t, a)
-	require.True(t, a.ID() == activityID1)
+	require.True(t, a.ID().String() == activityID1.String())
 
 	a, err = it.Next()
 	require.NoError(t, err)
 	require.NotNil(t, a)
-	require.True(t, a.ID() == activityID2)
+	require.True(t, a.ID().String() == activityID2.String())
 
 	a, err = it.Next()
 	require.Error(t, err)

--- a/pkg/activitypub/store/memstore/memstore.go
+++ b/pkg/activitypub/store/memstore/memstore.go
@@ -58,7 +58,7 @@ func (s *Store) PutActor(actor *vocab.ActorType) error {
 
 	logger.Debugf("[%s] Storing actor [%s]", s.serviceName, actor.ID())
 
-	s.actorStore[actor.ID()] = actor
+	s.actorStore[actor.ID().String()] = actor
 
 	return nil
 }
@@ -88,10 +88,10 @@ func (s *Store) AddActivity(storeType spi.ActivityStoreType, activity *vocab.Act
 
 // GetActivity returns the activity for the given ID from the given activity store
 // or ErrNotFound error if it wasn't found.
-func (s *Store) GetActivity(storeType spi.ActivityStoreType, activityID string) (*vocab.ActivityType, error) {
+func (s *Store) GetActivity(storeType spi.ActivityStoreType, activityID *url.URL) (*vocab.ActivityType, error) {
 	logger.Debugf("[%s] Retrieving activity from %s - ID: %s", s.serviceName, storeType, activityID)
 
-	return s.activityStores[storeType].get(activityID)
+	return s.activityStores[storeType].get(activityID.String())
 }
 
 // QueryActivities queries the given activity store using the provided criteria
@@ -144,7 +144,7 @@ func (s *activityStore) add(activity *vocab.ActivityType) error {
 	defer s.mutex.Unlock()
 
 	s.activities = append(s.activities, activity)
-	s.activityByID[activity.ID()] = activity
+	s.activityByID[activity.ID().String()] = activity
 
 	return nil
 }

--- a/pkg/activitypub/store/spi/spi.go
+++ b/pkg/activitypub/store/spi/spi.go
@@ -62,7 +62,7 @@ type Store interface {
 	AddActivity(storeType ActivityStoreType, activity *vocab.ActivityType) error
 	// GetActivity returns the activity for the given ID from the given activity store
 	// or an ErrNotFound error if it wasn't found.
-	GetActivity(storeType ActivityStoreType, activityID string) (*vocab.ActivityType, error)
+	GetActivity(storeType ActivityStoreType, activityID *url.URL) (*vocab.ActivityType, error)
 	// QueryActivities queries the given activity store using the provided criteria
 	// and returns a results iterator.
 	QueryActivities(storeType ActivityStoreType, query *Criteria, opts ...QueryOpt) (ActivityIterator, error)

--- a/pkg/activitypub/vocab/activitytype.go
+++ b/pkg/activitypub/vocab/activitytype.go
@@ -62,7 +62,7 @@ func (t *ActivityType) UnmarshalJSON(bytes []byte) error {
 }
 
 // NewCreateActivity returns a new 'Create' activity.
-func NewCreateActivity(id string, obj *ObjectProperty, opts ...Opt) *ActivityType {
+func NewCreateActivity(id *url.URL, obj *ObjectProperty, opts ...Opt) *ActivityType {
 	options := NewOptions(opts...)
 
 	return &ActivityType{
@@ -82,7 +82,7 @@ func NewCreateActivity(id string, obj *ObjectProperty, opts ...Opt) *ActivityTyp
 }
 
 // NewAnnounceActivity returns a new 'Announce' activity.
-func NewAnnounceActivity(id string, obj *ObjectProperty, opts ...Opt) *ActivityType {
+func NewAnnounceActivity(id *url.URL, obj *ObjectProperty, opts ...Opt) *ActivityType {
 	options := NewOptions(opts...)
 
 	return &ActivityType{
@@ -101,7 +101,7 @@ func NewAnnounceActivity(id string, obj *ObjectProperty, opts ...Opt) *ActivityT
 }
 
 // NewFollowActivity returns a new 'Follow' activity.
-func NewFollowActivity(id string, obj *ObjectProperty, opts ...Opt) *ActivityType {
+func NewFollowActivity(id *url.URL, obj *ObjectProperty, opts ...Opt) *ActivityType {
 	options := NewOptions(opts...)
 
 	return &ActivityType{
@@ -119,7 +119,7 @@ func NewFollowActivity(id string, obj *ObjectProperty, opts ...Opt) *ActivityTyp
 }
 
 // NewAcceptActivity returns a new 'Accept' activity.
-func NewAcceptActivity(id string, obj *ObjectProperty, opts ...Opt) *ActivityType {
+func NewAcceptActivity(id *url.URL, obj *ObjectProperty, opts ...Opt) *ActivityType {
 	options := NewOptions(opts...)
 
 	return &ActivityType{
@@ -137,7 +137,7 @@ func NewAcceptActivity(id string, obj *ObjectProperty, opts ...Opt) *ActivityTyp
 }
 
 // NewRejectActivity returns a new 'Reject' activity.
-func NewRejectActivity(id string, obj *ObjectProperty, opts ...Opt) *ActivityType {
+func NewRejectActivity(id *url.URL, obj *ObjectProperty, opts ...Opt) *ActivityType {
 	options := NewOptions(opts...)
 
 	return &ActivityType{
@@ -155,7 +155,7 @@ func NewRejectActivity(id string, obj *ObjectProperty, opts ...Opt) *ActivityTyp
 }
 
 // NewLikeActivity returns a new 'Like' activity.
-func NewLikeActivity(id string, obj *ObjectProperty, opts ...Opt) *ActivityType {
+func NewLikeActivity(id *url.URL, obj *ObjectProperty, opts ...Opt) *ActivityType {
 	options := NewOptions(opts...)
 
 	return &ActivityType{
@@ -176,7 +176,7 @@ func NewLikeActivity(id string, obj *ObjectProperty, opts ...Opt) *ActivityType 
 }
 
 // NewOfferActivity returns a new 'Offer' activity.
-func NewOfferActivity(id string, obj *ObjectProperty, opts ...Opt) *ActivityType {
+func NewOfferActivity(id *url.URL, obj *ObjectProperty, opts ...Opt) *ActivityType {
 	options := NewOptions(opts...)
 
 	return &ActivityType{

--- a/pkg/activitypub/vocab/actortype.go
+++ b/pkg/activitypub/vocab/actortype.go
@@ -137,7 +137,7 @@ func (t *ActorType) UnmarshalJSON(bytes []byte) error {
 }
 
 // NewService returns a new 'Service' actor type.
-func NewService(id string, opts ...Opt) *ActorType {
+func NewService(id *url.URL, opts ...Opt) *ActorType {
 	options := NewOptions(opts...)
 
 	return &ActorType{

--- a/pkg/activitypub/vocab/actortype_test.go
+++ b/pkg/activitypub/vocab/actortype_test.go
@@ -16,12 +16,12 @@ import (
 
 func TestActor(t *testing.T) {
 	const (
-		serviceID  = "https://alice.example.com/services/orb"
 		keyID      = "https://alice.example.com/services/orb#main-key"
 		keyOwnerID = "https://alice.example.com/services/orb"
 		keyPem     = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhki....."
 	)
 
+	serviceID := mustParseURL("https://alice.example.com/services/orb")
 	followers := mustParseURL("https://sally.example.com/services/orb/followers")
 	following := mustParseURL("https://sally.example.com/services/orb/following")
 	inbox := mustParseURL("https://alice.example.com/services/orb/inbox")
@@ -67,7 +67,7 @@ func TestActor(t *testing.T) {
 
 		id := a.ID()
 		require.NotNil(t, id)
-		require.Equal(t, serviceID, id)
+		require.Equal(t, serviceID.String(), id.String())
 
 		context := a.Context()
 		require.NotNil(t, context)
@@ -121,7 +121,7 @@ func TestActor(t *testing.T) {
 
 		id := a.ID()
 		require.NotNil(t, id)
-		require.Equal(t, serviceID, id)
+		require.Equal(t, serviceID.String(), id.String())
 
 		require.NotNil(t, a.Context())
 		require.Nil(t, a.PublicKey())

--- a/pkg/activitypub/vocab/anchorcredreftype.go
+++ b/pkg/activitypub/vocab/anchorcredreftype.go
@@ -6,6 +6,10 @@ SPDX-License-Identifier: Apache-2.0
 
 package vocab
 
+import (
+	"net/url"
+)
+
 // AnchorCredentialReferenceType defines an "AnchorCredentialReference" type.
 type AnchorCredentialReferenceType struct {
 	*ObjectType
@@ -19,7 +23,7 @@ type anchorCredentialReferenceType struct {
 }
 
 // NewAnchorCredentialReference returns a new "AnchorCredentialReference".
-func NewAnchorCredentialReference(id, anchorCredIRI, cid string, opts ...Opt) *AnchorCredentialReferenceType {
+func NewAnchorCredentialReference(id, anchorCredID *url.URL, cid string, opts ...Opt) *AnchorCredentialReferenceType {
 	options := NewOptions(opts...)
 
 	return &AnchorCredentialReferenceType{
@@ -32,7 +36,7 @@ func NewAnchorCredentialReference(id, anchorCredIRI, cid string, opts ...Opt) *A
 			Target: NewObjectProperty(
 				WithObject(
 					NewObject(
-						WithID(anchorCredIRI), WithCID(cid), WithType(TypeContentAddressedStorage),
+						WithID(anchorCredID), WithCID(cid), WithType(TypeContentAddressedStorage),
 					),
 				),
 			),
@@ -42,7 +46,7 @@ func NewAnchorCredentialReference(id, anchorCredIRI, cid string, opts ...Opt) *A
 
 // NewAnchorCredentialReferenceWithDocument returns a new "AnchorCredentialReference" with the given document embedded.
 func NewAnchorCredentialReferenceWithDocument(
-	id, anchorCredIRI, cid string, doc Document, opts ...Opt) (*AnchorCredentialReferenceType, error) {
+	id, anchorCredID *url.URL, cid string, doc Document, opts ...Opt) (*AnchorCredentialReferenceType, error) {
 	options := NewOptions(opts...)
 
 	obj, err := NewObjectWithDocument(doc)
@@ -60,7 +64,7 @@ func NewAnchorCredentialReferenceWithDocument(
 			Target: NewObjectProperty(
 				WithObject(
 					NewObject(
-						WithID(anchorCredIRI), WithCID(cid), WithType(TypeContentAddressedStorage),
+						WithID(anchorCredID), WithCID(cid), WithType(TypeContentAddressedStorage),
 					),
 				),
 			),

--- a/pkg/activitypub/vocab/anchorcredreftype_test.go
+++ b/pkg/activitypub/vocab/anchorcredreftype_test.go
@@ -14,10 +14,11 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
 )
 
-const (
-	txID          = "https://org1.com/transactions/tx1"
-	cid           = "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
-	anchorCredIRI = "https://sally.example.com/cas/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
+const cid = "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
+
+var (
+	anchorCredIRI = newMockID(host1, "/cas/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy")
+	txID          = mustParseURL("https://org1.com/transactions/tx1")
 )
 
 func TestNewAnchorCredentialReference(t *testing.T) {
@@ -26,14 +27,14 @@ func TestNewAnchorCredentialReference(t *testing.T) {
 			WithTarget(
 				NewObjectProperty(
 					WithObject(
-						NewObject(WithID(cid), WithType(TypeContentAddressedStorage)),
+						NewObject(WithID(anchorCredIRI), WithCID(cid), WithType(TypeContentAddressedStorage)),
 					),
 				),
 			),
 		)
 
 		require.NotNil(t, ref)
-		require.Equal(t, txID, ref.ID())
+		require.Equal(t, txID.String(), ref.ID().String())
 
 		contextProp := ref.Context()
 		require.NotNil(t, contextProp)
@@ -48,7 +49,7 @@ func TestNewAnchorCredentialReference(t *testing.T) {
 
 		targetObjProp := targetProp.Object()
 		require.NotNil(t, targetObjProp)
-		require.Equal(t, anchorCredIRI, targetObjProp.ID())
+		require.Equal(t, anchorCredIRI.String(), targetObjProp.ID().String())
 		require.Equal(t, cid, targetObjProp.CID())
 
 		targetTypeProp := targetObjProp.Type()
@@ -68,7 +69,7 @@ func TestNewAnchorCredentialReference(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NotNil(t, ref)
-		require.Equal(t, txID, ref.ID())
+		require.Equal(t, txID.String(), ref.ID().String())
 
 		contextProp := ref.Context()
 		require.NotNil(t, contextProp)
@@ -83,7 +84,7 @@ func TestNewAnchorCredentialReference(t *testing.T) {
 
 		targetObjProp := targetProp.Object()
 		require.NotNil(t, targetObjProp)
-		require.Equal(t, anchorCredIRI, targetObjProp.ID())
+		require.Equal(t, anchorCredIRI.String(), targetObjProp.ID().String())
 		require.Equal(t, cid, targetObjProp.CID())
 
 		targetTypeProp := targetObjProp.Type()
@@ -112,7 +113,7 @@ func TestAnchorCredentialReferenceMarshal(t *testing.T) {
 			WithTarget(
 				NewObjectProperty(
 					WithObject(
-						NewObject(WithID(cid), WithType(TypeContentAddressedStorage)),
+						NewObject(WithID(anchorCredIRI), WithCID(cid), WithType(TypeContentAddressedStorage)),
 					),
 				),
 			),
@@ -129,7 +130,7 @@ func TestAnchorCredentialReferenceMarshal(t *testing.T) {
 		ref := &AnchorCredentialReferenceType{}
 		require.NoError(t, json.Unmarshal([]byte(anchorCredentialReference), ref))
 
-		require.Equal(t, txID, ref.ID())
+		require.Equal(t, txID.String(), ref.ID().String())
 
 		contextProp := ref.Context()
 		require.NotNil(t, contextProp)
@@ -144,7 +145,7 @@ func TestAnchorCredentialReferenceMarshal(t *testing.T) {
 
 		targetObjProp := targetProp.Object()
 		require.NotNil(t, targetObjProp)
-		require.Equal(t, anchorCredIRI, targetObjProp.ID())
+		require.Equal(t, anchorCredIRI.String(), targetObjProp.ID().String())
 		require.Equal(t, cid, targetObjProp.CID())
 
 		targetTypeProp := targetObjProp.Type()
@@ -170,7 +171,7 @@ func TestAnchorCredentialReferenceMarshal(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(anchorCredentialReferenceWithDoc), ref))
 
 		require.NotNil(t, ref)
-		require.Equal(t, txID, ref.ID())
+		require.Equal(t, txID.String(), ref.ID().String())
 
 		contextProp := ref.Context()
 		require.NotNil(t, contextProp)
@@ -185,7 +186,7 @@ func TestAnchorCredentialReferenceMarshal(t *testing.T) {
 
 		targetObjProp := targetProp.Object()
 		require.NotNil(t, targetObjProp)
-		require.Equal(t, anchorCredIRI, targetObjProp.ID())
+		require.Equal(t, anchorCredIRI.String(), targetObjProp.ID().String())
 		require.Equal(t, cid, targetObjProp.CID())
 
 		targetTypeProp := targetObjProp.Type()

--- a/pkg/activitypub/vocab/collection_test.go
+++ b/pkg/activitypub/vocab/collection_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
 )
 
-const service1Inbox = "https://org1.com/services/service1/inbox"
+var service1Inbox = mustParseURL("https://org1.com/services/service1/inbox")
 
 func TestCollectionMarshal(t *testing.T) {
 	first := mustParseURL("https://org1.com/services/service1/inbox?page=true")
@@ -44,7 +44,7 @@ func TestCollectionMarshal(t *testing.T) {
 	t.Run("Unmarshal", func(t *testing.T) {
 		c := &CollectionType{}
 		require.NoError(t, json.Unmarshal([]byte(jsonCollection), c))
-		require.Equal(t, service1Inbox, c.ID())
+		require.Equal(t, service1Inbox.String(), c.ID().String())
 
 		context := c.Context()
 		require.NotNil(t, context)
@@ -109,7 +109,7 @@ func TestOrderedCollectionMarshal(t *testing.T) {
 	t.Run("Unmarshal", func(t *testing.T) {
 		c := &OrderedCollectionType{}
 		require.NoError(t, json.Unmarshal([]byte(jsonOrderedCollection), c))
-		require.Equal(t, service1Inbox, c.ID())
+		require.Equal(t, service1Inbox.String(), c.ID().String())
 
 		context := c.Context()
 		require.NotNil(t, context)

--- a/pkg/activitypub/vocab/collectionpage_test.go
+++ b/pkg/activitypub/vocab/collectionpage_test.go
@@ -15,9 +15,9 @@ import (
 )
 
 func TestCollectionPageMarshal(t *testing.T) {
-	collPage1 := "https://org1.com/services/service1/inbox?page=1"
-	collPage2 := "https://org1.com/services/service1/inbox?page=2"
-	collPage3 := "https://org1.com/services/service1/inbox?page=3"
+	collPage1 := mustParseURL("https://org1.com/services/service1/inbox?page=1")
+	collPage2 := mustParseURL("https://org1.com/services/service1/inbox?page=2")
+	collPage3 := mustParseURL("https://org1.com/services/service1/inbox?page=3")
 	activity1 := mustParseURL("https://org1.com/activities/activity1")
 	activity2 := mustParseURL("https://org1.com/activities/activity2")
 	activity3 := mustParseURL("https://org1.com/activities/activity3")
@@ -32,9 +32,9 @@ func TestCollectionPageMarshal(t *testing.T) {
 		coll := NewCollectionPage(items,
 			WithContext(ContextActivityStreams),
 			WithID(collPage2),
-			WithPartOf(mustParseURL(service1Inbox)),
-			WithPrev(mustParseURL(collPage1)),
-			WithNext(mustParseURL(collPage3)),
+			WithPartOf(service1Inbox),
+			WithPrev(collPage1),
+			WithNext(collPage3),
 		)
 
 		bytes, err := canonicalizer.MarshalCanonical(coll)
@@ -47,7 +47,7 @@ func TestCollectionPageMarshal(t *testing.T) {
 	t.Run("Unmarshal", func(t *testing.T) {
 		c := &CollectionPageType{}
 		require.NoError(t, json.Unmarshal([]byte(jsonCollectionPage), c))
-		require.Equal(t, collPage2, c.ID())
+		require.Equal(t, collPage2.String(), c.ID().String())
 
 		context := c.Context()
 		require.NotNil(t, context)
@@ -55,15 +55,15 @@ func TestCollectionPageMarshal(t *testing.T) {
 
 		partOf := c.PartOf()
 		require.NotNil(t, partOf)
-		require.Equal(t, service1Inbox, partOf.String())
+		require.Equal(t, service1Inbox.String(), partOf.String())
 
 		prev := c.Prev()
 		require.NotNil(t, prev)
-		require.Equal(t, collPage1, prev.String())
+		require.Equal(t, collPage1.String(), prev.String())
 
 		next := c.Next()
 		require.NotNil(t, next)
-		require.Equal(t, collPage3, next.String())
+		require.Equal(t, collPage3.String(), next.String())
 
 		require.Equal(t, 3, c.TotalItems())
 
@@ -73,9 +73,9 @@ func TestCollectionPageMarshal(t *testing.T) {
 }
 
 func TestOrderedCollectionPageMarshal(t *testing.T) {
-	collPage1 := "https://org1.com/services/service1/inbox?page=1"
-	collPage2 := "https://org1.com/services/service1/inbox?page=2"
-	collPage3 := "https://org1.com/services/service1/inbox?page=3"
+	collPage1 := mustParseURL("https://org1.com/services/service1/inbox?page=1")
+	collPage2 := mustParseURL("https://org1.com/services/service1/inbox?page=2")
+	collPage3 := mustParseURL("https://org1.com/services/service1/inbox?page=3")
 	activity1 := mustParseURL("https://org1.com/activities/activity1")
 	activity2 := mustParseURL("https://org1.com/activities/activity2")
 	activity3 := mustParseURL("https://org1.com/activities/activity3")
@@ -90,9 +90,9 @@ func TestOrderedCollectionPageMarshal(t *testing.T) {
 		coll := NewOrderedCollectionPage(items,
 			WithContext(ContextActivityStreams),
 			WithID(collPage2),
-			WithPartOf(mustParseURL(service1Inbox)),
-			WithPrev(mustParseURL(collPage1)),
-			WithNext(mustParseURL(collPage3)),
+			WithPartOf(service1Inbox),
+			WithPrev(collPage1),
+			WithNext(collPage3),
 		)
 
 		bytes, err := canonicalizer.MarshalCanonical(coll)
@@ -105,7 +105,7 @@ func TestOrderedCollectionPageMarshal(t *testing.T) {
 	t.Run("Unmarshal", func(t *testing.T) {
 		c := &OrderedCollectionPageType{}
 		require.NoError(t, json.Unmarshal([]byte(jsonOrderedCollectionPage), c))
-		require.Equal(t, collPage2, c.ID())
+		require.Equal(t, collPage2.String(), c.ID().String())
 
 		context := c.Context()
 		require.NotNil(t, context)
@@ -113,15 +113,15 @@ func TestOrderedCollectionPageMarshal(t *testing.T) {
 
 		partOf := c.PartOf()
 		require.NotNil(t, partOf)
-		require.Equal(t, service1Inbox, partOf.String())
+		require.Equal(t, service1Inbox.String(), partOf.String())
 
 		prev := c.Prev()
 		require.NotNil(t, prev)
-		require.Equal(t, collPage1, prev.String())
+		require.Equal(t, collPage1.String(), prev.String())
 
 		next := c.Next()
 		require.NotNil(t, next)
-		require.Equal(t, collPage3, next.String())
+		require.Equal(t, collPage3.String(), next.String())
 
 		require.Equal(t, 3, c.TotalItems())
 

--- a/pkg/activitypub/vocab/objectproperty_test.go
+++ b/pkg/activitypub/vocab/objectproperty_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	collID  = "https://org1.com/services/service1/inbox"
+	collID  = mustParseURL("https://org1.com/services/service1/inbox")
 	first   = mustParseURL("https://org1.com/services/service1/inbox?page=true")
 	last    = mustParseURL("https://org1.com/services/service1/inbox?page=true&end=true")
 	current = mustParseURL("https://org1.com/services/service1/inbox?page=2")
@@ -232,7 +232,7 @@ func TestObjectProperty_UnmarshalJSON(t *testing.T) {
 		require.NotNil(t, context)
 		require.True(t, context.Contains(ContextOrb))
 
-		require.Equal(t, objectPropertyID, obj.ID())
+		require.Equal(t, objectPropertyID.String(), obj.ID().String())
 
 		typeProp = obj.Type()
 		require.NotNil(t, typeProp)
@@ -256,7 +256,7 @@ func TestObjectProperty_UnmarshalJSON(t *testing.T) {
 		require.NotNil(t, context)
 		require.True(t, context.Contains(ContextActivityStreams))
 
-		require.Equal(t, collID, coll.ID())
+		require.Equal(t, collID.String(), coll.ID().String())
 
 		curr := coll.Current()
 		require.NotNil(t, curr)
@@ -305,7 +305,7 @@ func TestObjectProperty_UnmarshalJSON(t *testing.T) {
 		require.NotNil(t, context)
 		require.True(t, context.Contains(ContextActivityStreams))
 
-		require.Equal(t, collID, coll.ID())
+		require.Equal(t, collID.String(), coll.ID().String())
 
 		curr := coll.Current()
 		require.NotNil(t, curr)
@@ -338,14 +338,14 @@ func TestObjectProperty_UnmarshalJSON(t *testing.T) {
 	})
 }
 
-const (
-	objectPropertyID = "some_obj_ID"
+var objectPropertyID = mustParseURL("https://example.com/some_obj_ID")
 
+const (
 	jsonIRIObjectProperty = `"https://example.com/obj1"`
 
 	jsonEmbeddedObjectProperty = `{
   "@context": "https://trustbloc.github.io/Context/orb-v1.json",
-  "id": "some_obj_ID",
+  "id": "https://example.com/some_obj_ID",
   "type": "VerifiableCredential"
 }`
 	jsonCollectionObjectProperty = `{

--- a/pkg/activitypub/vocab/objecttype.go
+++ b/pkg/activitypub/vocab/objecttype.go
@@ -28,7 +28,7 @@ func NewObject(opts ...Opt) *ObjectType {
 	return &ObjectType{
 		object: &objectType{
 			Context:   NewContextProperty(options.Context...),
-			ID:        options.ID,
+			ID:        NewURLProperty(options.ID),
 			CID:       options.CID,
 			Type:      NewTypeProperty(options.Types...),
 			To:        NewURLCollectionProperty(options.To...),
@@ -62,7 +62,7 @@ func NewObjectWithDocument(doc Document, opts ...Opt) (*ObjectType, error) {
 
 type objectType struct {
 	Context   *ContextProperty       `json:"@context,omitempty"`
-	ID        string                 `json:"id,omitempty"`
+	ID        *URLProperty           `json:"id,omitempty"`
 	Type      *TypeProperty          `json:"type,omitempty"`
 	To        *URLCollectionProperty `json:"to,omitempty"`
 	Published *time.Time             `json:"published,omitempty"`
@@ -77,7 +77,7 @@ func (t *ObjectType) Context() *ContextProperty {
 }
 
 // ID returns the object's ID.
-func (t *ObjectType) ID() string {
+func (t *ObjectType) ID() *URLProperty {
 	return t.object.ID
 }
 

--- a/pkg/activitypub/vocab/objecttype_test.go
+++ b/pkg/activitypub/vocab/objecttype_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestObjectType_WithoutDocument(t *testing.T) {
-	const id = "http://sally.example.com/transactions/bafkreihwsn"
-
+	id := mustParseURL("http://sally.example.com/transactions/bafkreihwsn")
 	to1 := mustParseURL("https://to1")
 	to2 := mustParseURL("https://to2")
 
@@ -39,7 +38,7 @@ func TestObjectType_WithoutDocument(t *testing.T) {
 		require.NotNil(t, context)
 		require.True(t, context.Contains(ContextCredentials, ContextOrb))
 
-		require.Equal(t, id, obj.ID())
+		require.Equal(t, id.String(), obj.ID().String())
 
 		typeProp := obj.Type()
 		require.NotNil(t, typeProp)
@@ -82,7 +81,7 @@ func TestObjectType_WithoutDocument(t *testing.T) {
 		require.NotNil(t, context)
 		require.True(t, context.Contains(ContextCredentials, ContextOrb))
 
-		require.Equal(t, id, obj.ID())
+		require.Equal(t, id.String(), obj.ID().String())
 
 		typeProp := obj.Type()
 		require.NotNil(t, typeProp)
@@ -97,8 +96,7 @@ func TestObjectType_WithoutDocument(t *testing.T) {
 }
 
 func TestObjectType_WithDocument(t *testing.T) {
-	const id = "http://sally.example.com/transactions/bafkreihwsn"
-
+	id := mustParseURL("http://sally.example.com/transactions/bafkreihwsn")
 	to1 := mustParseURL("https://to1")
 	to2 := mustParseURL("https://to2")
 
@@ -150,7 +148,7 @@ func TestObjectType_WithDocument(t *testing.T) {
 		require.NotNil(t, context)
 		require.True(t, context.Contains(ContextCredentials, ContextOrb))
 
-		require.Equal(t, id, obj.ID())
+		require.Equal(t, id.String(), obj.ID().String())
 
 		typeProp := obj.Type()
 		require.NotNil(t, typeProp)

--- a/pkg/activitypub/vocab/options.go
+++ b/pkg/activitypub/vocab/options.go
@@ -14,7 +14,7 @@ import (
 // Options holds all of the options for building an ActivityPub object.
 type Options struct {
 	Context   []Context
-	ID        string
+	ID        *url.URL
 	To        []*url.URL
 	Published *time.Time
 	StartTime *time.Time
@@ -50,7 +50,7 @@ func WithContext(context ...Context) Opt {
 }
 
 // WithID sets the 'id' property on the object.
-func WithID(id string) Opt {
+func WithID(id *url.URL) Opt {
 	return func(opts *Options) {
 		opts.ID = id
 	}

--- a/pkg/activitypub/vocab/options_test.go
+++ b/pkg/activitypub/vocab/options_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestNewOptions(t *testing.T) {
-	const id = "https://example.com/1234"
+	id := mustParseURL("https://example.com/1234")
 
 	to1 := mustParseURL("https://to1")
 	to2 := mustParseURL("https://to2")
@@ -60,7 +60,10 @@ func TestNewOptions(t *testing.T) {
 		iri: NewURLProperty(mustParseURL("https://property_result")),
 	}
 
-	anchorRef := NewAnchorCredentialReference("anchor_cred_ref_id", "anchor_cred_iri", "cid")
+	anchorRef := NewAnchorCredentialReference(
+		mustParseURL("https://example.com/anchor_cred_ref_id"),
+		mustParseURL("https://example.com/anchor_cred_iri"),
+		"cid")
 
 	opts := NewOptions(
 		WithID(id),


### PR DESCRIPTION
The ID of an ActivityPub object was changed from string to *url.URL since it is always resolvable.

closes #132

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>