### PR TITLE
refactor: Added support for activity references from any object

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -312,9 +312,9 @@ func startOrbServices(parameters *orbParameters) error {
 	}
 
 	apCfg := &aphandler.Config{
-		BasePath:   activityPubServicesPath,
-		ServiceIRI: apServiceIRI,
-		PageSize:   100, // TODO: Make configurable
+		BasePath:  activityPubServicesPath,
+		ObjectIRI: apServiceIRI,
+		PageSize:  100, // TODO: Make configurable
 	}
 
 	httpServer := httpserver.New(

--- a/pkg/activitypub/resthandler/referencehandler.go
+++ b/pkg/activitypub/resthandler/referencehandler.go
@@ -112,8 +112,8 @@ func (h *reference) handle(w http.ResponseWriter, req *http.Request) {
 func (h *reference) handleReference(rw http.ResponseWriter, _ *http.Request) {
 	coll, err := h.getReference()
 	if err != nil {
-		logger.Errorf("[%s] Error retrieving %s for service IRI [%s]: %s",
-			h.endpoint, h.refType, h.ServiceIRI, err)
+		logger.Errorf("[%s] Error retrieving %s for object IRI [%s]: %s",
+			h.endpoint, h.refType, h.ObjectIRI, err)
 
 		h.writeResponse(rw, http.StatusInternalServerError, nil)
 
@@ -122,8 +122,8 @@ func (h *reference) handleReference(rw http.ResponseWriter, _ *http.Request) {
 
 	collBytes, err := h.marshal(coll)
 	if err != nil {
-		logger.Errorf("[%s] Unable to marshal %s collection for service IRI [%s]: %s",
-			h.endpoint, h.refType, h.ServiceIRI, err)
+		logger.Errorf("[%s] Unable to marshal %s collection for object IRI [%s]: %s",
+			h.endpoint, h.refType, h.ObjectIRI, err)
 
 		h.writeResponse(rw, http.StatusInternalServerError, nil)
 
@@ -146,8 +146,8 @@ func (h *reference) handleReferencePage(rw http.ResponseWriter, req *http.Reques
 	}
 
 	if err != nil {
-		logger.Errorf("[%s] Error retrieving page for service IRI [%s]: %s",
-			h.endpoint, h.ServiceIRI, err)
+		logger.Errorf("[%s] Error retrieving page for object IRI [%s]: %s",
+			h.endpoint, h.ObjectIRI, err)
 
 		h.writeResponse(rw, http.StatusInternalServerError, nil)
 
@@ -156,8 +156,8 @@ func (h *reference) handleReferencePage(rw http.ResponseWriter, req *http.Reques
 
 	pageBytes, err := h.marshal(page)
 	if err != nil {
-		logger.Errorf("[%s] Unable to marshal page for service IRI [%s]: %s",
-			h.endpoint, h.ServiceIRI, err)
+		logger.Errorf("[%s] Unable to marshal page for object IRI [%s]: %s",
+			h.endpoint, h.ObjectIRI, err)
 
 		h.writeResponse(rw, http.StatusInternalServerError, nil)
 
@@ -167,10 +167,11 @@ func (h *reference) handleReferencePage(rw http.ResponseWriter, req *http.Reques
 	h.writeResponse(rw, http.StatusOK, pageBytes)
 }
 
+//nolint:dupl
 func (h *reference) getReference() (interface{}, error) {
 	it, err := h.activityStore.QueryReferences(h.refType,
 		spi.NewCriteria(
-			spi.WithActorIRI(h.ServiceIRI),
+			spi.WithObjectIRI(h.ObjectIRI),
 		),
 	)
 	if err != nil {
@@ -202,7 +203,7 @@ func (h *reference) getReference() (interface{}, error) {
 func (h *reference) getPage(opts ...spi.QueryOpt) (interface{}, error) {
 	it, err := h.activityStore.QueryReferences(
 		h.refType,
-		spi.NewCriteria(spi.WithActorIRI(h.ServiceIRI)),
+		spi.NewCriteria(spi.WithObjectIRI(h.ObjectIRI)),
 		opts...,
 	)
 	if err != nil {

--- a/pkg/activitypub/resthandler/referencehandler_test.go
+++ b/pkg/activitypub/resthandler/referencehandler_test.go
@@ -25,9 +25,9 @@ const followersURL = "https://example.com/services/orb/followers"
 
 func TestNewFollowers(t *testing.T) {
 	cfg := &Config{
-		BasePath:   basePath,
-		ServiceIRI: serviceIRI,
-		PageSize:   4,
+		BasePath:  basePath,
+		ObjectIRI: serviceIRI,
+		PageSize:  4,
 	}
 
 	h := NewFollowers(cfg, memstore.New(""))
@@ -39,9 +39,9 @@ func TestNewFollowers(t *testing.T) {
 
 func TestNewFollowing(t *testing.T) {
 	cfg := &Config{
-		BasePath:   basePath,
-		ServiceIRI: serviceIRI,
-		PageSize:   4,
+		BasePath:  basePath,
+		ObjectIRI: serviceIRI,
+		PageSize:  4,
 	}
 
 	h := NewFollowing(cfg, memstore.New(""))
@@ -53,9 +53,9 @@ func TestNewFollowing(t *testing.T) {
 
 func TestNewWitnesses(t *testing.T) {
 	cfg := &Config{
-		BasePath:   basePath,
-		ServiceIRI: serviceIRI,
-		PageSize:   4,
+		BasePath:  basePath,
+		ObjectIRI: serviceIRI,
+		PageSize:  4,
 	}
 
 	h := NewWitnesses(cfg, memstore.New(""))
@@ -67,9 +67,9 @@ func TestNewWitnesses(t *testing.T) {
 
 func TestNewWitnessing(t *testing.T) {
 	cfg := &Config{
-		BasePath:   basePath,
-		ServiceIRI: serviceIRI,
-		PageSize:   4,
+		BasePath:  basePath,
+		ObjectIRI: serviceIRI,
+		PageSize:  4,
 	}
 
 	h := NewWitnessing(cfg, memstore.New(""))
@@ -91,9 +91,9 @@ func TestFollowers_Handler(t *testing.T) {
 	}
 
 	cfg := &Config{
-		BasePath:   basePath,
-		ServiceIRI: serviceIRI,
-		PageSize:   4,
+		BasePath:  basePath,
+		ObjectIRI: serviceIRI,
+		PageSize:  4,
 	}
 
 	t.Run("Success", func(t *testing.T) {
@@ -119,8 +119,8 @@ func TestFollowers_Handler(t *testing.T) {
 
 	t.Run("Store error", func(t *testing.T) {
 		cfg := &Config{
-			ServiceIRI: serviceIRI,
-			PageSize:   4,
+			ObjectIRI: serviceIRI,
+			PageSize:  4,
 		}
 
 		errExpected := fmt.Errorf("injected store error")
@@ -143,8 +143,8 @@ func TestFollowers_Handler(t *testing.T) {
 
 	t.Run("Marshal error", func(t *testing.T) {
 		cfg := &Config{
-			ServiceIRI: serviceIRI,
-			PageSize:   4,
+			ObjectIRI: serviceIRI,
+			PageSize:  4,
 		}
 
 		h := NewFollowers(cfg, activityStore)
@@ -179,8 +179,8 @@ func TestFollowers_PageHandler(t *testing.T) {
 	}
 
 	cfg := &Config{
-		ServiceIRI: serviceIRI,
-		PageSize:   4,
+		ObjectIRI: serviceIRI,
+		PageSize:  4,
 	}
 
 	h := NewFollowers(cfg, activityStore)
@@ -217,8 +217,8 @@ func TestFollowers_PageHandler(t *testing.T) {
 		s.QueryReferencesReturns(nil, errExpected)
 
 		cfg := &Config{
-			ServiceIRI: serviceIRI,
-			PageSize:   4,
+			ObjectIRI: serviceIRI,
+			PageSize:  4,
 		}
 
 		h := NewFollowers(cfg, s)
@@ -239,8 +239,8 @@ func TestFollowers_PageHandler(t *testing.T) {
 
 	t.Run("Marshal error", func(t *testing.T) {
 		cfg := &Config{
-			ServiceIRI: serviceIRI,
-			PageSize:   4,
+			ObjectIRI: serviceIRI,
+			PageSize:  4,
 		}
 
 		h := NewFollowers(cfg, activityStore)
@@ -278,9 +278,9 @@ func TestWitnesses_Handler(t *testing.T) {
 	}
 
 	cfg := &Config{
-		BasePath:   basePath,
-		ServiceIRI: serviceIRI,
-		PageSize:   4,
+		BasePath:  basePath,
+		ObjectIRI: serviceIRI,
+		PageSize:  4,
 	}
 
 	h := NewWitnesses(cfg, activityStore)
@@ -311,9 +311,9 @@ func TestWitnessing_Handler(t *testing.T) {
 	}
 
 	cfg := &Config{
-		BasePath:   basePath,
-		ServiceIRI: serviceIRI,
-		PageSize:   4,
+		BasePath:  basePath,
+		ObjectIRI: serviceIRI,
+		PageSize:  4,
 	}
 
 	h := NewWitnessing(cfg, activityStore)
@@ -342,9 +342,9 @@ func TestLiked_Handler(t *testing.T) {
 	}
 
 	cfg := &Config{
-		BasePath:   basePath,
-		ServiceIRI: serviceIRI,
-		PageSize:   4,
+		BasePath:  basePath,
+		ObjectIRI: serviceIRI,
+		PageSize:  4,
 	}
 
 	h := NewLiked(cfg, activityStore)

--- a/pkg/activitypub/resthandler/resthandler.go
+++ b/pkg/activitypub/resthandler/resthandler.go
@@ -45,9 +45,9 @@ const (
 
 // Config contains configuration parameters for the handler.
 type Config struct {
-	BasePath   string
-	ServiceIRI *url.URL
-	PageSize   int
+	BasePath  string
+	ObjectIRI *url.URL
+	PageSize  int
 }
 
 type handler struct {
@@ -64,7 +64,7 @@ type handler struct {
 }
 
 func newHandler(endpoint string, cfg *Config, s spi.Store, h common.HTTPRequestHandler, params ...string) *handler {
-	id, err := url.Parse(fmt.Sprintf("%s%s", cfg.ServiceIRI, endpoint))
+	id, err := url.Parse(fmt.Sprintf("%s%s", cfg.ObjectIRI, endpoint))
 	if err != nil {
 		// This is called on startup so it's better to panic if the config is bad.
 		panic(err)

--- a/pkg/activitypub/resthandler/resthandler_test.go
+++ b/pkg/activitypub/resthandler/resthandler_test.go
@@ -21,9 +21,9 @@ import (
 
 func TestNewHandler(t *testing.T) {
 	cfg := &Config{
-		BasePath:   basePath,
-		ServiceIRI: serviceIRI,
-		PageSize:   4,
+		BasePath:  basePath,
+		ObjectIRI: serviceIRI,
+		PageSize:  4,
 	}
 
 	h := newHandler("", cfg, memstore.New(""),
@@ -65,9 +65,9 @@ func TestGetLastPageNum(t *testing.T) {
 
 func TestGetCurrentPrevNext(t *testing.T) {
 	cfg := &Config{
-		BasePath:   basePath,
-		ServiceIRI: serviceIRI,
-		PageSize:   4,
+		BasePath:  basePath,
+		ObjectIRI: serviceIRI,
+		PageSize:  4,
 	}
 
 	h := newHandler("", cfg, memstore.New(""), nil)
@@ -157,9 +157,9 @@ func TestGetCurrentPrevNext(t *testing.T) {
 
 func TestGetIDPrevNextURL(t *testing.T) {
 	cfg := &Config{
-		BasePath:   basePath,
-		ServiceIRI: serviceIRI,
-		PageSize:   4,
+		BasePath:  basePath,
+		ObjectIRI: serviceIRI,
+		PageSize:  4,
 	}
 
 	h := newHandler("", cfg, memstore.New(""), nil)

--- a/pkg/activitypub/resthandler/serviceshandler.go
+++ b/pkg/activitypub/resthandler/serviceshandler.go
@@ -27,9 +27,9 @@ func NewServices(cfg *Config, activityStore spi.Store) *Services {
 }
 
 func (h *Services) handle(w http.ResponseWriter, _ *http.Request) {
-	service, err := h.activityStore.GetActor(h.ServiceIRI)
+	service, err := h.activityStore.GetActor(h.ObjectIRI)
 	if err != nil {
-		logger.Errorf("[%s] Error retrieving service [%s]: %s", h.endpoint, h.ServiceIRI, err)
+		logger.Errorf("[%s] Error retrieving service [%s]: %s", h.endpoint, h.ObjectIRI, err)
 
 		h.writeResponse(w, http.StatusInternalServerError, nil)
 
@@ -38,7 +38,7 @@ func (h *Services) handle(w http.ResponseWriter, _ *http.Request) {
 
 	serviceBytes, err := h.marshal(service)
 	if err != nil {
-		logger.Errorf("[%s] Unable to marshal service [%s]: %s", h.endpoint, h.ServiceIRI, err)
+		logger.Errorf("[%s] Unable to marshal service [%s]: %s", h.endpoint, h.ObjectIRI, err)
 
 		h.writeResponse(w, http.StatusInternalServerError, nil)
 

--- a/pkg/activitypub/resthandler/serviceshandler_test.go
+++ b/pkg/activitypub/resthandler/serviceshandler_test.go
@@ -27,9 +27,9 @@ var serviceIRI = testutil.MustParseURL("https://example1.com/services/orb")
 
 func TestNewServices(t *testing.T) {
 	cfg := &Config{
-		BasePath:   basePath,
-		ServiceIRI: serviceIRI,
-		PageSize:   4,
+		BasePath:  basePath,
+		ObjectIRI: serviceIRI,
+		PageSize:  4,
 	}
 
 	h := NewServices(cfg, memstore.New(""))
@@ -41,9 +41,9 @@ func TestNewServices(t *testing.T) {
 
 func TestServices_Handler(t *testing.T) {
 	cfg := &Config{
-		BasePath:   basePath,
-		ServiceIRI: serviceIRI,
-		PageSize:   4,
+		BasePath:  basePath,
+		ObjectIRI: serviceIRI,
+		PageSize:  4,
 	}
 
 	activityStore := memstore.New("")

--- a/pkg/activitypub/service/activityhandler/activityhandler.go
+++ b/pkg/activitypub/service/activityhandler/activityhandler.go
@@ -351,7 +351,7 @@ func (h *Handler) postRejectFollow(follow *vocab.ActivityType, toIRI *url.URL) e
 func (h *Handler) hasFollower(actorIRI *url.URL) (bool, error) {
 	it, err := h.store.QueryReferences(store.Follower,
 		store.NewCriteria(
-			store.WithActorIRI(h.ServiceIRI),
+			store.WithObjectIRI(h.ServiceIRI),
 			store.WithReferenceIRI(actorIRI),
 		),
 	)
@@ -496,7 +496,7 @@ func (h *Handler) handleAnnounceCollection(items []*vocab.ObjectProperty) error 
 }
 
 func (h *Handler) announceAnchorCredential(create *vocab.ActivityType) error {
-	it, err := h.store.QueryReferences(store.Follower, store.NewCriteria(store.WithActorIRI(h.ServiceIRI)))
+	it, err := h.store.QueryReferences(store.Follower, store.NewCriteria(store.WithObjectIRI(h.ServiceIRI)))
 	if err != nil {
 		return err
 	}
@@ -559,7 +559,7 @@ func (h *Handler) announceAnchorCredential(create *vocab.ActivityType) error {
 }
 
 func (h *Handler) announceAnchorCredentialRef(ref *vocab.AnchorCredentialReferenceType) error {
-	it, err := h.store.QueryReferences(store.Follower, store.NewCriteria(store.WithActorIRI(h.ServiceIRI)))
+	it, err := h.store.QueryReferences(store.Follower, store.NewCriteria(store.WithObjectIRI(h.ServiceIRI)))
 	if err != nil {
 		return err
 	}

--- a/pkg/activitypub/service/activityhandler/activityhandler_test.go
+++ b/pkg/activitypub/service/activityhandler/activityhandler_test.go
@@ -277,7 +277,7 @@ func TestHandler_HandleFollowActivity(t *testing.T) {
 		require.NotNil(t, gotActivity[follow.ID().String()])
 		mutex.Unlock()
 
-		it, err := h.store.QueryReferences(store.Follower, store.NewCriteria(store.WithActorIRI(h.ServiceIRI)))
+		it, err := h.store.QueryReferences(store.Follower, store.NewCriteria(store.WithObjectIRI(h.ServiceIRI)))
 		require.NoError(t, err)
 
 		followers, err := storeutil.ReadReferences(it, -1)
@@ -322,7 +322,7 @@ func TestHandler_HandleFollowActivity(t *testing.T) {
 			require.Nil(t, gotActivity[follow.ID().String()])
 			mutex.Unlock()
 
-			it, err := h.store.QueryReferences(store.Follower, store.NewCriteria(store.WithActorIRI(h.ServiceIRI)))
+			it, err := h.store.QueryReferences(store.Follower, store.NewCriteria(store.WithObjectIRI(h.ServiceIRI)))
 			require.NoError(t, err)
 
 			followers, err := storeutil.ReadReferences(it, -1)
@@ -447,7 +447,7 @@ func TestHandler_HandleAcceptActivity(t *testing.T) {
 		require.NotNil(t, gotActivity[accept.ID().String()])
 		mutex.Unlock()
 
-		it, err := h.store.QueryReferences(store.Following, store.NewCriteria(store.WithActorIRI(h.ServiceIRI)))
+		it, err := h.store.QueryReferences(store.Following, store.NewCriteria(store.WithObjectIRI(h.ServiceIRI)))
 		require.NoError(t, err)
 
 		following, err := storeutil.ReadReferences(it, -1)
@@ -587,7 +587,7 @@ func TestHandler_HandleRejectActivity(t *testing.T) {
 		require.NotNil(t, gotActivity[reject.ID().String()])
 		mutex.Unlock()
 
-		it, err := h.store.QueryReferences(store.Following, store.NewCriteria(store.WithActorIRI(h.ServiceIRI)))
+		it, err := h.store.QueryReferences(store.Following, store.NewCriteria(store.WithObjectIRI(h.ServiceIRI)))
 		require.NoError(t, err)
 
 		following, err := storeutil.ReadReferences(it, -1)
@@ -926,7 +926,7 @@ func TestHandler_HandleOfferActivity(t *testing.T) {
 		mutex.Unlock()
 		require.Len(t, witness.AnchorCreds(), 1)
 
-		it, err := h.store.QueryReferences(store.Liked, store.NewCriteria(store.WithActorIRI(h.ServiceIRI)))
+		it, err := h.store.QueryReferences(store.Liked, store.NewCriteria(store.WithObjectIRI(h.ServiceIRI)))
 		require.NoError(t, err)
 
 		liked, err := storeutil.ReadReferences(it, -1)
@@ -1112,7 +1112,7 @@ func TestHandler_HandleLikeActivity(t *testing.T) {
 
 		require.NotEmpty(t, proofHandler.Proof(anchorCredID.String()))
 
-		it, err := h.store.QueryReferences(store.Like, store.NewCriteria(store.WithActorIRI(h.ServiceIRI)))
+		it, err := h.store.QueryReferences(store.Like, store.NewCriteria(store.WithObjectIRI(h.ServiceIRI)))
 		require.NoError(t, err)
 
 		likes, err := storeutil.ReadReferences(it, -1)

--- a/pkg/activitypub/service/mocks/activitystore.gen.go
+++ b/pkg/activitypub/service/mocks/activitystore.gen.go
@@ -34,11 +34,10 @@ type ActivityStore struct {
 		result1 *vocab.ActorType
 		result2 error
 	}
-	AddActivityStub        func(storeType spi.ActivityStoreType, activity *vocab.ActivityType) error
+	AddActivityStub        func(activity *vocab.ActivityType) error
 	addActivityMutex       sync.RWMutex
 	addActivityArgsForCall []struct {
-		storeType spi.ActivityStoreType
-		activity  *vocab.ActivityType
+		activity *vocab.ActivityType
 	}
 	addActivityReturns struct {
 		result1 error
@@ -46,10 +45,9 @@ type ActivityStore struct {
 	addActivityReturnsOnCall map[int]struct {
 		result1 error
 	}
-	GetActivityStub        func(storeType spi.ActivityStoreType, activityID *url.URL) (*vocab.ActivityType, error)
+	GetActivityStub        func(activityID *url.URL) (*vocab.ActivityType, error)
 	getActivityMutex       sync.RWMutex
 	getActivityArgsForCall []struct {
-		storeType  spi.ActivityStoreType
 		activityID *url.URL
 	}
 	getActivityReturns struct {
@@ -60,12 +58,11 @@ type ActivityStore struct {
 		result1 *vocab.ActivityType
 		result2 error
 	}
-	QueryActivitiesStub        func(storeType spi.ActivityStoreType, query *spi.Criteria, opts ...spi.QueryOpt) (spi.ActivityIterator, error)
+	QueryActivitiesStub        func(query *spi.Criteria, opts ...spi.QueryOpt) (spi.ActivityIterator, error)
 	queryActivitiesMutex       sync.RWMutex
 	queryActivitiesArgsForCall []struct {
-		storeType spi.ActivityStoreType
-		query     *spi.Criteria
-		opts      []spi.QueryOpt
+		query *spi.Criteria
+		opts  []spi.QueryOpt
 	}
 	queryActivitiesReturns struct {
 		result1 spi.ActivityIterator
@@ -75,11 +72,11 @@ type ActivityStore struct {
 		result1 spi.ActivityIterator
 		result2 error
 	}
-	AddReferenceStub        func(refType spi.ReferenceType, actorIRI *url.URL, referenceIRI *url.URL) error
+	AddReferenceStub        func(refType spi.ReferenceType, objectIRI *url.URL, referenceIRI *url.URL) error
 	addReferenceMutex       sync.RWMutex
 	addReferenceArgsForCall []struct {
 		refType      spi.ReferenceType
-		actorIRI     *url.URL
+		objectIRI    *url.URL
 		referenceIRI *url.URL
 	}
 	addReferenceReturns struct {
@@ -88,11 +85,11 @@ type ActivityStore struct {
 	addReferenceReturnsOnCall map[int]struct {
 		result1 error
 	}
-	DeleteReferenceStub        func(refType spi.ReferenceType, actorIRI *url.URL, referenceIRI *url.URL) error
+	DeleteReferenceStub        func(refType spi.ReferenceType, objectIRI *url.URL, referenceIRI *url.URL) error
 	deleteReferenceMutex       sync.RWMutex
 	deleteReferenceArgsForCall []struct {
 		refType      spi.ReferenceType
-		actorIRI     *url.URL
+		objectIRI    *url.URL
 		referenceIRI *url.URL
 	}
 	deleteReferenceReturns struct {
@@ -219,17 +216,16 @@ func (fake *ActivityStore) GetActorReturnsOnCall(i int, result1 *vocab.ActorType
 	}{result1, result2}
 }
 
-func (fake *ActivityStore) AddActivity(storeType spi.ActivityStoreType, activity *vocab.ActivityType) error {
+func (fake *ActivityStore) AddActivity(activity *vocab.ActivityType) error {
 	fake.addActivityMutex.Lock()
 	ret, specificReturn := fake.addActivityReturnsOnCall[len(fake.addActivityArgsForCall)]
 	fake.addActivityArgsForCall = append(fake.addActivityArgsForCall, struct {
-		storeType spi.ActivityStoreType
-		activity  *vocab.ActivityType
-	}{storeType, activity})
-	fake.recordInvocation("AddActivity", []interface{}{storeType, activity})
+		activity *vocab.ActivityType
+	}{activity})
+	fake.recordInvocation("AddActivity", []interface{}{activity})
 	fake.addActivityMutex.Unlock()
 	if fake.AddActivityStub != nil {
-		return fake.AddActivityStub(storeType, activity)
+		return fake.AddActivityStub(activity)
 	}
 	if specificReturn {
 		return ret.result1
@@ -243,10 +239,10 @@ func (fake *ActivityStore) AddActivityCallCount() int {
 	return len(fake.addActivityArgsForCall)
 }
 
-func (fake *ActivityStore) AddActivityArgsForCall(i int) (spi.ActivityStoreType, *vocab.ActivityType) {
+func (fake *ActivityStore) AddActivityArgsForCall(i int) *vocab.ActivityType {
 	fake.addActivityMutex.RLock()
 	defer fake.addActivityMutex.RUnlock()
-	return fake.addActivityArgsForCall[i].storeType, fake.addActivityArgsForCall[i].activity
+	return fake.addActivityArgsForCall[i].activity
 }
 
 func (fake *ActivityStore) AddActivityReturns(result1 error) {
@@ -268,17 +264,16 @@ func (fake *ActivityStore) AddActivityReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *ActivityStore) GetActivity(storeType spi.ActivityStoreType, activityID *url.URL) (*vocab.ActivityType, error) {
+func (fake *ActivityStore) GetActivity(activityID *url.URL) (*vocab.ActivityType, error) {
 	fake.getActivityMutex.Lock()
 	ret, specificReturn := fake.getActivityReturnsOnCall[len(fake.getActivityArgsForCall)]
 	fake.getActivityArgsForCall = append(fake.getActivityArgsForCall, struct {
-		storeType  spi.ActivityStoreType
 		activityID *url.URL
-	}{storeType, activityID})
-	fake.recordInvocation("GetActivity", []interface{}{storeType, activityID})
+	}{activityID})
+	fake.recordInvocation("GetActivity", []interface{}{activityID})
 	fake.getActivityMutex.Unlock()
 	if fake.GetActivityStub != nil {
-		return fake.GetActivityStub(storeType, activityID)
+		return fake.GetActivityStub(activityID)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -292,10 +287,10 @@ func (fake *ActivityStore) GetActivityCallCount() int {
 	return len(fake.getActivityArgsForCall)
 }
 
-func (fake *ActivityStore) GetActivityArgsForCall(i int) (spi.ActivityStoreType, *url.URL) {
+func (fake *ActivityStore) GetActivityArgsForCall(i int) *url.URL {
 	fake.getActivityMutex.RLock()
 	defer fake.getActivityMutex.RUnlock()
-	return fake.getActivityArgsForCall[i].storeType, fake.getActivityArgsForCall[i].activityID
+	return fake.getActivityArgsForCall[i].activityID
 }
 
 func (fake *ActivityStore) GetActivityReturns(result1 *vocab.ActivityType, result2 error) {
@@ -320,18 +315,17 @@ func (fake *ActivityStore) GetActivityReturnsOnCall(i int, result1 *vocab.Activi
 	}{result1, result2}
 }
 
-func (fake *ActivityStore) QueryActivities(storeType spi.ActivityStoreType, query *spi.Criteria, opts ...spi.QueryOpt) (spi.ActivityIterator, error) {
+func (fake *ActivityStore) QueryActivities(query *spi.Criteria, opts ...spi.QueryOpt) (spi.ActivityIterator, error) {
 	fake.queryActivitiesMutex.Lock()
 	ret, specificReturn := fake.queryActivitiesReturnsOnCall[len(fake.queryActivitiesArgsForCall)]
 	fake.queryActivitiesArgsForCall = append(fake.queryActivitiesArgsForCall, struct {
-		storeType spi.ActivityStoreType
-		query     *spi.Criteria
-		opts      []spi.QueryOpt
-	}{storeType, query, opts})
-	fake.recordInvocation("QueryActivities", []interface{}{storeType, query, opts})
+		query *spi.Criteria
+		opts  []spi.QueryOpt
+	}{query, opts})
+	fake.recordInvocation("QueryActivities", []interface{}{query, opts})
 	fake.queryActivitiesMutex.Unlock()
 	if fake.QueryActivitiesStub != nil {
-		return fake.QueryActivitiesStub(storeType, query, opts...)
+		return fake.QueryActivitiesStub(query, opts...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -345,10 +339,10 @@ func (fake *ActivityStore) QueryActivitiesCallCount() int {
 	return len(fake.queryActivitiesArgsForCall)
 }
 
-func (fake *ActivityStore) QueryActivitiesArgsForCall(i int) (spi.ActivityStoreType, *spi.Criteria, []spi.QueryOpt) {
+func (fake *ActivityStore) QueryActivitiesArgsForCall(i int) (*spi.Criteria, []spi.QueryOpt) {
 	fake.queryActivitiesMutex.RLock()
 	defer fake.queryActivitiesMutex.RUnlock()
-	return fake.queryActivitiesArgsForCall[i].storeType, fake.queryActivitiesArgsForCall[i].query, fake.queryActivitiesArgsForCall[i].opts
+	return fake.queryActivitiesArgsForCall[i].query, fake.queryActivitiesArgsForCall[i].opts
 }
 
 func (fake *ActivityStore) QueryActivitiesReturns(result1 spi.ActivityIterator, result2 error) {
@@ -373,18 +367,18 @@ func (fake *ActivityStore) QueryActivitiesReturnsOnCall(i int, result1 spi.Activ
 	}{result1, result2}
 }
 
-func (fake *ActivityStore) AddReference(refType spi.ReferenceType, actorIRI *url.URL, referenceIRI *url.URL) error {
+func (fake *ActivityStore) AddReference(refType spi.ReferenceType, objectIRI *url.URL, referenceIRI *url.URL) error {
 	fake.addReferenceMutex.Lock()
 	ret, specificReturn := fake.addReferenceReturnsOnCall[len(fake.addReferenceArgsForCall)]
 	fake.addReferenceArgsForCall = append(fake.addReferenceArgsForCall, struct {
 		refType      spi.ReferenceType
-		actorIRI     *url.URL
+		objectIRI    *url.URL
 		referenceIRI *url.URL
-	}{refType, actorIRI, referenceIRI})
-	fake.recordInvocation("AddReference", []interface{}{refType, actorIRI, referenceIRI})
+	}{refType, objectIRI, referenceIRI})
+	fake.recordInvocation("AddReference", []interface{}{refType, objectIRI, referenceIRI})
 	fake.addReferenceMutex.Unlock()
 	if fake.AddReferenceStub != nil {
-		return fake.AddReferenceStub(refType, actorIRI, referenceIRI)
+		return fake.AddReferenceStub(refType, objectIRI, referenceIRI)
 	}
 	if specificReturn {
 		return ret.result1
@@ -401,7 +395,7 @@ func (fake *ActivityStore) AddReferenceCallCount() int {
 func (fake *ActivityStore) AddReferenceArgsForCall(i int) (spi.ReferenceType, *url.URL, *url.URL) {
 	fake.addReferenceMutex.RLock()
 	defer fake.addReferenceMutex.RUnlock()
-	return fake.addReferenceArgsForCall[i].refType, fake.addReferenceArgsForCall[i].actorIRI, fake.addReferenceArgsForCall[i].referenceIRI
+	return fake.addReferenceArgsForCall[i].refType, fake.addReferenceArgsForCall[i].objectIRI, fake.addReferenceArgsForCall[i].referenceIRI
 }
 
 func (fake *ActivityStore) AddReferenceReturns(result1 error) {
@@ -423,18 +417,18 @@ func (fake *ActivityStore) AddReferenceReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *ActivityStore) DeleteReference(refType spi.ReferenceType, actorIRI *url.URL, referenceIRI *url.URL) error {
+func (fake *ActivityStore) DeleteReference(refType spi.ReferenceType, objectIRI *url.URL, referenceIRI *url.URL) error {
 	fake.deleteReferenceMutex.Lock()
 	ret, specificReturn := fake.deleteReferenceReturnsOnCall[len(fake.deleteReferenceArgsForCall)]
 	fake.deleteReferenceArgsForCall = append(fake.deleteReferenceArgsForCall, struct {
 		refType      spi.ReferenceType
-		actorIRI     *url.URL
+		objectIRI    *url.URL
 		referenceIRI *url.URL
-	}{refType, actorIRI, referenceIRI})
-	fake.recordInvocation("DeleteReference", []interface{}{refType, actorIRI, referenceIRI})
+	}{refType, objectIRI, referenceIRI})
+	fake.recordInvocation("DeleteReference", []interface{}{refType, objectIRI, referenceIRI})
 	fake.deleteReferenceMutex.Unlock()
 	if fake.DeleteReferenceStub != nil {
-		return fake.DeleteReferenceStub(refType, actorIRI, referenceIRI)
+		return fake.DeleteReferenceStub(refType, objectIRI, referenceIRI)
 	}
 	if specificReturn {
 		return ret.result1
@@ -451,7 +445,7 @@ func (fake *ActivityStore) DeleteReferenceCallCount() int {
 func (fake *ActivityStore) DeleteReferenceArgsForCall(i int) (spi.ReferenceType, *url.URL, *url.URL) {
 	fake.deleteReferenceMutex.RLock()
 	defer fake.deleteReferenceMutex.RUnlock()
-	return fake.deleteReferenceArgsForCall[i].refType, fake.deleteReferenceArgsForCall[i].actorIRI, fake.deleteReferenceArgsForCall[i].referenceIRI
+	return fake.deleteReferenceArgsForCall[i].refType, fake.deleteReferenceArgsForCall[i].objectIRI, fake.deleteReferenceArgsForCall[i].referenceIRI
 }
 
 func (fake *ActivityStore) DeleteReferenceReturns(result1 error) {

--- a/pkg/activitypub/service/service.go
+++ b/pkg/activitypub/service/service.go
@@ -66,6 +66,7 @@ func New(cfg *Config, activityStore store.Store,
 	ob, err := outbox.New(
 		&outbox.Config{
 			ServiceName:      cfg.ServiceEndpoint,
+			ServiceIRI:       cfg.ServiceIRI,
 			Topic:            activitiesTopic,
 			RedeliveryConfig: cfg.RetryOpts,
 		},
@@ -88,6 +89,7 @@ func New(cfg *Config, activityStore store.Store,
 	ib, err := inbox.New(
 		&inbox.Config{
 			ServiceEndpoint: cfg.ServiceEndpoint,
+			ServiceIRI:      cfg.ServiceIRI,
 			Topic:           activitiesTopic,
 		},
 		activityStore,


### PR DESCRIPTION
The ActivityPub storage can now store references from any object (not just actors) to a collection of activities. Activities are stored in a single place and the inbox and outbox are collections of references to the activities.

closes #143

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>