### PR TITLE
feat: Implemented 'InviteWitness' activity

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -345,6 +345,7 @@ func startOrbServices(parameters *orbParameters) error {
 		apspi.WithProofHandler(mockProofHandler(func(anchorCredID string, _, endTime time.Time, proof []byte) error {
 			return monitoringSvc.Watch(anchorCredID, endTime, proof)
 		})),
+		// apspi.WithWitnessInvitationAuth(inviteWitnessAuth),
 		apspi.WithWitness(vct.New(parameters.vctURL, vcSigner, vct.WithHTTPClient(httpClient))),
 		// apspi.WithFollowerAuth(followerAuth),
 		apspi.WithAnchorCredentialHandler(handler.New(anchorCh)),

--- a/pkg/activitypub/service/activityhandler/outboxhandler.go
+++ b/pkg/activitypub/service/activityhandler/outboxhandler.go
@@ -26,6 +26,9 @@ func NewOutbox(cfg *Config, s store.Store, t httpTransport) *Outbox {
 		func(follow *vocab.ActivityType) error {
 			return h.undoAddReference(follow, store.Following)
 		},
+		func(inviteWitness *vocab.ActivityType) error {
+			return h.undoAddReference(inviteWitness, store.Witness)
+		},
 	)
 
 	return h

--- a/pkg/activitypub/service/spi/spi.go
+++ b/pkg/activitypub/service/spi/spi.go
@@ -100,6 +100,7 @@ type Handlers struct {
 	UndeliverableHandler    UndeliverableActivityHandler
 	AnchorCredentialHandler AnchorCredentialHandler
 	FollowerAuth            ActorAuth
+	WitnessInvitationAuth   ActorAuth
 	Witness                 WitnessHandler
 	ProofHandler            ProofHandler
 }
@@ -125,6 +126,13 @@ func WithAnchorCredentialHandler(handler AnchorCredentialHandler) HandlerOpt {
 func WithFollowerAuth(handler ActorAuth) HandlerOpt {
 	return func(options *Handlers) {
 		options.FollowerAuth = handler
+	}
+}
+
+// WithWitnessInvitationAuth sets the handler that decides whether or not to accept an 'InviteWitness' request.
+func WithWitnessInvitationAuth(handler ActorAuth) HandlerOpt {
+	return func(options *Handlers) {
+		options.WitnessInvitationAuth = handler
 	}
 }
 

--- a/pkg/activitypub/vocab/activitytype.go
+++ b/pkg/activitypub/vocab/activitytype.go
@@ -123,6 +123,24 @@ func NewFollowActivity(obj *ObjectProperty, opts ...Opt) *ActivityType {
 	}
 }
 
+// NewInviteWitnessActivity returns a new 'InviteWitness' activity.
+func NewInviteWitnessActivity(obj *ObjectProperty, opts ...Opt) *ActivityType {
+	options := NewOptions(opts...)
+
+	return &ActivityType{
+		ObjectType: NewObject(
+			WithContext(getContexts(options, ContextActivityStreams, ContextOrb)...),
+			WithID(options.ID),
+			WithType(TypeInviteWitness),
+			WithTo(options.To...),
+		),
+		activity: &activityType{
+			Actor:  NewURLProperty(options.Actor),
+			Object: obj,
+		},
+	}
+}
+
 // NewAcceptActivity returns a new 'Accept' activity.
 func NewAcceptActivity(obj *ObjectProperty, opts ...Opt) *ActivityType {
 	options := NewOptions(opts...)

--- a/pkg/activitypub/vocab/objectproperty.go
+++ b/pkg/activitypub/vocab/objectproperty.go
@@ -182,7 +182,7 @@ func (p *ObjectProperty) UnmarshalJSON(bytes []byte) error {
 	case obj.object.Type.Is(TypeOrderedCollection):
 		err = p.unmarshalOrderedCollection(bytes)
 
-	case obj.object.Type.IsAny(TypeFollow, TypeAccept, TypeReject, TypeOffer, TypeLike):
+	case obj.object.Type.IsAny(TypeFollow, TypeAccept, TypeReject, TypeOffer, TypeLike, TypeInviteWitness):
 		err = p.unmarshalActivity(bytes)
 
 	case obj.object.Type.Is(TypeAnchorCredentialRef):

--- a/pkg/activitypub/vocab/vocab.go
+++ b/pkg/activitypub/vocab/vocab.go
@@ -52,6 +52,8 @@ const (
 	TypeReject Type = "Reject"
 	// TypeLike specifies the 'Like' activity type.
 	TypeLike Type = "Like"
+	// TypeInviteWitness specifies the 'InviteWitness' activity type.
+	TypeInviteWitness Type = "InviteWitness"
 
 	// TypeVerifiableCredential specifies the "VerifiableCredential" object type.
 	TypeVerifiableCredential Type = "VerifiableCredential"


### PR DESCRIPTION
Implemented the 'InviteWitness' activity to manage the witness/witnessing collections. For example, Service1 posts the 'InviteWitness' activity to Service2 to ‘ask’ Service2 to be a witness. Service2 either Accepts or Rejects the request. If accepted, Service2 is added to Service1's witnesses collection and Service1 is added to Service2's witnessing collection. Service1 can use ‘Undo’ to remove Service2 from its witnesses collection, which will also remove Service1 from Service2's witnessing collection.

closes #116

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>