### PR TITLE
feat: Verify HTTP signatures in REST endpoints

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -426,15 +426,15 @@ func startOrbServices(parameters *orbParameters) error {
 		activityPubService.InboxHTTPHandler(),
 		aphandler.NewServices(apServiceCfg, apStore, publicKey),
 		aphandler.NewPublicKeys(apServiceCfg, apStore, publicKey),
-		aphandler.NewFollowers(apServiceCfg, apStore),
-		aphandler.NewFollowing(apServiceCfg, apStore),
-		aphandler.NewOutbox(apServiceCfg, apStore),
-		aphandler.NewInbox(apServiceCfg, apStore),
-		aphandler.NewWitnesses(apServiceCfg, apStore),
-		aphandler.NewWitnessing(apServiceCfg, apStore),
-		aphandler.NewLiked(apServiceCfg, apStore),
-		aphandler.NewLikes(apTxnCfg, apStore),
-		aphandler.NewShares(apTxnCfg, apStore))
+		aphandler.NewFollowers(apServiceCfg, apStore, sigVerifier),
+		aphandler.NewFollowing(apServiceCfg, apStore, sigVerifier),
+		aphandler.NewOutbox(apServiceCfg, apStore, sigVerifier),
+		aphandler.NewInbox(apServiceCfg, apStore, sigVerifier),
+		aphandler.NewWitnesses(apServiceCfg, apStore, sigVerifier),
+		aphandler.NewWitnessing(apServiceCfg, apStore, sigVerifier),
+		aphandler.NewLiked(apServiceCfg, apStore, sigVerifier),
+		aphandler.NewLikes(apTxnCfg, apStore, sigVerifier),
+		aphandler.NewShares(apTxnCfg, apStore, sigVerifier))
 
 	handlers = append(handlers,
 		endpointDiscoveryOp.GetRESTHandlers()...)

--- a/pkg/activitypub/resthandler/activityhandler_test.go
+++ b/pkg/activitypub/resthandler/activityhandler_test.go
@@ -40,7 +40,7 @@ func TestNewOutbox(t *testing.T) {
 		PageSize:  4,
 	}
 
-	h := NewOutbox(cfg, memstore.New(""))
+	h := NewOutbox(cfg, memstore.New(""), &mocks.SignatureVerifier{})
 	require.NotNil(t, h)
 	require.Equal(t, "/services/orb/outbox", h.Path())
 	require.Equal(t, http.MethodGet, h.Method())
@@ -64,7 +64,7 @@ func TestNewInbox(t *testing.T) {
 		PageSize:  4,
 	}
 
-	h := NewInbox(cfg, memstore.New(""))
+	h := NewInbox(cfg, memstore.New(""), &mocks.SignatureVerifier{})
 	require.NotNil(t, h)
 	require.Equal(t, "/services/orb/inbox", h.Path())
 	require.Equal(t, http.MethodGet, h.Method())
@@ -87,7 +87,7 @@ func TestNewShares(t *testing.T) {
 		ObjectIRI: transactionsIRI,
 	}
 
-	h := NewShares(cfg, memstore.New(""))
+	h := NewShares(cfg, memstore.New(""), &mocks.SignatureVerifier{})
 	require.NotNil(t, h)
 	require.Equal(t, "/transactions/{id}/shares", h.Path())
 	require.Equal(t, http.MethodGet, h.Method())
@@ -124,7 +124,7 @@ func TestNewLikes(t *testing.T) {
 		ObjectIRI: transactionsIRI,
 	}
 
-	h := NewLikes(cfg, memstore.New(""))
+	h := NewLikes(cfg, memstore.New(""), &mocks.SignatureVerifier{})
 	require.NotNil(t, h)
 	require.Equal(t, "/transactions/{id}/likes", h.Path())
 	require.Equal(t, http.MethodGet, h.Method())
