### PR TITLE
refactor: Move common testing functions into testutil

### DIFF
--- a/pkg/activitypub/resthandler/activityhandler_test.go
+++ b/pkg/activitypub/resthandler/activityhandler_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/trustbloc/orb/pkg/activitypub/service/mocks"
 	"github.com/trustbloc/orb/pkg/activitypub/store/memstore"
 	"github.com/trustbloc/orb/pkg/activitypub/store/spi"
+	"github.com/trustbloc/orb/pkg/internal/testutil"
 )
 
 const outboxURL = "https://example.com/services/orb/outbox"
@@ -81,7 +82,7 @@ func TestActivities_Handler(t *testing.T) {
 
 		t.Logf("%s", respBytes)
 
-		require.Equal(t, getCanonical(t, outboxJSON), getCanonical(t, string(respBytes)))
+		require.Equal(t, testutil.GetCanonical(t, outboxJSON), testutil.GetCanonical(t, string(respBytes)))
 		require.NoError(t, result.Body.Close())
 	})
 
@@ -248,7 +249,7 @@ func handleActivitiesRequest(t *testing.T, serviceIRI *url.URL, as spi.Store, pa
 
 	t.Logf("%s", respBytes)
 
-	require.Equal(t, getCanonical(t, expected), getCanonical(t, string(respBytes)))
+	require.Equal(t, testutil.GetCanonical(t, expected), testutil.GetCanonical(t, string(respBytes)))
 }
 
 const (

--- a/pkg/activitypub/resthandler/referencehandler_test.go
+++ b/pkg/activitypub/resthandler/referencehandler_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/trustbloc/orb/pkg/activitypub/service/mocks"
 	"github.com/trustbloc/orb/pkg/activitypub/store/memstore"
 	"github.com/trustbloc/orb/pkg/activitypub/store/spi"
+	"github.com/trustbloc/orb/pkg/internal/testutil"
 )
 
 const followersURL = "https://example.com/services/orb/followers"
@@ -79,7 +80,9 @@ func TestNewWitnessing(t *testing.T) {
 }
 
 func TestFollowers_Handler(t *testing.T) {
-	followers := newMockURIs(19, func(i int) string { return fmt.Sprintf("https://example%d.com/services/orb", i) })
+	followers := testutil.NewMockURLs(19, func(i int) string {
+		return fmt.Sprintf("https://example%d.com/services/orb", i)
+	})
 
 	activityStore := memstore.New("")
 
@@ -110,7 +113,7 @@ func TestFollowers_Handler(t *testing.T) {
 
 		t.Logf("%s", respBytes)
 
-		require.Equal(t, getCanonical(t, followersJSON), getCanonical(t, string(respBytes)))
+		require.Equal(t, testutil.GetCanonical(t, followersJSON), testutil.GetCanonical(t, string(respBytes)))
 		require.NoError(t, result.Body.Close())
 	})
 
