### PR TITLE
test: ActivityPub BDD tests: offer/like

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -45,6 +45,7 @@ import (
 
 	aphandler "github.com/trustbloc/orb/pkg/activitypub/resthandler"
 	apservice "github.com/trustbloc/orb/pkg/activitypub/service"
+	apmocks "github.com/trustbloc/orb/pkg/activitypub/service/mocks"
 	apspi "github.com/trustbloc/orb/pkg/activitypub/service/spi"
 	apmemstore "github.com/trustbloc/orb/pkg/activitypub/store/memstore"
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
@@ -332,11 +333,15 @@ func startOrbServices(parameters *orbParameters) error {
 		},
 	}
 
+	// TODO: A mock witness handler is set here so that the integration tests don't panic.
+	//  This needs to be replaced with a real witness handler.
+	mockWitnessHandler := apmocks.NewWitnessHandler().WithProof([]byte(mockProof))
+
 	activityPubService, err := apservice.New(apConfig,
 		apStore, httpClient,
 		// TODO: Define all of the ActivityPub handlers
 		//apspi.WithProofHandler(proofHandler),
-		//apspi.WithWitness(witnessHandler),
+		apspi.WithWitness(mockWitnessHandler),
 		//apspi.WithFollowerAuth(followerAuth),
 		//apspi.WithAnchorCredentialHandler(anchorCredHandler),
 		//apspi.WithUndeliverableHandler(undeliverableHandler),
@@ -596,3 +601,18 @@ func (m mockTxnProvider) RegisterForAnchor() <-chan []string {
 func (m mockTxnProvider) RegisterForDID() <-chan []string {
 	return m.registerForDID
 }
+
+const mockProof = `{
+ "@context": [
+   "https://w3id.org/security/v1",
+   "https://w3c-ccg.github.io/lds-jws2020/contexts/lds-jws2020-v1.json"
+ ],
+ "mockProof": {
+   "type": "JsonWebSignature2020",
+   "proofPurpose": "assertionMethod",
+   "created": "2021-01-27T09:30:15Z",
+   "verificationMethod": "did:example:abcd#key",
+   "domain": "https://witness1.example.com/ledgers/maple2021",
+   "jws": "eyJ..."
+ }
+}`

--- a/test/bdd/features/activitypub.feature
+++ b/test/bdd/features/activitypub.feature
@@ -31,7 +31,7 @@ Feature:
     And the JSON path "witnessing" of the response equals "https://orb.domain2.com/services/orb/witnessing"
 
   @activitypub_follow
-  Scenario: Follow ActivityPub service
+  Scenario: follow/accept
     # domain2 follows domain1
     When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content from file "./fixtures/testdata/follow_activity.json"
 
@@ -65,7 +65,7 @@ Feature:
     And the JSON path "items" of the response contains "https://orb.domain1.com/services/orb"
 
   @activitypub_create
-  Scenario: Create/announce
+  Scenario: create/announce
     # domain2 follows domain1
     When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content from file "./fixtures/testdata/follow_activity.json"
 
@@ -89,3 +89,26 @@ Feature:
     When an HTTP GET is sent to "https://localhost:48426/services/orb/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.type" of the response contains "Announce"
+
+  @activitypub_offer
+  Scenario: offer/like
+    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content from file "./fixtures/testdata/offer_activity.json"
+
+    Then we wait 2 seconds
+
+    # The 'Offer' activity should be in the inbox of domain1.
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox?page=true"
+    Then the JSON path "type" of the response equals "OrderedCollectionPage"
+    And the JSON path "orderedItems.#.id" of the response contains "https://orb.domain2.com/services/orb/activities/63b3d005-6cb6-673d-6379-18be1ee84973"
+
+    # The 'Like' should be in the 'liked' collection of domain1.
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/liked?page=true"
+    Then the JSON path "type" of the response equals "OrderedCollectionPage"
+    And the JSON path "orderedItems.#.type" of the response contains "Like"
+    And the JSON path "orderedItems.#.object" of the response contains "http://orb.domain2.com/transactions/bafkreihwsn"
+
+    # A 'Like' activity should be in the inbox of domain2.
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/inbox?page=true"
+    Then the JSON path "type" of the response equals "OrderedCollectionPage"
+    And the JSON path "orderedItems.#.type" of the response contains "Like"
+    And the JSON path "orderedItems.#.object" of the response contains "http://orb.domain2.com/transactions/bafkreihwsn"

--- a/test/bdd/fixtures/testdata/offer_activity.json
+++ b/test/bdd/fixtures/testdata/offer_activity.json
@@ -1,0 +1,33 @@
+{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "actor": "https://orb.domain2.com/services/orb",
+  "startTime": "2021-03-31T01:30:10Z",
+  "endTime": "2029-03-31T23:31:10Z",
+  "id": "https://orb.domain2.com/services/orb/activities/63b3d005-6cb6-673d-6379-18be1ee84973",
+  "object": {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"
+    ],
+    "credentialSubject": {
+      "operationCount": 2,
+      "coreIndex": "bafkreihwsn",
+      "namespace": "did:orb",
+      "previousAnchors": {
+        "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
+        "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w"
+      },
+      "version": "1"
+    },
+    "id": "http://orb.domain2.com/transactions/bafkreihwsn",
+    "issuanceDate": "2021-03-31T09:30:10Z",
+    "issuer": "https://orb.domain2.com/services/orb",
+    "proof": {},
+    "type": [
+      "VerifiableCredential",
+      "AnchorCredential"
+    ]
+  },
+  "to": ["https://orb.domain1.com/services/orb/witnesses","https://www.w3.org/ns/activitystreams#Public"],
+  "type": "Offer"
+}

--- a/test/bdd/httpclient.go
+++ b/test/bdd/httpclient.go
@@ -21,10 +21,6 @@ const (
 	tokenPrefix = "Bearer "
 )
 
-type httpPath = string
-type httpMethod = string
-type authToken = string
-
 type httpClient struct {
 	state *state
 }

--- a/test/bdd/state.go
+++ b/test/bdd/state.go
@@ -12,6 +12,10 @@ import (
 	"strings"
 )
 
+type httpPath = string
+type httpMethod = string
+type authToken = string
+
 type state struct {
 	vars          map[string]string
 	responseValue string


### PR DESCRIPTION
Added BDD test for the ActivityPub service for the offer/like flow. A mock witness handler was added temporarily, otherwise the service would panic.

closes #169

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>