### PR TITLE
fix: Remove 'likes' and 'shares' from the actor

### DIFF
--- a/pkg/activitypub/resthandler/serviceshandler_test.go
+++ b/pkg/activitypub/resthandler/serviceshandler_test.go
@@ -124,9 +124,7 @@ func newMockService() *vocab.ActorType {
 	outbox := testutil.MustParseURL("https://example1.com.com/services/orb/outbox")
 	witnesses := testutil.MustParseURL("https://example1.com.com/services/orb/witnesses")
 	witnessing := testutil.MustParseURL("https://example1.com.com/services/orb/witnessing")
-	likes := testutil.MustParseURL("https://example1.com.com/services/orb/likes")
 	liked := testutil.MustParseURL("https://example1.com.com/services/orb/liked")
-	shares := testutil.MustParseURL("https://example1.com.com/services/orb/shares")
 
 	publicKey := &vocab.PublicKeyType{
 		ID:           keyID,
@@ -142,9 +140,7 @@ func newMockService() *vocab.ActorType {
 		vocab.WithFollowing(following),
 		vocab.WithWitnesses(witnesses),
 		vocab.WithWitnessing(witnessing),
-		vocab.WithLikes(likes),
 		vocab.WithLiked(liked),
-		vocab.WithShares(shares),
 	)
 }
 
@@ -166,8 +162,6 @@ const serviceJSON = `{
   "followers": "https://example1.com/services/orb/followers",
   "following": "https://example1.com/services/orb/following",
   "liked": "https://example1.com.com/services/orb/liked",
-  "likes": "https://example1.com.com/services/orb/likes",
-  "shares": "https://example1.com.com/services/orb/shares",
   "witnesses": "https://example1.com.com/services/orb/witnesses",
   "witnessing": "https://example1.com.com/services/orb/witnessing"
 }`

--- a/pkg/activitypub/vocab/actortype.go
+++ b/pkg/activitypub/vocab/actortype.go
@@ -32,8 +32,6 @@ type actorType struct {
 	Following  *URLProperty   `json:"following"`
 	Witnesses  *URLProperty   `json:"witnesses"`
 	Witnessing *URLProperty   `json:"witnessing"`
-	Shares     *URLProperty   `json:"shares"`
-	Likes      *URLProperty   `json:"likes"`
 	Liked      *URLProperty   `json:"liked"`
 }
 
@@ -96,24 +94,6 @@ func (t *ActorType) Witnessing() *url.URL {
 	return t.actor.Witnessing.URL()
 }
 
-// Shares returns the URL of the actor's shares.
-func (t *ActorType) Shares() *url.URL {
-	if t.actor.Shares == nil {
-		return nil
-	}
-
-	return t.actor.Shares.URL()
-}
-
-// Likes returns the URL of the actor's likes.
-func (t *ActorType) Likes() *url.URL {
-	if t.actor.Likes == nil {
-		return nil
-	}
-
-	return t.actor.Likes.URL()
-}
-
 // Liked returns the URL of what the actor has liked.
 func (t *ActorType) Liked() *url.URL {
 	if t.actor.Liked == nil {
@@ -154,8 +134,6 @@ func NewService(id *url.URL, opts ...Opt) *ActorType {
 			Following:  NewURLProperty(options.Following),
 			Witnesses:  NewURLProperty(options.Witnesses),
 			Witnessing: NewURLProperty(options.Witnessing),
-			Shares:     NewURLProperty(options.Shares),
-			Likes:      NewURLProperty(options.Likes),
 			Liked:      NewURLProperty(options.Liked),
 		},
 	}

--- a/pkg/activitypub/vocab/actortype_test.go
+++ b/pkg/activitypub/vocab/actortype_test.go
@@ -30,9 +30,7 @@ func TestActor(t *testing.T) {
 	outbox := testutil.MustParseURL("https://alice.example.com/services/orb/outbox")
 	witnesses := testutil.MustParseURL("https://alice.example.com/services/orb/witnesses")
 	witnessing := testutil.MustParseURL("https://alice.example.com/services/orb/witnessing")
-	likes := testutil.MustParseURL("https://alice.example.com/services/orb/likes")
 	liked := testutil.MustParseURL("https://alice.example.com/services/orb/liked")
-	shares := testutil.MustParseURL("https://alice.example.com/services/orb/shares")
 
 	publicKey := &PublicKeyType{
 		ID:           keyID,
@@ -49,9 +47,7 @@ func TestActor(t *testing.T) {
 			WithFollowing(following),
 			WithWitnesses(witnesses),
 			WithWitnessing(witnessing),
-			WithLikes(likes),
 			WithLiked(liked),
-			WithShares(shares),
 		)
 
 		bytes, err := canonicalizer.MarshalCanonical(service)
@@ -105,17 +101,9 @@ func TestActor(t *testing.T) {
 		require.NotNil(t, wtng)
 		require.Equal(t, witnessing.String(), wtng.String())
 
-		lks := a.Likes()
-		require.NotNil(t, lks)
-		require.Equal(t, likes.String(), lks.String())
-
 		lkd := a.Liked()
 		require.NotNil(t, lkd)
 		require.Equal(t, liked.String(), lkd.String())
-
-		shrs := a.Shares()
-		require.NotNil(t, shrs)
-		require.Equal(t, shares.String(), shrs.String())
 	})
 
 	t.Run("Empty actor", func(t *testing.T) {
@@ -133,9 +121,7 @@ func TestActor(t *testing.T) {
 		require.Nil(t, a.Following())
 		require.Nil(t, a.Witnesses())
 		require.Nil(t, a.Witnessing())
-		require.Nil(t, a.Likes())
 		require.Nil(t, a.Liked())
-		require.Nil(t, a.Shares())
 	})
 }
 
@@ -158,8 +144,6 @@ const jsonService = `{
   "following": "https://sally.example.com/services/orb/following",
   "witnesses": "https://alice.example.com/services/orb/witnesses",
   "witnessing": "https://alice.example.com/services/orb/witnessing",
-  "likes": "https://alice.example.com/services/orb/likes",
-  "liked": "https://alice.example.com/services/orb/liked",
-  "shares": "https://alice.example.com/services/orb/shares"
+  "liked": "https://alice.example.com/services/orb/liked"
 }
 `

--- a/pkg/activitypub/vocab/options.go
+++ b/pkg/activitypub/vocab/options.go
@@ -247,9 +247,7 @@ type ActorOptions struct {
 	Following  *url.URL
 	Witnesses  *url.URL
 	Witnessing *url.URL
-	Likes      *url.URL
 	Liked      *url.URL
-	Shares     *url.URL
 }
 
 // WithPublicKey sets the 'publicKey' property on the actor.
@@ -301,24 +299,10 @@ func WithWitnessing(witnessing *url.URL) Opt {
 	}
 }
 
-// WithLikes sets the 'likes' property on the actor.
-func WithLikes(likes *url.URL) Opt {
-	return func(opts *Options) {
-		opts.Likes = likes
-	}
-}
-
 // WithLiked sets the 'liked' property on the actor.
 func WithLiked(liked *url.URL) Opt {
 	return func(opts *Options) {
 		opts.Liked = liked
-	}
-}
-
-// WithShares sets the 'shares' property on the actor.
-func WithShares(shares *url.URL) Opt {
-	return func(opts *Options) {
-		opts.Shares = shares
 	}
 }
 

--- a/pkg/activitypub/vocab/options_test.go
+++ b/pkg/activitypub/vocab/options_test.go
@@ -44,9 +44,7 @@ func TestNewOptions(t *testing.T) {
 	following := testutil.MustParseURL("https://following")
 	witnesses := testutil.MustParseURL("https://witnesses")
 	witnessing := testutil.MustParseURL("https://witnessing")
-	likes := testutil.MustParseURL("https://likes")
 	liked := testutil.MustParseURL("https://liked")
-	shares := testutil.MustParseURL("https://shares")
 
 	publicKey := &PublicKeyType{
 		ID:           "key_id",
@@ -95,9 +93,7 @@ func TestNewOptions(t *testing.T) {
 		WithInbox(inbox),
 		WithOutbox(outbox),
 		WithPublicKey(publicKey),
-		WithLikes(likes),
 		WithLiked(liked),
-		WithShares(shares),
 		WithWitnesses(witnesses),
 		WithWitnessing(witnessing),
 	)
@@ -147,9 +143,7 @@ func TestNewOptions(t *testing.T) {
 	require.Equal(t, outbox.String(), opts.Outbox.String())
 	require.Equal(t, publicKey, opts.PublicKey)
 
-	require.Equal(t, likes.String(), opts.Likes.String())
 	require.Equal(t, liked.String(), opts.Liked.String())
-	require.Equal(t, shares.String(), opts.Shares.String())
 	require.Equal(t, witnesses.String(), opts.Witnesses.String())
 	require.Equal(t, witnessing.String(), opts.Witnessing.String())
 }


### PR DESCRIPTION
Removed 'likes' from the actor since 'likes' is a property of the object that was 'liked'. Similarly, 'shares' was removed from the actor since 'shares' is a property of the object that was shared (announced).

closes #139

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>