### PR TITLE
chore: Remove creating activity id/actor in handler

### DIFF
--- a/pkg/anchor/handler/credential.go
+++ b/pkg/anchor/handler/credential.go
@@ -32,14 +32,3 @@ func (h *AnchorCredentialHandler) HandleAnchorCredential(id *url.URL, cid string
 
 	return nil
 }
-
-/*
-func unmarshalAnchorCredentialReference(bytes []byte) (*vocab.AnchorCredentialReferenceType, error) {
-	r := &vocab.AnchorCredentialReferenceType{}
-
-	if err := json.Unmarshal(bytes, &r); err != nil {
-		return nil, err
-	}
-
-	return r, nil
-} */


### PR DESCRIPTION
There is no need to add activity id and actor - it is now generated by activity pub.

Closes #217

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>