### PR TITLE
feat: Sign ActivityPub HTTP requests

### DIFF
--- a/cmd/orb-server/go.sum
+++ b/cmd/orb-server/go.sum
@@ -310,6 +310,8 @@ github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxm
 github.com/go-chi/render v1.0.1 h1:4/5tis2cKaNdnv9zFLfXzcquC9HbeZgCnxGnKrltBS8=
 github.com/go-chi/render v1.0.1/go.mod h1:pq4Rr7HbnsdaeHagklXub+p6Wd16Af5l9koip1OvJns=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
+github.com/go-fed/httpsig v1.1.1-0.20201223112313-55836744818e h1:oRq/fiirun5HqlEWMLIcDmLpIELlG4iGbd0s8iqgPi8=
+github.com/go-fed/httpsig v1.1.1-0.20201223112313-55836744818e/go.mod h1:RCMrTZvN1bJYtofsG4rd5NaO5obxQ5xBkdiS7xsT7bM=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ module github.com/trustbloc/orb
 require (
 	github.com/ThreeDotsLabs/watermill v1.2.0-rc.4
 	github.com/ThreeDotsLabs/watermill-http v1.1.3
+	github.com/go-fed/httpsig v1.1.1-0.20201223112313-55836744818e
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/mux v1.8.0
 	github.com/hyperledger/aries-framework-go v0.1.7-0.20210310014234-cfa8c6d6e2f4

--- a/go.sum
+++ b/go.sum
@@ -303,6 +303,8 @@ github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxm
 github.com/go-chi/render v1.0.1 h1:4/5tis2cKaNdnv9zFLfXzcquC9HbeZgCnxGnKrltBS8=
 github.com/go-chi/render v1.0.1/go.mod h1:pq4Rr7HbnsdaeHagklXub+p6Wd16Af5l9koip1OvJns=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
+github.com/go-fed/httpsig v1.1.1-0.20201223112313-55836744818e h1:oRq/fiirun5HqlEWMLIcDmLpIELlG4iGbd0s8iqgPi8=
+github.com/go-fed/httpsig v1.1.1-0.20201223112313-55836744818e/go.mod h1:RCMrTZvN1bJYtofsG4rd5NaO5obxQ5xBkdiS7xsT7bM=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/pkg/activitypub/client/transport/transport_test.go
+++ b/pkg/activitypub/client/transport/transport_test.go
@@ -21,8 +21,10 @@ import (
 //go:generate counterfeiter -o ../mocks/httpclient.gen.go --fake-name HTTPClient . httpClient
 //go:generate counterfeiter -o ../mocks/httpsigner.gen.go --fake-name HTTPSigner . Signer
 
+const publicKeyID = "https://alice.example.com/services/orb#main-key"
+
 func TestNew(t *testing.T) {
-	tp := New(http.DefaultClient, nil, "", DefaultSigner(), DefaultSigner())
+	tp := New(http.DefaultClient, nil, testutil.MustParseURL(publicKeyID), DefaultSigner(), DefaultSigner())
 	require.NotNil(t, tp)
 }
 
@@ -41,7 +43,7 @@ func TestTransport_Post(t *testing.T) {
 	httpClient.DoReturns(resp, nil)
 
 	t.Run("Success", func(t *testing.T) {
-		tp := New(httpClient, nil, "", DefaultSigner(), DefaultSigner())
+		tp := New(httpClient, nil, testutil.MustParseURL(publicKeyID), DefaultSigner(), DefaultSigner())
 		require.NotNil(t, tp)
 
 		//nolint:bodyclose
@@ -57,7 +59,7 @@ func TestTransport_Post(t *testing.T) {
 		signer := &mocks.HTTPSigner{}
 		signer.SignRequestReturns(errExpected)
 
-		tp := New(httpClient, nil, "", signer, signer)
+		tp := New(httpClient, nil, testutil.MustParseURL(publicKeyID), signer, signer)
 		require.NotNil(t, tp)
 
 		//nolint:bodyclose
@@ -76,7 +78,7 @@ func TestTransport_Get(t *testing.T) {
 	httpClient.DoReturns(resp, nil)
 
 	t.Run("Success", func(t *testing.T) {
-		tp := New(httpClient, nil, "", DefaultSigner(), DefaultSigner())
+		tp := New(httpClient, nil, testutil.MustParseURL(publicKeyID), DefaultSigner(), DefaultSigner())
 		require.NotNil(t, tp)
 
 		//nolint:bodyclose
@@ -91,7 +93,7 @@ func TestTransport_Get(t *testing.T) {
 		signer := &mocks.HTTPSigner{}
 		signer.SignRequestReturns(errExpected)
 
-		tp := New(httpClient, nil, "", signer, signer)
+		tp := New(httpClient, nil, testutil.MustParseURL(publicKeyID), signer, signer)
 		require.NotNil(t, tp)
 
 		//nolint:bodyclose

--- a/pkg/activitypub/httpsig/signer.go
+++ b/pkg/activitypub/httpsig/signer.go
@@ -1,0 +1,91 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package httpsig
+
+import (
+	"crypto"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-fed/httpsig"
+	"github.com/trustbloc/edge-core/pkg/log"
+)
+
+var logger = log.New("activitypub_httpsig")
+
+const (
+	dateHeader        = "Date"
+	defaultExpiration = 60 * time.Second
+)
+
+// DefaultGetSignerConfig returns the default configuration for signing HTTP GET requests.
+func DefaultGetSignerConfig() SignerConfig {
+	return SignerConfig{
+		Algorithms: []httpsig.Algorithm{"ed25519", "rsa-sha256", "rsa-sha512"},
+		Headers:    []string{"(request-target)", "Date"},
+	}
+}
+
+// DefaultPostSignerConfig returns the default configuration for signing HTTP POST requests.
+func DefaultPostSignerConfig() SignerConfig {
+	return SignerConfig{
+		Algorithms:      []httpsig.Algorithm{"ed25519", "rsa-sha256", "rsa-sha512"},
+		DigestAlgorithm: "SHA-256",
+		Headers:         []string{"(request-target)", "Date", "Digest"},
+	}
+}
+
+// SignerConfig contains the confoguration for signing HTTP requests.
+type SignerConfig struct {
+	Algorithms      []httpsig.Algorithm
+	DigestAlgorithm httpsig.DigestAlgorithm
+	Headers         []string
+	Expiration      time.Duration
+}
+
+// Signer signs HTTP requests.
+type Signer struct {
+	SignerConfig
+}
+
+// NewSigner returns a new signer.
+func NewSigner(cfg SignerConfig) *Signer {
+	s := &Signer{
+		SignerConfig: cfg,
+	}
+
+	if s.Expiration == 0 {
+		s.Expiration = defaultExpiration
+	}
+
+	return s
+}
+
+// SignRequest signs an HTTP request.
+func (s *Signer) SignRequest(pKey crypto.PrivateKey, pubKeyID string, req *http.Request, body []byte) error {
+	logger.Debugf("Signing request for %s. Public key ID [%s]", req.RequestURI, pubKeyID)
+
+	signer, _, err := httpsig.NewSigner(s.Algorithms, s.DigestAlgorithm, s.Headers,
+		httpsig.Signature, int64(s.Expiration.Seconds()))
+	if err != nil {
+		return fmt.Errorf("new signer: %w", err)
+	}
+
+	req.Header.Add(dateHeader, date())
+
+	err = signer.SignRequest(pKey, pubKeyID, req, body)
+	if err != nil {
+		return fmt.Errorf("sign request: %w", err)
+	}
+
+	return nil
+}
+
+func date() string {
+	return fmt.Sprintf("%s GMT", time.Now().UTC().Format("Mon, 02 Jan 2006 15:04:05"))
+}

--- a/pkg/activitypub/httpsig/signer_test.go
+++ b/pkg/activitypub/httpsig/signer_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package httpsig
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSigner(t *testing.T) {
+	t.Run("GET", func(t *testing.T) {
+		s := NewSigner(DefaultGetSignerConfig())
+
+		_, privKey, err := ed25519.GenerateKey(rand.Reader)
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodPost, "https://domain1.com", nil)
+		require.NoError(t, err)
+
+		require.NoError(t, s.SignRequest(privKey, "pubKeyID", req, nil))
+
+		require.NotEmpty(t, req.Header[dateHeader])
+		require.NotEmpty(t, req.Header["Signature"])
+	})
+
+	t.Run("POST", func(t *testing.T) {
+		s := NewSigner(DefaultPostSignerConfig())
+
+		_, privKey, err := ed25519.GenerateKey(rand.Reader)
+		require.NoError(t, err)
+
+		payload := []byte("payload")
+
+		req, err := http.NewRequest(http.MethodPost, "https://domain1.com", bytes.NewBuffer(payload))
+		require.NoError(t, err)
+
+		require.NoError(t, s.SignRequest(privKey, "pubKeyID", req, payload))
+
+		require.NotEmpty(t, req.Header[dateHeader])
+		require.NotEmpty(t, req.Header["Digest"])
+		require.NotEmpty(t, req.Header["Signature"])
+	})
+
+	t.Run("Signer error", func(t *testing.T) {
+		s := NewSigner(SignerConfig{})
+
+		_, privKey, err := ed25519.GenerateKey(rand.Reader)
+		require.NoError(t, err)
+
+		payload := []byte("payload")
+
+		req, err := http.NewRequest(http.MethodPost, "https://domain1.com", bytes.NewBuffer(payload))
+		require.NoError(t, err)
+
+		err = s.SignRequest(privKey, "pubKeyID", req, payload)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unknown or unsupported Digest algorithm")
+	})
+}

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -306,6 +306,7 @@ github.com/go-asn1-ber/asn1-ber v1.3.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkPro
 github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-chi/render v1.0.1/go.mod h1:pq4Rr7HbnsdaeHagklXub+p6Wd16Af5l9koip1OvJns=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
+github.com/go-fed/httpsig v1.1.1-0.20201223112313-55836744818e/go.mod h1:RCMrTZvN1bJYtofsG4rd5NaO5obxQ5xBkdiS7xsT7bM=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=


### PR DESCRIPTION
Added a 'go-fed' implementation of HTTP signatures. All ActivityPub requests (GET and POST) are now signed. A future commit will validate the signatures.

closes #175

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>