### PR TITLE
feat: 'likes' and 'shares' REST endpoints

### DIFF
--- a/pkg/activitypub/resthandler/activityhandler.go
+++ b/pkg/activitypub/resthandler/activityhandler.go
@@ -43,6 +43,36 @@ func NewInbox(cfg *Config, activityStore spi.Store) *Outbox {
 	}
 }
 
+// Shares implements the 'shares' REST handler that retrieves an object's 'Announce' activities.
+type Shares struct {
+	*activities
+}
+
+// NewShares returns a new 'shares' REST handler.
+func NewShares(cfg *Config, activityStore spi.Store) *Shares {
+	h := &Shares{}
+
+	h.activities = newActivities(SharesPath, spi.Share, cfg, activityStore,
+		getObjectIRIFromParam(cfg.ObjectIRI), getID("shares"))
+
+	return h
+}
+
+// Likes implements the 'likes' REST handler that retrieves an object's 'Like' activities.
+type Likes struct {
+	*activities
+}
+
+// NewLikes returns a new 'likes' REST handler.
+func NewLikes(cfg *Config, activityStore spi.Store) *Likes {
+	h := &Likes{}
+
+	h.activities = newActivities(LikesPath, spi.Like, cfg, activityStore,
+		getObjectIRIFromParam(cfg.ObjectIRI), getID("likes"))
+
+	return h
+}
+
 type getIDFunc func(objectIRI *url.URL) (*url.URL, error)
 
 type getObjectIRIFunc func(req *http.Request) (*url.URL, error)

--- a/pkg/activitypub/resthandler/resthandler.go
+++ b/pkg/activitypub/resthandler/resthandler.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"strconv"
 
+	"github.com/gorilla/mux"
 	"github.com/trustbloc/edge-core/pkg/log"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/common"
 
@@ -36,11 +37,16 @@ const (
 	WitnessingPath = "/witnessing"
 	// LikedPath specifies the service's 'liked' endpoint.
 	LikedPath = "/liked"
+	// SharesPath specifies the object's 'shares' endpoint.
+	SharesPath = "/{id}/shares"
+	// LikesPath specifies the object's 'likes' endpoint.
+	LikesPath = "/{id}/likes"
 )
 
 const (
 	pageParam    = "page"
 	pageNumParam = "page-num"
+	idParam      = "id"
 )
 
 // Config contains configuration parameters for the handler.
@@ -311,4 +317,20 @@ func getObjectIRI(baseObjectIRI *url.URL) getObjectIRIFunc {
 	return func(*http.Request) (*url.URL, error) {
 		return baseObjectIRI, nil
 	}
+}
+
+func getObjectIRIFromParam(baseObjectIRI *url.URL) getObjectIRIFunc {
+	return func(req *http.Request) (*url.URL, error) {
+		id := getIDParam(req)
+		if id == "" {
+			return nil, fmt.Errorf("id not specified in URL")
+		}
+
+		return url.Parse(fmt.Sprintf("%s/%s", baseObjectIRI, id))
+	}
+}
+
+//nolint:gochecknoglobals
+var getIDParam = func(req *http.Request) string {
+	return mux.Vars(req)[idParam]
 }

--- a/pkg/activitypub/resthandler/resthandler_test.go
+++ b/pkg/activitypub/resthandler/resthandler_test.go
@@ -299,3 +299,15 @@ func setPaging(h *handler, page, pageNum string) func() {
 		h.getParams = getParamsRestore
 	}
 }
+
+func setIDParam(id string) func() {
+	restore := getIDParam
+
+	getIDParam = func(req *http.Request) string {
+		return id
+	}
+
+	return func() {
+		getIDParam = restore
+	}
+}


### PR DESCRIPTION
Added a 'likes' endpoint that returns an object's Like activities and a 'shares' endpoint that returns the object's Announce activities. The ID of the object is specified in the URL.

closes #99
closes #101

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>