### PR TITLE
test: ActivityPub BDD tests: create/announce

### DIFF
--- a/pkg/activitypub/resthandler/activityhandler.go
+++ b/pkg/activitypub/resthandler/activityhandler.go
@@ -68,7 +68,7 @@ func NewActivities(path string, refType spi.ReferenceType, cfg *Config, activity
 		getObjectIRI: getObjectIRI,
 	}
 
-	h.handler = newHandler(path, cfg, activityStore, h.handle, pageParam, pageNumParam)
+	h.handler = newHandler(path, cfg, activityStore, h.handle)
 
 	return h
 }

--- a/test/bdd/features/activitypub.feature
+++ b/test/bdd/features/activitypub.feature
@@ -32,9 +32,19 @@ Feature:
 
   @activitypub_follow
   Scenario: Follow ActivityPub service
+    # domain2 follows domain1
     When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content from file "./fixtures/testdata/follow_activity.json"
 
-    Then we wait 2 seconds
+    Then we wait 3 seconds
+
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox"
+    Then the JSON path "type" of the response equals "OrderedCollection"
+    And the JSON path "id" of the response equals "https://orb.domain1.com/services/orb/inbox"
+    And the JSON path "first" of the response equals "https://orb.domain1.com/services/orb/inbox?page=true"
+
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox?page=true"
+    Then the JSON path "type" of the response equals "OrderedCollectionPage"
+    And the JSON path "orderedItems.#.id" of the response contains "https://orb.domain2.com/services/orb/activities/97b3d005-abb6-422d-a889-18bc1ee84988"
 
     When an HTTP GET is sent to "https://localhost:48326/services/orb/followers"
     Then the JSON path "type" of the response equals "Collection"
@@ -53,3 +63,29 @@ Feature:
     When an HTTP GET is sent to "https://localhost:48426/services/orb/following?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response contains "https://orb.domain1.com/services/orb"
+
+  @activitypub_create
+  Scenario: Create/announce
+    # domain2 follows domain1
+    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content from file "./fixtures/testdata/follow_activity.json"
+
+    Then we wait 2 seconds
+
+    # Post 'Create' activity to domain1
+    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content from file "./fixtures/testdata/create_activity.json"
+
+    Then we wait 2 seconds
+
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox?page=true"
+    Then the JSON path "type" of the response equals "OrderedCollectionPage"
+    And the JSON path "orderedItems.#.id" of the response contains "https://orb.domain1.com/services/orb/activities/77bdd005-bbb6-223d-b889-58bc1de84985"
+
+    # An 'Announce' activity should have been posted to domain1's followers (domain2).
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/outbox?page=true"
+    Then the JSON path "type" of the response equals "OrderedCollectionPage"
+    And the JSON path "orderedItems.#.type" of the response contains "Announce"
+
+    # An 'Announce' activity should have been received by domain2 since it's a follower of domain1.
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/inbox?page=true"
+    Then the JSON path "type" of the response equals "OrderedCollectionPage"
+    And the JSON path "orderedItems.#.type" of the response contains "Announce"

--- a/test/bdd/fixtures/testdata/create_activity.json
+++ b/test/bdd/fixtures/testdata/create_activity.json
@@ -1,0 +1,27 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"
+  ],
+  "id": "https://orb.domain1.com/services/orb/activities/77bdd005-bbb6-223d-b889-58bc1de84985",
+  "type": "Create",
+  "actor": "https://orb.domain1.com/services/orb",
+  "to": [
+    "https://orb.domain1.com/services/orb/followers",
+    "https://www.w3.org/ns/activitystreams#Public"
+  ],
+  "published": "2021-03-31T09:30:10Z",
+  "object": {
+    "@context": [
+      "https://www.w3.org/ns/activitystreams",
+      "https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"
+    ],
+    "id": "https://orb.domain1.com/transactions/bafkreihwsnuregceqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
+    "type": "AnchorCredentialReference",
+    "target": {
+      "type": "ContentAddressedStorage",
+      "id": "https://orb.domain1.com/cas/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
+      "cid": "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
+    }
+  }
+}


### PR DESCRIPTION
Added BDD test for the ActivityPub service for the create/announce flow.

closes #168

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>