### PR TITLE
fix: Return 'Like' activities in 'liked' REST endpoint

### DIFF
--- a/pkg/activitypub/resthandler/activityhandler.go
+++ b/pkg/activitypub/resthandler/activityhandler.go
@@ -27,16 +27,23 @@ func NewInbox(cfg *Config, activityStore spi.Store) *Activities {
 		getObjectIRI(cfg.ObjectIRI), getID("inbox"))
 }
 
-// NewShares returns a new 'shares' REST handler that retrieves an object's 'Announce' Activities.
+// NewShares returns a new 'shares' REST handler that retrieves an object's 'Announce' activities.
 func NewShares(cfg *Config, activityStore spi.Store) *Activities {
 	return NewActivities(SharesPath, spi.Share, cfg, activityStore,
 		getObjectIRIFromParam(cfg.ObjectIRI), getID("shares"))
 }
 
-// NewLikes returns a new 'likes' REST handler that retrieves an object's 'Like' Activities.
+// NewLikes returns a new 'likes' REST handler that retrieves an object's 'Like' activities.
 func NewLikes(cfg *Config, activityStore spi.Store) *Activities {
 	return NewActivities(LikesPath, spi.Like, cfg, activityStore,
 		getObjectIRIFromParam(cfg.ObjectIRI), getID("likes"))
+}
+
+// NewLiked returns a new 'liked' REST handler that retrieves a service's 'Like' activities, i.e. the Like
+// activities that were posted by the given service.
+func NewLiked(cfg *Config, activityStore spi.Store) *Activities {
+	return NewActivities(LikedPath, spi.Liked, cfg, activityStore,
+		getObjectIRI(cfg.ObjectIRI), getID("liked"))
 }
 
 type getIDFunc func(objectIRI *url.URL) (*url.URL, error)

--- a/pkg/activitypub/resthandler/referencehandler.go
+++ b/pkg/activitypub/resthandler/referencehandler.go
@@ -40,12 +40,6 @@ func NewWitnessing(cfg *Config, activityStore spi.Store) *Reference {
 		getObjectIRI(cfg.ObjectIRI), getID("witnessing"))
 }
 
-// NewLiked returns a new 'liked' REST handler that retrieves a service's list of objects that were 'liked'.
-func NewLiked(cfg *Config, activityStore spi.Store) *Reference {
-	return NewReference(LikedPath, spi.Liked, spi.SortDescending, true, cfg, activityStore,
-		getObjectIRI(cfg.ObjectIRI), getID("liked"))
-}
-
 type createCollectionFunc func(items []*vocab.ObjectProperty, opts ...vocab.Opt) interface{}
 
 // Reference implements a REST handler that retrieves references as a collection of IRIs.

--- a/pkg/activitypub/resthandler/referencehandler_test.go
+++ b/pkg/activitypub/resthandler/referencehandler_test.go
@@ -403,37 +403,6 @@ func TestWitnessing_Handler(t *testing.T) {
 	})
 }
 
-func TestLiked_Handler(t *testing.T) {
-	liked := testutil.NewMockURLs(19, func(i int) string { return fmt.Sprintf("https://example.com/transactions%d", i+1) })
-
-	activityStore := memstore.New("")
-
-	for _, ref := range liked {
-		require.NoError(t, activityStore.AddReference(spi.Liked, serviceIRI, ref))
-	}
-
-	cfg := &Config{
-		BasePath:  basePath,
-		ObjectIRI: serviceIRI,
-		PageSize:  4,
-	}
-
-	h := NewLiked(cfg, activityStore)
-	require.NotNil(t, h)
-
-	t.Run("Main page -> Success", func(t *testing.T) {
-		handleRequest(t, h.handler, h.handle, "false", "", likedJSON)
-	})
-
-	t.Run("First page -> Success", func(t *testing.T) {
-		handleRequest(t, h.handler, h.handle, "true", "", likedFirstPageJSON)
-	})
-
-	t.Run("Page by num -> Success", func(t *testing.T) {
-		handleRequest(t, h.handler, h.handle, "true", "3", likedPage3JSON)
-	})
-}
-
 func handleRequest(t *testing.T, h *handler, handle http.HandlerFunc, page, pageNum, expected string) {
 	restorePaging := setPaging(h, page, pageNum)
 	defer restorePaging()
@@ -588,44 +557,6 @@ const (
     "https://example14.com/services/orb",
     "https://example15.com/services/orb",
     "https://example16.com/services/orb"
-  ]
-}`
-
-	likedJSON = `{
-  "@context": "https://www.w3.org/ns/activitystreams",
-  "id": "https://example1.com/services/orb/liked",
-  "type": "OrderedCollection",
-  "totalItems": 19,
-  "first": "https://example1.com/services/orb/liked?page=true",
-  "last": "https://example1.com/services/orb/liked?page=true&page-num=0"
-}`
-
-	likedFirstPageJSON = `{
-  "@context": "https://www.w3.org/ns/activitystreams",
-  "id": "https://example1.com/services/orb/liked?page=true&page-num=4",
-  "type": "OrderedCollectionPage",
-  "totalItems": 19,
-  "next": "https://example1.com/services/orb/liked?page=true&page-num=3",
-  "orderedItems": [
-    "https://example.com/transactions19",
-    "https://example.com/transactions18",
-    "https://example.com/transactions17",
-    "https://example.com/transactions16"
-  ]
-}`
-
-	likedPage3JSON = `{
-  "@context": "https://www.w3.org/ns/activitystreams",
-  "id": "https://example1.com/services/orb/liked?page=true&page-num=3",
-  "type": "OrderedCollectionPage",
-  "totalItems": 19,
-  "next": "https://example1.com/services/orb/liked?page=true&page-num=2",
-  "prev": "https://example1.com/services/orb/liked?page=true&page-num=4",
-  "orderedItems": [
-    "https://example.com/transactions15",
-    "https://example.com/transactions14",
-    "https://example.com/transactions13",
-    "https://example.com/transactions12"
   ]
 }`
 )


### PR DESCRIPTION
In order to be consistent with the 'likes' REST endpoint, the 'Liked' activities are now returned in 'liked' requests.

closes #147

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>