@@ -170,7 +170,7 @@ func TestActivities_Handler(t *testing.T) {
 	}
 
 	t.Run("Success", func(t *testing.T) {
-		h := NewOutbox(cfg, activityStore)
+		h := NewOutbox(cfg, activityStore, &mocks.SignatureVerifier{})
 		require.NotNil(t, h)
 
 		rw := httptest.NewRecorder()
@@ -196,7 +196,7 @@ func TestActivities_Handler(t *testing.T) {
 		s := &mocks.ActivityStore{}
 		s.QueryReferencesReturns(nil, errExpected)
 
-		h := NewOutbox(cfg, s)
+		h := NewOutbox(cfg, s, &mocks.SignatureVerifier{})
 		require.NotNil(t, h)
 
 		rw := httptest.NewRecorder()
@@ -210,7 +210,7 @@ func TestActivities_Handler(t *testing.T) {
 	})
 
 	t.Run("Marshal error", func(t *testing.T) {
-		h := NewOutbox(cfg, activityStore)
+		h := NewOutbox(cfg, activityStore, &mocks.SignatureVerifier{})
 		require.NotNil(t, h)
 
 		errExpected := fmt.Errorf("injected marshal error")
@@ -230,7 +230,7 @@ func TestActivities_Handler(t *testing.T) {
 	})
 
 	t.Run("GetObjectIRI error", func(t *testing.T) {
-		h := NewOutbox(cfg, activityStore)
+		h := NewOutbox(cfg, activityStore, &mocks.SignatureVerifier{})
 		require.NotNil(t, h)
 
 		errExpected := fmt.Errorf("injected error")
@@ -250,7 +250,7 @@ func TestActivities_Handler(t *testing.T) {
 	})
 
 	t.Run("GetID error", func(t *testing.T) {
-		h := NewOutbox(cfg, activityStore)
+		h := NewOutbox(cfg, activityStore, &mocks.SignatureVerifier{})
 		require.NotNil(t, h)
 
 		errExpected := fmt.Errorf("injected error")
@@ -313,7 +313,7 @@ func TestActivities_PageHandler(t *testing.T) {
 			PageSize:  4,
 		}
 
-		h := NewOutbox(cfg, s)
+		h := NewOutbox(cfg, s, &mocks.SignatureVerifier{})
 		require.NotNil(t, h)
 
 		restorePaging := setPaging(h.handler, "true", "0")
@@ -335,7 +335,7 @@ func TestActivities_PageHandler(t *testing.T) {
 			PageSize:  4,
 		}
 
-		h := NewOutbox(cfg, activityStore)
+		h := NewOutbox(cfg, activityStore, &mocks.SignatureVerifier{})
 		require.NotNil(t, h)
 
 		restorePaging := setPaging(h.handler, "true", "0")
@@ -379,7 +379,7 @@ func TestShares_Handler(t *testing.T) {
 	}
 
 	t.Run("Success", func(t *testing.T) {
-		h := NewShares(cfg, activityStore)
+		h := NewShares(cfg, activityStore, &mocks.SignatureVerifier{})
 		require.NotNil(t, h)
 
 		restore := setIDParam(objectID)
@@ -426,7 +426,7 @@ func TestShares_PageHandler(t *testing.T) {
 	}
 
 	t.Run("First page -> Success", func(t *testing.T) {
-		h := NewShares(cfg, activityStore)
+		h := NewShares(cfg, activityStore, &mocks.SignatureVerifier{})
 		require.NotNil(t, h)
 
 		restorePaging := setPaging(h.handler, "true", "")
@@ -453,7 +453,7 @@ func TestShares_PageHandler(t *testing.T) {
 	})
 
 	t.Run("By page -> Success", func(t *testing.T) {
-		h := NewShares(cfg, activityStore)
+		h := NewShares(cfg, activityStore, &mocks.SignatureVerifier{})
 		require.NotNil(t, h)
 
 		restorePaging := setPaging(h.handler, "true", "1")
@@ -498,7 +498,7 @@ func TestLiked_Handler(t *testing.T) {
 		PageSize:  2,
 	}
 
-	h := NewLiked(cfg, activityStore)
+	h := NewLiked(cfg, activityStore, &mocks.SignatureVerifier{})
 	require.NotNil(t, h)
 
 	t.Run("Main page -> Success", func(t *testing.T) {
@@ -516,7 +516,7 @@ func handleActivitiesRequest(t *testing.T, serviceIRI *url.URL, as spi.Store, pa
 		PageSize:  4,
 	}
 
-	h := NewOutbox(cfg, as)
+	h := NewOutbox(cfg, as, &mocks.SignatureVerifier{})
 	require.NotNil(t, h)
 
 	restorePaging := setPaging(h.handler, page, pageNum)

--- a/pkg/activitypub/resthandler/referencehandler_test.go
+++ b/pkg/activitypub/resthandler/referencehandler_test.go
@@ -31,7 +31,7 @@ func TestNewFollowers(t *testing.T) {
 		PageSize:  4,
 	}
 
-	h := NewFollowers(cfg, memstore.New(""))
+	h := NewFollowers(cfg, memstore.New(""), &mocks.SignatureVerifier{})
 	require.NotNil(t, h)
 	require.Equal(t, "/services/orb/followers", h.Path())
 	require.Equal(t, http.MethodGet, h.Method())
@@ -55,7 +55,7 @@ func TestNewFollowing(t *testing.T) {
 		PageSize:  4,
 	}
 
-	h := NewFollowing(cfg, memstore.New(""))
+	h := NewFollowing(cfg, memstore.New(""), &mocks.SignatureVerifier{})
 	require.NotNil(t, h)
 	require.Equal(t, "/services/orb/following", h.Path())
 	require.Equal(t, http.MethodGet, h.Method())
@@ -79,7 +79,7 @@ func TestNewWitnesses(t *testing.T) {
 		PageSize:  4,
 	}
 
-	h := NewWitnesses(cfg, memstore.New(""))
+	h := NewWitnesses(cfg, memstore.New(""), &mocks.SignatureVerifier{})
 	require.NotNil(t, h)
 	require.Equal(t, "/services/orb/witnesses", h.Path())
 	require.Equal(t, http.MethodGet, h.Method())
@@ -103,7 +103,7 @@ func TestNewWitnessing(t *testing.T) {
 		PageSize:  4,
 	}
 
-	h := NewWitnessing(cfg, memstore.New(""))
+	h := NewWitnessing(cfg, memstore.New(""), &mocks.SignatureVerifier{})
 	require.NotNil(t, h)
 	require.Equal(t, "/services/orb/witnessing", h.Path())
 	require.Equal(t, http.MethodGet, h.Method())
@@ -138,7 +138,7 @@ func TestFollowers_Handler(t *testing.T) {
 	}
 
 	t.Run("Success", func(t *testing.T) {
-		h := NewFollowers(cfg, activityStore)
+		h := NewFollowers(cfg, activityStore, &mocks.SignatureVerifier{})
 		require.NotNil(t, h)
 
 		rw := httptest.NewRecorder()
@@ -164,7 +164,7 @@ func TestFollowers_Handler(t *testing.T) {
 		s := &mocks.ActivityStore{}
 		s.QueryReferencesReturns(nil, errExpected)
 
-		h := NewFollowers(cfg, s)
+		h := NewFollowers(cfg, s, &mocks.SignatureVerifier{})
 		require.NotNil(t, h)
 
 		rw := httptest.NewRecorder()
@@ -178,7 +178,7 @@ func TestFollowers_Handler(t *testing.T) {
 	})
 
 	t.Run("Marshal error", func(t *testing.T) {
-		h := NewFollowers(cfg, activityStore)
+		h := NewFollowers(cfg, activityStore, &mocks.SignatureVerifier{})
 		require.NotNil(t, h)
 
 		errExpected := fmt.Errorf("injected marshal error")
@@ -198,7 +198,7 @@ func TestFollowers_Handler(t *testing.T) {
 	})
 
 	t.Run("GetObjectIRI error", func(t *testing.T) {
-		h := NewFollowers(cfg, activityStore)
+		h := NewFollowers(cfg, activityStore, &mocks.SignatureVerifier{})
 		require.NotNil(t, h)
 
 		errExpected := fmt.Errorf("injected error")
@@ -218,7 +218,7 @@ func TestFollowers_Handler(t *testing.T) {
 	})
 
 	t.Run("GetID error", func(t *testing.T) {
-		h := NewFollowers(cfg, activityStore)
+		h := NewFollowers(cfg, activityStore, &mocks.SignatureVerifier{})
 		require.NotNil(t, h)
 
 		errExpected := fmt.Errorf("injected error")
@@ -254,7 +254,7 @@ func TestFollowers_PageHandler(t *testing.T) {
 		PageSize:  4,
 	}
 
-	h := NewFollowers(cfg, activityStore)
+	h := NewFollowers(cfg, activityStore, &mocks.SignatureVerifier{})
 	require.NotNil(t, h)
 
 	t.Run("First page -> Success", func(t *testing.T) {
@@ -292,7 +292,7 @@ func TestFollowers_PageHandler(t *testing.T) {
 			PageSize:  4,
 		}
 
-		h := NewFollowers(cfg, s)
+		h := NewFollowers(cfg, s, &mocks.SignatureVerifier{})
 		require.NotNil(t, h)
 
 		restorePaging := setPaging(h.handler, "true", "0")
@@ -314,7 +314,7 @@ func TestFollowers_PageHandler(t *testing.T) {
 			PageSize:  4,
 		}
 
-		h := NewFollowers(cfg, activityStore)
+		h := NewFollowers(cfg, activityStore, &mocks.SignatureVerifier{})
 		require.NotNil(t, h)
 
 		restorePaging := setPaging(h.handler, "true", "0")
@@ -354,7 +354,7 @@ func TestWitnesses_Handler(t *testing.T) {
 		PageSize:  4,
 	}
 
-	h := NewWitnesses(cfg, activityStore)
+	h := NewWitnesses(cfg, activityStore, &mocks.SignatureVerifier{})
 	require.NotNil(t, h)
 
 	t.Run("Main page -> Success", func(t *testing.T) {
@@ -387,7 +387,7 @@ func TestWitnessing_Handler(t *testing.T) {
 		PageSize:  4,
 	}
 
-	h := NewWitnessing(cfg, activityStore)
+	h := NewWitnessing(cfg, activityStore, &mocks.SignatureVerifier{})
 	require.NotNil(t, h)
 
 	t.Run("Main page -> Success", func(t *testing.T) {

--- a/pkg/activitypub/resthandler/resthandler.go
+++ b/pkg/activitypub/resthandler/resthandler.go
@@ -65,18 +65,21 @@ type handler struct {
 	params        map[string]string
 	activityStore spi.Store
 	handler       common.HTTPRequestHandler
+	verifier      signatureVerifier
 	marshal       func(v interface{}) ([]byte, error)
 	writeResponse func(w http.ResponseWriter, status int, body []byte)
 	getParams     func(req *http.Request) map[string][]string
 }
 
-func newHandler(endpoint string, cfg *Config, s spi.Store, h common.HTTPRequestHandler, params ...string) *handler {
+func newHandler(endpoint string, cfg *Config, s spi.Store, h common.HTTPRequestHandler,
+	verifier signatureVerifier, params ...string) *handler {
 	return &handler{
 		Config:        cfg,
 		endpoint:      fmt.Sprintf("%s%s", cfg.BasePath, endpoint),
 		params:        paramsBuilder(params).build(),
 		activityStore: s,
 		handler:       h,
+		verifier:      verifier,
 		marshal:       json.Marshal,
 		getParams: func(req *http.Request) map[string][]string {
 			return req.URL.Query()

--- a/pkg/activitypub/resthandler/resthandler_test.go
+++ b/pkg/activitypub/resthandler/resthandler_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/trustbloc/orb/pkg/activitypub/service/mocks"
 	"github.com/trustbloc/orb/pkg/activitypub/store/memstore"
 	"github.com/trustbloc/orb/pkg/activitypub/store/spi"
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
@@ -28,7 +29,7 @@ func TestNewHandler(t *testing.T) {
 
 	h := newHandler("", cfg, memstore.New(""),
 		func(writer http.ResponseWriter, request *http.Request) {},
-		pageNumParam, pageParam,
+		&mocks.SignatureVerifier{}, pageNumParam, pageParam,
 	)
 
 	require.NotNil(t, h)
@@ -70,7 +71,7 @@ func TestGetCurrentPrevNext(t *testing.T) {
 		PageSize:  4,
 	}
 
-	h := newHandler("", cfg, memstore.New(""), nil)
+	h := newHandler("", cfg, memstore.New(""), nil, &mocks.SignatureVerifier{})
 
 	t.Run("Sort ascending", func(t *testing.T) {
 		t.Run("No page-num", func(t *testing.T) {
@@ -162,7 +163,7 @@ func TestGetIDPrevNextURL(t *testing.T) {
 		PageSize:  4,
 	}
 
-	h := newHandler("", cfg, memstore.New(""), nil)
+	h := newHandler("", cfg, memstore.New(""), nil, &mocks.SignatureVerifier{})
 
 	id := testutil.MustParseURL(fmt.Sprintf("%s%s", cfg.ObjectIRI, ""))
 

--- a/pkg/activitypub/resthandler/serviceshandler.go
+++ b/pkg/activitypub/resthandler/serviceshandler.go
@@ -31,7 +31,7 @@ func NewServices(cfg *Config, activityStore spi.Store, publicKey *vocab.PublicKe
 		publicKey: publicKey,
 	}
 
-	h.handler = newHandler("", cfg, activityStore, h.handle)
+	h.handler = newHandler("", cfg, activityStore, h.handle, nil)
 
 	return h
 }
@@ -42,7 +42,7 @@ func NewPublicKeys(cfg *Config, activityStore spi.Store, publicKey *vocab.Public
 		publicKey: publicKey,
 	}
 
-	h.handler = newHandler(PublicKeysPath, cfg, activityStore, h.handlePublicKey)
+	h.handler = newHandler(PublicKeysPath, cfg, activityStore, h.handlePublicKey, nil)
 
 	return h
 }

--- a/test/bdd/features/activitypub.feature
+++ b/test/bdd/features/activitypub.feature
@@ -158,3 +158,11 @@ Feature:
 
     # Invalid signature on POST
     When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content "${followActivity}" of type "application/json" signed with private key from file "${domain1KeyFile}" using key ID "${domain2KeyID}" and the returned status code is 401
+
+    # No signature on GET
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox" and the returned status code is 401
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/followers" and the returned status code is 401
+
+    # Invalid signature on GET
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox" signed with private key from file "${domain2KeyFile}" using key ID "${domain1KeyID}" and the returned status code is 401
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/followers" signed with private key from file "${domain2KeyFile}" using key ID "${domain1KeyID}" and the returned status code is 401


### PR DESCRIPTION
HTTP signatures are validated at the following endpoints:

- /inbox
- /outbox
- /followers
- /following
- /witnesses
- /witnessing
- /likes
- /liked
- /shares

closes #234

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>