### PR TITLE
feat: HTTP signature verifier

### DIFF
--- a/pkg/activitypub/client/client.go
+++ b/pkg/activitypub/client/client.go
@@ -68,6 +68,26 @@ func (c *Client) GetActor(actorIRI *url.URL) (*vocab.ActorType, error) {
 	return actor, nil
 }
 
+// GetPublicKey retrieves the public key at the given IRI.
+//nolint:interfacer
+func (c *Client) GetPublicKey(keyIRI *url.URL) (*vocab.PublicKeyType, error) {
+	respBytes, err := c.get(keyIRI)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response from %s: %w", keyIRI, err)
+	}
+
+	logger.Debugf("Got response from %s: %s", keyIRI, respBytes)
+
+	pubKey := &vocab.PublicKeyType{}
+
+	err = json.Unmarshal(respBytes, pubKey)
+	if err != nil {
+		return nil, fmt.Errorf("invalid public key in response from %s: %w", keyIRI, err)
+	}
+
+	return pubKey, nil
+}
+
 // GetReferences returns an iterator that reads all references at the given IRI. The IRI either resolves
 // to an ActivityPub actor, collection or ordered collection.
 func (c *Client) GetReferences(iri *url.URL) (ReferenceIterator, error) {

--- a/pkg/activitypub/client/transport/transport.go
+++ b/pkg/activitypub/client/transport/transport.go
@@ -14,7 +14,11 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+
+	"github.com/trustbloc/edge-core/pkg/log"
 )
+
+var logger = log.New("activitypub_client")
 
 // Signer signs an HTTP request and adds the signature to the header of the request.
 type Signer interface {
@@ -90,6 +94,8 @@ func (t *Transport) Post(ctx context.Context, r *Request, payload []byte) (*http
 		return nil, fmt.Errorf("sign request: %w", err)
 	}
 
+	logger.Debugf("Signed HTTP POST to %s. Headers: %s", r.URL, req.Header)
+
 	return t.client.Do(req)
 }
 
@@ -101,6 +107,8 @@ func (t *Transport) Get(ctx context.Context, r *Request) (*http.Response, error)
 	}
 
 	req.Header = r.Header
