### PR TITLE
feat: Added REST endpoint to retrieve a public key

### DIFF
--- a/pkg/activitypub/resthandler/resthandler.go
+++ b/pkg/activitypub/resthandler/resthandler.go
@@ -23,6 +23,8 @@ import (
 var logger = log.New("activitypub_resthandler")
 
 const (
+	// PublicKeysPath specifies the service's "keys" endpoint.
+	PublicKeysPath = "/keys/{id}"
 	// FollowersPath specifies the service's 'followers' endpoint.
 	FollowersPath = "/followers"
 	// FollowingPath specifies the service's 'following' endpoint.

--- a/pkg/activitypub/vocab/actortype.go
+++ b/pkg/activitypub/vocab/actortype.go
@@ -12,9 +12,20 @@ import (
 
 // PublicKeyType defines a public key object.
 type PublicKeyType struct {
-	ID           string `json:"id"`
-	Owner        string `json:"owner"`
-	PublicKeyPem string `json:"publicKeyPem"`
+	ID           *URLProperty `json:"id"`
+	Owner        *URLProperty `json:"owner"`
+	PublicKeyPem string       `json:"publicKeyPem"`
+}
+
+// NewPublicKey returns a new public key object.
+func NewPublicKey(opts ...Opt) *PublicKeyType {
+	options := NewOptions(opts...)
+
+	return &PublicKeyType{
+		ID:           NewURLProperty(options.ID),
+		Owner:        NewURLProperty(options.Owner),
+		PublicKeyPem: options.PublicKeyPem,
+	}
 }
 
 // ActorType defines an 'actor'.

--- a/pkg/activitypub/vocab/options.go
+++ b/pkg/activitypub/vocab/options.go
@@ -26,6 +26,7 @@ type Options struct {
 	CollectionOptions
 	ActivityOptions
 	ActorOptions
+	PublicKeyOptions
 }
 
 // Opt is an for an object, activity, etc.
@@ -303,6 +304,26 @@ func WithWitnessing(witnessing *url.URL) Opt {
 func WithLiked(liked *url.URL) Opt {
 	return func(opts *Options) {
 		opts.Liked = liked
+	}
+}
+
+// PublicKeyOptions holds the options for a Public Key.
+type PublicKeyOptions struct {
+	Owner        *url.URL
+	PublicKeyPem string
+}
+
+// WithOwner sets the 'owner' property on the public key.
+func WithOwner(owner *url.URL) Opt {
+	return func(opts *Options) {
+		opts.Owner = owner
+	}
+}
+
+// WithPublicKeyPem sets the 'publicKeyPem' property on the public key.
+func WithPublicKeyPem(pem string) Opt {
+	return func(opts *Options) {
+		opts.PublicKeyPem = pem
 	}
 }
 

--- a/pkg/activitypub/vocab/options_test.go
+++ b/pkg/activitypub/vocab/options_test.go
@@ -46,11 +46,11 @@ func TestNewOptions(t *testing.T) {
 	witnessing := testutil.MustParseURL("https://witnessing")
 	liked := testutil.MustParseURL("https://liked")
 
-	publicKey := &PublicKeyType{
-		ID:           "key_id",
-		Owner:        "owner_id",
-		PublicKeyPem: "pem",
-	}
+	publicKey := NewPublicKey(
+		WithID(testutil.MustParseURL("https://actor/keys/main-key")),
+		WithOwner(testutil.MustParseURL("https://actor")),
+		WithPublicKeyPem("pem"),
+	)
 
 	target := &ObjectProperty{
 		iri: NewURLProperty(testutil.MustParseURL("https://property_iri")),

--- a/pkg/internal/aptestutil/aptestutil.go
+++ b/pkg/internal/aptestutil/aptestutil.go
@@ -16,11 +16,7 @@ import (
 
 // NewMockService returns a mock 'Service' type actor with the given IRI.
 func NewMockService(serviceIRI *url.URL) *vocab.ActorType {
-	const (
-		keyID      = "https://example1.com/services/orb#main-key"
-		keyOwnerID = "https://example1.com/services/orb"
-		keyPem     = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhki....."
-	)
+	const keyPem = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhki....."
 
 	followers := testutil.NewMockID(serviceIRI, "/followers")
 	following := testutil.NewMockID(serviceIRI, "/following")
@@ -30,11 +26,11 @@ func NewMockService(serviceIRI *url.URL) *vocab.ActorType {
 	witnessing := testutil.NewMockID(serviceIRI, "/witnessing")
 	liked := testutil.NewMockID(serviceIRI, "/liked")
 
-	publicKey := &vocab.PublicKeyType{
-		ID:           keyID,
-		Owner:        keyOwnerID,
-		PublicKeyPem: keyPem,
-	}
+	publicKey := vocab.NewPublicKey(
+		vocab.WithID(testutil.NewMockID(serviceIRI, "/keys/main-key")),
+		vocab.WithOwner(serviceIRI),
+		vocab.WithPublicKeyPem(keyPem),
+	)
 
 	return vocab.NewService(serviceIRI,
 		vocab.WithPublicKey(publicKey),

--- a/test/bdd/features/activitypub.feature
+++ b/test/bdd/features/activitypub.feature
@@ -22,6 +22,7 @@ Feature:
     And the JSON path "liked" of the response equals "${domain1IRI}/liked"
     And the JSON path "witnesses" of the response equals "${domain1IRI}/witnesses"
     And the JSON path "witnessing" of the response equals "${domain1IRI}/witnessing"
+    And the JSON path "publicKey.id" of the response equals "${domain1IRI}/keys/main-key"
 
     When an HTTP GET is sent to "https://localhost:48426/services/orb"
     Then the JSON path "type" of the response equals "Service"
@@ -32,6 +33,19 @@ Feature:
     And the JSON path "liked" of the response equals "${domain2IRI}/liked"
     And the JSON path "witnesses" of the response equals "${domain2IRI}/witnesses"
     And the JSON path "witnessing" of the response equals "${domain2IRI}/witnessing"
+    And the JSON path "publicKey.id" of the response equals "${domain2IRI}/keys/main-key"
+
+  @activitypub_pubkey
+  Scenario: Get service public key
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/keys/main-key"
+    Then the JSON path "id" of the response equals "https://orb.domain1.com/services/orb/keys/main-key"
+    Then the JSON path "owner" of the response equals "https://orb.domain1.com/services/orb"
+    Then the JSON path "publicKeyPem" of the response is not empty
+
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/keys/main-key"
+    Then the JSON path "id" of the response equals "https://orb.domain2.com/services/orb/keys/main-key"
+    Then the JSON path "owner" of the response equals "https://orb.domain2.com/services/orb"
+    Then the JSON path "publicKeyPem" of the response is not empty
 
   @activitypub_follow
   Scenario: follow/accept/undo


### PR DESCRIPTION
Added a REST endpoint to return an actor's public key.

Also refactored the PublicKey type to use an IRI instead of string for the 'id' and 'owner' fields.

closes #223

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>