### PR TITLE
feat: Intelligent endpoint resolution for ActivityPub 'to' property

### DIFF
--- a/pkg/activitypub/client/client.go
+++ b/pkg/activitypub/client/client.go
@@ -67,7 +67,25 @@ func (c *Client) GetActor(actorIRI *url.URL) (*vocab.ActorType, error) {
 	return actor, nil
 }
 
-func (c *Client) get(iri fmt.Stringer) ([]byte, error) {
+// GetReferences returns an iterator that reads all references at the given IRI. The IRI either resolves
+// to an ActivityPub actor, collection or ordered collection.
+func (c *Client) GetReferences(iri *url.URL) (ReferenceIterator, error) {
+	respBytes, err := c.get(iri)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response from %s: %w", iri, err)
+	}
+
+	logger.Debugf("Got response from %s: %s", iri, respBytes)
+
+	items, firstPage, totalItems, err := unmarshalReference(respBytes)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarsalling response from %s: %w", iri, err)
+	}
+
+	return newIterator(items, firstPage, totalItems, c.get), nil
+}
+
+func (c *Client) get(iri *url.URL) ([]byte, error) {
 	req, err := http.NewRequest(http.MethodGet, iri.String(), nil)
 	if err != nil {
 		return nil, errors.WithMessage(err, "unable to create HTTP request")
@@ -96,4 +114,163 @@ func (c *Client) get(iri fmt.Stringer) ([]byte, error) {
 	}
 
 	return respBytes, nil
+}
+
+type getFunc func(iri *url.URL) ([]byte, error)
+
+type referenceIterator struct {
+	totalItems   int
+	currentItems []*url.URL
+	currentIndex int
+	nextPage     *url.URL
+	get          getFunc
+}
+
+func newIterator(items []*url.URL, nextPage *url.URL, totalItems int, retrieve getFunc) *referenceIterator {
+	return &referenceIterator{
+		currentItems: items,
+		totalItems:   totalItems,
+		nextPage:     nextPage,
+		get:          retrieve,
+		currentIndex: 0,
+	}
+}
+
+func (it *referenceIterator) Next() (*url.URL, error) {
+	if it.currentIndex >= len(it.currentItems) {
+		err := it.getNextPage()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	item := it.currentItems[it.currentIndex]
+
+	it.currentIndex++
+
+	return item, nil
+}
+
+func (it *referenceIterator) TotalItems() int {
+	return it.totalItems
+}
+
+func (it *referenceIterator) getNextPage() error {
+	if it.nextPage == nil {
+		logger.Debugf("No more pages")
+
+		return ErrNotFound
+	}
+
+	logger.Debugf("Retrieving next page %s", it.nextPage)
+
+	respBytes, err := it.get(it.nextPage)
+	if err != nil {
+		return fmt.Errorf("request to %s failed: %w", it.nextPage, err)
+	}
+
+	logger.Debugf("Got response from %s: %s", it.nextPage, respBytes)
+
+	refs, nextPage, err := unmarshalCollectionPage(respBytes)
+	if err != nil {
+		return err
+	}
+
+	logger.Debugf("Got page %s with %d items. Next page: %s", it.nextPage, len(refs), nextPage)
+
+	it.currentItems = refs
+	it.currentIndex = 0
+	it.nextPage = nextPage
+
+	return nil
+}
+
+func unmarshalReference(respBytes []byte) (items []*url.URL, nextPage *url.URL, totalCount int, err error) {
+	obj := &vocab.ObjectType{}
+
+	if err := json.Unmarshal(respBytes, &obj); err != nil {
+		return nil, nil, 0, err
+	}
+
+	switch {
+	case obj.Type().Is(vocab.TypeService):
+		actor := &vocab.ActorType{}
+		if err := json.Unmarshal(respBytes, actor); err != nil {
+			return nil, nil, 0, fmt.Errorf("invalid service in response: %w", err)
+		}
+
+		return []*url.URL{actor.ID().URL()}, nil, 1, nil
+
+	case obj.Type().Is(vocab.TypeCollection):
+		coll := &vocab.CollectionType{}
+		if err := json.Unmarshal(respBytes, coll); err != nil {
+			return nil, nil, 0, fmt.Errorf("invalid collection in response: %w", err)
+		}
+
+		return nil, coll.First(), coll.TotalItems(), nil
+
+	case obj.Type().Is(vocab.TypeOrderedCollection):
+		coll := &vocab.OrderedCollectionType{}
+		if err := json.Unmarshal(respBytes, coll); err != nil {
+			return nil, nil, 0, fmt.Errorf("invalid ordered collection in response: %w", err)
+		}
+
+		return nil, coll.First(), coll.TotalItems(), nil
+
+	default:
+		return nil, nil, 0, fmt.Errorf("expecting Service, Collection or OrderedCollection in response payload")
+	}
+}
+
+func unmarshalCollectionPage(respBytes []byte) ([]*url.URL, *url.URL, error) {
+	obj := &vocab.ObjectType{}
+
+	if err := json.Unmarshal(respBytes, &obj); err != nil {
+		return nil, nil, err
+	}
+
+	var items []*vocab.ObjectProperty
+
+	var next *url.URL
+
+	switch {
+	case obj.Type().Is(vocab.TypeCollectionPage):
+		coll := &vocab.CollectionPageType{}
+
+		err := json.Unmarshal(respBytes, coll)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid collection page in response: %w", err)
+		}
+
+		next = coll.Next()
+		items = coll.Items()
+
+	case obj.Type().Is(vocab.TypeOrderedCollectionPage):
+		coll := &vocab.OrderedCollectionPageType{}
+
+		err := json.Unmarshal(respBytes, coll)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid ordered collection page in response: %w", err)
+		}
+
+		next = coll.Next()
+		items = coll.Items()
+
+	default:
+		return nil, nil, fmt.Errorf("expecting CollectionPage or OrderedCollectionPage in response payload")
+	}
+
+	var refs []*url.URL
+
+	for _, item := range items {
+		if item.IRI() != nil {
+			logger.Debugf("Adding %s to the recipient list", item.IRI())
+
+			refs = append(refs, item.IRI())
+		} else {
+			logger.Warnf("expecting IRI item for collection but got %s", item.Type())
+		}
+	}
+
+	return refs, next, nil
 }