+
+	logger.Debugf("Signed HTTP GET to %s. Headers: %s", r.URL, req.Header)
 
 	err = t.getSigner.SignRequest(t.privateKey, t.publicKeyID.String(), req, nil)
 	if err != nil {

--- a/pkg/activitypub/client/transport/transport_test.go
+++ b/pkg/activitypub/client/transport/transport_test.go
@@ -21,7 +21,7 @@ import (
 //go:generate counterfeiter -o ../mocks/httpclient.gen.go --fake-name HTTPClient . httpClient
 //go:generate counterfeiter -o ../mocks/httpsigner.gen.go --fake-name HTTPSigner . Signer
 
-const publicKeyID = "https://alice.example.com/services/orb#main-key"
+const publicKeyID = "https://alice.example.com/services/orb/keys/main-key"
 
 func TestNew(t *testing.T) {
 	tp := New(http.DefaultClient, nil, testutil.MustParseURL(publicKeyID), DefaultSigner(), DefaultSigner())

--- a/pkg/activitypub/httpsig/signer_test.go
+++ b/pkg/activitypub/httpsig/signer_test.go
@@ -23,7 +23,7 @@ func TestSigner(t *testing.T) {
 		_, privKey, err := ed25519.GenerateKey(rand.Reader)
 		require.NoError(t, err)
 
-		req, err := http.NewRequest(http.MethodPost, "https://domain1.com", nil)
+		req, err := http.NewRequest(http.MethodGet, "https://domain1.com", nil)
 		require.NoError(t, err)
 
 		require.NoError(t, s.SignRequest(privKey, "pubKeyID", req, nil))

--- a/pkg/activitypub/httpsig/verifier.go
+++ b/pkg/activitypub/httpsig/verifier.go
@@ -1,0 +1,119 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package httpsig
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/go-fed/httpsig"
+
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+)
+
+// DefaultVerifierConfig returns the default configuration for verifying HTTP requests.
+func DefaultVerifierConfig() VerifierConfig {
+	return VerifierConfig{
+		Algorithms: []httpsig.Algorithm{httpsig.ED25519},
+	}
+}
+
+// VerifierConfig contains the configuration for verifying HTTP requests.
+type VerifierConfig struct {
+	Algorithms []httpsig.Algorithm
+}
+
+type actorRetriever interface {
+	GetActor(actorIRI *url.URL) (*vocab.ActorType, error)
+	GetPublicKey(keyIRI *url.URL) (*vocab.PublicKeyType, error)
+}
+
+// Verifier verifies signatures of HTTP requests.
+type Verifier struct {
+	VerifierConfig
+	retriever actorRetriever
+}
+
+// NewVerifier returns a new HTTP signature verifier.
+func NewVerifier(cfg VerifierConfig, retriever actorRetriever) *Verifier {
+	return &Verifier{
+		VerifierConfig: cfg,
+		retriever:      retriever,
+	}
+}
+
+// VerifyRequest verifies the HTTP signature on the request and returns the IRI of the actor
+// for the key ID in the request header. The actor IRI may then be used to verify that it
+// matches the actor in a posted activity.
+func (v *Verifier) VerifyRequest(req *http.Request) (*url.URL, error) {
+	logger.Debugf("Verifying HTTP %s request from %s with headers %s", req.Method, req.URL, req.Header)
+
+	verifier, err := httpsig.NewVerifier(req)
+	if err != nil {
+		return nil, fmt.Errorf("new verifier: %w", err)
+	}
+
+	pubKey, err := v.loadAndVerifyPublicKey(verifier.KeyId())
+	if err != nil {
+		return nil, fmt.Errorf("unable to verify public key for ID [%s]: %w", verifier.KeyId(), err)
+	}
+
+	block, rest := pem.Decode([]byte(pubKey.PublicKeyPem))
+	if block == nil {
+		logger.Warnf("invalid public key: nil block. Rest: %s", rest)
+
+		return nil, fmt.Errorf("invalid public key for ID [%s]: nil block", verifier.KeyId())
+	}
+
+	pk, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse public key for ID [%s]: %w", verifier.KeyId(), err)
+	}
+
+	// TODO: Resolve the algorithm from the keyId according to
+	// https://tools.ietf.org/html/draft-cavage-http-signatures-12#section-2.5.
+	// Use the first algorithm for now.
+	algo := v.Algorithms[0]
+
+	logger.Debugf("Verifying HTTP signature with public key [%s]", verifier.KeyId())
+
+	return pubKey.Owner.URL(), verifier.Verify(pk, algo)
+}
+
+func (v *Verifier) loadAndVerifyPublicKey(keyID string) (*vocab.PublicKeyType, error) {
+	keyIRI, err := url.Parse(keyID)
+	if err != nil {
+		return nil, fmt.Errorf("parse key IRI [%s]: %w", keyID, err)
+	}
+
+	pubKey, err := v.retriever.GetPublicKey(keyIRI)
+	if err != nil {
+		return nil, fmt.Errorf("retrieve public key for ID [%s]: %w", keyID, err)
+	}
+
+	// Ensure that the public key ID matches the key ID of the specified owner. Otherwise it could
+	// be an attempt to impersonate an actor.
+	actor, err := v.retriever.GetActor(pubKey.Owner.URL())
+	if err != nil {
+		return nil, fmt.Errorf("retrieve actor [%s]: %w", pubKey.Owner, err)
+	}
+
+	if actor.PublicKey() == nil {
+		return nil, fmt.Errorf("unable to verify owner [%s] of public key [%s] since owner has nil key",
+			actor.ID(), keyID)
+	}
+
+	if actor.PublicKey().ID.String() != pubKey.ID.String() {
+		return nil, fmt.Errorf("public key of actor does not match the public key ID in the request: [%s]",
+			actor.PublicKey().ID)
+	}
+
+	return pubKey, nil
+}

--- a/pkg/activitypub/httpsig/verifier_test.go
+++ b/pkg/activitypub/httpsig/verifier_test.go
@@ -1,0 +1,198 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package httpsig
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/pkg/activitypub/service/mocks"
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+	"github.com/trustbloc/orb/pkg/internal/aptestutil"
+	"github.com/trustbloc/orb/pkg/internal/testutil"
+)
+
+func TestVerifier_VerifyRequest(t *testing.T) {
+	actorIRI := testutil.MustParseURL("https://example.com/services/orb")
+	pubKeyIRI := testutil.NewMockID(actorIRI, "/keys/main-key")
+
+	signer := NewSigner(DefaultPostSignerConfig())
+	require.NotNil(t, signer)
+
+	payload := []byte("payload")
+
+	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	pubKeyPem, err := getPublicKeyPem(pubKey)
+	require.NoError(t, err)
+
+	publicKey := vocab.NewPublicKey(
+		vocab.WithID(pubKeyIRI),
+		vocab.WithOwner(actorIRI),
+		vocab.WithPublicKeyPem(string(pubKeyPem)),
+	)
+
+	retriever := mocks.NewActorRetriever().
+		WithPublicKey(publicKey).
+		WithActor(aptestutil.NewMockService(actorIRI, aptestutil.WithPublicKey(publicKey)))
+
+	t.Run("Success", func(t *testing.T) {
+		v := NewVerifier(DefaultVerifierConfig(), retriever)
+		require.NotNil(t, v)
+
+		req, err := http.NewRequest(http.MethodPost, "https://domain1.com", bytes.NewBuffer(payload))
+		require.NoError(t, err)
+
+		require.NoError(t, signer.SignRequest(privKey, publicKey.ID.String(), req, payload))
+
+		actorID, err := v.VerifyRequest(req)
+		require.NoError(t, err)
+		require.NotNil(t, actorID)
+		require.Equal(t, actorIRI.String(), actorID.String())
+	})
+
+	t.Run("Invalid key ID", func(t *testing.T) {
+		v := NewVerifier(DefaultVerifierConfig(), retriever)
+		require.NotNil(t, v)
+
+		req, err := http.NewRequest(http.MethodPost, "https://domain1.com", bytes.NewBuffer(payload))
+		require.NoError(t, err)
+
+		require.NoError(t, signer.SignRequest(privKey, "invalid key \nID", req, payload))
+
+		actorID, err := v.VerifyRequest(req)
+		require.Error(t, err)
+		require.Nil(t, actorID)
+		require.Contains(t, err.Error(), "invalid control character in URL")
+	})
+
+	t.Run("Invalid public key pem", func(t *testing.T) {
+		invalidPubKey := vocab.NewPublicKey(
+			vocab.WithID(pubKeyIRI),
+			vocab.WithOwner(actorIRI),
+			vocab.WithPublicKeyPem("invalid"),
+		)
+
+		v := NewVerifier(
+			DefaultVerifierConfig(),
+			mocks.NewActorRetriever().
+				WithPublicKey(invalidPubKey).
+				WithActor(aptestutil.NewMockService(actorIRI, aptestutil.WithPublicKey(invalidPubKey))),
+		)
+		require.NotNil(t, v)
+
+		req, err := http.NewRequest(http.MethodPost, "https://domain1.com", bytes.NewBuffer(payload))
+		require.NoError(t, err)
+
+		require.NoError(t, signer.SignRequest(privKey, invalidPubKey.ID.String(), req, payload))
+
+		actorID, err := v.VerifyRequest(req)
+		require.Error(t, err)
+		require.Nil(t, actorID)
+		require.Contains(t, err.Error(), "invalid public key for ID")
+	})
+
+	t.Run("Public key not found -> error", func(t *testing.T) {
+		v := NewVerifier(DefaultVerifierConfig(), retriever)
+		require.NotNil(t, v)
+
+		req, err := http.NewRequest(http.MethodPost, "https://domain1.com", bytes.NewBuffer(payload))
+		require.NoError(t, err)
+
+		require.NoError(t, signer.SignRequest(privKey, "https://domainx/key1", req, payload))
+
+		actorID, err := v.VerifyRequest(req)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not found")
+		require.Nil(t, actorID)
+	})
+
+	t.Run("Actor not found -> error", func(t *testing.T) {
+		v := NewVerifier(
+			DefaultVerifierConfig(),
+			mocks.NewActorRetriever().WithPublicKey(publicKey),
+		)
+		require.NotNil(t, v)
+
+		req, err := http.NewRequest(http.MethodPost, "https://domain1.com", bytes.NewBuffer(payload))
+		require.NoError(t, err)
+
+		require.NoError(t, signer.SignRequest(privKey, publicKey.ID.String(), req, payload))
+
+		actorID, err := v.VerifyRequest(req)
+		require.Error(t, err)
+		require.Nil(t, actorID)
+		require.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("Actor nil public key -> error", func(t *testing.T) {
+		v := NewVerifier(
+			DefaultVerifierConfig(),
+			mocks.NewActorRetriever().
+				WithPublicKey(publicKey).
+				WithActor(aptestutil.NewMockService(actorIRI, aptestutil.WithPublicKey(nil))),
+		)
+		require.NotNil(t, v)
+
+		req, err := http.NewRequest(http.MethodPost, "https://domain1.com", bytes.NewBuffer(payload))
+		require.NoError(t, err)
+
+		require.NoError(t, signer.SignRequest(privKey, publicKey.ID.String(), req, payload))
+
+		actorID, err := v.VerifyRequest(req)
+		require.Error(t, err)
+		require.Nil(t, actorID)
+		require.Contains(t, err.Error(), "owner has nil key")
+	})
+
+	t.Run("Actor key mismatch -> error", func(t *testing.T) {
+		actorPublicKey := vocab.NewPublicKey(
+			vocab.WithID(testutil.NewMockID(actorIRI, "/keys/key-1")),
+			vocab.WithOwner(actorIRI),
+			vocab.WithPublicKeyPem(string(pubKeyPem)),
+		)
+
+		v := NewVerifier(
+			DefaultVerifierConfig(),
+			mocks.NewActorRetriever().
+				WithPublicKey(publicKey).
+				WithActor(aptestutil.NewMockService(actorIRI, aptestutil.WithPublicKey(actorPublicKey))),
+		)
+		require.NotNil(t, v)
+
+		req, err := http.NewRequest(http.MethodPost, "https://domain1.com", bytes.NewBuffer(payload))
+		require.NoError(t, err)
+
+		require.NoError(t, signer.SignRequest(privKey, publicKey.ID.String(), req, payload))
+
+		actorID, err := v.VerifyRequest(req)
+		require.Error(t, err)
+		require.Nil(t, actorID)
+		require.Contains(t, err.Error(), "public key of actor does not match the public key ID in the request")
+	})
+}
+
+func getPublicKeyPem(pubKey interface{}) ([]byte, error) {
+	keyBytes, err := x509.MarshalPKIXPublicKey(pubKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return pem.EncodeToMemory(&pem.Block{
+		Type:    "PUBLIC KEY",
+		Headers: nil,
+		Bytes:   keyBytes,
+	}), nil
+}

--- a/pkg/activitypub/service/mocks/mockactorretriever.go
+++ b/pkg/activitypub/service/mocks/mockactorretriever.go
@@ -1,0 +1,66 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+)
+
+// ActorRetriever is a mock retriever for actors and public keys of actors.
+type ActorRetriever struct {
+	actors map[string]*vocab.ActorType
+	keys   map[string]*vocab.PublicKeyType
+}
+
+// NewActorRetriever returns a mock actor retriever.
+func NewActorRetriever() *ActorRetriever {
+	return &ActorRetriever{
+		actors: make(map[string]*vocab.ActorType),
+		keys:   make(map[string]*vocab.PublicKeyType),
+	}
+}
+
+// WithPublicKey adds the given public key to the map of keys which is used
+// by GetPublicKey.
+func (m *ActorRetriever) WithPublicKey(key *vocab.PublicKeyType) *ActorRetriever {
+	m.keys[key.ID.String()] = key
+
+	return m
+}
+
+// WithActor adds the given actor to the map of actors which is used
+// by GetActor.
+func (m *ActorRetriever) WithActor(actor *vocab.ActorType) *ActorRetriever {
+	m.actors[actor.ID().String()] = actor
+
+	return m
+}
+
+// GetPublicKey returns the public key for the given IRI.
+//nolint:interfacer
+func (m *ActorRetriever) GetPublicKey(keyIRI *url.URL) (*vocab.PublicKeyType, error) {
+	key, ok := m.keys[keyIRI.String()]
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+
+	return key, nil
+}
+
+// GetActor returns the actor for the given IRI.
+//nolint:interfacer
+func (m *ActorRetriever) GetActor(actorIRI *url.URL) (*vocab.ActorType, error) {
+	actor, ok := m.actors[actorIRI.String()]
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+
+	return actor, nil
+}


### PR DESCRIPTION
Implemented an HTTP signature verifier to verify the signature in the HTTP request header. The following steps are performed:

- The public key is retrieved using the key ID in the header (which must be an IRI).
- The owner of the public key is retrieved and the key ID of the owner (actor) must match the key ID in the request header, otherwise the request is rejected.
- The signature in the header is verified using the public key.

closes #238

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>