### PR TITLE
chore: Fix master lock race condition, increase test start time

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -184,9 +184,11 @@ func startOrbServices(parameters *orbParameters) error {
 		Cas: casClient,
 		// TODO: For now fetch signing public key from local KMS (this will handled differently later on: webfinger or did:web)
 		Pkf: func(_, keyID string) (*verifier.PublicKey, error) {
-			pubKeyBytes, err := localKMS.ExportPubKeyBytes(keyID[1:])
+			kid := keyID[1:]
+
+			pubKeyBytes, err := localKMS.ExportPubKeyBytes(kid)
 			if err != nil {
-				return nil, fmt.Errorf("failed to export public key[%s] from kms: %s", keyID, err.Error())
+				return nil, fmt.Errorf("failed to export public key[%s] from kms: %s", kid, err.Error())
 			}
 
 			return &verifier.PublicKey{
@@ -569,6 +571,8 @@ func prepareMasterKeyReader(kmsSecretsStoreProvider ariesstorage.Provider) (*byt
 	masterKey, err := masterKeyStore.Get(masterKeyDBKeyName)
 	if err != nil {
 		if errors.Is(err, ariesstorage.ErrDataNotFound) {
+			logger.Infof("master key[%s] not found, creating new one ...", masterKeyDBKeyName)
+
 			masterKeyRaw := random.GetRandomBytes(uint32(masterKeyNumBytes))
 			masterKey = []byte(base64.URLEncoding.EncodeToString(masterKeyRaw))
 

--- a/pkg/protocolversion/versions/v1_0/factory/factory.go
+++ b/pkg/protocolversion/versions/v1_0/factory/factory.go
@@ -42,7 +42,7 @@ func (v *Factory) Create(version string, casClient cas.Client, opStore ctxcommon
 	p := protocol.Protocol{
 		GenesisTime:                  0,
 		MultihashAlgorithms:          []uint{18},
-		MaxOperationCount:            1, // T0DO: issue-164 Revert to 5000 for release, for now cut right away
+		MaxOperationCount:            5000,
 		MaxOperationSize:             2500,
 		MaxOperationHashLength:       100,
 		MaxDeltaSize:                 1700,

--- a/test/bdd/bddtests_test.go
+++ b/test/bdd/bddtests_test.go
@@ -47,7 +47,7 @@ func TestMain(m *testing.M) {
 					panic(fmt.Sprintf("Error composing system in BDD context: %s", err))
 				}
 
-				testSleep := 15
+				testSleep := 20
 				if os.Getenv("TEST_SLEEP") != "" {
 					testSleep, _ = strconv.Atoi(os.Getenv("TEST_SLEEP"))
 				}

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - DID_ALIASES=did:alias.com
       - ALLOWED_ORIGINS=origin.com,source.com
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
-      - BATCH_WRITER_TIMEOUT=300
+      - BATCH_WRITER_TIMEOUT=200
       - CAS_URL=ipfs:5001
       - ANCHOR_CREDENTIAL_ISSUER=http://peer1.com
       - ANCHOR_CREDENTIAL_URL=http://peer1.com/vc
@@ -35,7 +35,7 @@ services:
       - DATABASE_PREFIX=orb
       - KMSSECRETS_DATABASE_TYPE=couchdb
       - KMSSECRETS_DATABASE_URL=${COUCHDB_USERNAME}:${COUCHDB_PASSWORD}@couchdb.example.com:5984
-      - KMSSECRETS_DATABASE_PREFIX=orbkms
+      - KMSSECRETS_DATABASE_PREFIX=orb1kms
     ports:
       - 48326:443
     command:  /bin/sh -c "sleep 10;orb start"
@@ -62,7 +62,7 @@ services:
       - DID_ALIASES=did:alias.com
       - ALLOWED_ORIGINS=origin.com,source.com
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
-      - BATCH_WRITER_TIMEOUT=300
+      - BATCH_WRITER_TIMEOUT=200
       - CAS_URL=ipfs:5001
       - ANCHOR_CREDENTIAL_ISSUER=http://peer2.com
       - ANCHOR_CREDENTIAL_URL=http://peer2.com/vc
@@ -73,7 +73,7 @@ services:
       - DATABASE_PREFIX=orb
       - KMSSECRETS_DATABASE_TYPE=couchdb
       - KMSSECRETS_DATABASE_URL=${COUCHDB_USERNAME}:${COUCHDB_PASSWORD}@couchdb.example.com:5984
-      - KMSSECRETS_DATABASE_PREFIX=orbkms
+      - KMSSECRETS_DATABASE_PREFIX=orb2kms
     ports:
       - 48426:443
     command:  /bin/sh -c "sleep 10;orb start"


### PR DESCRIPTION
Fix race issue related to creating master lock. Both servers were creating master lock in the same database during start-up which caused issues after re-start. 

Quick fix (this PR) is done by writing to different database but this will be a problem once we start using both servers for DIDs. 

Intermediate fix can be done by staggering server starts and proper fix is described in #179

Also, increase BDD test start wait time.

Closes #177

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>