### PR TITLE
test: ActivityPub BDD tests: follow/accept

### DIFF
--- a/cmd/orb-server/startcmd/params.go
+++ b/cmd/orb-server/startcmd/params.go
@@ -19,6 +19,13 @@ const (
 	hostURLFlagUsage     = "URL to run the orb-server instance on. Format: HostName:Port."
 	hostURLEnvKey        = "ORB_HOST_URL"
 
+	externalEndpointFlagName      = "external-endpoint"
+	externalEndpointFlagShorthand = "e"
+	externalEndpointFlagUsage     = "External endpoint that clients use to invoke services." +
+		" This endpoint is used to generate IDs of anchor credentials and ActivityPub objects and" +
+		" should be resolvable by external clients. Format: HostName[:Port]."
+	externalEndpointEnvKey = "ORB_EXTERNAL_ENDPOINT"
+
 	tlsCertificateFlagName      = "tls-certificate"
 	tlsCertificateFlagShorthand = "y"
 	tlsCertificateFlagUsage     = "TLS certificate for ORB server. " + commonEnvVarUsageText + tlsCertificateLEnvKey
@@ -124,6 +131,7 @@ const (
 
 type orbParameters struct {
 	hostURL                string
+	externalEndpoint       string
 	didNamespace           string
 	didAliases             []string
 	casURL                 string
@@ -160,6 +168,15 @@ func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 	hostURL, err := cmdutils.GetUserSetVarFromString(cmd, hostURLFlagName, hostURLEnvKey, false)
 	if err != nil {
 		return nil, err
+	}
+
+	externalEndpoint, err := cmdutils.GetUserSetVarFromString(cmd, externalEndpointFlagName, externalEndpointEnvKey, true)
+	if err != nil {
+		return nil, err
+	}
+
+	if externalEndpoint == "" {
+		externalEndpoint = hostURL
 	}
 
 	tlsCertificate, err := cmdutils.GetUserSetVarFromString(cmd, tlsCertificateFlagName, tlsCertificateLEnvKey, true)
@@ -213,6 +230,7 @@ func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 
 	return &orbParameters{
 		hostURL:                hostURL,
+		externalEndpoint:       externalEndpoint,
 		tlsKey:                 tlsKey,
 		tlsCertificate:         tlsCertificate,
 		didNamespace:           didNamespace,
@@ -307,6 +325,7 @@ func getDBParameters(cmd *cobra.Command) (*dbParameters, error) {
 
 func createFlags(startCmd *cobra.Command) {
 	startCmd.Flags().StringP(hostURLFlagName, hostURLFlagShorthand, "", hostURLFlagUsage)
+	startCmd.Flags().StringP(externalEndpointFlagName, externalEndpointFlagShorthand, "", externalEndpointFlagUsage)
 	startCmd.Flags().StringP(tlsCertificateFlagName, tlsCertificateFlagShorthand, "", tlsCertificateFlagUsage)
 	startCmd.Flags().StringP(tlsKeyFlagName, tlsKeyFlagShorthand, "", tlsKeyFlagUsage)
 	startCmd.Flags().StringP(casURLFlagName, casURLFlagShorthand, "", casURLFlagUsage)

--- a/cmd/orb-server/startcmd/params_test.go
+++ b/cmd/orb-server/startcmd/params_test.go
@@ -240,8 +240,10 @@ func TestStartCmdValidArgsEnvVar(t *testing.T) {
 func TestStartCmdValidArgs(t *testing.T) {
 	startCmd := GetStartCmd()
 
-	args := []string{"--" + hostURLFlagName, "localhost:8247", "--" + casURLFlagName,
-		"localhost:8081", "--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
+	args := []string{"--" + hostURLFlagName, "localhost:8247",
+		"--" + externalEndpointFlagName, "orb.example.com",
+		"--" + casURLFlagName, "localhost:8081",
+		"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
 		"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption, "--" + tokenFlagName, "tk1",
 		"--" + anchorCredentialSignatureSuiteFlagName, "suite",
 		"--" + anchorCredentialDomainFlagName, "domain.com",

--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -8,6 +8,7 @@ package startcmd
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -251,12 +252,12 @@ func startOrbServices(parameters *orbParameters) error {
 
 	opProcessor := processor.New(parameters.didNamespace, opStore, pc)
 
-	apServiceIRI, err := url.Parse(fmt.Sprintf("https://%s%s", parameters.hostURL, activityPubServicesPath))
+	apServiceIRI, err := url.Parse(fmt.Sprintf("https://%s%s", parameters.externalEndpoint, activityPubServicesPath))
 	if err != nil {
 		return fmt.Errorf("invalid service IRI: %s", err.Error())
 	}
 
-	apTransactionsIRI, err := url.Parse(fmt.Sprintf("https://%s%s", parameters.hostURL, activityPubTransactionsPath))
+	apTransactionsIRI, err := url.Parse(fmt.Sprintf("https://%s%s", parameters.externalEndpoint, activityPubTransactionsPath))
 	if err != nil {
 		return fmt.Errorf("invalid transactions IRI: %s", err.Error())
 	}
@@ -315,7 +316,13 @@ func startOrbServices(parameters *orbParameters) error {
 	apStore := apmemstore.New(apConfig.ServiceEndpoint)
 
 	// TODO: Configure the HTTP client with TLS
-	httpClient := &http.Client{}
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true, //nolint: gosec
+			},
+		},
+	}
 
 	activityPubService, err := apservice.New(apConfig,
 		apStore, httpClient,

--- a/pkg/activitypub/resthandler/referencehandler.go
+++ b/pkg/activitypub/resthandler/referencehandler.go
@@ -66,7 +66,7 @@ func NewReference(path string, refType spi.ReferenceType, sortOrder spi.SortOrde
 		getObjectIRI:         getObjectIRI,
 	}
 
-	h.handler = newHandler(path, cfg, activityStore, h.handle, pageParam, pageNumParam)
+	h.handler = newHandler(path, cfg, activityStore, h.handle)
 
 	return h
 }

--- a/pkg/activitypub/service/inbox/inbox.go
+++ b/pkg/activitypub/service/inbox/inbox.go
@@ -187,7 +187,7 @@ func (h *Inbox) handle(msg *message.Message) {
 
 		msg.Nack()
 	} else {
-		logger.Warnf("[%s] Successfully handled message [%s]", h.ServiceEndpoint, msg.UUID)
+		logger.Debugf("[%s] Successfully handled message [%s]", h.ServiceEndpoint, msg.UUID)
 
 		msg.Ack()
 	}

--- a/test/bdd/features/activitypub.feature
+++ b/test/bdd/features/activitypub.feature
@@ -1,0 +1,55 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+@all
+@activitypub
+Feature:
+
+  @activitypub_service
+  Scenario: Get ActivityPub service
+    When an HTTP GET is sent to "https://localhost:48326/services/orb"
+    Then the JSON path "type" of the response equals "Service"
+    And the JSON path "inbox" of the response equals "https://orb.domain1.com/services/orb/inbox"
+    And the JSON path "outbox" of the response equals "https://orb.domain1.com/services/orb/outbox"
+    And the JSON path "followers" of the response equals "https://orb.domain1.com/services/orb/followers"
+    And the JSON path "following" of the response equals "https://orb.domain1.com/services/orb/following"
+    And the JSON path "liked" of the response equals "https://orb.domain1.com/services/orb/liked"
+    And the JSON path "witnesses" of the response equals "https://orb.domain1.com/services/orb/witnesses"
+    And the JSON path "witnessing" of the response equals "https://orb.domain1.com/services/orb/witnessing"
+
+    When an HTTP GET is sent to "https://localhost:48426/services/orb"
+    Then the JSON path "type" of the response equals "Service"
+    And the JSON path "inbox" of the response equals "https://orb.domain2.com/services/orb/inbox"
+    And the JSON path "outbox" of the response equals "https://orb.domain2.com/services/orb/outbox"
+    And the JSON path "followers" of the response equals "https://orb.domain2.com/services/orb/followers"
+    And the JSON path "following" of the response equals "https://orb.domain2.com/services/orb/following"
+    And the JSON path "liked" of the response equals "https://orb.domain2.com/services/orb/liked"
+    And the JSON path "witnesses" of the response equals "https://orb.domain2.com/services/orb/witnesses"
+    And the JSON path "witnessing" of the response equals "https://orb.domain2.com/services/orb/witnessing"
+
+  @activitypub_follow
+  Scenario: Follow ActivityPub service
+    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content from file "./fixtures/testdata/follow_activity.json"
+
+    Then we wait 2 seconds
+
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/followers"
+    Then the JSON path "type" of the response equals "Collection"
+    And the JSON path "id" of the response equals "https://orb.domain1.com/services/orb/followers"
+    And the JSON path "first" of the response equals "https://orb.domain1.com/services/orb/followers?page=true"
+
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/followers?page=true"
+    Then the JSON path "type" of the response equals "CollectionPage"
+    And the JSON path "items" of the response contains "https://orb.domain2.com/services/orb"
+
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/following"
+    Then the JSON path "type" of the response equals "Collection"
+    And the JSON path "id" of the response equals "https://orb.domain2.com/services/orb/following"
+    And the JSON path "first" of the response equals "https://orb.domain2.com/services/orb/following?page=true"
+
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/following?page=true"
+    Then the JSON path "type" of the response equals "CollectionPage"
+    And the JSON path "items" of the response contains "https://orb.domain1.com/services/orb"

--- a/test/bdd/features/did-sidetree.feature
+++ b/test/bdd/features/did-sidetree.feature
@@ -134,10 +134,10 @@ Feature:
       Then check success response contains "#canonicalId"
       Then check success response contains "recoveryKey"
 
-      Then container "orb" is stopped
+      Then container "orb-domain1" is stopped
       Then we wait 3 seconds
 
-      Then container "orb" is started
+      Then container "orb-domain1" is started
       Then we wait 15 seconds
 
       When client sends request to resolve DID document with canonical id

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -7,11 +7,17 @@ version: '2'
 
 services:
 
-  orb:
-    container_name: orb
+  orb-domain1:
+    container_name: orb.domain1.com
     image: ${ORB_FIXTURE_IMAGE}:latest
     environment:
-      - ORB_HOST_URL=0.0.0.0:48326
+      - LOG_LEVEL=DEBUG
+      - ORB_HOST_URL=0.0.0.0:443
+      # ORB_EXTERNAL_ENDPOINT is the endpoint that external clients use to invoke services. This endpoint is used
+      # to generate IDs of anchor credentials and ActivityPub objects and should be resolvable by external
+      # clients. This endpoint does not (typically) target a single node in the cluster but instead, a load
+      # balancer servicing multiple nodes.
+      - ORB_EXTERNAL_ENDPOINT=orb.domain1.com
       - ORB_TLS_CERTIFICATE=/etc/orb/tls/ec-pubCert.pem
       - ORB_TLS_KEY=/etc/orb/tls/ec-key.pem
       - DID_NAMESPACE=did:orb
@@ -29,7 +35,43 @@ services:
       - KMSSECRETS_DATABASE_URL=${COUCHDB_USERNAME}:${COUCHDB_PASSWORD}@couchdb.example.com:5984
       - KMSSECRETS_DATABASE_PREFIX=orbkms
     ports:
-      - 48326:48326
+      - 48326:443
+    command:  /bin/sh -c "sleep 10;orb start"
+    volumes:
+      - ./keys/tls:/etc/orb/tls
+    depends_on:
+      - ipfs
+      - couchdb.example.com
+
+  orb-domain2:
+    container_name: orb.domain2.com
+    image: ${ORB_FIXTURE_IMAGE}:latest
+    environment:
+      - LOG_LEVEL=DEBUG
+      - ORB_HOST_URL=0.0.0.0:443
+      # ORB_EXTERNAL_ENDPOINT is the endpoint that external clients use to invoke services. This endpoint is used
+      # to generate IDs of anchor credentials and ActivityPub objects and should be resolvable by external
+      # clients. This endpoint does not (typically) target a single node in the cluster but instead, a load
+      # balancer servicing multiple nodes.
+      - ORB_EXTERNAL_ENDPOINT=orb.domain2.com
+      - ORB_TLS_CERTIFICATE=/etc/orb/tls/ec-pubCert.pem
+      - ORB_TLS_KEY=/etc/orb/tls/ec-key.pem
+      - DID_NAMESPACE=did:orb
+      - DID_ALIASES=did:alias.com
+      - ALLOWED_ORIGINS=origin.com,source.com
+      - CAS_URL=ipfs:5001
+      - ANCHOR_CREDENTIAL_ISSUER=http://peer2.com
+      - ANCHOR_CREDENTIAL_URL=http://peer2.com/vc
+      - ANCHOR_CREDENTIAL_SIGNATURE_SUITE=Ed25519Signature2018
+      - ANCHOR_CREDENTIAL_DOMAIN=domain.com
+      - DATABASE_TYPE=couchdb
+      - DATABASE_URL=${COUCHDB_USERNAME}:${COUCHDB_PASSWORD}@couchdb.example.com:5984
+      - DATABASE_PREFIX=orb
+      - KMSSECRETS_DATABASE_TYPE=couchdb
+      - KMSSECRETS_DATABASE_URL=${COUCHDB_USERNAME}:${COUCHDB_PASSWORD}@couchdb.example.com:5984
+      - KMSSECRETS_DATABASE_PREFIX=orbkms
+    ports:
+      - 48426:443
     command:  /bin/sh -c "sleep 10;orb start"
     volumes:
       - ./keys/tls:/etc/orb/tls

--- a/test/bdd/fixtures/testdata/follow_activity.json
+++ b/test/bdd/fixtures/testdata/follow_activity.json
@@ -1,0 +1,8 @@
+{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "id": "https://orb.domain2.com/services/orb/activities/97b3d005-abb6-422d-a889-18bc1ee84988",
+  "type": "Follow",
+  "actor": "https://orb.domain2.com/services/orb",
+  "to": "https://orb.domain1.com/services/orb",
+  "object": "https://orb.domain1.com/services/orb"
+}


### PR DESCRIPTION
Added a BDD test for the follow/accept flows, as well as a test to retrieve the service. Also:

- Added external-endpoint as a startup parameter. This endpoint is used to construct the ID of the service (actor).
- Added another Orb node to Docker so that inter-process communincation may be tested.

closes #57

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>