### PR TITLE
feat: Implemented ActivityPub 'Undo' activity to remove follower/following

### DIFF
--- a/pkg/activitypub/service/activityhandler/outboxhandler.go
+++ b/pkg/activitypub/service/activityhandler/outboxhandler.go
@@ -1,0 +1,74 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package activityhandler
+
+import (
+	"fmt"
+
+	store "github.com/trustbloc/orb/pkg/activitypub/store/spi"
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+)
+
+// Outbox handles activities posted to the outbox.
+type Outbox struct {
+	*handler
+}
+
+// NewOutbox returns a new ActivityPub outbox activity handler.
+func NewOutbox(cfg *Config, s store.Store, httpClient httpClient) *Outbox {
+	h := &Outbox{}
+
+	h.handler = newHandler(cfg, s, httpClient, h.undoFollowing)
+
+	h.undoFollow = h.undoFollowing
+
+	return h
+}
+
+// HandleActivity handles the ActivityPub activity in the outbox.
+func (h *Outbox) HandleActivity(activity *vocab.ActivityType) error {
+	typeProp := activity.Type()
+
+	switch {
+	case typeProp.Is(vocab.TypeUndo):
+		return h.handleUndoActivity(activity)
+	default:
+		// Nothing to do for activity.
+		return nil
+	}
+}
+
+func (h *Outbox) undoFollowing(follow *vocab.ActivityType) error {
+	// Make sure that the actor IRI is this service. If not then ignore the message.
+	if follow.Actor().String() != h.ServiceIRI.String() {
+		logger.Infof("[%s] Not handling 'Undo' of follow activity %s since this service %s"+
+			" is not the actor %s", h.ServiceName, follow.ID(), h.ServiceIRI, follow.Actor())
+
+		return nil
+	}
+
+	iri := follow.Object().IRI()
+	if iri == nil {
+		return fmt.Errorf("no IRI specified in 'object' field of the 'Follow' activity")
+	}
+
+	err := h.store.DeleteReference(store.Following, h.ServiceIRI, iri)
+	if err != nil {
+		if err == store.ErrNotFound {
+			logger.Infof("[%s] %s not found in following collection of %s", h.ServiceName, iri, h.ServiceIRI)
+
+			return nil
+		}
+
+		return fmt.Errorf("unable to delete %s from %s's collection of following", iri, h.ServiceIRI)
+	}
+
+	logger.Debugf("[%s] %s was successfully deleted from %s's collection of following",
+		h.ServiceIRI, iri, h.ServiceIRI)
+
+	return nil
+}

--- a/pkg/activitypub/store/spi/spi.go
+++ b/pkg/activitypub/store/spi/spi.go
@@ -60,7 +60,8 @@ type Store interface {
 	QueryActivities(query *Criteria, opts ...QueryOpt) (ActivityIterator, error)
 	// AddReference adds the reference of the given type to the given object.
 	AddReference(refType ReferenceType, objectIRI *url.URL, referenceIRI *url.URL) error
-	// DeleteReference deletes the reference of the given type from the given object.
+	// DeleteReference deletes the reference of the given type from the given object. If the reference
+	// is not found then ErrNotFound is returned.
 	DeleteReference(refType ReferenceType, objectIRI *url.URL, referenceIRI *url.URL) error
 	// QueryReferences returns the list of references of the given type according to the given query.
 	QueryReferences(refType ReferenceType, query *Criteria, opts ...QueryOpt) (ReferenceIterator, error)

--- a/pkg/activitypub/vocab/activitytype.go
+++ b/pkg/activitypub/vocab/activitytype.go
@@ -194,3 +194,21 @@ func NewOfferActivity(id *url.URL, obj *ObjectProperty, opts ...Opt) *ActivityTy
 		},
 	}
 }
+
+// NewUndoActivity returns a new 'Undo' activity.
+func NewUndoActivity(id *url.URL, obj *ObjectProperty, opts ...Opt) *ActivityType {
+	options := NewOptions(opts...)
+
+	return &ActivityType{
+		ObjectType: NewObject(
+			WithContext(getContexts(options, ContextActivityStreams)...),
+			WithID(id),
+			WithType(TypeUndo),
+			WithTo(options.To...),
+		),
+		activity: &activityType{
+			Actor:  NewURLProperty(options.Actor),
+			Object: obj,
+		},
+	}
+}

--- a/pkg/activitypub/vocab/vocab.go
+++ b/pkg/activitypub/vocab/vocab.go
@@ -64,6 +64,8 @@ const (
 	TypeAnchorCredentialRef Type = "AnchorCredentialReference"
 	// TypeOffer specifies the "Offer" activity type.
 	TypeOffer Type = "Offer"
+	// TypeUndo specifies the "Undo" activity type.
+	TypeUndo Type = "Undo"
 )
 
 const (

--- a/test/bdd/features/activitypub.feature
+++ b/test/bdd/features/activitypub.feature
@@ -31,7 +31,7 @@ Feature:
     And the JSON path "witnessing" of the response equals "https://orb.domain2.com/services/orb/witnessing"
 
   @activitypub_follow
-  Scenario: follow/accept
+  Scenario: follow/accept/undo
     # domain2 follows domain1
     When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content from file "./fixtures/testdata/follow_activity.json"
 
@@ -63,6 +63,14 @@ Feature:
     When an HTTP GET is sent to "https://localhost:48426/services/orb/following?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response contains "https://orb.domain1.com/services/orb"
+
+    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content from file "./fixtures/testdata/undo_follow_activity.json"
+
+    Then we wait 3 seconds
+
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/followers?page=true"
+    Then the JSON path "type" of the response equals "CollectionPage"
+    And the JSON path "items" of the response does not contain "https://orb.domain2.com/services/orb"
 
   @activitypub_create
   Scenario: create/announce

--- a/test/bdd/fixtures/testdata/undo_follow_activity.json
+++ b/test/bdd/fixtures/testdata/undo_follow_activity.json
@@ -1,0 +1,8 @@
+{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "id": "https://orb.domain2.com/services/orb/activities/77bcd005-bbb6-233d-c889-98bc1ce64983",
+  "type": "Undo",
+  "actor": "https://orb.domain2.com/services/orb",
+  "to": "https://orb.domain1.com/services/orb",
+  "object": "https://orb.domain2.com/services/orb/activities/97b3d005-abb6-422d-a889-18bc1ee84988"
+}


### PR DESCRIPTION
When the inbox receives an 'Undo' activity then the actor is removed from the 'followers' collection. When an 'Undo' activity is posted to the outbox then the object IRI is removed from the 'following' collection.

closes #118

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>