### PR TITLE
refactor: Refactor ActivityPub 'Follow' handler

### DIFF
--- a/pkg/activitypub/service/mocks/mockfollowerauth.go
+++ b/pkg/activitypub/service/mocks/mockfollowerauth.go
@@ -10,39 +10,39 @@ import (
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
 )
 
-// FollowerAuth implements a mock follower authorization.
-type FollowerAuth struct {
+// ActorAuth implements a mock actor authorization handler.
+type ActorAuth struct {
 	accept bool
 	err    error
 }
 
-// NewFollowerAuth returns a mock follower authorization.
-func NewFollowerAuth() *FollowerAuth {
-	return &FollowerAuth{}
+// NewActorAuth returns a mock actor authorization.
+func NewActorAuth() *ActorAuth {
+	return &ActorAuth{}
 }
 
-// WithAccept ensures that the request to follow is accepted.
-func (m *FollowerAuth) WithAccept() *FollowerAuth {
+// WithAccept ensures that the request is accepted.
+func (m *ActorAuth) WithAccept() *ActorAuth {
 	m.accept = true
 
 	return m
 }
 
-// WithReject ensures that the request to follow is rejected.
-func (m *FollowerAuth) WithReject() *FollowerAuth {
+// WithReject ensures that the request is rejected.
+func (m *ActorAuth) WithReject() *ActorAuth {
 	m.accept = false
 
 	return m
 }
 
 // WithError injects an error into the handler.
-func (m *FollowerAuth) WithError(err error) *FollowerAuth {
+func (m *ActorAuth) WithError(err error) *ActorAuth {
 	m.err = err
 
 	return m
 }
 
-// AuthorizeFollower is a mock implementation that returns the injected values.
-func (m *FollowerAuth) AuthorizeFollower(follower *vocab.ActorType) (bool, error) {
+// AuthorizeActor is a mock implementation that returns the injected values.
+func (m *ActorAuth) AuthorizeActor(follower *vocab.ActorType) (bool, error) {
 	return m.accept, m.err
 }

--- a/pkg/activitypub/service/outbox/outbox.go
+++ b/pkg/activitypub/service/outbox/outbox.go
@@ -196,6 +196,8 @@ func (h *Outbox) Post(activity *vocab.ActivityType) (*url.URL, error) {
 		return nil, fmt.Errorf("marshal: %w", err)
 	}
 
+	logger.Debugf("[%s] Posting activity: %s", h.ServiceName, activityBytes)
+
 	err = h.activityStore.AddActivity(activity)
 	if err != nil {
 		return nil, fmt.Errorf("store activity: %w", err)

--- a/pkg/activitypub/service/service_test.go
+++ b/pkg/activitypub/service/service_test.go
@@ -768,7 +768,7 @@ func TestService_Offer(t *testing.T) {
 type mockProviders struct {
 	actorRetriever          *mocks.ActorRetriever
 	anchorCredentialHandler *mocks.AnchorCredentialHandler
-	followerAuth            *mocks.FollowerAuth
+	followerAuth            *mocks.ActorAuth
 	undeliverableHandler    *mocks.UndeliverableHandler
 	proofHandler            *mocks.ProofHandler
 	witnessHandler          *mocks.WitnessHandler
@@ -791,7 +791,7 @@ func newServiceWithMocks(t *testing.T, endpoint string,
 	providers := &mockProviders{
 		actorRetriever:          mocks.NewActorRetriever(),
 		anchorCredentialHandler: mocks.NewAnchorCredentialHandler(),
-		followerAuth:            mocks.NewFollowerAuth(),
+		followerAuth:            mocks.NewActorAuth(),
 		undeliverableHandler:    mocks.NewUndeliverableHandler(),
 		proofHandler:            mocks.NewProofHandler(),
 		witnessHandler:          mocks.NewWitnessHandler(),

--- a/pkg/activitypub/service/spi/spi.go
+++ b/pkg/activitypub/service/spi/spi.go
@@ -63,10 +63,10 @@ type AnchorCredentialHandler interface {
 	HandleAnchorCredential(id *url.URL, cid string, anchorCred []byte) error
 }
 
-// FollowerAuth makes the decision of whether or not a request by the given
-// follower should be accepted.
-type FollowerAuth interface {
-	AuthorizeFollower(follower *vocab.ActorType) (bool, error)
+// ActorAuth makes the decision of whether or not a request by the given
+// actor should be accepted.
+type ActorAuth interface {
+	AuthorizeActor(actor *vocab.ActorType) (bool, error)
 }
 
 // WitnessHandler is a handler that witnesses an anchor credential.
@@ -99,7 +99,7 @@ type UndeliverableActivityHandler interface {
 type Handlers struct {
 	UndeliverableHandler    UndeliverableActivityHandler
 	AnchorCredentialHandler AnchorCredentialHandler
-	FollowerAuth            FollowerAuth
+	FollowerAuth            ActorAuth
 	Witness                 WitnessHandler
 	ProofHandler            ProofHandler
 }
@@ -122,7 +122,7 @@ func WithAnchorCredentialHandler(handler AnchorCredentialHandler) HandlerOpt {
 }
 
 // WithFollowerAuth sets the handler that decides whether or not to accept a 'Follow' request.
-func WithFollowerAuth(handler FollowerAuth) HandlerOpt {
+func WithFollowerAuth(handler ActorAuth) HandlerOpt {
 	return func(options *Handlers) {
 		options.FollowerAuth = handler
 	}


### PR DESCRIPTION
The ActivityPub 'Follow' handler was refactored so that the code may be reused for the 'InviteWitness' handler.

closes #248

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>