### PR TITLE
fix: REST handler for '/services' returns dynamically constructed service

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -45,6 +45,7 @@ import (
 	apservice "github.com/trustbloc/orb/pkg/activitypub/service"
 	apspi "github.com/trustbloc/orb/pkg/activitypub/service/spi"
 	apmemstore "github.com/trustbloc/orb/pkg/activitypub/store/memstore"
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
 	"github.com/trustbloc/orb/pkg/anchor/builder"
 	"github.com/trustbloc/orb/pkg/anchor/graph"
 	"github.com/trustbloc/orb/pkg/anchor/proofs"
@@ -341,6 +342,13 @@ func startOrbServices(parameters *orbParameters) error {
 		PageSize:  100, // TODO: Make configurable
 	}
 
+	// FIXME: Configure with real values.
+	publicKey := &vocab.PublicKeyType{
+		ID:           apServiceIRI.String() + "#main-key",
+		Owner:        apServiceIRI.String(),
+		PublicKeyPem: "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhki.....",
+	}
+
 	orbResolver := resolver.NewResolveHandler(
 		parameters.didNamespace,
 		parameters.didAliases,
@@ -356,7 +364,7 @@ func startOrbServices(parameters *orbParameters) error {
 		diddochandler.NewUpdateHandler(baseUpdatePath, didDocHandler, pc),
 		diddochandler.NewResolveHandler(baseResolvePath, orbResolver),
 		activityPubService.InboxHTTPHandler(),
-		aphandler.NewServices(apServiceCfg, apStore),
+		aphandler.NewServices(apServiceCfg, apStore, publicKey),
 		aphandler.NewFollowers(apServiceCfg, apStore),
 		aphandler.NewFollowing(apServiceCfg, apStore),
 		aphandler.NewOutbox(apServiceCfg, apStore),

--- a/pkg/activitypub/resthandler/serviceshandler.go
+++ b/pkg/activitypub/resthandler/serviceshandler.go
@@ -7,19 +7,26 @@ SPDX-License-Identifier: Apache-2.0
 package resthandler
 
 import (
+	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/trustbloc/orb/pkg/activitypub/store/spi"
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
 )
 
 // Services implements the 'services' REST handler to retrieve a given ActivityPub service (actor).
 type Services struct {
 	*handler
+
+	publicKey *vocab.PublicKeyType
 }
 
 // NewServices returns a new 'services' REST handler.
-func NewServices(cfg *Config, activityStore spi.Store) *Services {
-	h := &Services{}
+func NewServices(cfg *Config, activityStore spi.Store, publicKey *vocab.PublicKeyType) *Services {
+	h := &Services{
+		publicKey: publicKey,
+	}
 
 	h.handler = newHandler("", cfg, activityStore, h.handle)
 
@@ -27,16 +34,16 @@ func NewServices(cfg *Config, activityStore spi.Store) *Services {
 }
 
 func (h *Services) handle(w http.ResponseWriter, _ *http.Request) {
-	service, err := h.activityStore.GetActor(h.ObjectIRI)
+	s, err := h.newService()
 	if err != nil {
-		logger.Errorf("[%s] Error retrieving service [%s]: %s", h.endpoint, h.ObjectIRI, err)
+		logger.Errorf("[%s] Invalid service configuration [%s]: %s", h.endpoint, h.ObjectIRI, err)
 
 		h.writeResponse(w, http.StatusInternalServerError, nil)
 
 		return
 	}
 
-	serviceBytes, err := h.marshal(service)
+	serviceBytes, err := h.marshal(s)
 	if err != nil {
 		logger.Errorf("[%s] Unable to marshal service [%s]: %s", h.endpoint, h.ObjectIRI, err)
 
@@ -46,4 +53,56 @@ func (h *Services) handle(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	h.writeResponse(w, http.StatusOK, serviceBytes)
+}
+
+func (h *Services) newService() (*vocab.ActorType, error) {
+	inbox, err := newID(h.ObjectIRI, InboxPath)
+	if err != nil {
+		return nil, err
+	}
+
+	outbox, err := newID(h.ObjectIRI, OutboxPath)
+	if err != nil {
+		return nil, err
+	}
+
+	followers, err := newID(h.ObjectIRI, FollowersPath)
+	if err != nil {
+		return nil, err
+	}
+
+	following, err := newID(h.ObjectIRI, FollowingPath)
+	if err != nil {
+		return nil, err
+	}
+
+	witnesses, err := newID(h.ObjectIRI, WitnessesPath)
+	if err != nil {
+		return nil, err
+	}
+
+	witnessing, err := newID(h.ObjectIRI, WitnessingPath)
+	if err != nil {
+		return nil, err
+	}
+
+	liked, err := newID(h.ObjectIRI, LikedPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return vocab.NewService(h.ObjectIRI,
+		vocab.WithPublicKey(h.publicKey),
+		vocab.WithInbox(inbox),
+		vocab.WithOutbox(outbox),
+		vocab.WithFollowers(followers),
+		vocab.WithFollowing(following),
+		vocab.WithWitnesses(witnesses),
+		vocab.WithWitnessing(witnessing),
+		vocab.WithLiked(liked),
+	), nil
+}
+
+func newID(iri fmt.Stringer, path string) (*url.URL, error) {
+	return url.Parse(iri.String() + path)
 }


### PR DESCRIPTION
The REST handler for '/services' now constructs a service using configuration parameters from the local server as opposed to retrieving it from storage.

closes #166

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>