### PR TITLE
feat: Outbox Post sets the ID and 'actor' of activity

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -96,7 +96,7 @@ const (
 	activityPubServicesPath     = "/services/orb"
 	activityPubTransactionsPath = "/transactions"
 
-	casPath     = "/cas"
+	casPath = "/cas"
 )
 
 type server interface {
@@ -638,7 +638,7 @@ const mockProof = `{
    "https://w3id.org/security/v1",
    "https://w3c-ccg.github.io/lds-jws2020/contexts/lds-jws2020-v1.json"
  ],
- "mockProof": {
+ "proof": {
    "type": "JsonWebSignature2020",
    "proofPurpose": "assertionMethod",
    "created": "2021-01-27T09:30:15Z",

--- a/pkg/activitypub/service/activityhandler/activityhandler.go
+++ b/pkg/activitypub/service/activityhandler/activityhandler.go
@@ -14,7 +14,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/trustbloc/edge-core/pkg/log"
 
 	"github.com/trustbloc/orb/pkg/activitypub/client"
@@ -170,16 +169,6 @@ func defaultOptions() *service.Handlers {
 		FollowerAuth:            &acceptAllFollowerAuth{},
 		ProofHandler:            &noOpProofHandler{},
 	}
-}
-
-func (h *handler) newActivityID() *url.URL {
-	id, err := url.Parse(fmt.Sprintf("%s/%s", h.ServiceIRI.String(), uuid.New()))
-	if err != nil {
-		// Should never happen since we've already validated the URLs
-		panic(err)
-	}
-
-	return id
 }
 
 func (h *handler) resolveActor(iri *url.URL) (*vocab.ActorType, error) {

--- a/pkg/activitypub/service/activityhandler/activityhandler_test.go
+++ b/pkg/activitypub/service/activityhandler/activityhandler_test.go
@@ -112,7 +112,7 @@ func TestHandler_HandleCreateActivity(t *testing.T) {
 	anchorCredHandler := mocks.NewAnchorCredentialHandler()
 
 	activityStore := memstore.New(cfg.ServiceName)
-	ob := mocks.NewOutbox()
+	ob := mocks.NewOutbox().WithActivityID(testutil.NewMockID(service1IRI, "/activities/123456789"))
 
 	require.NoError(t, activityStore.AddReference(store.Follower, service1IRI, service3IRI))
 
@@ -958,9 +958,10 @@ func TestHandler_HandleOfferActivity(t *testing.T) {
 		ServiceIRI:  service1IRI,
 	}
 
+	ob := mocks.NewOutbox().WithActivityID(testutil.NewMockID(service1IRI, "/activities/123456789"))
 	witness := mocks.NewWitnessHandler()
 
-	h := NewInbox(cfg, memstore.New(cfg.ServiceName), &mocks.Outbox{}, &clientmocks.HTTPClient{}, spi.WithWitness(witness))
+	h := NewInbox(cfg, memstore.New(cfg.ServiceName), ob, &clientmocks.HTTPClient{}, spi.WithWitness(witness))
 	require.NotNil(t, h)
 
 	h.Start()
@@ -1182,7 +1183,7 @@ func TestHandler_HandleLikeActivity(t *testing.T) {
 
 		like := vocab.NewLikeActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(anchorCredID)),
-			vocab.WithID(h.newActivityID()),
+			vocab.WithID(newActivityID(h.ServiceIRI)),
 			vocab.WithActor(h.ServiceIRI),
 			vocab.WithTo(service2IRI),
 			vocab.WithStartTime(&startTime),
@@ -1224,7 +1225,7 @@ func TestHandler_HandleLikeActivity(t *testing.T) {
 
 		like := vocab.NewLikeActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(anchorCredID)),
-			vocab.WithID(h.newActivityID()),
+			vocab.WithID(newActivityID(h.ServiceIRI)),
 			vocab.WithActor(h.ServiceIRI),
 			vocab.WithTo(service2IRI),
 			vocab.WithStartTime(&startTime),
@@ -1246,7 +1247,7 @@ func TestHandler_HandleLikeActivity(t *testing.T) {
 
 		like := vocab.NewLikeActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(anchorCredID)),
-			vocab.WithID(h.newActivityID()),
+			vocab.WithID(newActivityID(h.ServiceIRI)),
 			vocab.WithActor(h.ServiceIRI),
 			vocab.WithTo(service2IRI),
 			vocab.WithEndTime(&endTime),
@@ -1268,7 +1269,7 @@ func TestHandler_HandleLikeActivity(t *testing.T) {
 
 		like := vocab.NewLikeActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(anchorCredID)),
-			vocab.WithID(h.newActivityID()),
+			vocab.WithID(newActivityID(h.ServiceIRI)),
 			vocab.WithActor(h.ServiceIRI),
 			vocab.WithTo(service2IRI),
 			vocab.WithStartTime(&startTime),
@@ -1289,7 +1290,7 @@ func TestHandler_HandleLikeActivity(t *testing.T) {
 
 		like := vocab.NewLikeActivity(
 			vocab.NewObjectProperty(),
-			vocab.WithID(h.newActivityID()),
+			vocab.WithID(newActivityID(h.ServiceIRI)),
 			vocab.WithActor(h.ServiceIRI),
 			vocab.WithTo(service2IRI),
 			vocab.WithStartTime(&startTime),
@@ -1310,7 +1311,7 @@ func TestHandler_HandleLikeActivity(t *testing.T) {
 
 		like := vocab.NewLikeActivity(
 			vocab.NewObjectProperty(vocab.WithIRI(anchorCredID)),
-			vocab.WithID(h.newActivityID()),
+			vocab.WithID(newActivityID(h.ServiceIRI)),
 			vocab.WithActor(h.ServiceIRI),
 			vocab.WithTo(service2IRI),
 			vocab.WithStartTime(&startTime),
@@ -1410,7 +1411,7 @@ func TestHandler_HandleUndoActivity(t *testing.T) {
 
 	unsupported := vocab.NewLikeActivity(
 		vocab.NewObjectProperty(vocab.WithIRI(service1IRI)),
-		vocab.WithID(inboxHandler.newActivityID()),
+		vocab.WithID(newActivityID(inboxHandler.ServiceIRI)),
 		vocab.WithActor(service2IRI),
 		vocab.WithTo(service1IRI),
 	)

--- a/pkg/activitypub/service/mocks/mockoutbox.go
+++ b/pkg/activitypub/service/mocks/mockoutbox.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package mocks
 
 import (
+	"net/url"
 	"sync"
 
 	"github.com/trustbloc/orb/pkg/activitypub/service/spi"
@@ -18,6 +19,7 @@ type Outbox struct {
 	mutex      sync.RWMutex
 	activities Activities
 	err        error
+	activityID *url.URL
 }
 
 // NewOutbox returns a mock outbox.
@@ -32,6 +34,13 @@ func (m *Outbox) WithError(err error) *Outbox {
 	return m
 }
 
+// WithActivityID sets the ID of the posted activity.
+func (m *Outbox) WithActivityID(id *url.URL) *Outbox {
+	m.activityID = id
+
+	return m
+}
+
 // Activities returns the activities that were posted to the outbox.
 func (m *Outbox) Activities() Activities {
 	m.mutex.RLock()
@@ -42,9 +51,9 @@ func (m *Outbox) Activities() Activities {
 
 // Post post an activity to the outbox. The activity is simply stored
 // so that it may be retrieved by the Activies function.
-func (m *Outbox) Post(activity *vocab.ActivityType) error {
+func (m *Outbox) Post(activity *vocab.ActivityType) (*url.URL, error) {
 	if m.err != nil {
-		return m.err
+		return nil, m.err
 	}
 
 	m.mutex.Lock()
@@ -52,7 +61,7 @@ func (m *Outbox) Post(activity *vocab.ActivityType) error {
 
 	m.activities = append(m.activities, activity)
 
-	return nil
+	return m.activityID, nil
 }
 
 // Start does nothing.

--- a/pkg/activitypub/service/spi/spi.go
+++ b/pkg/activitypub/service/spi/spi.go
@@ -49,7 +49,8 @@ type ServiceLifecycle interface {
 type Outbox interface {
 	ServiceLifecycle
 
-	Post(activity *vocab.ActivityType) error
+	// Post posts an activity to the outbox and returns the ID of the activity.
+	Post(activity *vocab.ActivityType) (*url.URL, error)
 }
 
 // Inbox defines the functions for an ActivityPub inbox.

--- a/pkg/activitypub/store/memstore/memstore.go
+++ b/pkg/activitypub/store/memstore/memstore.go
@@ -96,7 +96,7 @@ func (s *Store) GetActivity(activityID *url.URL) (*vocab.ActivityType, error) {
 // QueryActivities queries the given activity store using the provided criteria
 // and returns a results iterator.
 func (s *Store) QueryActivities(query *spi.Criteria, opts ...spi.QueryOpt) (spi.ActivityIterator, error) {
-	logger.Debugf("[%s] Querying activity %s - Query: %+v", s.serviceName, query)
+	logger.Debugf("[%s] Querying activities - Query: %+v", s.serviceName, query)
 
 	if query.ReferenceType != "" && query.ObjectIRI != nil {
 		return s.queryActivitiesByRef(query.ReferenceType, query, opts...)
@@ -110,15 +110,31 @@ func (s *Store) AddReference(referenceType spi.ReferenceType, objectIRI, referen
 	logger.Debugf("[%s] Adding reference of type %s to object %s: %s",
 		s.serviceName, referenceType, objectIRI, referenceIRI)
 
+	if objectIRI == nil {
+		return fmt.Errorf("nil object IRI")
+	}
+
+	if referenceIRI == nil {
+		return fmt.Errorf("nil reference IRI")
+	}
+
 	return s.referenceStores[referenceType].add(objectIRI, referenceIRI)
 }
 
 // DeleteReference deletes the reference of the given type from the given actor.
-func (s *Store) DeleteReference(referenceType spi.ReferenceType, actorIRI, referenceIRI *url.URL) error {
-	logger.Debugf("[%s] Deleting reference of type %s from actor %s: %s",
-		s.serviceName, referenceType, actorIRI, referenceIRI)
+func (s *Store) DeleteReference(referenceType spi.ReferenceType, objectIRI, referenceIRI *url.URL) error {
+	logger.Debugf("[%s] Deleting reference of type %s from object %s: %s",
+		s.serviceName, referenceType, objectIRI, referenceIRI)
 
-	return s.referenceStores[referenceType].delete(actorIRI, referenceIRI)
+	if objectIRI == nil {
+		return fmt.Errorf("nil object IRI")
+	}
+
+	if referenceIRI == nil {
+		return fmt.Errorf("nil reference IRI")
+	}
+
+	return s.referenceStores[referenceType].delete(objectIRI, referenceIRI)
 }
 
 // QueryReferences returns the list of references of the given type according to the given query.

--- a/pkg/activitypub/store/memstore/memstore_test.go
+++ b/pkg/activitypub/store/memstore/memstore_test.go
@@ -137,6 +137,30 @@ func TestStore_Reference(t *testing.T) {
 	checkRefQueryResults(t, it, actor3)
 }
 
+func TestStore_ReferenceError(t *testing.T) {
+	s := New("service1")
+	require.NotNil(t, s)
+
+	actor1 := testutil.MustParseURL("https://actor1")
+	actor2 := testutil.MustParseURL("https://actor2")
+
+	t.Run("AddReference - Nil object IRI -> error", func(t *testing.T) {
+		require.EqualError(t, s.AddReference(spi.Follower, nil, actor2), "nil object IRI")
+	})
+
+	t.Run("AddReference - Nil reference -> error", func(t *testing.T) {
+		require.EqualError(t, s.AddReference(spi.Follower, actor1, nil), "nil reference IRI")
+	})
+
+	t.Run("DeleteReference - Nil object IRI -> error", func(t *testing.T) {
+		require.EqualError(t, s.DeleteReference(spi.Follower, nil, actor2), "nil object IRI")
+	})
+
+	t.Run("DeleteReference - Nil reference -> error", func(t *testing.T) {
+		require.EqualError(t, s.DeleteReference(spi.Follower, actor1, nil), "nil reference IRI")
+	})
+}
+
 func TestStore_Actors(t *testing.T) {
 	s := New("service1")
 	require.NotNil(t, s)

--- a/pkg/activitypub/vocab/activitytype.go
+++ b/pkg/activitypub/vocab/activitytype.go
@@ -33,6 +33,11 @@ func (t *ActivityType) Actor() *url.URL {
 	return t.activity.Actor.URL()
 }
 
+// SetActor sets the actor for the activity.
+func (t *ActivityType) SetActor(iri *url.URL) {
+	t.activity.Actor = NewURLProperty(iri)
+}
+
 // Target returns the target of the activity.
 func (t *ActivityType) Target() *ObjectProperty {
 	return t.activity.Target

--- a/pkg/activitypub/vocab/activitytype_test.go
+++ b/pkg/activitypub/vocab/activitytype_test.go
@@ -53,14 +53,15 @@ func TestCreateTypeMarshal(t *testing.T) {
 
 		create := NewCreateActivity(
 			NewObjectProperty(WithObject(obj)),
-			WithID(createActivityID),
-			WithActor(service1),
 			WithTarget(targetProperty),
 			WithTo(followers),
 			WithTo(public),
 			WithContext(ContextOrb),
 			WithPublishedTime(&published),
 		)
+
+		create.SetID(createActivityID)
+		create.SetActor(service1)
 
 		bytes, err := canonicalizer.MarshalCanonical(create)
 		require.NoError(t, err)

--- a/pkg/activitypub/vocab/objecttype.go
+++ b/pkg/activitypub/vocab/objecttype.go
@@ -79,6 +79,11 @@ func (t *ObjectType) ID() *URLProperty {
 	return t.object.ID
 }
 
+// SetID sets the object's ID.
+func (t *ObjectType) SetID(id *url.URL) {
+	t.object.ID = NewURLProperty(id)
+}
+
 // Type returns the type of the object.
 func (t *ObjectType) Type() *TypeProperty {
 	return t.object.Type

--- a/pkg/activitypub/vocab/objecttype_test.go
+++ b/pkg/activitypub/vocab/objecttype_test.go
@@ -27,7 +27,6 @@ func TestObjectType_WithoutDocument(t *testing.T) {
 
 	t.Run("NewObject", func(t *testing.T) {
 		obj := NewObject(
-			WithID(id),
 			WithContext(ContextCredentials, ContextOrb),
 			WithType(TypeVerifiableCredential, TypeAnchorCredential),
 			WithTo(to1, to2),
@@ -35,6 +34,8 @@ func TestObjectType_WithoutDocument(t *testing.T) {
 			WithStartTime(&startTime),
 			WithEndTime(&endTime),
 		)
+
+		obj.SetID(id)
 
 		context := obj.Context()
 		require.NotNil(t, context)

--- a/pkg/anchor/writer/writer.go
+++ b/pkg/anchor/writer/writer.go
@@ -48,7 +48,7 @@ type Providers struct {
 }
 
 type outbox interface {
-	Post(activity *vocab.ActivityType) error
+	Post(activity *vocab.ActivityType) (*url.URL, error)
 }
 
 type opProcessor interface {
@@ -298,7 +298,9 @@ func (c *Writer) postActivity(vc *verifiable.Credential, cid string) error { //n
 		vocab.WithID(activityID),
 	)
 
-	return c.Outbox.Post(create)
+	_, err = c.Outbox.Post(create)
+
+	return err
 }
 
 func newActivityID(serviceName string) (*url.URL, error) {

--- a/pkg/anchor/writer/writer_test.go
+++ b/pkg/anchor/writer/writer_test.go
@@ -55,7 +55,6 @@ func TestNew(t *testing.T) {
 		DidAnchors:    memdidanchorref.New(),
 		AnchorBuilder: &mockTxnBuilder{},
 		ProofHandler:  &mockProofHandler{vcCh: make(chan *verifiable.Credential, 100)},
-		Outbox:        &mockOutbox{},
 		Store:         vcStore,
 	}
 
@@ -576,12 +575,12 @@ type mockOutbox struct {
 	Err error
 }
 
-func (m *mockOutbox) Post(activity *vocab.ActivityType) error {
+func (m *mockOutbox) Post(activity *vocab.ActivityType) (*url.URL, error) {
 	if m.Err != nil {
-		return m.Err
+		return nil, m.Err
 	}
 
-	return nil
+	return activity.ID().URL(), nil
 }
 
 //nolint:gochecknoglobals,lll


### PR DESCRIPTION
The Outbox.Post signature has changed such that the ID of the activity is returned upon a successful post. When posting an activity to the Outbox then, if the 'id' field hasn't already been set, the Outbox sets the 'id' field of the activity to a unique ID. Also, if the 'actor' field is set then the Outbox validates that it is set to the service IRI otherwise an error is returned. If the 'actor' field is not set then it is set to the service IRI.

closes #182

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>