--- a/pkg/activitypub/client/client_test.go
+++ b/pkg/activitypub/client/client_test.go
@@ -11,11 +11,14 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/edge-core/pkg/log"
 
 	"github.com/trustbloc/orb/pkg/activitypub/client/mocks"
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
 	"github.com/trustbloc/orb/pkg/internal/aptestutil"
 	"github.com/trustbloc/orb/pkg/internal/testutil"
 )
@@ -110,5 +113,321 @@ func TestClient_GetActor(t *testing.T) {
 		require.Nil(t, actor)
 
 		require.NoError(t, result.Body.Close())
+	})
+}
+
+func TestClient_GetReferences(t *testing.T) {
+	log.SetLevel("activitypub_client", log.DEBUG)
+
+	serviceIRI := testutil.MustParseURL("https://example.com/services/service1")
+	collIRI := testutil.NewMockID(serviceIRI, "/followers")
+
+	first := testutil.NewMockID(collIRI, "?page=true")
+
+	followers := []*url.URL{
+		testutil.MustParseURL("https://example2.com/services/service2"),
+		testutil.MustParseURL("https://example3.com/services/service3"),
+		testutil.MustParseURL("https://example4.com/services/service4"),
+	}
+
+	collBytes, err := json.Marshal(aptestutil.NewMockCollection(collIRI, first, len(followers)))
+	require.NoError(t, err)
+
+	t.Run("Service -> Success", func(t *testing.T) {
+		serviceBytes, e := json.Marshal(aptestutil.NewMockService(serviceIRI))
+		require.NoError(t, e)
+
+		httpClient := &mocks.HTTPClient{}
+
+		rw := httptest.NewRecorder()
+
+		_, e = rw.Write(serviceBytes)
+		require.NoError(t, e)
+
+		result := rw.Result()
+
+		httpClient.DoReturns(result, nil)
+
+		c := New(httpClient)
+		require.NotNil(t, t, c)
+
+		it, e := c.GetReferences(serviceIRI)
+		require.NoError(t, e)
+		require.NotNil(t, it)
+
+		refs, e := ReadReferences(it, -1)
+		require.NoError(t, e)
+		require.Len(t, refs, 1)
+		require.Equal(t, serviceIRI.String(), refs[0].String())
+
+		require.NoError(t, result.Body.Close())
+	})
+
+	t.Run("Collection -> Success", func(t *testing.T) {
+		collPage1Bytes, e := json.Marshal(aptestutil.NewMockCollectionPage(
+			testutil.NewMockID(collIRI, "?page=0"),
+			testutil.NewMockID(collIRI, "?page=1"),
+			collIRI, len(followers),
+			followers[0], followers[1],
+		))
+		require.NoError(t, e)
+
+		collPage2Bytes, e := json.Marshal(aptestutil.NewMockCollectionPage(
+			testutil.NewMockID(collIRI, "?page=1"),
+			nil,
+			collIRI, len(followers),
+			followers[2],
+		))
+		require.NoError(t, e)
+
+		httpClient := &mocks.HTTPClient{}
+
+		rw1 := httptest.NewRecorder()
+
+		_, e = rw1.Write(collBytes)
+		require.NoError(t, e)
+
+		rw2 := httptest.NewRecorder()
+
+		_, e = rw2.Write(collPage1Bytes)
+		require.NoError(t, e)
+
+		rw3 := httptest.NewRecorder()
+
+		_, e = rw3.Write(collPage2Bytes)
+		require.NoError(t, e)
+
+		result1 := rw1.Result()
+		result2 := rw2.Result()
+		result3 := rw3.Result()
+
+		httpClient.DoReturnsOnCall(0, result1, nil)
+		httpClient.DoReturnsOnCall(1, result2, nil)
+		httpClient.DoReturnsOnCall(2, result3, nil)
+
+		c := New(httpClient)
+		require.NotNil(t, t, c)
+
+		it, e := c.GetReferences(collIRI)
+		require.NoError(t, e)
+		require.NotNil(t, it)
+		require.Equal(t, len(followers), it.TotalItems())
+
+		refs, e := ReadReferences(it, -1)
+		require.NoError(t, e)
+		require.Len(t, refs, len(followers))
+		require.Equal(t, followers[0].String(), refs[0].String())
+		require.Equal(t, followers[1].String(), refs[1].String())
+		require.Equal(t, followers[2].String(), refs[2].String())
+
+		require.NoError(t, result1.Body.Close())
+		require.NoError(t, result2.Body.Close())
+		require.NoError(t, result3.Body.Close())
+	})
+
+	t.Run("OrderedCollection -> Success", func(t *testing.T) {
+		orderedCollBytes, e := json.Marshal(aptestutil.NewMockOrderedCollection(collIRI, first, len(followers)))
+		require.NoError(t, e)
+
+		collPage1Bytes, e := json.Marshal(aptestutil.NewMockOrderedCollectionPage(
+			testutil.NewMockID(collIRI, "?page=0"),
+			testutil.NewMockID(collIRI, "?page=1"),
+			collIRI, len(followers),
+			followers[0], followers[1],
+		))
+		require.NoError(t, e)
+
+		collPage2Bytes, e := json.Marshal(aptestutil.NewMockOrderedCollectionPage(
+			testutil.NewMockID(collIRI, "?page=1"),
+			nil,
+			collIRI, len(followers),
+			followers[2],
+		))
+		require.NoError(t, e)
+
+		httpClient := &mocks.HTTPClient{}
+
+		rw1 := httptest.NewRecorder()
+
+		_, e = rw1.Write(orderedCollBytes)
+		require.NoError(t, e)
+
+		rw2 := httptest.NewRecorder()
+
+		_, e = rw2.Write(collPage1Bytes)
+		require.NoError(t, e)
+
+		rw3 := httptest.NewRecorder()
+
+		_, e = rw3.Write(collPage2Bytes)
+		require.NoError(t, e)
+
+		result1 := rw1.Result()
+		result2 := rw2.Result()
+		result3 := rw3.Result()
+
+		httpClient.DoReturnsOnCall(0, result1, nil)
+		httpClient.DoReturnsOnCall(1, result2, nil)
+		httpClient.DoReturnsOnCall(2, result3, nil)
+
+		c := New(httpClient)
+		require.NotNil(t, t, c)
+
+		it, e := c.GetReferences(collIRI)
+		require.NoError(t, e)
+		require.NotNil(t, it)
+
+		refs, e := ReadReferences(it, -1)
+		require.NoError(t, e)
+		require.Len(t, refs, len(followers))
+		require.Equal(t, followers[0].String(), refs[0].String())
+		require.Equal(t, followers[1].String(), refs[1].String())
+		require.Equal(t, followers[2].String(), refs[2].String())
+
+		require.NoError(t, result1.Body.Close())
+		require.NoError(t, result2.Body.Close())
+		require.NoError(t, result3.Body.Close())
+	})
+
+	t.Run("HTTP client error", func(t *testing.T) {
+		errExpected := fmt.Errorf("injected HTTP client error")
+
+		httpClient := &mocks.HTTPClient{}
+
+		httpClient.DoReturns(nil, errExpected)
+
+		c := New(httpClient)
+		require.NotNil(t, t, c)
+
+		actor, e := c.GetReferences(collIRI)
+		require.Error(t, e)
+		require.Contains(t, e.Error(), errExpected.Error())
+		require.Nil(t, actor)
+	})
+
+	t.Run("Unmarshal collection error", func(t *testing.T) {
+		rw := httptest.NewRecorder()
+
+		_, err = rw.Write([]byte("{"))
+		require.NoError(t, err)
+
+		httpClient := &mocks.HTTPClient{}
+
+		result := rw.Result()
+
+		httpClient.DoReturns(result, nil)
+
+		c := New(httpClient)
+		require.NotNil(t, t, c)
+
+		it, e := c.GetReferences(collIRI)
+		require.Error(t, e)
+		require.Contains(t, e.Error(), "unexpected end of JSON input")
+		require.Nil(t, it)
+
+		require.NoError(t, result.Body.Close())
+	})
+
+	t.Run("Invalid collection error", func(t *testing.T) {
+		invalidCollBytes, e := json.Marshal(vocab.NewObject())
+		require.NoError(t, e)
+
+		rw := httptest.NewRecorder()
+
+		_, e = rw.Write(invalidCollBytes)
+		require.NoError(t, e)
+
+		httpClient := &mocks.HTTPClient{}
+
+		result := rw.Result()
+
+		httpClient.DoReturns(result, nil)
+
+		c := New(httpClient)
+		require.NotNil(t, t, c)
+
+		it, e := c.GetReferences(collIRI)
+		require.Error(t, e)
+		require.Contains(t, e.Error(), "expecting Service, Collection or OrderedCollection in response payload")
+		require.Nil(t, it)
+
+		require.NoError(t, result.Body.Close())
+	})
+
+	t.Run("Unmarshal collection page error", func(t *testing.T) {
+		httpClient := &mocks.HTTPClient{}
+
+		rw1 := httptest.NewRecorder()
+
+		_, err = rw1.Write(collBytes)
+		require.NoError(t, err)
+
+		rw2 := httptest.NewRecorder()
+
+		_, err = rw2.Write([]byte("{"))
+		require.NoError(t, err)
+
+		result1 := rw1.Result()
+		result2 := rw2.Result()
+
+		httpClient.DoReturnsOnCall(0, result1, nil)
+		httpClient.DoReturnsOnCall(1, result2, nil)
+
+		c := New(httpClient)
+		require.NotNil(t, t, c)
+
+		it, err := c.GetReferences(collIRI)
+		require.NoError(t, err)
+		require.NotNil(t, it)
+		require.Equal(t, len(followers), it.TotalItems())
+
+		refs, err := ReadReferences(it, -1)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unexpected end of JSON input")
+		require.Empty(t, refs)
+
+		require.NoError(t, result1.Body.Close())
+		require.NoError(t, result2.Body.Close())
+	})
+
+	t.Run("Invalid collection page error", func(t *testing.T) {
+		actorIRI := testutil.MustParseURL("https://example.com/services/service1")
+
+		invalidCollBytes, err := json.Marshal(aptestutil.NewMockService(actorIRI))
+		require.NoError(t, err)
+
+		httpClient := &mocks.HTTPClient{}
+
+		rw1 := httptest.NewRecorder()
+
+		_, err = rw1.Write(collBytes)
+		require.NoError(t, err)
+
+		rw2 := httptest.NewRecorder()
+
+		_, err = rw2.Write(invalidCollBytes)
+		require.NoError(t, err)
+
+		result1 := rw1.Result()
+		result2 := rw2.Result()
+
+		httpClient.DoReturnsOnCall(0, result1, nil)
+		httpClient.DoReturnsOnCall(1, result2, nil)
+
+		c := New(httpClient)
+		require.NotNil(t, t, c)
+
+		it, err := c.GetReferences(collIRI)
+		require.NoError(t, err)
+		require.NotNil(t, it)
+		require.Equal(t, len(followers), it.TotalItems())
+
+		refs, err := ReadReferences(it, -1)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "expecting CollectionPage or OrderedCollectionPage in response payload")
+		require.Nil(t, refs)
+
+		require.NoError(t, result1.Body.Close())
+		require.NoError(t, result2.Body.Close())
 	})
 }

--- a/pkg/activitypub/client/util.go
+++ b/pkg/activitypub/client/util.go
@@ -1,0 +1,32 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package client
+
+import (
+	"net/url"
+)
+
+// ReadReferences reads the references from the given iterator up to a maximum number
+// specified by maxItems. If maxItems <= 0 then all references are read.
+func ReadReferences(it ReferenceIterator, maxItems int) ([]*url.URL, error) {
+	var refs []*url.URL
+
+	for maxItems <= 0 || len(refs) < maxItems {
+		ref, err := it.Next()
+		if err != nil {
+			if err == ErrNotFound {
+				break
+			}
+
+			return nil, err
+		}
+
+		refs = append(refs, ref)
+	}
+
+	return refs, nil
+}


### PR DESCRIPTION
If the 'to' field contains the IRI of a collection or ordered collection then the individual URIs are resolved and the activity is published to each of the URIs.

closes #137

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>