### PR TITLE
refactor: Removed ID from activity constructors

### DIFF
--- a/pkg/activitypub/resthandler/activityhandler_test.go
+++ b/pkg/activitypub/resthandler/activityhandler_test.go
@@ -551,7 +551,7 @@ func newMockActivities(t vocab.Type, num int, getURI func(i int) string) []*voca
 
 func newMockActivity(t vocab.Type, id *url.URL) *vocab.ActivityType {
 	if t == vocab.TypeAnnounce {
-		return vocab.NewAnnounceActivity(id, vocab.NewObjectProperty(vocab.WithIRI(id)))
+		return vocab.NewAnnounceActivity(vocab.NewObjectProperty(vocab.WithIRI(id)), vocab.WithID(id))
 	}
 
 	if t == vocab.TypeLike {
@@ -566,8 +566,9 @@ func newMockActivity(t vocab.Type, id *url.URL) *vocab.ActivityType {
 		startTime := getStaticTime()
 		endTime := startTime.Add(1 * time.Minute)
 
-		return vocab.NewLikeActivity(id,
+		return vocab.NewLikeActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(credID)),
+			vocab.WithID(id),
 			vocab.WithActor(actor),
 			vocab.WithStartTime(&startTime),
 			vocab.WithEndTime(&endTime),
@@ -575,7 +576,7 @@ func newMockActivity(t vocab.Type, id *url.URL) *vocab.ActivityType {
 		)
 	}
 
-	return vocab.NewCreateActivity(id, vocab.NewObjectProperty())
+	return vocab.NewCreateActivity(vocab.NewObjectProperty(), vocab.WithID(id))
 }
 
 func getStaticTime() time.Time {

--- a/pkg/activitypub/resthandler/resthandler_test.go
+++ b/pkg/activitypub/resthandler/resthandler_test.go
@@ -274,14 +274,16 @@ func newMockCreateActivities(num int) []*vocab.ActivityType {
 }
 
 func newMockCreateActivity(id, objID string) *vocab.ActivityType {
-	return vocab.NewCreateActivity(testutil.MustParseURL(id), vocab.NewObjectProperty(
-		vocab.WithAnchorCredentialReference(
-			vocab.NewAnchorCredentialReference(
-				testutil.MustParseURL(objID),
-				testutil.MustParseURL("https://example.com/cas/bafkd34G7hD6gbj94fnKm5D"),
-				"bafkd34G7hD6gbj94fnKm5D"),
+	return vocab.NewCreateActivity(
+		vocab.NewObjectProperty(
+			vocab.WithAnchorCredentialReference(
+				vocab.NewAnchorCredentialReference(
+					testutil.MustParseURL(objID),
+					testutil.MustParseURL("https://example.com/cas/bafkd34G7hD6gbj94fnKm5D"),
+					"bafkd34G7hD6gbj94fnKm5D"),
+			),
 		),
-	),
+		vocab.WithID(testutil.MustParseURL(id)),
 	)
 }
 

--- a/pkg/activitypub/service/activityhandler/activityhandler_test.go
+++ b/pkg/activitypub/service/activityhandler/activityhandler_test.go
@@ -153,8 +153,9 @@ func TestHandler_HandleCreateActivity(t *testing.T) {
 
 		published := time.Now()
 
-		create := vocab.NewCreateActivity(newActivityID(service1IRI),
+		create := vocab.NewCreateActivity(
 			vocab.NewObjectProperty(vocab.WithObject(obj)),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithActor(service1IRI),
 			vocab.WithTarget(targetProperty),
 			vocab.WithContext(vocab.ContextOrb),
@@ -197,12 +198,13 @@ func TestHandler_HandleCreateActivity(t *testing.T) {
 
 		published := time.Now()
 
-		create := vocab.NewCreateActivity(newActivityID(service1IRI),
+		create := vocab.NewCreateActivity(
 			vocab.NewObjectProperty(
 				vocab.WithAnchorCredentialReference(
 					vocab.NewAnchorCredentialReference(refID, anchorCredID, cid),
 				),
 			),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithActor(service1IRI),
 			vocab.WithTo(service2IRI),
 			vocab.WithContext(vocab.ContextOrb),
@@ -242,8 +244,9 @@ func TestHandler_HandleCreateActivity(t *testing.T) {
 	t.Run("Unsupported object type", func(t *testing.T) {
 		published := time.Now()
 
-		create := vocab.NewCreateActivity(newActivityID(service1IRI),
+		create := vocab.NewCreateActivity(
 			vocab.NewObjectProperty(vocab.WithObject(vocab.NewObject(vocab.WithType(vocab.TypeService)))),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithActor(service1IRI),
 			vocab.WithContext(vocab.ContextOrb),
 			vocab.WithTo(service2IRI),
@@ -304,8 +307,9 @@ func TestHandler_HandleFollowActivity(t *testing.T) {
 	t.Run("Accept", func(t *testing.T) {
 		followerAuth.WithAccept()
 
-		follow := vocab.NewFollowActivity(newActivityID(service2IRI),
+		follow := vocab.NewFollowActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(service1IRI)),
+			vocab.WithID(newActivityID(service2IRI)),
 			vocab.WithActor(service2IRI),
 			vocab.WithTo(service1IRI),
 		)
@@ -328,8 +332,9 @@ func TestHandler_HandleFollowActivity(t *testing.T) {
 		require.Len(t, ob.Activities().QueryByType(vocab.TypeAccept), 1)
 
 		// Post another follow. Should reply with accept since it's already a follower.
-		follow = vocab.NewFollowActivity(newActivityID(service2IRI),
+		follow = vocab.NewFollowActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(service1IRI)),
+			vocab.WithID(newActivityID(service2IRI)),
 			vocab.WithActor(service2IRI),
 			vocab.WithTo(service1IRI),
 		)
@@ -346,8 +351,9 @@ func TestHandler_HandleFollowActivity(t *testing.T) {
 	})
 
 	t.Run("Reject", func(t *testing.T) {
-		follow := vocab.NewFollowActivity(newActivityID(service3IRI),
+		follow := vocab.NewFollowActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(service1IRI)),
+			vocab.WithID(newActivityID(service3IRI)),
 			vocab.WithActor(service3IRI),
 			vocab.WithTo(service1IRI),
 		)
@@ -374,8 +380,9 @@ func TestHandler_HandleFollowActivity(t *testing.T) {
 	})
 
 	t.Run("No actor in Follow activity", func(t *testing.T) {
-		follow := vocab.NewFollowActivity(newActivityID(service2IRI),
+		follow := vocab.NewFollowActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(service1IRI)),
+			vocab.WithID(newActivityID(service2IRI)),
 			vocab.WithTo(service1IRI),
 		)
 
@@ -383,8 +390,9 @@ func TestHandler_HandleFollowActivity(t *testing.T) {
 	})
 
 	t.Run("No object IRI in Follow activity", func(t *testing.T) {
-		follow := vocab.NewFollowActivity(newActivityID(service2IRI),
+		follow := vocab.NewFollowActivity(
 			vocab.NewObjectProperty(),
+			vocab.WithID(newActivityID(service2IRI)),
 			vocab.WithActor(service2IRI),
 			vocab.WithTo(service1IRI),
 		)
@@ -394,8 +402,9 @@ func TestHandler_HandleFollowActivity(t *testing.T) {
 	})
 
 	t.Run("Object IRI does not match target service IRI in Follow activity", func(t *testing.T) {
-		follow := vocab.NewFollowActivity(newActivityID(service2IRI),
+		follow := vocab.NewFollowActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(service3IRI)),
+			vocab.WithID(newActivityID(service2IRI)),
 			vocab.WithActor(service2IRI),
 			vocab.WithTo(service1IRI),
 		)
@@ -404,8 +413,9 @@ func TestHandler_HandleFollowActivity(t *testing.T) {
 	})
 
 	t.Run("Resolve actor error", func(t *testing.T) {
-		follow := vocab.NewFollowActivity(newActivityID(service4IRI),
+		follow := vocab.NewFollowActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(service1IRI)),
+			vocab.WithID(newActivityID(service4IRI)),
 			vocab.WithActor(service4IRI),
 			vocab.WithTo(service1IRI),
 		)
@@ -422,8 +432,9 @@ func TestHandler_HandleFollowActivity(t *testing.T) {
 			followerAuth.WithError(nil)
 		}()
 
-		follow := vocab.NewFollowActivity(newActivityID(service3IRI),
+		follow := vocab.NewFollowActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(service1IRI)),
+			vocab.WithID(newActivityID(service3IRI)),
 			vocab.WithActor(service3IRI),
 			vocab.WithTo(service1IRI),
 		)
@@ -468,14 +479,16 @@ func TestHandler_HandleAcceptActivity(t *testing.T) {
 	}()
 
 	t.Run("Success", func(t *testing.T) {
-		follow := vocab.NewFollowActivity(newActivityID(service2IRI),
+		follow := vocab.NewFollowActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(service1IRI)),
+			vocab.WithID(newActivityID(service2IRI)),
 			vocab.WithActor(service2IRI),
 			vocab.WithTo(service1IRI),
 		)
 
-		accept := vocab.NewAcceptActivity(newActivityID(service1IRI),
+		accept := vocab.NewAcceptActivity(
 			vocab.NewObjectProperty(vocab.WithActivity(follow)),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithActor(service1IRI),
 			vocab.WithTo(service2IRI),
 		)
@@ -498,14 +511,16 @@ func TestHandler_HandleAcceptActivity(t *testing.T) {
 	})
 
 	t.Run("No actor in Accept activity", func(t *testing.T) {
-		follow := vocab.NewFollowActivity(newActivityID(service2IRI),
+		follow := vocab.NewFollowActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(service1IRI)),
+			vocab.WithID(newActivityID(service2IRI)),
 			vocab.WithActor(service2IRI),
 			vocab.WithTo(service1IRI),
 		)
 
-		accept := vocab.NewAcceptActivity(newActivityID(service1IRI),
+		accept := vocab.NewAcceptActivity(
 			vocab.NewObjectProperty(vocab.WithActivity(follow)),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithTo(service2IRI),
 		)
 
@@ -513,8 +528,9 @@ func TestHandler_HandleAcceptActivity(t *testing.T) {
 	})
 
 	t.Run("No Follow activity specified in 'object' field", func(t *testing.T) {
-		accept := vocab.NewAcceptActivity(newActivityID(service1IRI),
+		accept := vocab.NewAcceptActivity(
 			vocab.NewObjectProperty(),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithActor(service1IRI),
 			vocab.WithTo(service2IRI),
 		)
@@ -524,13 +540,15 @@ func TestHandler_HandleAcceptActivity(t *testing.T) {
 	})
 
 	t.Run("Object is not a Follow activity", func(t *testing.T) {
-		follow := vocab.NewAnnounceActivity(newActivityID(service2IRI),
+		follow := vocab.NewAnnounceActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(service1IRI)),
+			vocab.WithID(newActivityID(service2IRI)),
 			vocab.WithTo(service1IRI),
 		)
 
-		accept := vocab.NewAcceptActivity(newActivityID(service1IRI),
+		accept := vocab.NewAcceptActivity(
 			vocab.NewObjectProperty(vocab.WithActivity(follow)),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithActor(service1IRI),
 			vocab.WithTo(service2IRI),
 		)
@@ -540,13 +558,15 @@ func TestHandler_HandleAcceptActivity(t *testing.T) {
 	})
 
 	t.Run("No actor specified in the Follow activity", func(t *testing.T) {
-		follow := vocab.NewFollowActivity(newActivityID(service2IRI),
+		follow := vocab.NewFollowActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(service1IRI)),
+			vocab.WithID(newActivityID(service2IRI)),
 			vocab.WithTo(service1IRI),
 		)
 
-		accept := vocab.NewAcceptActivity(newActivityID(service1IRI),
+		accept := vocab.NewAcceptActivity(
 			vocab.NewObjectProperty(vocab.WithActivity(follow)),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithActor(service1IRI),
 			vocab.WithTo(service2IRI),
 		)
@@ -556,14 +576,16 @@ func TestHandler_HandleAcceptActivity(t *testing.T) {
 	})
 
 	t.Run("Follow actor does not match target service IRI in Accept activity", func(t *testing.T) {
-		follow := vocab.NewFollowActivity(newActivityID(service2IRI),
+		follow := vocab.NewFollowActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(service1IRI)),
+			vocab.WithID(newActivityID(service2IRI)),
 			vocab.WithActor(service1IRI),
 			vocab.WithTo(service1IRI),
 		)
 
-		accept := vocab.NewAcceptActivity(newActivityID(service1IRI),
+		accept := vocab.NewAcceptActivity(
 			vocab.NewObjectProperty(vocab.WithActivity(follow)),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithActor(service1IRI),
 			vocab.WithTo(service2IRI),
 		)
@@ -608,14 +630,16 @@ func TestHandler_HandleRejectActivity(t *testing.T) {
 	}()
 
 	t.Run("Success", func(t *testing.T) {
-		follow := vocab.NewFollowActivity(newActivityID(service2IRI),
+		follow := vocab.NewFollowActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(service1IRI)),
+			vocab.WithID(newActivityID(service2IRI)),
 			vocab.WithActor(service2IRI),
 			vocab.WithTo(service1IRI),
 		)
 
-		reject := vocab.NewRejectActivity(newActivityID(service1IRI),
+		reject := vocab.NewRejectActivity(
 			vocab.NewObjectProperty(vocab.WithActivity(follow)),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithActor(service1IRI),
 			vocab.WithTo(service2IRI),
 		)
@@ -637,14 +661,16 @@ func TestHandler_HandleRejectActivity(t *testing.T) {
 	})
 
 	t.Run("No actor in Reject activity", func(t *testing.T) {
-		follow := vocab.NewFollowActivity(newActivityID(service2IRI),
+		follow := vocab.NewFollowActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(service1IRI)),
+			vocab.WithID(newActivityID(service2IRI)),
 			vocab.WithActor(service2IRI),
 			vocab.WithTo(service1IRI),
 		)
 
-		reject := vocab.NewRejectActivity(newActivityID(service1IRI),
+		reject := vocab.NewRejectActivity(
 			vocab.NewObjectProperty(vocab.WithActivity(follow)),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithTo(service2IRI),
 		)
 
@@ -652,8 +678,9 @@ func TestHandler_HandleRejectActivity(t *testing.T) {
 	})
 
 	t.Run("No Follow activity specified in 'object' field", func(t *testing.T) {
-		reject := vocab.NewRejectActivity(newActivityID(service1IRI),
+		reject := vocab.NewRejectActivity(
 			vocab.NewObjectProperty(),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithActor(service1IRI),
 			vocab.WithTo(service2IRI),
 		)
@@ -663,13 +690,15 @@ func TestHandler_HandleRejectActivity(t *testing.T) {
 	})
 
 	t.Run("Object is not a Follow activity", func(t *testing.T) {
-		follow := vocab.NewAnnounceActivity(newActivityID(service2IRI),
+		follow := vocab.NewAnnounceActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(service1IRI)),
+			vocab.WithID(newActivityID(service2IRI)),
 			vocab.WithTo(service1IRI),
 		)
 
-		reject := vocab.NewRejectActivity(newActivityID(service1IRI),
+		reject := vocab.NewRejectActivity(
 			vocab.NewObjectProperty(vocab.WithActivity(follow)),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithActor(service1IRI),
 			vocab.WithTo(service2IRI),
 		)
@@ -679,13 +708,15 @@ func TestHandler_HandleRejectActivity(t *testing.T) {
 	})
 
 	t.Run("No actor specified in the Follow activity", func(t *testing.T) {
-		follow := vocab.NewFollowActivity(newActivityID(service2IRI),
+		follow := vocab.NewFollowActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(service1IRI)),
+			vocab.WithID(newActivityID(service2IRI)),
 			vocab.WithTo(service1IRI),
 		)
 
-		reject := vocab.NewRejectActivity(newActivityID(service1IRI),
+		reject := vocab.NewRejectActivity(
 			vocab.NewObjectProperty(vocab.WithActivity(follow)),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithActor(service1IRI),
 			vocab.WithTo(service2IRI),
 		)
@@ -695,14 +726,16 @@ func TestHandler_HandleRejectActivity(t *testing.T) {
 	})
 
 	t.Run("Follow actor does not match target service IRI in Reject activity", func(t *testing.T) {
-		follow := vocab.NewFollowActivity(newActivityID(service2IRI),
+		follow := vocab.NewFollowActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(service1IRI)),
+			vocab.WithID(newActivityID(service2IRI)),
 			vocab.WithActor(service1IRI),
 			vocab.WithTo(service1IRI),
 		)
 
-		reject := vocab.NewRejectActivity(newActivityID(service1IRI),
+		reject := vocab.NewRejectActivity(
 			vocab.NewObjectProperty(vocab.WithActivity(follow)),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithActor(service1IRI),
 			vocab.WithTo(service2IRI),
 		)
@@ -757,12 +790,13 @@ func TestHandler_HandleAnnounceActivity(t *testing.T) {
 
 		published := time.Now()
 
-		announce := vocab.NewAnnounceActivity(newActivityID(service1IRI),
+		announce := vocab.NewAnnounceActivity(
 			vocab.NewObjectProperty(
 				vocab.WithCollection(
 					vocab.NewCollection(items),
 				),
 			),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithActor(service2IRI),
 			vocab.WithTo(service2IRI),
 			vocab.WithPublishedTime(&published),
@@ -788,12 +822,13 @@ func TestHandler_HandleAnnounceActivity(t *testing.T) {
 
 		published := time.Now()
 
-		announce := vocab.NewAnnounceActivity(newActivityID(service1IRI),
+		announce := vocab.NewAnnounceActivity(
 			vocab.NewObjectProperty(
 				vocab.WithOrderedCollection(
 					vocab.NewOrderedCollection(items),
 				),
 			),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithActor(service1IRI),
 			vocab.WithTo(service2IRI),
 			vocab.WithPublishedTime(&published),
@@ -822,12 +857,13 @@ func TestHandler_HandleAnnounceActivity(t *testing.T) {
 
 		published := time.Now()
 
-		announce := vocab.NewAnnounceActivity(newActivityID(service1IRI),
+		announce := vocab.NewAnnounceActivity(
 			vocab.NewObjectProperty(
 				vocab.WithCollection(
 					vocab.NewCollection(items),
 				),
 			),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithActor(service1IRI),
 			vocab.WithTo(service2IRI),
 			vocab.WithPublishedTime(&published),
@@ -851,12 +887,13 @@ func TestHandler_HandleAnnounceActivity(t *testing.T) {
 
 		published := time.Now()
 
-		announce := vocab.NewAnnounceActivity(newActivityID(service1IRI),
+		announce := vocab.NewAnnounceActivity(
 			vocab.NewObjectProperty(
 				vocab.WithCollection(
 					vocab.NewCollection(items),
 				),
 			),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithActor(service2IRI),
 			vocab.WithTo(service2IRI),
 			vocab.WithPublishedTime(&published),
@@ -876,12 +913,13 @@ func TestHandler_HandleAnnounceActivity(t *testing.T) {
 
 		published := time.Now()
 
-		announce := vocab.NewAnnounceActivity(newActivityID(service1IRI),
+		announce := vocab.NewAnnounceActivity(
 			vocab.NewObjectProperty(
 				vocab.WithOrderedCollection(
 					vocab.NewOrderedCollection(items),
 				),
 			),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithActor(service2IRI),
 			vocab.WithTo(service2IRI),
 			vocab.WithPublishedTime(&published),
@@ -895,10 +933,11 @@ func TestHandler_HandleAnnounceActivity(t *testing.T) {
 	t.Run("Anchor credential ref - unsupported object type", func(t *testing.T) {
 		published := time.Now()
 
-		announce := vocab.NewAnnounceActivity(newActivityID(service1IRI),
+		announce := vocab.NewAnnounceActivity(
 			vocab.NewObjectProperty(
 				vocab.WithActor(service1IRI),
 			),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithActor(service2IRI),
 			vocab.WithTo(service2IRI),
 			vocab.WithPublishedTime(&published),
@@ -951,8 +990,9 @@ func TestHandler_HandleOfferActivity(t *testing.T) {
 		startTime := time.Now()
 		endTime := startTime.Add(time.Hour)
 
-		offer := vocab.NewOfferActivity(newActivityID(service1IRI),
+		offer := vocab.NewOfferActivity(
 			vocab.NewObjectProperty(vocab.WithObject(obj)),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithActor(service1IRI),
 			vocab.WithTo(service2IRI),
 			vocab.WithStartTime(&startTime),
@@ -985,8 +1025,9 @@ func TestHandler_HandleOfferActivity(t *testing.T) {
 		startTime := time.Now()
 		endTime := startTime.Add(time.Hour)
 
-		offer := vocab.NewOfferActivity(newActivityID(service1IRI),
+		offer := vocab.NewOfferActivity(
 			vocab.NewObjectProperty(vocab.WithObject(obj)),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithActor(service1IRI),
 			vocab.WithTo(service2IRI),
 			vocab.WithStartTime(&startTime),
@@ -1010,7 +1051,7 @@ func TestHandler_HandleOfferActivity(t *testing.T) {
 		startTime := time.Now()
 		endTime := startTime.Add(time.Hour)
 
-		offer := vocab.NewOfferActivity(newActivityID(service1IRI),
+		offer := vocab.NewOfferActivity(
 			vocab.NewObjectProperty(vocab.WithObject(obj)),
 			vocab.WithActor(service1IRI),
 			vocab.WithTo(service2IRI),
@@ -1027,8 +1068,9 @@ func TestHandler_HandleOfferActivity(t *testing.T) {
 
 		endTime := time.Now().Add(time.Hour)
 
-		offer := vocab.NewOfferActivity(newActivityID(service1IRI),
+		offer := vocab.NewOfferActivity(
 			vocab.NewObjectProperty(vocab.WithObject(obj)),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithActor(service1IRI),
 			vocab.WithTo(service2IRI),
 			vocab.WithEndTime(&endTime),
@@ -1045,7 +1087,7 @@ func TestHandler_HandleOfferActivity(t *testing.T) {
 
 		startTime := time.Now()
 
-		offer := vocab.NewOfferActivity(newActivityID(service1IRI),
+		offer := vocab.NewOfferActivity(
 			vocab.NewObjectProperty(vocab.WithObject(obj)),
 			vocab.WithActor(service1IRI),
 			vocab.WithTo(service2IRI),
@@ -1061,8 +1103,9 @@ func TestHandler_HandleOfferActivity(t *testing.T) {
 		startTime := time.Now()
 		endTime := startTime.Add(time.Hour)
 
-		offer := vocab.NewOfferActivity(newActivityID(service1IRI),
+		offer := vocab.NewOfferActivity(
 			vocab.NewObjectProperty(vocab.WithObject(vocab.NewObject(vocab.WithType(vocab.TypeAnnounce)))),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithActor(service1IRI),
 			vocab.WithTo(service2IRI),
 			vocab.WithStartTime(&startTime),
@@ -1078,8 +1121,9 @@ func TestHandler_HandleOfferActivity(t *testing.T) {
 		startTime := time.Now()
 		endTime := startTime.Add(time.Hour)
 
-		offer := vocab.NewOfferActivity(newActivityID(service1IRI),
+		offer := vocab.NewOfferActivity(
 			vocab.NewObjectProperty(),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithActor(service1IRI),
 			vocab.WithTo(service2IRI),
 			vocab.WithStartTime(&startTime),
@@ -1136,8 +1180,9 @@ func TestHandler_HandleLikeActivity(t *testing.T) {
 
 		anchorCredID := newTransactionID(h.ServiceIRI)
 
-		like := vocab.NewLikeActivity(h.newActivityID(),
+		like := vocab.NewLikeActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(anchorCredID)),
+			vocab.WithID(h.newActivityID()),
 			vocab.WithActor(h.ServiceIRI),
 			vocab.WithTo(service2IRI),
 			vocab.WithStartTime(&startTime),
@@ -1177,8 +1222,9 @@ func TestHandler_HandleLikeActivity(t *testing.T) {
 
 		anchorCredID := newTransactionID(h.ServiceIRI)
 
-		like := vocab.NewLikeActivity(h.newActivityID(),
+		like := vocab.NewLikeActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(anchorCredID)),
+			vocab.WithID(h.newActivityID()),
 			vocab.WithActor(h.ServiceIRI),
 			vocab.WithTo(service2IRI),
 			vocab.WithStartTime(&startTime),
@@ -1198,8 +1244,9 @@ func TestHandler_HandleLikeActivity(t *testing.T) {
 
 		anchorCredID := newTransactionID(h.ServiceIRI)
 
-		like := vocab.NewLikeActivity(h.newActivityID(),
+		like := vocab.NewLikeActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(anchorCredID)),
+			vocab.WithID(h.newActivityID()),
 			vocab.WithActor(h.ServiceIRI),
 			vocab.WithTo(service2IRI),
 			vocab.WithEndTime(&endTime),
@@ -1219,8 +1266,9 @@ func TestHandler_HandleLikeActivity(t *testing.T) {
 
 		anchorCredID := newTransactionID(h.ServiceIRI)
 
-		like := vocab.NewLikeActivity(h.newActivityID(),
+		like := vocab.NewLikeActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(anchorCredID)),
+			vocab.WithID(h.newActivityID()),
 			vocab.WithActor(h.ServiceIRI),
 			vocab.WithTo(service2IRI),
 			vocab.WithStartTime(&startTime),
@@ -1239,8 +1287,9 @@ func TestHandler_HandleLikeActivity(t *testing.T) {
 		startTime := time.Now()
 		endTime := startTime.Add(time.Hour)
 
-		like := vocab.NewLikeActivity(h.newActivityID(),
+		like := vocab.NewLikeActivity(
 			vocab.NewObjectProperty(),
+			vocab.WithID(h.newActivityID()),
 			vocab.WithActor(h.ServiceIRI),
 			vocab.WithTo(service2IRI),
 			vocab.WithStartTime(&startTime),
@@ -1259,8 +1308,9 @@ func TestHandler_HandleLikeActivity(t *testing.T) {
 
 		anchorCredID := newTransactionID(h.ServiceIRI)
 
-		like := vocab.NewLikeActivity(h.newActivityID(),
+		like := vocab.NewLikeActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(anchorCredID)),
+			vocab.WithID(h.newActivityID()),
 			vocab.WithActor(h.ServiceIRI),
 			vocab.WithTo(service2IRI),
 			vocab.WithStartTime(&startTime),
@@ -1330,32 +1380,37 @@ func TestHandler_HandleUndoActivity(t *testing.T) {
 		}
 	}()
 
-	follow := vocab.NewFollowActivity(newActivityID(service2IRI),
+	follow := vocab.NewFollowActivity(
 		vocab.NewObjectProperty(vocab.WithIRI(service1IRI)),
+		vocab.WithID(newActivityID(service2IRI)),
 		vocab.WithActor(service2IRI),
 		vocab.WithTo(service1IRI),
 	)
 
-	followNoIRI := vocab.NewFollowActivity(newActivityID(service2IRI),
+	followNoIRI := vocab.NewFollowActivity(
 		vocab.NewObjectProperty(),
+		vocab.WithID(newActivityID(service2IRI)),
 		vocab.WithActor(service2IRI),
 		vocab.WithTo(service1IRI),
 	)
 
-	followIRINotLocalService := vocab.NewFollowActivity(newActivityID(service2IRI),
+	followIRINotLocalService := vocab.NewFollowActivity(
 		vocab.NewObjectProperty(vocab.WithIRI(service3IRI)),
+		vocab.WithID(newActivityID(service2IRI)),
 		vocab.WithActor(service2IRI),
 		vocab.WithTo(service1IRI),
 	)
 
-	followActorNotLocalService := vocab.NewFollowActivity(newActivityID(service2IRI),
+	followActorNotLocalService := vocab.NewFollowActivity(
 		vocab.NewObjectProperty(vocab.WithIRI(service1IRI)),
+		vocab.WithID(newActivityID(service2IRI)),
 		vocab.WithActor(service3IRI),
 		vocab.WithTo(service1IRI),
 	)
 
-	unsupported := vocab.NewLikeActivity(inboxHandler.newActivityID(),
+	unsupported := vocab.NewLikeActivity(
 		vocab.NewObjectProperty(vocab.WithIRI(service1IRI)),
+		vocab.WithID(inboxHandler.newActivityID()),
 		vocab.WithActor(service2IRI),
 		vocab.WithTo(service1IRI),
 	)
@@ -1371,8 +1426,9 @@ func TestHandler_HandleUndoActivity(t *testing.T) {
 	require.NoError(t, inboxHandler.store.AddActivity(unsupported))
 
 	t.Run("No actor in activity", func(t *testing.T) {
-		undo := vocab.NewUndoActivity(newActivityID(service2IRI),
+		undo := vocab.NewUndoActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(follow.ID().URL())),
+			vocab.WithID(newActivityID(service2IRI)),
 			vocab.WithTo(service1IRI),
 		)
 
@@ -1380,8 +1436,10 @@ func TestHandler_HandleUndoActivity(t *testing.T) {
 	})
 
 	t.Run("No object IRI in activity", func(t *testing.T) {
-		undo := vocab.NewUndoActivity(newActivityID(service2IRI),
+		undo := vocab.NewUndoActivity(
 			vocab.NewObjectProperty(),
+			vocab.WithID(newActivityID(service2IRI)),
+			vocab.WithID(newActivityID(service2IRI)),
 			vocab.WithActor(service2IRI),
 			vocab.WithTo(service1IRI),
 		)
@@ -1391,8 +1449,9 @@ func TestHandler_HandleUndoActivity(t *testing.T) {
 	})
 
 	t.Run("Activity not found in storage", func(t *testing.T) {
-		undo := vocab.NewUndoActivity(newActivityID(service2IRI),
+		undo := vocab.NewUndoActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(newActivityID(service3IRI))),
+			vocab.WithID(newActivityID(service2IRI)),
 			vocab.WithActor(service2IRI),
 			vocab.WithTo(service1IRI),
 		)
@@ -1403,7 +1462,7 @@ func TestHandler_HandleUndoActivity(t *testing.T) {
 	})
 
 	t.Run("Actor of Undo does not match the actor in Follow activity", func(t *testing.T) {
-		undo := vocab.NewUndoActivity(newActivityID(service2IRI),
+		undo := vocab.NewUndoActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(follow.ID().URL())),
 			vocab.WithActor(service3IRI),
 			vocab.WithTo(service1IRI),
@@ -1415,8 +1474,9 @@ func TestHandler_HandleUndoActivity(t *testing.T) {
 	})
 
 	t.Run("Unsupported activity type for 'Undo'", func(t *testing.T) {
-		undo := vocab.NewUndoActivity(newActivityID(service2IRI),
+		undo := vocab.NewUndoActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(unsupported.ID().URL())),
+			vocab.WithID(newActivityID(service2IRI)),
 			vocab.WithActor(service2IRI),
 			vocab.WithTo(service1IRI),
 		)
@@ -1439,8 +1499,9 @@ func TestHandler_HandleUndoActivity(t *testing.T) {
 
 			require.True(t, containsIRI(followers, service2IRI))
 
-			undo := vocab.NewUndoActivity(newActivityID(service2IRI),
+			undo := vocab.NewUndoActivity(
 				vocab.NewObjectProperty(vocab.WithIRI(follow.ID().URL())),
+				vocab.WithID(newActivityID(service2IRI)),
 				vocab.WithActor(service2IRI),
 				vocab.WithTo(service1IRI),
 			)
@@ -1464,8 +1525,9 @@ func TestHandler_HandleUndoActivity(t *testing.T) {
 		})
 
 		t.Run("No IRI -> error", func(t *testing.T) {
-			undo := vocab.NewUndoActivity(newActivityID(service2IRI),
+			undo := vocab.NewUndoActivity(
 				vocab.NewObjectProperty(vocab.WithIRI(followNoIRI.ID().URL())),
+				vocab.WithID(newActivityID(service2IRI)),
 				vocab.WithActor(service2IRI),
 				vocab.WithTo(service1IRI),
 			)
@@ -1475,8 +1537,9 @@ func TestHandler_HandleUndoActivity(t *testing.T) {
 		})
 
 		t.Run("IRI not local service -> error", func(t *testing.T) {
-			undo := vocab.NewUndoActivity(newActivityID(service2IRI),
+			undo := vocab.NewUndoActivity(
 				vocab.NewObjectProperty(vocab.WithIRI(followIRINotLocalService.ID().URL())),
+				vocab.WithID(newActivityID(service2IRI)),
 				vocab.WithActor(service2IRI),
 				vocab.WithTo(service1IRI),
 			)
@@ -1494,7 +1557,7 @@ func TestHandler_HandleUndoActivity(t *testing.T) {
 
 			require.False(t, containsIRI(followers, service2IRI))
 
-			undo := vocab.NewUndoActivity(newActivityID(service2IRI),
+			undo := vocab.NewUndoActivity(
 				vocab.NewObjectProperty(vocab.WithIRI(follow.ID().URL())),
 				vocab.WithActor(service2IRI),
 				vocab.WithTo(service1IRI),
@@ -1523,7 +1586,7 @@ func TestHandler_HandleUndoActivity(t *testing.T) {
 
 			require.True(t, containsIRI(following, service1IRI))
 
-			undo := vocab.NewUndoActivity(newActivityID(service2IRI),
+			undo := vocab.NewUndoActivity(
 				vocab.NewObjectProperty(vocab.WithIRI(follow.ID().URL())),
 				vocab.WithActor(service2IRI),
 				vocab.WithTo(service1IRI),
@@ -1548,8 +1611,9 @@ func TestHandler_HandleUndoActivity(t *testing.T) {
 		})
 
 		t.Run("No IRI -> error", func(t *testing.T) {
-			undo := vocab.NewUndoActivity(newActivityID(service2IRI),
+			undo := vocab.NewUndoActivity(
 				vocab.NewObjectProperty(vocab.WithIRI(followNoIRI.ID().URL())),
+				vocab.WithID(newActivityID(service2IRI)),
 				vocab.WithActor(service2IRI),
 				vocab.WithTo(service1IRI),
 			)
@@ -1559,7 +1623,7 @@ func TestHandler_HandleUndoActivity(t *testing.T) {
 		})
 
 		t.Run("Actor not local service -> error", func(t *testing.T) {
-			undo := vocab.NewUndoActivity(newActivityID(service2IRI),
+			undo := vocab.NewUndoActivity(
 				vocab.NewObjectProperty(vocab.WithIRI(followActorNotLocalService.ID().URL())),
 				vocab.WithActor(service3IRI),
 				vocab.WithTo(service1IRI),
@@ -1578,8 +1642,9 @@ func TestHandler_HandleUndoActivity(t *testing.T) {
 
 			require.False(t, containsIRI(followers, service1IRI))
 
-			undo := vocab.NewUndoActivity(newActivityID(service2IRI),
+			undo := vocab.NewUndoActivity(
 				vocab.NewObjectProperty(vocab.WithIRI(follow.ID().URL())),
+				vocab.WithID(newActivityID(service2IRI)),
 				vocab.WithActor(service2IRI),
 				vocab.WithTo(service1IRI),
 			)

--- a/pkg/activitypub/service/activityhandler/inboxhandler.go
+++ b/pkg/activitypub/service/activityhandler/inboxhandler.go
@@ -261,8 +261,9 @@ func (h *Inbox) handleRejectActivity(reject *vocab.ActivityType) error {
 }
 
 func (h *Inbox) postAcceptFollow(follow *vocab.ActivityType, toIRI *url.URL) error {
-	acceptActivity := vocab.NewAcceptActivity(h.newActivityID(),
+	acceptActivity := vocab.NewAcceptActivity(
 		vocab.NewObjectProperty(vocab.WithActivity(follow)),
+		vocab.WithID(h.newActivityID()),
 		vocab.WithActor(h.ServiceIRI),
 		vocab.WithTo(toIRI),
 	)
@@ -279,8 +280,9 @@ func (h *Inbox) postAcceptFollow(follow *vocab.ActivityType, toIRI *url.URL) err
 }
 
 func (h *Inbox) postRejectFollow(follow *vocab.ActivityType, toIRI *url.URL) error {
-	reject := vocab.NewRejectActivity(h.newActivityID(),
+	reject := vocab.NewRejectActivity(
 		vocab.NewObjectProperty(vocab.WithActivity(follow)),
+		vocab.WithID(h.newActivityID()),
 		vocab.WithActor(h.ServiceIRI),
 		vocab.WithTo(toIRI),
 	)
@@ -359,8 +361,9 @@ func (h *Inbox) handleOfferActivity(offer *vocab.ActivityType) error {
 	startTime := time.Now()
 	endTime := startTime.Add(h.MaxWitnessDelay)
 
-	like := vocab.NewLikeActivity(h.newActivityID(),
+	like := vocab.NewLikeActivity(
 		vocab.NewObjectProperty(vocab.WithIRI(anchorCred.ID().URL())),
+		vocab.WithID(h.newActivityID()),
 		vocab.WithActor(h.ServiceIRI),
 		vocab.WithTo(offer.Actor()),
 		vocab.WithStartTime(&startTime),
@@ -467,7 +470,7 @@ func (h *Inbox) announceAnchorCredential(create *vocab.ActivityType) error {
 
 	published := time.Now()
 
-	announce := vocab.NewAnnounceActivity(h.newActivityID(),
+	announce := vocab.NewAnnounceActivity(
 		vocab.NewObjectProperty(
 			vocab.WithCollection(
 				vocab.NewCollection(
@@ -479,6 +482,7 @@ func (h *Inbox) announceAnchorCredential(create *vocab.ActivityType) error {
 				),
 			),
 		),
+		vocab.WithID(h.newActivityID()),
 		vocab.WithActor(h.ServiceIRI),
 		vocab.WithTo(followers...),
 		vocab.WithPublishedTime(&published),
@@ -523,7 +527,7 @@ func (h *Inbox) announceAnchorCredentialRef(ref *vocab.AnchorCredentialReference
 
 	published := time.Now()
 
-	announce := vocab.NewAnnounceActivity(h.newActivityID(),
+	announce := vocab.NewAnnounceActivity(
 		vocab.NewObjectProperty(
 			vocab.WithCollection(
 				vocab.NewCollection(
@@ -535,6 +539,7 @@ func (h *Inbox) announceAnchorCredentialRef(ref *vocab.AnchorCredentialReference
 				),
 			),
 		),
+		vocab.WithID(h.newActivityID()),
 		vocab.WithActor(h.ServiceIRI),
 		vocab.WithTo(followers...),
 		vocab.WithPublishedTime(&published),

--- a/pkg/activitypub/service/inbox/inbox_test.go
+++ b/pkg/activitypub/service/inbox/inbox_test.go
@@ -99,7 +99,7 @@ func TestInbox_Handle(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		activityHandler.HandleActivityReturns(nil)
 
-		activity := vocab.NewCreateActivity(newActivityID(cfg.ServiceEndpoint),
+		activity := vocab.NewCreateActivity(
 			vocab.NewObjectProperty(
 				vocab.WithObject(
 					vocab.NewObject(
@@ -107,6 +107,7 @@ func TestInbox_Handle(t *testing.T) {
 					),
 				),
 			),
+			vocab.WithID(newActivityID(cfg.ServiceEndpoint)),
 		)
 
 		req, err := newHTTPRequest(service1InboxURL, activity)
@@ -180,7 +181,7 @@ func TestInbox_Error(t *testing.T) {
 
 		activityHandler.HandleActivityReturns(errors.New("injected handler error"))
 
-		activity := vocab.NewCreateActivity(newActivityID(cfg.ServiceEndpoint),
+		activity := vocab.NewCreateActivity(
 			vocab.NewObjectProperty(
 				vocab.WithObject(
 					vocab.NewObject(
@@ -188,6 +189,7 @@ func TestInbox_Error(t *testing.T) {
 					),
 				),
 			),
+			vocab.WithID(newActivityID(cfg.ServiceEndpoint)),
 		)
 
 		req, err := newHTTPRequest(service1InboxURL, activity)
@@ -233,7 +235,7 @@ func TestInbox_Error(t *testing.T) {
 
 		activityStore.AddActivityReturns(errors.New("injected store error"))
 
-		activity := vocab.NewCreateActivity(newActivityID(cfg.ServiceEndpoint),
+		activity := vocab.NewCreateActivity(
 			vocab.NewObjectProperty(
 				vocab.WithObject(
 					vocab.NewObject(
@@ -241,6 +243,7 @@ func TestInbox_Error(t *testing.T) {
 					),
 				),
 			),
+			vocab.WithID(newActivityID(cfg.ServiceEndpoint)),
 		)
 
 		req, err := newHTTPRequest(service1InboxURL, activity)
@@ -292,7 +295,7 @@ func TestInbox_Error(t *testing.T) {
 
 		activityHandler.HandleActivityReturns(errors.New("injected handler error"))
 
-		activity := vocab.NewCreateActivity(newActivityID(cfg.ServiceEndpoint),
+		activity := vocab.NewCreateActivity(
 			vocab.NewObjectProperty(
 				vocab.WithObject(
 					vocab.NewObject(
@@ -300,6 +303,7 @@ func TestInbox_Error(t *testing.T) {
 					),
 				),
 			),
+			vocab.WithID(newActivityID(cfg.ServiceEndpoint)),
 		)
 
 		req, err := newHTTPRequest(service1InboxURL, activity)

--- a/pkg/activitypub/service/outbox/outbox_test.go
+++ b/pkg/activitypub/service/outbox/outbox_test.go
@@ -201,7 +201,7 @@ func TestOutbox_Post(t *testing.T) {
 	objIRI, err := url.Parse("http://example.com/transactions/txn1")
 	require.NoError(t, err)
 
-	activity := vocab.NewCreateActivity(newActivityID(cfg.ServiceName),
+	activity := vocab.NewCreateActivity(
 		vocab.NewObjectProperty(
 			vocab.WithObject(
 				vocab.NewObject(
@@ -209,6 +209,7 @@ func TestOutbox_Post(t *testing.T) {
 				),
 			),
 		),
+		vocab.WithID(newActivityID(cfg.ServiceIRI)),
 		vocab.WithTo(
 			testutil.MustParseURL(vocab.PublicIRI),
 			testutil.NewMockID(service1URL, resthandler.FollowersPath),
@@ -284,7 +285,7 @@ func TestOutbox_PostError(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, ob)
 
-		activity := vocab.NewCreateActivity(newActivityID(cfg.ServiceName), nil)
+		activity := vocab.NewCreateActivity(nil, vocab.WithID(newActivityID(cfg.ServiceIRI)))
 
 		require.True(t, errors.Is(ob.Post(activity), spi.ErrNotStarted))
 	})
@@ -302,7 +303,7 @@ func TestOutbox_PostError(t *testing.T) {
 
 		ob.Start()
 
-		activity := vocab.NewCreateActivity(newActivityID(cfg.ServiceName), nil)
+		activity := vocab.NewCreateActivity(nil, vocab.WithID(newActivityID(cfg.ServiceIRI)))
 
 		require.True(t, errors.Is(ob.Post(activity), errExpected))
 
@@ -324,7 +325,7 @@ func TestOutbox_PostError(t *testing.T) {
 
 		ob.Start()
 
-		activity := vocab.NewCreateActivity(newActivityID(cfg.ServiceName), nil)
+		activity := vocab.NewCreateActivity(nil, vocab.WithID(newActivityID(cfg.ServiceIRI)))
 
 		require.True(t, errors.Is(ob.Post(activity), errExpected))
 
@@ -345,7 +346,7 @@ func TestOutbox_PostError(t *testing.T) {
 
 		ob.jsonMarshal = func(v interface{}) ([]byte, error) { return nil, errExpected }
 
-		activity := vocab.NewCreateActivity(newActivityID(cfg.ServiceName), nil)
+		activity := vocab.NewCreateActivity(nil, vocab.WithID(newActivityID(cfg.ServiceIRI)))
 
 		require.True(t, errors.Is(ob.Post(activity), errExpected))
 
@@ -364,7 +365,7 @@ func TestOutbox_PostError(t *testing.T) {
 
 		ob.Start()
 
-		activity := vocab.NewCreateActivity(newActivityID(cfg.ServiceName),
+		activity := vocab.NewCreateActivity(
 			vocab.NewObjectProperty(
 				vocab.WithObject(
 					vocab.NewObject(
@@ -372,6 +373,7 @@ func TestOutbox_PostError(t *testing.T) {
 					),
 				),
 			),
+			vocab.WithID(newActivityID(cfg.ServiceIRI)),
 			vocab.WithTo(service2URL),
 		)
 
@@ -402,7 +404,7 @@ func TestOutbox_PostError(t *testing.T) {
 
 		ob.jsonUnmarshal = func(data []byte, v interface{}) error { return errExpected }
 
-		activity := vocab.NewCreateActivity(newActivityID(cfg.ServiceName),
+		activity := vocab.NewCreateActivity(
 			vocab.NewObjectProperty(
 				vocab.WithObject(
 					vocab.NewObject(
@@ -410,6 +412,7 @@ func TestOutbox_PostError(t *testing.T) {
 					),
 				),
 			),
+			vocab.WithID(newActivityID(cfg.ServiceIRI)),
 			vocab.WithTo(service2URL),
 		)
 
@@ -433,7 +436,7 @@ func TestOutbox_PostError(t *testing.T) {
 
 		ob.Start()
 
-		activity := vocab.NewCreateActivity(newActivityID(cfg.ServiceName),
+		activity := vocab.NewCreateActivity(
 			vocab.NewObjectProperty(
 				vocab.WithObject(
 					vocab.NewObject(
@@ -441,6 +444,7 @@ func TestOutbox_PostError(t *testing.T) {
 					),
 				),
 			),
+			vocab.WithID(newActivityID(cfg.ServiceIRI)),
 			vocab.WithTo(service2URL),
 		)
 
@@ -453,8 +457,8 @@ func TestOutbox_PostError(t *testing.T) {
 	})
 }
 
-func newActivityID(serviceName string) *url.URL {
-	return testutil.MustParseURL(fmt.Sprintf("%s/%s", serviceName, uuid.New()))
+func newActivityID(servicIRI fmt.Stringer) *url.URL {
+	return testutil.NewMockID(servicIRI, uuid.New().String())
 }
 
 type testHandler struct {

--- a/pkg/activitypub/service/service_test.go
+++ b/pkg/activitypub/service/service_test.go
@@ -157,8 +157,9 @@ func TestService_Create(t *testing.T) {
 		panic(err)
 	}
 
-	create := vocab.NewCreateActivity(newActivityID(service1IRI),
+	create := vocab.NewCreateActivity(
 		vocab.NewObjectProperty(vocab.WithObject(obj)),
+		vocab.WithID(newActivityID(service1IRI)),
 		vocab.WithActor(service1IRI),
 		vocab.WithTarget(targetProperty),
 		vocab.WithContext(vocab.ContextOrb),
@@ -284,8 +285,9 @@ func TestService_Follow(t *testing.T) {
 		actorIRI := service1IRI
 		targetIRI := service2IRI
 
-		follow := vocab.NewFollowActivity(newActivityID(actorIRI),
+		follow := vocab.NewFollowActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(targetIRI)),
+			vocab.WithID(newActivityID(actorIRI)),
 			vocab.WithActor(actorIRI),
 			vocab.WithTo(targetIRI),
 		)
@@ -362,8 +364,9 @@ func TestService_Follow(t *testing.T) {
 		actorIRI := service2IRI
 		targetIRI := service1IRI
 
-		follow := vocab.NewFollowActivity(newActivityID(actorIRI),
+		follow := vocab.NewFollowActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(targetIRI)),
+			vocab.WithID(newActivityID(actorIRI)),
 			vocab.WithActor(actorIRI),
 			vocab.WithTo(targetIRI),
 		)
@@ -561,12 +564,13 @@ func TestService_Announce(t *testing.T) {
 
 		published := time.Now()
 
-		announce := vocab.NewAnnounceActivity(newActivityID(service2IRI),
+		announce := vocab.NewAnnounceActivity(
 			vocab.NewObjectProperty(
 				vocab.WithCollection(
 					vocab.NewCollection(items),
 				),
 			),
+			vocab.WithID(newActivityID(service2IRI)),
 			vocab.WithActor(service2IRI),
 			vocab.WithTo(service3IRI),
 			vocab.WithPublishedTime(&published),
@@ -619,12 +623,13 @@ func TestService_Announce(t *testing.T) {
 
 		published := time.Now()
 
-		announce := vocab.NewAnnounceActivity(newActivityID(service2IRI),
+		announce := vocab.NewAnnounceActivity(
 			vocab.NewObjectProperty(
 				vocab.WithCollection(
 					vocab.NewCollection(items),
 				),
 			),
+			vocab.WithID(newActivityID(service2IRI)),
 			vocab.WithActor(service2IRI),
 			vocab.WithTo(service3IRI),
 			vocab.WithPublishedTime(&published),
@@ -672,8 +677,9 @@ func TestService_Announce(t *testing.T) {
 
 		followerAuth2.WithAccept()
 
-		follow := vocab.NewFollowActivity(newActivityID(service3IRI),
+		follow := vocab.NewFollowActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(service2IRI)),
+			vocab.WithID(newActivityID(service3IRI)),
 			vocab.WithActor(service3IRI),
 			vocab.WithTo(service2IRI),
 		)
@@ -707,8 +713,9 @@ func TestService_Announce(t *testing.T) {
 		}
 
 		// Service1 posts a 'Create' to Service2
-		create := vocab.NewCreateActivity(newActivityID(service1IRI),
+		create := vocab.NewCreateActivity(
 			vocab.NewObjectProperty(vocab.WithObject(obj)),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithTarget(targetProperty),
 			vocab.WithContext(vocab.ContextOrb),
 			vocab.WithTo(service2IRI),
@@ -873,8 +880,9 @@ func TestService_Offer(t *testing.T) {
 		startTime := time.Now()
 		endTime := startTime.Add(time.Hour)
 
-		offer := vocab.NewOfferActivity(newActivityID(service1IRI),
+		offer := vocab.NewOfferActivity(
 			vocab.NewObjectProperty(vocab.WithObject(obj)),
+			vocab.WithID(newActivityID(service1IRI)),
 			vocab.WithActor(service1IRI),
 			vocab.WithTo(service2IRI),
 			vocab.WithStartTime(&startTime),

--- a/pkg/activitypub/store/memstore/iterator_test.go
+++ b/pkg/activitypub/store/memstore/iterator_test.go
@@ -24,8 +24,8 @@ func TestActivityIterator(t *testing.T) {
 		activityID2 = testutil.MustParseURL("https://example.com/activities/activity2")
 	)
 
-	activity1 := vocab.NewAnnounceActivity(activityID1, vocab.NewObjectProperty())
-	activity2 := vocab.NewAnnounceActivity(activityID2, vocab.NewObjectProperty())
+	activity1 := vocab.NewAnnounceActivity(vocab.NewObjectProperty(), vocab.WithID(activityID1))
+	activity2 := vocab.NewAnnounceActivity(vocab.NewObjectProperty(), vocab.WithID(activityID2))
 
 	results := []*vocab.ActivityType{activity1, activity2}
 

--- a/pkg/activitypub/store/memstore/memstore_test.go
+++ b/pkg/activitypub/store/memstore/memstore_test.go
@@ -35,7 +35,7 @@ func TestStore_Activity(t *testing.T) {
 	require.True(t, errors.Is(err, spi.ErrNotFound))
 	require.Nil(t, a)
 
-	activity1 := vocab.NewCreateActivity(activityID1, vocab.NewObjectProperty())
+	activity1 := vocab.NewCreateActivity(vocab.NewObjectProperty(), vocab.WithID(activityID1))
 	require.NoError(t, s.AddActivity(activity1))
 
 	a, err = s.GetActivity(activityID1)
@@ -43,10 +43,10 @@ func TestStore_Activity(t *testing.T) {
 	require.NotNil(t, a)
 	require.Equal(t, activity1, a)
 
-	activity2 := vocab.NewAnnounceActivity(activityID2, vocab.NewObjectProperty())
+	activity2 := vocab.NewAnnounceActivity(vocab.NewObjectProperty(), vocab.WithID(activityID2))
 	require.NoError(t, s.AddActivity(activity2))
 
-	activity3 := vocab.NewCreateActivity(activityID3, vocab.NewObjectProperty())
+	activity3 := vocab.NewCreateActivity(vocab.NewObjectProperty(), vocab.WithID(activityID3))
 	require.NoError(t, s.AddActivity(activity3))
 
 	require.NoError(t, s.AddReference(spi.Inbox, serviceID1, activityID1))
@@ -344,8 +344,8 @@ func newMockActivities(t vocab.Type, num int) []*vocab.ActivityType {
 
 func newMockActivity(t vocab.Type, id *url.URL) *vocab.ActivityType {
 	if t == vocab.TypeAnnounce {
-		return vocab.NewAnnounceActivity(id, vocab.NewObjectProperty(vocab.WithIRI(id)))
+		return vocab.NewAnnounceActivity(vocab.NewObjectProperty(vocab.WithIRI(id)), vocab.WithID(id))
 	}
 
-	return vocab.NewCreateActivity(id, vocab.NewObjectProperty())
+	return vocab.NewCreateActivity(vocab.NewObjectProperty(), vocab.WithID(id))
 }

--- a/pkg/activitypub/vocab/activitytype.go
+++ b/pkg/activitypub/vocab/activitytype.go
@@ -62,13 +62,13 @@ func (t *ActivityType) UnmarshalJSON(bytes []byte) error {
 }
 
 // NewCreateActivity returns a new 'Create' activity.
-func NewCreateActivity(id *url.URL, obj *ObjectProperty, opts ...Opt) *ActivityType {
+func NewCreateActivity(obj *ObjectProperty, opts ...Opt) *ActivityType {
 	options := NewOptions(opts...)
 
 	return &ActivityType{
 		ObjectType: NewObject(
 			WithContext(getContexts(options, ContextActivityStreams)...),
-			WithID(id),
+			WithID(options.ID),
 			WithType(TypeCreate),
 			WithTo(options.To...),
 			WithPublishedTime(options.Published),
@@ -82,13 +82,13 @@ func NewCreateActivity(id *url.URL, obj *ObjectProperty, opts ...Opt) *ActivityT
 }
 
 // NewAnnounceActivity returns a new 'Announce' activity.
-func NewAnnounceActivity(id *url.URL, obj *ObjectProperty, opts ...Opt) *ActivityType {
+func NewAnnounceActivity(obj *ObjectProperty, opts ...Opt) *ActivityType {
 	options := NewOptions(opts...)
 
 	return &ActivityType{
 		ObjectType: NewObject(
 			WithContext(getContexts(options, ContextActivityStreams)...),
-			WithID(id),
+			WithID(options.ID),
 			WithType(TypeAnnounce),
 			WithTo(options.To...),
 			WithPublishedTime(options.Published),
@@ -101,13 +101,13 @@ func NewAnnounceActivity(id *url.URL, obj *ObjectProperty, opts ...Opt) *Activit
 }
 
 // NewFollowActivity returns a new 'Follow' activity.
-func NewFollowActivity(id *url.URL, obj *ObjectProperty, opts ...Opt) *ActivityType {
+func NewFollowActivity(obj *ObjectProperty, opts ...Opt) *ActivityType {
 	options := NewOptions(opts...)
 
 	return &ActivityType{
 		ObjectType: NewObject(
 			WithContext(getContexts(options, ContextActivityStreams)...),
-			WithID(id),
+			WithID(options.ID),
 			WithType(TypeFollow),
 			WithTo(options.To...),
 		),
@@ -119,13 +119,13 @@ func NewFollowActivity(id *url.URL, obj *ObjectProperty, opts ...Opt) *ActivityT
 }
 
 // NewAcceptActivity returns a new 'Accept' activity.
-func NewAcceptActivity(id *url.URL, obj *ObjectProperty, opts ...Opt) *ActivityType {
+func NewAcceptActivity(obj *ObjectProperty, opts ...Opt) *ActivityType {
 	options := NewOptions(opts...)
 
 	return &ActivityType{
 		ObjectType: NewObject(
 			WithContext(getContexts(options, ContextActivityStreams)...),
-			WithID(id),
+			WithID(options.ID),
 			WithType(TypeAccept),
 			WithTo(options.To...),
 		),
@@ -137,13 +137,13 @@ func NewAcceptActivity(id *url.URL, obj *ObjectProperty, opts ...Opt) *ActivityT
 }
 
 // NewRejectActivity returns a new 'Reject' activity.
-func NewRejectActivity(id *url.URL, obj *ObjectProperty, opts ...Opt) *ActivityType {
+func NewRejectActivity(obj *ObjectProperty, opts ...Opt) *ActivityType {
 	options := NewOptions(opts...)
 
 	return &ActivityType{
 		ObjectType: NewObject(
 			WithContext(getContexts(options, ContextActivityStreams)...),
-			WithID(id),
+			WithID(options.ID),
 			WithType(TypeReject),
 			WithTo(options.To...),
 		),
@@ -155,13 +155,13 @@ func NewRejectActivity(id *url.URL, obj *ObjectProperty, opts ...Opt) *ActivityT
 }
 
 // NewLikeActivity returns a new 'Like' activity.
-func NewLikeActivity(id *url.URL, obj *ObjectProperty, opts ...Opt) *ActivityType {
+func NewLikeActivity(obj *ObjectProperty, opts ...Opt) *ActivityType {
 	options := NewOptions(opts...)
 
 	return &ActivityType{
 		ObjectType: NewObject(
 			WithContext(getContexts(options, ContextActivityStreams)...),
-			WithID(id),
+			WithID(options.ID),
 			WithType(TypeLike),
 			WithTo(options.To...),
 			WithStartTime(options.StartTime),
@@ -176,13 +176,13 @@ func NewLikeActivity(id *url.URL, obj *ObjectProperty, opts ...Opt) *ActivityTyp
 }
 
 // NewOfferActivity returns a new 'Offer' activity.
-func NewOfferActivity(id *url.URL, obj *ObjectProperty, opts ...Opt) *ActivityType {
+func NewOfferActivity(obj *ObjectProperty, opts ...Opt) *ActivityType {
 	options := NewOptions(opts...)
 
 	return &ActivityType{
 		ObjectType: NewObject(
 			WithContext(getContexts(options, ContextActivityStreams)...),
-			WithID(id),
+			WithID(options.ID),
 			WithType(TypeOffer),
 			WithTo(options.To...),
 			WithStartTime(options.StartTime),
@@ -196,13 +196,13 @@ func NewOfferActivity(id *url.URL, obj *ObjectProperty, opts ...Opt) *ActivityTy
 }
 
 // NewUndoActivity returns a new 'Undo' activity.
-func NewUndoActivity(id *url.URL, obj *ObjectProperty, opts ...Opt) *ActivityType {
+func NewUndoActivity(obj *ObjectProperty, opts ...Opt) *ActivityType {
 	options := NewOptions(opts...)
 
 	return &ActivityType{
 		ObjectType: NewObject(
 			WithContext(getContexts(options, ContextActivityStreams)...),
-			WithID(id),
+			WithID(options.ID),
 			WithType(TypeUndo),
 			WithTo(options.To...),
 		),

--- a/pkg/activitypub/vocab/activitytype_test.go
+++ b/pkg/activitypub/vocab/activitytype_test.go
@@ -51,8 +51,9 @@ func TestCreateTypeMarshal(t *testing.T) {
 		obj, err := NewObjectWithDocument(MustUnmarshalToDoc([]byte(anchorCredential1)))
 		require.NoError(t, err)
 
-		create := NewCreateActivity(createActivityID,
+		create := NewCreateActivity(
 			NewObjectProperty(WithObject(obj)),
+			WithID(createActivityID),
 			WithActor(service1),
 			WithTarget(targetProperty),
 			WithTo(followers),
@@ -111,12 +112,13 @@ func TestCreateTypeMarshal(t *testing.T) {
 		refID := newMockID(host1, "/transactions/bafkreihwsnuregceqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy")
 
 		t.Run("Marshal", func(t *testing.T) {
-			create := NewCreateActivity(createActivityID,
+			create := NewCreateActivity(
 				NewObjectProperty(
 					WithAnchorCredentialReference(
 						NewAnchorCredentialReference(refID, anchorCredIRI, cid),
 					),
 				),
+				WithID(createActivityID),
 				WithActor(service1),
 				WithTo(followers),
 				WithTo(public),
@@ -180,10 +182,11 @@ func TestCreateTypeMarshal(t *testing.T) {
 			anchorCredential, err := NewObjectWithDocument(MustUnmarshalToDoc([]byte(anchorCredential)))
 			require.NoError(t, err)
 
-			create := NewCreateActivity(createActivityID,
+			create := NewCreateActivity(
 				NewObjectProperty(
 					WithObject(anchorCredential),
 				),
+				WithID(createActivityID),
 				WithTarget(
 					NewObjectProperty(
 						WithObject(
@@ -261,8 +264,8 @@ func TestAnnounceTypeMarshal(t *testing.T) {
 
 		t.Run("Marshal", func(t *testing.T) {
 			announce := NewAnnounceActivity(
-				createActivityID,
 				NewObjectProperty(WithIRI(txn1)),
+				WithID(createActivityID),
 				WithActor(service1),
 				WithTo(followers), WithTo(public),
 				WithPublishedTime(&published),
@@ -336,8 +339,9 @@ func TestAnnounceTypeMarshal(t *testing.T) {
 
 			coll := NewCollection(items)
 
-			announce := NewAnnounceActivity(createActivityID,
+			announce := NewAnnounceActivity(
 				NewObjectProperty(WithCollection(coll)),
+				WithID(createActivityID),
 				WithActor(service1),
 				WithTo(followers), WithTo(public),
 				WithPublishedTime(&published),
@@ -430,12 +434,13 @@ func TestAnnounceTypeMarshal(t *testing.T) {
 				),
 			}
 
-			announce := NewAnnounceActivity(createActivityID,
+			announce := NewAnnounceActivity(
 				NewObjectProperty(
 					WithCollection(
 						NewCollection(items),
 					),
 				),
+				WithID(createActivityID),
 				WithActor(service1),
 				WithTo(followers), WithTo(public),
 				WithPublishedTime(&published),
@@ -511,8 +516,9 @@ func TestFollowTypeMarshal(t *testing.T) {
 	org2Service := testutil.MustParseURL("https://org1.com/services/service2")
 
 	t.Run("Marshal", func(t *testing.T) {
-		follow := NewFollowActivity(followActivityID,
+		follow := NewFollowActivity(
 			NewObjectProperty(WithIRI(org2Service)),
+			WithID(followActivityID),
 			WithActor(org1Service),
 			WithTo(org2Service),
 		)
@@ -552,8 +558,9 @@ func TestAcceptTypeMarshal(t *testing.T) {
 	org1Service := testutil.MustParseURL("https://org1.com/services/service1")
 	org2Service := testutil.MustParseURL("https://org1.com/services/service2")
 
-	follow := NewFollowActivity(followActivityID,
+	follow := NewFollowActivity(
 		NewObjectProperty(WithIRI(org2Service)),
+		WithID(followActivityID),
 		WithTo(org2Service),
 		WithActor(org1Service),
 	)
@@ -561,8 +568,9 @@ func TestAcceptTypeMarshal(t *testing.T) {
 	follow.object.Context = nil
 
 	t.Run("Marshal", func(t *testing.T) {
-		accept := NewAcceptActivity(acceptActivityID,
+		accept := NewAcceptActivity(
 			NewObjectProperty(WithActivity(follow)),
+			WithID(acceptActivityID),
 			WithActor(org2Service),
 			WithTo(org1Service),
 		)
@@ -622,7 +630,8 @@ func TestRejectTypeMarshal(t *testing.T) {
 	org1Service := testutil.MustParseURL("https://org1.com/services/service1")
 	org2Service := testutil.MustParseURL("https://org1.com/services/service2")
 
-	follow := NewFollowActivity(followActivityID, NewObjectProperty(WithIRI(org2Service)),
+	follow := NewFollowActivity(NewObjectProperty(WithIRI(org2Service)),
+		WithID(followActivityID),
 		WithTo(org2Service),
 		WithActor(org1Service),
 	)
@@ -630,7 +639,8 @@ func TestRejectTypeMarshal(t *testing.T) {
 	follow.object.Context = nil
 
 	t.Run("Marshal", func(t *testing.T) {
-		accept := NewRejectActivity(rejectActivityID, NewObjectProperty(WithActivity(follow)),
+		accept := NewRejectActivity(NewObjectProperty(WithActivity(follow)),
+			WithID(rejectActivityID),
 			WithActor(org2Service),
 			WithTo(org1Service),
 		)
@@ -697,8 +707,9 @@ func TestOfferTypeMarshal(t *testing.T) {
 		obj, err := NewObjectWithDocument(MustUnmarshalToDoc([]byte(anchorCredential)))
 		require.NoError(t, err)
 
-		offer := NewOfferActivity(offerActivityID,
+		offer := NewOfferActivity(
 			NewObjectProperty(WithObject(obj)),
+			WithID(offerActivityID),
 			WithActor(service1),
 			WithTo(to, public),
 			WithStartTime(&startTime),
@@ -761,8 +772,9 @@ func TestLikeTypeMarshal(t *testing.T) {
 		result, err := NewObjectWithDocument(MustUnmarshalToDoc([]byte(jsonLikeResult)))
 		require.NoError(t, err)
 
-		like := NewLikeActivity(likeActivityID,
+		like := NewLikeActivity(
 			NewObjectProperty(WithIRI(credID)),
+			WithID(likeActivityID),
 			WithActor(actor),
 			WithTo(service1, public),
 			WithStartTime(&startTime),
@@ -830,8 +842,9 @@ func TestUndoTypeMarshal(t *testing.T) {
 	org2Service := testutil.MustParseURL("https://org1.com/services/service2")
 
 	t.Run("Marshal", func(t *testing.T) {
-		accept := NewUndoActivity(undoActivityID,
+		accept := NewUndoActivity(
 			NewObjectProperty(WithIRI(followActivityID)),
+			WithID(undoActivityID),
 			WithActor(org1Service),
 			WithTo(org2Service),
 		)


### PR DESCRIPTION
The ID argument was removed from all activity constructors. IDs may be optionally added using WithID(...).

closes #187

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>