@@ -165,7 +168,9 @@ func TestFollowers_Handler(t *testing.T) {
 }
 
 func TestFollowers_PageHandler(t *testing.T) {
-	followers := newMockURIs(19, func(i int) string { return fmt.Sprintf("https://example%d.com/services/orb", i+1) })
+	followers := testutil.NewMockURLs(19, func(i int) string {
+		return fmt.Sprintf("https://example%d.com/services/orb", i+1)
+	})
 
 	activityStore := memstore.New("")
 
@@ -262,7 +267,9 @@ func TestFollowers_PageHandler(t *testing.T) {
 }
 
 func TestWitnesses_Handler(t *testing.T) {
-	witnesses := newMockURIs(19, func(i int) string { return fmt.Sprintf("https://example%d.com/services/orb", i+1) })
+	witnesses := testutil.NewMockURLs(19, func(i int) string {
+		return fmt.Sprintf("https://example%d.com/services/orb", i+1)
+	})
 
 	activityStore := memstore.New("")
 
@@ -293,7 +300,9 @@ func TestWitnesses_Handler(t *testing.T) {
 }
 
 func TestWitnessing_Handler(t *testing.T) {
-	witnessing := newMockURIs(19, func(i int) string { return fmt.Sprintf("https://example%d.com/services/orb", i+1) })
+	witnessing := testutil.NewMockURLs(19, func(i int) string {
+		return fmt.Sprintf("https://example%d.com/services/orb", i+1)
+	})
 
 	activityStore := memstore.New("")
 
@@ -324,7 +333,7 @@ func TestWitnessing_Handler(t *testing.T) {
 }
 
 func TestLiked_Handler(t *testing.T) {
-	liked := newMockURIs(19, func(i int) string { return fmt.Sprintf("https://example.com/transactions%d", i+1) })
+	liked := testutil.NewMockURLs(19, func(i int) string { return fmt.Sprintf("https://example.com/transactions%d", i+1) })
 
 	activityStore := memstore.New("")
 
@@ -372,7 +381,7 @@ func handleRequest(t *testing.T, h *handler, handle http.HandlerFunc, page, page
 
 	t.Logf("%s", respBytes)
 
-	require.Equal(t, getCanonical(t, expected), getCanonical(t, string(respBytes)))
+	require.Equal(t, testutil.GetCanonical(t, expected), testutil.GetCanonical(t, string(respBytes)))
 }
 
 const (

--- a/pkg/activitypub/resthandler/resthandler_test.go
+++ b/pkg/activitypub/resthandler/resthandler_test.go
@@ -7,18 +7,16 @@ SPDX-License-Identifier: Apache-2.0
 package resthandler
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
 
 	"github.com/trustbloc/orb/pkg/activitypub/store/memstore"
 	"github.com/trustbloc/orb/pkg/activitypub/store/spi"
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+	"github.com/trustbloc/orb/pkg/internal/testutil"
 )
 
 func TestNewHandler(t *testing.T) {
@@ -263,38 +261,6 @@ func TestGetIDPrevNextURL(t *testing.T) {
 	})
 }
 
-func getCanonical(t *testing.T, raw string) string {
-	var expectedDoc map[string]interface{}
-
-	require.NoError(t, json.Unmarshal([]byte(raw), &expectedDoc))
-
-	bytes, err := canonicalizer.MarshalCanonical(expectedDoc)
-
-	require.NoError(t, err)
-
-	return string(bytes)
-}
-
-func mustParseURL(raw string) *url.URL {
-	u, err := url.Parse(raw)
-	if err != nil {
-		panic(err)
-	}
-
-	return u
-}
-
-//nolint:unparam
-func newMockURIs(num int, getURI func(i int) string) []*url.URL {
-	results := make([]*url.URL, num)
-
-	for i := 0; i < num; i++ {
-		results[i] = mustParseURL(getURI(i))
-	}
-
-	return results
-}
-
 func newMockCreateActivities(num int) []*vocab.ActivityType {
 	activities := make([]*vocab.ActivityType, num)
 
@@ -306,11 +272,11 @@ func newMockCreateActivities(num int) []*vocab.ActivityType {
 }
 
 func newMockCreateActivity(id, objID string) *vocab.ActivityType {
-	return vocab.NewCreateActivity(mustParseURL(id), vocab.NewObjectProperty(
+	return vocab.NewCreateActivity(testutil.MustParseURL(id), vocab.NewObjectProperty(
 		vocab.WithAnchorCredentialReference(
 			vocab.NewAnchorCredentialReference(
-				mustParseURL(objID),
-				mustParseURL("https://example.com/cas/bafkd34G7hD6gbj94fnKm5D"),
+				testutil.MustParseURL(objID),
+				testutil.MustParseURL("https://example.com/cas/bafkd34G7hD6gbj94fnKm5D"),
 				"bafkd34G7hD6gbj94fnKm5D"),
 		),
 	),

--- a/pkg/activitypub/resthandler/serviceshandler_test.go
+++ b/pkg/activitypub/resthandler/serviceshandler_test.go
@@ -18,11 +18,12 @@ import (
 	"github.com/trustbloc/orb/pkg/activitypub/service/mocks"
 	"github.com/trustbloc/orb/pkg/activitypub/store/memstore"
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+	"github.com/trustbloc/orb/pkg/internal/testutil"
 )
 
 const basePath = "/services/orb"
 
-var serviceIRI = mustParseURL("https://example1.com/services/orb")
+var serviceIRI = testutil.MustParseURL("https://example1.com/services/orb")
 
 func TestNewServices(t *testing.T) {
 	cfg := &Config{
@@ -66,7 +67,7 @@ func TestServices_Handler(t *testing.T) {
 
 		t.Logf("%s", respBytes)
 
-		require.Equal(t, getCanonical(t, serviceJSON), getCanonical(t, string(respBytes)))
+		require.Equal(t, testutil.GetCanonical(t, serviceJSON), testutil.GetCanonical(t, string(respBytes)))
 		require.NoError(t, result.Body.Close())
 	})
 
@@ -117,15 +118,15 @@ func newMockService() *vocab.ActorType {
 		keyPem     = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhki....."
 	)
 
-	followers := mustParseURL("https://example1.com/services/orb/followers")
-	following := mustParseURL("https://example1.com/services/orb/following")
-	inbox := mustParseURL("https://example1.com.com/services/orb/inbox")
-	outbox := mustParseURL("https://example1.com.com/services/orb/outbox")
-	witnesses := mustParseURL("https://example1.com.com/services/orb/witnesses")
-	witnessing := mustParseURL("https://example1.com.com/services/orb/witnessing")
-	likes := mustParseURL("https://example1.com.com/services/orb/likes")
-	liked := mustParseURL("https://example1.com.com/services/orb/liked")
-	shares := mustParseURL("https://example1.com.com/services/orb/shares")
+	followers := testutil.MustParseURL("https://example1.com/services/orb/followers")
+	following := testutil.MustParseURL("https://example1.com/services/orb/following")
+	inbox := testutil.MustParseURL("https://example1.com.com/services/orb/inbox")
+	outbox := testutil.MustParseURL("https://example1.com.com/services/orb/outbox")
+	witnesses := testutil.MustParseURL("https://example1.com.com/services/orb/witnesses")
+	witnessing := testutil.MustParseURL("https://example1.com.com/services/orb/witnessing")
+	likes := testutil.MustParseURL("https://example1.com.com/services/orb/likes")
+	liked := testutil.MustParseURL("https://example1.com.com/services/orb/liked")
+	shares := testutil.MustParseURL("https://example1.com.com/services/orb/shares")
 
 	publicKey := &vocab.PublicKeyType{
 		ID:           keyID,

--- a/pkg/activitypub/service/activityhandler/activityhandler_test.go
+++ b/pkg/activitypub/service/activityhandler/activityhandler_test.go
@@ -24,13 +24,14 @@ import (
 	store "github.com/trustbloc/orb/pkg/activitypub/store/spi"
 	"github.com/trustbloc/orb/pkg/activitypub/store/storeutil"
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+	"github.com/trustbloc/orb/pkg/internal/testutil"
 )
 
 const cid = "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
 
 var (
-	host1        = mustParseURL("https://sally.example.com")
-	anchorCredID = newMockID(host1, fmt.Sprintf("/cas/%s", cid))
+	host1        = testutil.MustParseURL("https://sally.example.com")
+	anchorCredID = testutil.NewMockID(host1, fmt.Sprintf("/cas/%s", cid))
 )
 
 func TestNew(t *testing.T) {
@@ -75,9 +76,9 @@ func TestHandler_HandleUnsupportedActivity(t *testing.T) {
 }
 
 func TestHandler_HandleCreateActivity(t *testing.T) {
-	service1IRI := mustParseURL("http://localhost:8301/services/service1")
-	service2IRI := mustParseURL("http://localhost:8302/services/service2")
-	service3IRI := mustParseURL("http://localhost:8303/services/service3")
+	service1IRI := testutil.MustParseURL("http://localhost:8301/services/service1")
+	service2IRI := testutil.MustParseURL("http://localhost:8302/services/service2")
+	service3IRI := testutil.MustParseURL("http://localhost:8303/services/service3")
 
 	cfg := &Config{
 		ServiceName: "service1",
@@ -161,7 +162,7 @@ func TestHandler_HandleCreateActivity(t *testing.T) {
 	})
 
 	t.Run("Anchor credential reference", func(t *testing.T) {
-		refID := mustParseURL("https://sally.example.com/transactions/bafkreihwsnuregceqh263vgdathcprnbvaty")
+		refID := testutil.MustParseURL("https://sally.example.com/transactions/bafkreihwsnuregceqh263vgdathcprnbvaty")
 
 		published := time.Now()
 
@@ -218,10 +219,10 @@ func TestHandler_HandleCreateActivity(t *testing.T) {
 }
 
 func TestHandler_HandleFollowActivity(t *testing.T) {
-	service1IRI := mustParseURL("http://localhost:8301/services/service1")
-	service2IRI := mustParseURL("http://localhost:8302/services/service2")
-	service3IRI := mustParseURL("http://localhost:8303/services/service3")
-	service4IRI := mustParseURL("http://localhost:8304/services/service4")
+	service1IRI := testutil.MustParseURL("http://localhost:8301/services/service1")
+	service2IRI := testutil.MustParseURL("http://localhost:8302/services/service2")
+	service3IRI := testutil.MustParseURL("http://localhost:8303/services/service3")
+	service4IRI := testutil.MustParseURL("http://localhost:8304/services/service4")
 
 	cfg := &Config{
 		ServiceName: "service1",
@@ -393,8 +394,8 @@ func TestHandler_HandleFollowActivity(t *testing.T) {
 }
 
 func TestHandler_HandleAcceptActivity(t *testing.T) {
-	service1IRI := mustParseURL("http://localhost:8301/services/service1")
-	service2IRI := mustParseURL("http://localhost:8302/services/service2")
+	service1IRI := testutil.MustParseURL("http://localhost:8301/services/service1")
+	service2IRI := testutil.MustParseURL("http://localhost:8302/services/service2")
 
 	cfg := &Config{
 		ServiceName: "service2",
@@ -533,8 +534,8 @@ func TestHandler_HandleAcceptActivity(t *testing.T) {
 }
 
 func TestHandler_HandleRejectActivity(t *testing.T) {
-	service1IRI := mustParseURL("http://localhost:8301/services/service1")
-	service2IRI := mustParseURL("http://localhost:8302/services/service2")
+	service1IRI := testutil.MustParseURL("http://localhost:8301/services/service1")
+	service2IRI := testutil.MustParseURL("http://localhost:8302/services/service2")
 
 	cfg := &Config{
 		ServiceName: "service2",
@@ -672,8 +673,8 @@ func TestHandler_HandleRejectActivity(t *testing.T) {
 }
 
 func TestHandler_HandleAnnounceActivity(t *testing.T) {
-	service1IRI := mustParseURL("http://localhost:8301/services/service1")
-	service2IRI := mustParseURL("http://localhost:8302/services/service2")
+	service1IRI := testutil.MustParseURL("http://localhost:8301/services/service1")
+	service2IRI := testutil.MustParseURL("http://localhost:8302/services/service2")
 
 	cfg := &Config{
 		ServiceName: "service1",
@@ -868,8 +869,8 @@ func TestHandler_HandleAnnounceActivity(t *testing.T) {
 }
 
 func TestHandler_HandleOfferActivity(t *testing.T) {
-	service1IRI := mustParseURL("http://localhost:8301/services/service1")
-	service2IRI := mustParseURL("http://localhost:8302/services/service2")
+	service1IRI := testutil.MustParseURL("http://localhost:8301/services/service1")
+	service2IRI := testutil.MustParseURL("http://localhost:8302/services/service2")
 
 	cfg := &Config{
 		ServiceName: "service1",
@@ -1052,8 +1053,8 @@ func TestHandler_HandleOfferActivity(t *testing.T) {
 func TestHandler_HandleLikeActivity(t *testing.T) {
 	log.SetLevel("activitypub_service", log.WARNING)
 
-	service1IRI := mustParseURL("http://localhost:8301/services/service1")
-	service2IRI := mustParseURL("http://localhost:8302/services/service2")
+	service1IRI := testutil.MustParseURL("http://localhost:8301/services/service1")
+	service2IRI := testutil.MustParseURL("http://localhost:8302/services/service2")
 
 	cfg := &Config{
 		ServiceName: "service1",
@@ -1230,24 +1231,11 @@ func TestHandler_HandleLikeActivity(t *testing.T) {
 }
 
 func newActivityID(id fmt.Stringer) *url.URL {
-	return newMockID(id, uuid.New().String())
+	return testutil.NewMockID(id, uuid.New().String())
 }
 
 func newTransactionID(id fmt.Stringer) *url.URL {
-	return newMockID(id, uuid.New().String())
-}
-
-func newMockID(serviceIRI fmt.Stringer, path string) *url.URL {
-	return mustParseURL(fmt.Sprintf("%s%s", serviceIRI, path))
-}
-
-func mustParseURL(raw string) *url.URL {
-	u, err := url.Parse(raw)
-	if err != nil {
-		panic(err)
-	}
-
-	return u
+	return testutil.NewMockID(id, uuid.New().String())
 }
 
 const anchorCredential1 = `{

--- a/pkg/activitypub/service/inbox/inbox_test.go
+++ b/pkg/activitypub/service/inbox/inbox_test.go
@@ -30,6 +30,7 @@ import (
 	store "github.com/trustbloc/orb/pkg/activitypub/store/spi"
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
 	"github.com/trustbloc/orb/pkg/httpserver"
+	"github.com/trustbloc/orb/pkg/internal/testutil"
 )
 
 //go:generate counterfeiter -o ../mocks/activityhandler.gen.go --fake-name ActivityHandler ../spi ActivityHandler
@@ -331,7 +332,7 @@ func newHTTPRequest(u string, activity *vocab.ActivityType) (*http.Request, erro
 }
 
 func newActivityID(serviceName string) *url.URL {
-	return mustParseURL(fmt.Sprintf("%s/%s", serviceName, uuid.New()))
+	return testutil.MustParseURL(fmt.Sprintf("%s/%s", serviceName, uuid.New()))
 }
 
 func startHTTPServer(t *testing.T, listenAddress string, handlers ...common.HTTPHandler) func() {
@@ -342,13 +343,4 @@ func startHTTPServer(t *testing.T, listenAddress string, handlers ...common.HTTP
 	return func() {
 		require.NoError(t, httpServer.Stop(context.Background()))
 	}
-}
-
-func mustParseURL(raw string) *url.URL {
-	u, err := url.Parse(raw)
-	if err != nil {
-		panic(err)
-	}
-
-	return u
 }

--- a/pkg/activitypub/service/outbox/outbox_test.go
+++ b/pkg/activitypub/service/outbox/outbox_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/trustbloc/orb/pkg/activitypub/store/memstore"
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
 	"github.com/trustbloc/orb/pkg/httpserver"
+	"github.com/trustbloc/orb/pkg/internal/testutil"
 )
 
 func TestNewOutbox(t *testing.T) {
@@ -330,7 +331,7 @@ func TestOutbox_PostError(t *testing.T) {
 }
 
 func newActivityID(serviceName string) *url.URL {
-	return mustParseURL(fmt.Sprintf("%s/%s", serviceName, uuid.New()))
+	return testutil.MustParseURL(fmt.Sprintf("%s/%s", serviceName, uuid.New()))
 }
 
 type testHandler struct {
@@ -355,13 +356,4 @@ func (m *testHandler) Method() string {
 
 func (m *testHandler) Handler() common.HTTPRequestHandler {
 	return m.handler
-}
-
-func mustParseURL(raw string) *url.URL {
-	u, err := url.Parse(raw)
-	if err != nil {
-		panic(err)
-	}
-
-	return u
 }

--- a/pkg/activitypub/service/service_test.go
+++ b/pkg/activitypub/service/service_test.go
@@ -28,13 +28,14 @@ import (
 	"github.com/trustbloc/orb/pkg/activitypub/store/storeutil"
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
 	"github.com/trustbloc/orb/pkg/httpserver"
+	"github.com/trustbloc/orb/pkg/internal/testutil"
 )
 
 const cid = "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
 
 var (
-	host1        = mustParseURL("https://sally.example.com")
-	anchorCredID = newMockID(host1, "/cas/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy")
+	host1        = testutil.MustParseURL("https://sally.example.com")
+	anchorCredID = testutil.NewMockID(host1, "/cas/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy")
 )
 
 func TestNewService(t *testing.T) {
@@ -66,8 +67,8 @@ func TestNewService(t *testing.T) {
 func TestService_Create(t *testing.T) {
 	log.SetLevel(wmlogger.Module, log.WARNING)
 
-	service1IRI := mustParseURL("http://localhost:8301/services/service1")
-	service2IRI := mustParseURL("http://localhost:8302/services/service2")
+	service1IRI := testutil.MustParseURL("http://localhost:8301/services/service1")
+	service2IRI := testutil.MustParseURL("http://localhost:8302/services/service2")
 
 	cfg1 := &Config{
 		ServiceEndpoint: "/services/service1",
@@ -147,7 +148,7 @@ func TestService_Create(t *testing.T) {
 		panic(err)
 	}
 
-	unavailableServiceIRI := mustParseURL("http://localhost:8304/services/service4")
+	unavailableServiceIRI := testutil.MustParseURL("http://localhost:8304/services/service4")
 
 	create := vocab.NewCreateActivity(newActivityID(service1IRI),
 		vocab.NewObjectProperty(vocab.WithObject(obj)),
@@ -181,8 +182,8 @@ func TestService_Create(t *testing.T) {
 func TestService_Follow(t *testing.T) {
 	log.SetLevel(wmlogger.Module, log.WARNING)
 
-	service1IRI := mustParseURL("http://localhost:8301/services/service1")
-	service2IRI := mustParseURL("http://localhost:8302/services/service2")
+	service1IRI := testutil.MustParseURL("http://localhost:8301/services/service1")
+	service2IRI := testutil.MustParseURL("http://localhost:8302/services/service2")
 
 	cfg1 := &Config{
 		ServiceEndpoint: "/services/service1",
@@ -390,9 +391,9 @@ func TestService_Follow(t *testing.T) {
 func TestService_Announce(t *testing.T) {
 	log.SetLevel(wmlogger.Module, log.WARNING)
 
-	service1IRI := mustParseURL("http://localhost:8301/services/service1")
-	service2IRI := mustParseURL("http://localhost:8302/services/service2")
-	service3IRI := mustParseURL("http://localhost:8303/services/service3")
+	service1IRI := testutil.MustParseURL("http://localhost:8301/services/service1")
+	service2IRI := testutil.MustParseURL("http://localhost:8302/services/service2")
+	service3IRI := testutil.MustParseURL("http://localhost:8303/services/service3")
 
 	cfg1 := &Config{
 		ServiceEndpoint: "/services/service1",
@@ -652,9 +653,9 @@ func TestService_Announce(t *testing.T) {
 func TestService_Offer(t *testing.T) {
 	log.SetLevel(wmlogger.Module, log.WARNING)
 
-	service1IRI := mustParseURL("http://localhost:8301/services/service1")
-	service2IRI := mustParseURL("http://localhost:8302/services/service2")
-	service3IRI := mustParseURL("http://localhost:8303/services/service3")
+	service1IRI := testutil.MustParseURL("http://localhost:8301/services/service1")
+	service2IRI := testutil.MustParseURL("http://localhost:8302/services/service2")
+	service3IRI := testutil.MustParseURL("http://localhost:8303/services/service3")
 
 	cfg1 := &Config{
 		ServiceEndpoint: "/services/service1",
@@ -796,24 +797,11 @@ func TestService_Offer(t *testing.T) {
 }
 
 func newActivityID(serviceName fmt.Stringer) *url.URL {
-	return mustParseURL(fmt.Sprintf("%s/%s", serviceName, uuid.New()))
+	return testutil.MustParseURL(fmt.Sprintf("%s/%s", serviceName, uuid.New()))
 }
 
 func newTransactionID(serviceName fmt.Stringer) *url.URL {
-	return mustParseURL(fmt.Sprintf("%s/%s", serviceName, uuid.New()))
-}
-
-func mustParseURL(raw string) *url.URL {
-	u, err := url.Parse(raw)
-	if err != nil {
-		panic(err)
-	}
-
-	return u
-}
-
-func newMockID(serviceIRI fmt.Stringer, path string) *url.URL {
-	return mustParseURL(fmt.Sprintf("%s%s", serviceIRI, path))
+	return testutil.MustParseURL(fmt.Sprintf("%s/%s", serviceName, uuid.New()))
 }
 
 func containsIRI(iris []*url.URL, iri fmt.Stringer) bool {

--- a/pkg/activitypub/store/memstore/iterator_test.go
+++ b/pkg/activitypub/store/memstore/iterator_test.go
@@ -15,12 +15,13 @@ import (
 
 	"github.com/trustbloc/orb/pkg/activitypub/store/spi"
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+	"github.com/trustbloc/orb/pkg/internal/testutil"
 )
 
 func TestActivityIterator(t *testing.T) {
 	var (
-		activityID1 = mustParseURL("https://example.com/activities/activity1")
-		activityID2 = mustParseURL("https://example.com/activities/activity2")
+		activityID1 = testutil.MustParseURL("https://example.com/activities/activity1")
+		activityID2 = testutil.MustParseURL("https://example.com/activities/activity2")
 	)
 
 	activity1 := vocab.NewAnnounceActivity(activityID1, vocab.NewObjectProperty())
@@ -51,8 +52,8 @@ func TestActivityIterator(t *testing.T) {
 }
 
 func TestReferenceIterator(t *testing.T) {
-	ref1 := mustParseURL("https://ref_1")
-	ref2 := mustParseURL("https://ref_2")
+	ref1 := testutil.MustParseURL("https://ref_1")
+	ref2 := testutil.MustParseURL("https://ref_2")
 
 	results := []*url.URL{ref1, ref2}
 

--- a/pkg/activitypub/store/memstore/memstore_test.go
+++ b/pkg/activitypub/store/memstore/memstore_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/trustbloc/orb/pkg/activitypub/store/spi"
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+	"github.com/trustbloc/orb/pkg/internal/testutil"
 )
 
 func TestStore_Activity(t *testing.T) {
@@ -23,10 +24,10 @@ func TestStore_Activity(t *testing.T) {
 	require.NotNil(t, s)
 
 	var (
-		activityID1 = mustParseURL("https://example.com/activities/activity1")
-		activityID2 = mustParseURL("https://example.com/activities/activity2")
-		activityID3 = mustParseURL("https://example.com/activities/activity3")
-		activityID4 = mustParseURL("https://example.com/activities/activity4")
+		activityID1 = testutil.MustParseURL("https://example.com/activities/activity1")
+		activityID2 = testutil.MustParseURL("https://example.com/activities/activity2")
+		activityID3 = testutil.MustParseURL("https://example.com/activities/activity3")
+		activityID4 = testutil.MustParseURL("https://example.com/activities/activity4")
 	)
 
 	a, err := s.GetActivity(spi.Inbox, activityID1)
@@ -78,9 +79,9 @@ func TestStore_Reference(t *testing.T) {
 	s := New("service1")
 	require.NotNil(t, s)
 
-	actor1 := mustParseURL("https://actor1")
-	actor2 := mustParseURL("https://actor2")
-	actor3 := mustParseURL("https://actor3")
+	actor1 := testutil.MustParseURL("https://actor1")
+	actor2 := testutil.MustParseURL("https://actor2")
+	actor3 := testutil.MustParseURL("https://actor3")
 
 	it, err := s.QueryReferences(spi.Follower, spi.NewCriteria())
 	require.EqualError(t, err, "actor IRI is required")
@@ -137,8 +138,8 @@ func TestStore_Actors(t *testing.T) {
 	s := New("service1")
 	require.NotNil(t, s)
 
-	actor1IRI := mustParseURL("https://actor1")
-	actor2IRI := mustParseURL("https://actor2")
+	actor1IRI := testutil.MustParseURL("https://actor1")
+	actor2IRI := testutil.MustParseURL("https://actor2")
 
 	a, err := s.GetActor(actor1IRI)
 	require.EqualError(t, err, spi.ErrNotFound.Error())
@@ -256,7 +257,9 @@ func TestActivityQueryResults(t *testing.T) {
 }
 
 func TestReferenceQueryResults(t *testing.T) {
-	results := refQueryResults(newMockURIs(10))
+	results := refQueryResults(testutil.NewMockURLs(10, func(i int) string {
+		return fmt.Sprintf("https://ref_%d", i)
+	}))
 
 	// No paging
 	filtered, totalItems := results.filter(spi.NewCriteria())
@@ -345,20 +348,11 @@ func containsIRI(iri fmt.Stringer, iris []*url.URL) bool {
 	return false
 }
 
-func mustParseURL(raw string) *url.URL {
-	u, err := url.Parse(raw)
-	if err != nil {
-		panic(err)
-	}
-
-	return u
-}
-
 func newMockActivities(t vocab.Type, num int) []*vocab.ActivityType {
 	activities := make([]*vocab.ActivityType, num)
 
 	for i := 0; i < num; i++ {
-		a := newMockActivity(t, mustParseURL(fmt.Sprintf("https://activity_%s_%d", t, i)))
+		a := newMockActivity(t, testutil.MustParseURL(fmt.Sprintf("https://activity_%s_%d", t, i)))
 		activities[i] = a
 	}
 
@@ -371,14 +365,4 @@ func newMockActivity(t vocab.Type, id *url.URL) *vocab.ActivityType {
 	}
 
 	return vocab.NewCreateActivity(id, vocab.NewObjectProperty())
-}
-
-func newMockURIs(num int) []*url.URL {
-	results := make([]*url.URL, num)
-
-	for i := 0; i < num; i++ {
-		results[i] = mustParseURL(fmt.Sprintf("https://ref_%d", i))
-	}
-
-	return results
 }

--- a/pkg/activitypub/vocab/activitytype_test.go
+++ b/pkg/activitypub/vocab/activitytype_test.go
@@ -15,12 +15,14 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
+
+	"github.com/trustbloc/orb/pkg/internal/testutil"
 )
 
 var (
-	host1    = mustParseURL("https://sally.example.com")
-	service1 = mustParseURL("https://sally.example.com/services/orb")
-	witness1 = mustParseURL("https://witness1.example.com/services/orb")
+	host1    = testutil.MustParseURL("https://sally.example.com")
+	service1 = testutil.MustParseURL("https://sally.example.com/services/orb")
+	witness1 = testutil.MustParseURL("https://witness1.example.com/services/orb")
 
 	createActivityID = newMockID(service1, "/activities/97bcd005-abb6-423d-a889-18bc1ce84988")
 	followActivityID = newMockID(service1, "/activities/97b3d005-abb6-422d-a889-18bc1ee84988")
@@ -32,7 +34,7 @@ var (
 
 func TestCreateTypeMarshal(t *testing.T) {
 	followers := newMockID(service1, "/followers")
-	public := mustParseURL("https://www.w3.org/ns/activitystreams#Public")
+	public := testutil.MustParseURL("https://www.w3.org/ns/activitystreams#Public")
 
 	published := getStaticTime()
 
@@ -63,7 +65,7 @@ func TestCreateTypeMarshal(t *testing.T) {
 
 		t.Log(string(bytes))
 
-		require.Equal(t, getCanonical(t, jsonCreate), string(bytes))
+		require.Equal(t, testutil.GetCanonical(t, jsonCreate), string(bytes))
 	})
 
 	t.Run("Unmarshal", func(t *testing.T) {
@@ -125,7 +127,7 @@ func TestCreateTypeMarshal(t *testing.T) {
 			require.NoError(t, err)
 			t.Log(string(bytes))
 
-			require.Equal(t, getCanonical(t, jsonCreateWithAnchorCredentialRef), string(bytes))
+			require.Equal(t, testutil.GetCanonical(t, jsonCreateWithAnchorCredentialRef), string(bytes))
 		})
 
 		t.Run("Unmarshal", func(t *testing.T) {
@@ -199,7 +201,7 @@ func TestCreateTypeMarshal(t *testing.T) {
 			require.NoError(t, err)
 			t.Log(string(bytes))
 
-			require.Equal(t, getCanonical(t, jsonCreateWithAnchorCredential), string(bytes))
+			require.Equal(t, testutil.GetCanonical(t, jsonCreateWithAnchorCredential), string(bytes))
 		})
 
 		t.Run("Unmarshal", func(t *testing.T) {
@@ -250,7 +252,7 @@ func TestCreateTypeMarshal(t *testing.T) {
 
 func TestAnnounceTypeMarshal(t *testing.T) {
 	followers := newMockID(service1, "/followers")
-	public := mustParseURL("https://www.w3.org/ns/activitystreams#Public")
+	public := testutil.MustParseURL("https://www.w3.org/ns/activitystreams#Public")
 	txn1 := newMockID(host1, "/transactions/bafkeexwtkfyvbkdidscmqywkyls3i")
 
 	t.Run("Single object", func(t *testing.T) {
@@ -269,7 +271,7 @@ func TestAnnounceTypeMarshal(t *testing.T) {
 			require.NoError(t, err)
 			t.Log(string(bytes))
 
-			require.Equal(t, getCanonical(t, jsonAnnounce), string(bytes))
+			require.Equal(t, testutil.GetCanonical(t, jsonAnnounce), string(bytes))
 		})
 
 		t.Run("Unmarshal", func(t *testing.T) {
@@ -344,7 +346,7 @@ func TestAnnounceTypeMarshal(t *testing.T) {
 			require.NoError(t, err)
 			t.Log(string(bytes))
 
-			require.Equal(t, getCanonical(t, jsonAnnounceWithAnchorCredRefs), string(bytes))
+			require.Equal(t, testutil.GetCanonical(t, jsonAnnounceWithAnchorCredRefs), string(bytes))
 		})
 
 		t.Run("Unmarshal", func(t *testing.T) {
@@ -442,7 +444,7 @@ func TestAnnounceTypeMarshal(t *testing.T) {
 			require.NoError(t, err)
 			t.Log(string(bytes))
 
-			require.Equal(t, getCanonical(t, jsonAnnounceWithAnchorCredRefAndEmbeddedCred), string(bytes))
+			require.Equal(t, testutil.GetCanonical(t, jsonAnnounceWithAnchorCredRefAndEmbeddedCred), string(bytes))
 		})
 
 		t.Run("Unmarshal", func(t *testing.T) {
@@ -504,8 +506,8 @@ func TestAnnounceTypeMarshal(t *testing.T) {
 }
 
 func TestFollowTypeMarshal(t *testing.T) {
-	org1Service := mustParseURL("https://org1.com/services/service1")
-	org2Service := mustParseURL("https://org1.com/services/service2")
+	org1Service := testutil.MustParseURL("https://org1.com/services/service1")
+	org2Service := testutil.MustParseURL("https://org1.com/services/service2")
 
 	t.Run("Marshal", func(t *testing.T) {
 		follow := NewFollowActivity(followActivityID,
@@ -518,7 +520,7 @@ func TestFollowTypeMarshal(t *testing.T) {
 		require.NoError(t, err)
 		t.Log(string(bytes))
 
-		require.Equal(t, getCanonical(t, jsonFollow), string(bytes))
+		require.Equal(t, testutil.GetCanonical(t, jsonFollow), string(bytes))
 	})
 
 	t.Run("Unmarshal", func(t *testing.T) {
@@ -546,8 +548,8 @@ func TestFollowTypeMarshal(t *testing.T) {
 }
 
 func TestAcceptTypeMarshal(t *testing.T) {
-	org1Service := mustParseURL("https://org1.com/services/service1")
-	org2Service := mustParseURL("https://org1.com/services/service2")
+	org1Service := testutil.MustParseURL("https://org1.com/services/service1")
+	org2Service := testutil.MustParseURL("https://org1.com/services/service2")
 
 	follow := NewFollowActivity(followActivityID,
 		NewObjectProperty(WithIRI(org2Service)),
@@ -568,7 +570,7 @@ func TestAcceptTypeMarshal(t *testing.T) {
 		require.NoError(t, err)
 		t.Log(string(bytes))
 
-		require.Equal(t, getCanonical(t, jsonAccept), string(bytes))
+		require.Equal(t, testutil.GetCanonical(t, jsonAccept), string(bytes))
 	})
 
 	t.Run("Unmarshal", func(t *testing.T) {
@@ -616,8 +618,8 @@ func TestAcceptTypeMarshal(t *testing.T) {
 }
 
 func TestRejectTypeMarshal(t *testing.T) {
-	org1Service := mustParseURL("https://org1.com/services/service1")
-	org2Service := mustParseURL("https://org1.com/services/service2")
+	org1Service := testutil.MustParseURL("https://org1.com/services/service1")
+	org2Service := testutil.MustParseURL("https://org1.com/services/service2")
 
 	follow := NewFollowActivity(followActivityID, NewObjectProperty(WithIRI(org2Service)),
 		WithTo(org2Service),
@@ -636,7 +638,7 @@ func TestRejectTypeMarshal(t *testing.T) {
 		require.NoError(t, err)
 		t.Log(string(bytes))
 
-		require.Equal(t, getCanonical(t, jsonReject), string(bytes))
+		require.Equal(t, testutil.GetCanonical(t, jsonReject), string(bytes))
 	})
 
 	t.Run("Unmarshal", func(t *testing.T) {
@@ -685,7 +687,7 @@ func TestRejectTypeMarshal(t *testing.T) {
 
 func TestOfferTypeMarshal(t *testing.T) {
 	to := newMockID(service1, "/witnesses")
-	public := mustParseURL(PublicIRI)
+	public := testutil.MustParseURL(PublicIRI)
 
 	startTime := getStaticTime()
 	endTime := startTime.Add(1 * time.Minute)
@@ -706,7 +708,7 @@ func TestOfferTypeMarshal(t *testing.T) {
 		require.NoError(t, err)
 		t.Log(string(bytes))
 
-		require.Equal(t, getCanonical(t, jsonOffer), string(bytes))
+		require.Equal(t, testutil.GetCanonical(t, jsonOffer), string(bytes))
 	})
 
 	t.Run("Unmarshal", func(t *testing.T) {
@@ -747,9 +749,9 @@ func TestOfferTypeMarshal(t *testing.T) {
 }
 
 func TestLikeTypeMarshal(t *testing.T) {
-	actor := mustParseURL("https://witness1.example.com/services/orb")
-	public := mustParseURL(PublicIRI)
-	credID := mustParseURL("http://sally.example.com/transactions/bafkreihwsn")
+	actor := testutil.MustParseURL("https://witness1.example.com/services/orb")
+	public := testutil.MustParseURL(PublicIRI)
+	credID := testutil.MustParseURL("http://sally.example.com/transactions/bafkreihwsn")
 
 	startTime := getStaticTime()
 	endTime := startTime.Add(1 * time.Minute)
@@ -771,7 +773,7 @@ func TestLikeTypeMarshal(t *testing.T) {
 		require.NoError(t, err)
 		t.Log(string(bytes))
 
-		require.Equal(t, getCanonical(t, jsonLike), string(bytes))
+		require.Equal(t, testutil.GetCanonical(t, jsonLike), string(bytes))
 	})
 
 	t.Run("Unmarshal", func(t *testing.T) {
@@ -818,12 +820,12 @@ func TestLikeTypeMarshal(t *testing.T) {
 		require.NoError(t, err)
 		t.Log(string(bytes))
 
-		require.Equal(t, getCanonical(t, jsonLike), string(bytes))
+		require.Equal(t, testutil.GetCanonical(t, jsonLike), string(bytes))
 	})
 }
 
 func newMockID(serviceIRI fmt.Stringer, path string) *url.URL {
-	return mustParseURL(fmt.Sprintf("%s%s", serviceIRI, path))
+	return testutil.MustParseURL(fmt.Sprintf("%s%s", serviceIRI, path))
 }
 
 const (

--- a/pkg/activitypub/vocab/actortype_test.go
+++ b/pkg/activitypub/vocab/actortype_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
+
+	"github.com/trustbloc/orb/pkg/internal/testutil"
 )
 
 func TestActor(t *testing.T) {
@@ -21,16 +23,16 @@ func TestActor(t *testing.T) {
 		keyPem     = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhki....."
 	)
 
-	serviceID := mustParseURL("https://alice.example.com/services/orb")
-	followers := mustParseURL("https://sally.example.com/services/orb/followers")
-	following := mustParseURL("https://sally.example.com/services/orb/following")
-	inbox := mustParseURL("https://alice.example.com/services/orb/inbox")
-	outbox := mustParseURL("https://alice.example.com/services/orb/outbox")
-	witnesses := mustParseURL("https://alice.example.com/services/orb/witnesses")
-	witnessing := mustParseURL("https://alice.example.com/services/orb/witnessing")
-	likes := mustParseURL("https://alice.example.com/services/orb/likes")
-	liked := mustParseURL("https://alice.example.com/services/orb/liked")
-	shares := mustParseURL("https://alice.example.com/services/orb/shares")
+	serviceID := testutil.MustParseURL("https://alice.example.com/services/orb")
+	followers := testutil.MustParseURL("https://sally.example.com/services/orb/followers")
+	following := testutil.MustParseURL("https://sally.example.com/services/orb/following")
+	inbox := testutil.MustParseURL("https://alice.example.com/services/orb/inbox")
+	outbox := testutil.MustParseURL("https://alice.example.com/services/orb/outbox")
+	witnesses := testutil.MustParseURL("https://alice.example.com/services/orb/witnesses")
+	witnessing := testutil.MustParseURL("https://alice.example.com/services/orb/witnessing")
+	likes := testutil.MustParseURL("https://alice.example.com/services/orb/likes")
+	liked := testutil.MustParseURL("https://alice.example.com/services/orb/liked")
+	shares := testutil.MustParseURL("https://alice.example.com/services/orb/shares")
 
 	publicKey := &PublicKeyType{
 		ID:           keyID,
@@ -56,7 +58,7 @@ func TestActor(t *testing.T) {
 		require.NoError(t, err)
 		t.Log(string(bytes))
 
-		require.Equal(t, getCanonical(t, jsonService), string(bytes))
+		require.Equal(t, testutil.GetCanonical(t, jsonService), string(bytes))
 	})
 
 	t.Run("Unmarshal", func(t *testing.T) {

--- a/pkg/activitypub/vocab/anchorcredreftype_test.go
+++ b/pkg/activitypub/vocab/anchorcredreftype_test.go
@@ -12,13 +12,15 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
+
+	"github.com/trustbloc/orb/pkg/internal/testutil"
 )
 
 const cid = "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
 
 var (
 	anchorCredIRI = newMockID(host1, "/cas/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy")
-	txID          = mustParseURL("https://org1.com/transactions/tx1")
+	txID          = testutil.MustParseURL("https://org1.com/transactions/tx1")
 )
 
 func TestNewAnchorCredentialReference(t *testing.T) {
@@ -123,7 +125,7 @@ func TestAnchorCredentialReferenceMarshal(t *testing.T) {
 		require.NoError(t, err)
 		t.Log(string(bytes))
 
-		require.Equal(t, getCanonical(t, anchorCredentialReference), string(bytes))
+		require.Equal(t, testutil.GetCanonical(t, anchorCredentialReference), string(bytes))
 	})
 
 	t.Run("Unmarshal", func(t *testing.T) {
@@ -163,7 +165,7 @@ func TestAnchorCredentialReferenceMarshal(t *testing.T) {
 		require.NoError(t, err)
 		t.Log(string(bytes))
 
-		require.Equal(t, getCanonical(t, anchorCredentialReferenceWithDoc), string(bytes))
+		require.Equal(t, testutil.GetCanonical(t, anchorCredentialReferenceWithDoc), string(bytes))
 	})
 
 	t.Run("Unmarshal with doc", func(t *testing.T) {

--- a/pkg/activitypub/vocab/collection_test.go
+++ b/pkg/activitypub/vocab/collection_test.go
@@ -12,16 +12,18 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
+
+	"github.com/trustbloc/orb/pkg/internal/testutil"
 )
 
-var service1Inbox = mustParseURL("https://org1.com/services/service1/inbox")
+var service1Inbox = testutil.MustParseURL("https://org1.com/services/service1/inbox")
 
 func TestCollectionMarshal(t *testing.T) {
-	first := mustParseURL("https://org1.com/services/service1/inbox?page=true")
-	last := mustParseURL("https://org1.com/services/service1/inbox?page=true&end=true")
-	current := mustParseURL("https://org1.com/services/service1/inbox?page=2")
-	txn1 := mustParseURL("https://org1.com/transactions/txn1")
-	txn2 := mustParseURL("https://org1.com/transactions/txn2")
+	first := testutil.MustParseURL("https://org1.com/services/service1/inbox?page=true")
+	last := testutil.MustParseURL("https://org1.com/services/service1/inbox?page=true&end=true")
+	current := testutil.MustParseURL("https://org1.com/services/service1/inbox?page=2")
+	txn1 := testutil.MustParseURL("https://org1.com/transactions/txn1")
+	txn2 := testutil.MustParseURL("https://org1.com/transactions/txn2")
 
 	t.Run("Marshal", func(t *testing.T) {
 		items := []*ObjectProperty{
@@ -38,7 +40,7 @@ func TestCollectionMarshal(t *testing.T) {
 		require.NoError(t, err)
 		t.Log(string(bytes))
 
-		require.Equal(t, getCanonical(t, jsonCollection), string(bytes))
+		require.Equal(t, testutil.GetCanonical(t, jsonCollection), string(bytes))
 	})
 
 	t.Run("Unmarshal", func(t *testing.T) {
@@ -82,11 +84,11 @@ func TestCollectionMarshal(t *testing.T) {
 }
 
 func TestOrderedCollectionMarshal(t *testing.T) {
-	first := mustParseURL("https://org1.com/services/service1/inbox?page=true")
-	last := mustParseURL("https://org1.com/services/service1/inbox?page=true&end=true")
-	current := mustParseURL("https://org1.com/services/service1/inbox?page=2")
-	txn1 := mustParseURL("https://org1.com/transactions/txn1")
-	txn2 := mustParseURL("https://org1.com/transactions/txn2")
+	first := testutil.MustParseURL("https://org1.com/services/service1/inbox?page=true")
+	last := testutil.MustParseURL("https://org1.com/services/service1/inbox?page=true&end=true")
+	current := testutil.MustParseURL("https://org1.com/services/service1/inbox?page=2")
+	txn1 := testutil.MustParseURL("https://org1.com/transactions/txn1")
+	txn2 := testutil.MustParseURL("https://org1.com/transactions/txn2")
 
 	t.Run("Marshal", func(t *testing.T) {
 		items := []*ObjectProperty{
@@ -103,7 +105,7 @@ func TestOrderedCollectionMarshal(t *testing.T) {
 		require.NoError(t, err)
 		t.Log(string(bytes))
 
-		require.Equal(t, getCanonical(t, jsonOrderedCollection), string(bytes))
+		require.Equal(t, testutil.GetCanonical(t, jsonOrderedCollection), string(bytes))
 	})
 
 	t.Run("Unmarshal", func(t *testing.T) {

--- a/pkg/activitypub/vocab/collectionpage_test.go
+++ b/pkg/activitypub/vocab/collectionpage_test.go
@@ -12,15 +12,17 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
+
+	"github.com/trustbloc/orb/pkg/internal/testutil"
 )
 
 func TestCollectionPageMarshal(t *testing.T) {
-	collPage1 := mustParseURL("https://org1.com/services/service1/inbox?page=1")
-	collPage2 := mustParseURL("https://org1.com/services/service1/inbox?page=2")
-	collPage3 := mustParseURL("https://org1.com/services/service1/inbox?page=3")
-	activity1 := mustParseURL("https://org1.com/activities/activity1")
-	activity2 := mustParseURL("https://org1.com/activities/activity2")
-	activity3 := mustParseURL("https://org1.com/activities/activity3")
+	collPage1 := testutil.MustParseURL("https://org1.com/services/service1/inbox?page=1")
+	collPage2 := testutil.MustParseURL("https://org1.com/services/service1/inbox?page=2")
+	collPage3 := testutil.MustParseURL("https://org1.com/services/service1/inbox?page=3")
+	activity1 := testutil.MustParseURL("https://org1.com/activities/activity1")
+	activity2 := testutil.MustParseURL("https://org1.com/activities/activity2")
+	activity3 := testutil.MustParseURL("https://org1.com/activities/activity3")
 
 	t.Run("Marshal", func(t *testing.T) {
 		items := []*ObjectProperty{
@@ -41,7 +43,7 @@ func TestCollectionPageMarshal(t *testing.T) {
 		require.NoError(t, err)
 		t.Log(string(bytes))
 
-		require.Equal(t, getCanonical(t, jsonCollectionPage), string(bytes))
+		require.Equal(t, testutil.GetCanonical(t, jsonCollectionPage), string(bytes))
 	})
 
 	t.Run("Unmarshal", func(t *testing.T) {
@@ -73,12 +75,12 @@ func TestCollectionPageMarshal(t *testing.T) {
 }
 
 func TestOrderedCollectionPageMarshal(t *testing.T) {
-	collPage1 := mustParseURL("https://org1.com/services/service1/inbox?page=1")
-	collPage2 := mustParseURL("https://org1.com/services/service1/inbox?page=2")
-	collPage3 := mustParseURL("https://org1.com/services/service1/inbox?page=3")
-	activity1 := mustParseURL("https://org1.com/activities/activity1")
-	activity2 := mustParseURL("https://org1.com/activities/activity2")
-	activity3 := mustParseURL("https://org1.com/activities/activity3")
+	collPage1 := testutil.MustParseURL("https://org1.com/services/service1/inbox?page=1")
+	collPage2 := testutil.MustParseURL("https://org1.com/services/service1/inbox?page=2")
+	collPage3 := testutil.MustParseURL("https://org1.com/services/service1/inbox?page=3")
+	activity1 := testutil.MustParseURL("https://org1.com/activities/activity1")
+	activity2 := testutil.MustParseURL("https://org1.com/activities/activity2")
+	activity3 := testutil.MustParseURL("https://org1.com/activities/activity3")
 
 	t.Run("Marshal", func(t *testing.T) {
 		items := []*ObjectProperty{
@@ -99,7 +101,7 @@ func TestOrderedCollectionPageMarshal(t *testing.T) {
 		require.NoError(t, err)
 		t.Log(string(bytes))
 
-		require.Equal(t, getCanonical(t, jsonOrderedCollectionPage), string(bytes))
+		require.Equal(t, testutil.GetCanonical(t, jsonOrderedCollectionPage), string(bytes))
 	})
 
 	t.Run("Unmarshal", func(t *testing.T) {

--- a/pkg/activitypub/vocab/objectproperty_test.go
+++ b/pkg/activitypub/vocab/objectproperty_test.go
@@ -12,15 +12,17 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
+
+	"github.com/trustbloc/orb/pkg/internal/testutil"
 )
 
 var (
-	collID  = mustParseURL("https://org1.com/services/service1/inbox")
-	first   = mustParseURL("https://org1.com/services/service1/inbox?page=true")
-	last    = mustParseURL("https://org1.com/services/service1/inbox?page=true&end=true")
-	current = mustParseURL("https://org1.com/services/service1/inbox?page=2")
-	txn1    = mustParseURL("https://org1.com/transactions/txn1")
-	txn2    = mustParseURL("https://org1.com/transactions/txn2")
+	collID  = testutil.MustParseURL("https://org1.com/services/service1/inbox")
+	first   = testutil.MustParseURL("https://org1.com/services/service1/inbox?page=true")
+	last    = testutil.MustParseURL("https://org1.com/services/service1/inbox?page=true&end=true")
+	current = testutil.MustParseURL("https://org1.com/services/service1/inbox?page=2")
+	txn1    = testutil.MustParseURL("https://org1.com/transactions/txn1")
+	txn2    = testutil.MustParseURL("https://org1.com/transactions/txn2")
 )
 
 func TestNewObjectProperty(t *testing.T) {
@@ -47,7 +49,7 @@ func TestNewObjectProperty(t *testing.T) {
 	})
 
 	t.Run("WithIRI", func(t *testing.T) {
-		iri := mustParseURL("https://example.com/obj1")
+		iri := testutil.MustParseURL("https://example.com/obj1")
 
 		p := NewObjectProperty(WithIRI(iri))
 		require.NotNil(t, p)
@@ -132,7 +134,7 @@ func TestObjectProperty_MarshalJSON(t *testing.T) {
 	})
 
 	t.Run("WithIRI", func(t *testing.T) {
-		iri := mustParseURL("https://example.com/obj1")
+		iri := testutil.MustParseURL("https://example.com/obj1")
 
 		p := NewObjectProperty(WithIRI(iri))
 
@@ -157,7 +159,7 @@ func TestObjectProperty_MarshalJSON(t *testing.T) {
 		require.NoError(t, err)
 		t.Log(string(bytes))
 
-		require.Equal(t, getCanonical(t, jsonEmbeddedObjectProperty), string(bytes))
+		require.Equal(t, testutil.GetCanonical(t, jsonEmbeddedObjectProperty), string(bytes))
 	})
 
 	t.Run("WithCollection", func(t *testing.T) {
@@ -178,7 +180,7 @@ func TestObjectProperty_MarshalJSON(t *testing.T) {
 		require.NoError(t, err)
 		t.Log(string(bytes))
 
-		require.Equal(t, getCanonical(t, jsonCollectionObjectProperty), string(bytes))
+		require.Equal(t, testutil.GetCanonical(t, jsonCollectionObjectProperty), string(bytes))
 	})
 
 	t.Run("WithOrderedCollection", func(t *testing.T) {
@@ -199,13 +201,13 @@ func TestObjectProperty_MarshalJSON(t *testing.T) {
 		require.NoError(t, err)
 		t.Log(string(bytes))
 
-		require.Equal(t, getCanonical(t, jsonOrderedCollectionObjectProperty), string(bytes))
+		require.Equal(t, testutil.GetCanonical(t, jsonOrderedCollectionObjectProperty), string(bytes))
 	})
 }
 
 func TestObjectProperty_UnmarshalJSON(t *testing.T) {
 	t.Run("WithIRI", func(t *testing.T) {
-		iri := mustParseURL("https://example.com/obj1")
+		iri := testutil.MustParseURL("https://example.com/obj1")
 
 		p := NewObjectProperty()
 		require.NoError(t, json.Unmarshal([]byte(jsonIRIObjectProperty), p))
@@ -338,7 +340,7 @@ func TestObjectProperty_UnmarshalJSON(t *testing.T) {
 	})
 }
 
-var objectPropertyID = mustParseURL("https://example.com/some_obj_ID")
+var objectPropertyID = testutil.MustParseURL("https://example.com/some_obj_ID")
 
 const (
 	jsonIRIObjectProperty = `"https://example.com/obj1"`

--- a/pkg/activitypub/vocab/objecttype_test.go
+++ b/pkg/activitypub/vocab/objecttype_test.go
@@ -12,12 +12,14 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
+
+	"github.com/trustbloc/orb/pkg/internal/testutil"
 )
 
 func TestObjectType_WithoutDocument(t *testing.T) {
-	id := mustParseURL("http://sally.example.com/transactions/bafkreihwsn")
-	to1 := mustParseURL("https://to1")
-	to2 := mustParseURL("https://to2")
+	id := testutil.MustParseURL("http://sally.example.com/transactions/bafkreihwsn")
+	to1 := testutil.MustParseURL("https://to1")
+	to2 := testutil.MustParseURL("https://to2")
 
 	publishedTime := getStaticTime()
 	startTime := getStaticTime()
@@ -68,7 +70,7 @@ func TestObjectType_WithoutDocument(t *testing.T) {
 		require.NoError(t, err)
 		t.Log(string(bytes))
 
-		require.Equal(t, getCanonical(t, jsonObject), string(bytes))
+		require.Equal(t, testutil.GetCanonical(t, jsonObject), string(bytes))
 	})
 
 	t.Run("Unmarshal", func(t *testing.T) {
@@ -96,9 +98,9 @@ func TestObjectType_WithoutDocument(t *testing.T) {
 }
 
 func TestObjectType_WithDocument(t *testing.T) {
-	id := mustParseURL("http://sally.example.com/transactions/bafkreihwsn")
-	to1 := mustParseURL("https://to1")
-	to2 := mustParseURL("https://to2")
+	id := testutil.MustParseURL("http://sally.example.com/transactions/bafkreihwsn")
+	to1 := testutil.MustParseURL("https://to1")
+	to2 := testutil.MustParseURL("https://to2")
 
 	publishedTime := getStaticTime()
 	startTime := getStaticTime()
@@ -135,7 +137,7 @@ func TestObjectType_WithDocument(t *testing.T) {
 		require.NoError(t, err)
 		t.Log(string(bytes))
 
-		require.Equal(t, getCanonical(t, jsonObjectWithDoc), string(bytes))
+		require.Equal(t, testutil.GetCanonical(t, jsonObjectWithDoc), string(bytes))
 	})
 
 	t.Run("Unmarshal", func(t *testing.T) {

--- a/pkg/activitypub/vocab/options_test.go
+++ b/pkg/activitypub/vocab/options_test.go
@@ -11,40 +11,42 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/pkg/internal/testutil"
 )
 
 func TestNewOptions(t *testing.T) {
-	id := mustParseURL("https://example.com/1234")
+	id := testutil.MustParseURL("https://example.com/1234")
 
-	to1 := mustParseURL("https://to1")
-	to2 := mustParseURL("https://to2")
+	to1 := testutil.MustParseURL("https://to1")
+	to2 := testutil.MustParseURL("https://to2")
 
 	coll := NewCollection(nil)
 	oColl := NewOrderedCollection(nil)
 	activity := &ActivityType{}
 	obj := &ObjectType{}
-	iri := mustParseURL("https://iri")
-	actor := mustParseURL("https://actor")
-	first := mustParseURL("https://first")
-	last := mustParseURL("https://last")
-	current := mustParseURL("https://current")
-	partOf := mustParseURL("https://activities")
-	next := mustParseURL("https://activities?page=3")
-	prev := mustParseURL("https://activities?page=1")
+	iri := testutil.MustParseURL("https://iri")
+	actor := testutil.MustParseURL("https://actor")
+	first := testutil.MustParseURL("https://first")
+	last := testutil.MustParseURL("https://last")
+	current := testutil.MustParseURL("https://current")
+	partOf := testutil.MustParseURL("https://activities")
+	next := testutil.MustParseURL("https://activities?page=3")
+	prev := testutil.MustParseURL("https://activities?page=1")
 
 	publishedTime := time.Now()
 	startTime := time.Now()
 	endTime := time.Now()
 
-	inbox := mustParseURL("https://inbox")
-	outbox := mustParseURL("https://outbox")
-	followers := mustParseURL("https://followers")
-	following := mustParseURL("https://following")
-	witnesses := mustParseURL("https://witnesses")
-	witnessing := mustParseURL("https://witnessing")
-	likes := mustParseURL("https://likes")
-	liked := mustParseURL("https://liked")
-	shares := mustParseURL("https://shares")
+	inbox := testutil.MustParseURL("https://inbox")
+	outbox := testutil.MustParseURL("https://outbox")
+	followers := testutil.MustParseURL("https://followers")
+	following := testutil.MustParseURL("https://following")
+	witnesses := testutil.MustParseURL("https://witnesses")
+	witnessing := testutil.MustParseURL("https://witnessing")
+	likes := testutil.MustParseURL("https://likes")
+	liked := testutil.MustParseURL("https://liked")
+	shares := testutil.MustParseURL("https://shares")
 
 	publicKey := &PublicKeyType{
 		ID:           "key_id",
@@ -53,16 +55,16 @@ func TestNewOptions(t *testing.T) {
 	}
 
 	target := &ObjectProperty{
-		iri: NewURLProperty(mustParseURL("https://property_iri")),
+		iri: NewURLProperty(testutil.MustParseURL("https://property_iri")),
 	}
 
 	result := &ObjectProperty{
-		iri: NewURLProperty(mustParseURL("https://property_result")),
+		iri: NewURLProperty(testutil.MustParseURL("https://property_result")),
 	}
 
 	anchorRef := NewAnchorCredentialReference(
-		mustParseURL("https://example.com/anchor_cred_ref_id"),
-		mustParseURL("https://example.com/anchor_cred_iri"),
+		testutil.MustParseURL("https://example.com/anchor_cred_ref_id"),
+		testutil.MustParseURL("https://example.com/anchor_cred_iri"),
 		"cid")
 
 	opts := NewOptions(

--- a/pkg/activitypub/vocab/vocab_test.go
+++ b/pkg/activitypub/vocab/vocab_test.go
@@ -7,13 +7,10 @@ SPDX-License-Identifier: Apache-2.0
 package vocab
 
 import (
-	"encoding/json"
-	"net/url"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
 )
 
 func TestDocument_MergeWith(t *testing.T) {
@@ -48,25 +45,4 @@ func getStaticTime() time.Time {
 	}
 
 	return time.Date(2021, time.January, 27, 9, 30, 10, 0, loc)
-}
-
-func mustParseURL(raw string) *url.URL {
-	u, err := url.Parse(raw)
-	if err != nil {
-		panic(err)
-	}
-
-	return u
-}
-
-func getCanonical(t *testing.T, raw string) string {
-	var expectedDoc map[string]interface{}
-
-	require.NoError(t, json.Unmarshal([]byte(raw), &expectedDoc))
-
-	bytes, err := canonicalizer.MarshalCanonical(expectedDoc)
-
-	require.NoError(t, err)
-
-	return string(bytes)
 }

--- a/pkg/internal/testutil/testutil.go
+++ b/pkg/internal/testutil/testutil.go
@@ -1,0 +1,58 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package testutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
+)
+
+// MustParseURL parses the given string and returns the URL.
+// If the given string is not a valid URL then the function panics.
+func MustParseURL(raw string) *url.URL {
+	u, err := url.Parse(raw)
+	if err != nil {
+		panic(err)
+	}
+
+	return u
+}
+
+// NewMockID returns a URL using the base IRI and the given path.
+func NewMockID(iri fmt.Stringer, path string) *url.URL {
+	return MustParseURL(fmt.Sprintf("%s%s", iri, path))
+}
+
+// NewMockURLs returns the given number of URLs using the given function to format each one.
+//nolint:unparam
+func NewMockURLs(num int, getURI func(i int) string) []*url.URL {
+	results := make([]*url.URL, num)
+
+	for i := 0; i < num; i++ {
+		results[i] = MustParseURL(getURI(i))
+	}
+
+	return results
+}
+
+// GetCanonical converts the given JSON string into a canonical JSON.
+func GetCanonical(t *testing.T, raw string) string {
+	var expectedDoc map[string]interface{}
+
+	require.NoError(t, json.Unmarshal([]byte(raw), &expectedDoc))
+
+	bytes, err := canonicalizer.MarshalCanonical(expectedDoc)
+
+	require.NoError(t, err)
+
+	return string(bytes)
+}


### PR DESCRIPTION
Moved common testing utilities to the testutil package so that they aren't replicated in multiple packages.

closes #135

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>