### PR TITLE
fix: Reject Offer activity if actor not in witnessing collection

### DIFF
--- a/pkg/activitypub/service/activityhandler/inboxhandler.go
+++ b/pkg/activitypub/service/activityhandler/inboxhandler.go
@@ -359,6 +359,16 @@ func (h *Inbox) handleOfferActivity(offer *vocab.ActivityType) error {
 		return fmt.Errorf("invalid 'Offer' activity [%s]: %w", offer.ID(), err)
 	}
 
+	isWitnessing, err := h.hasReference(offer.Actor(), store.Witnessing)
+	if err != nil {
+		return fmt.Errorf("retrieve reference: %w", err)
+	}
+
+	if !isWitnessing {
+		return fmt.Errorf("not handling 'Offer' activity [%s] since [%s] is not in the 'witnessing' collection",
+			offer.ID(), offer.Actor())
+	}
+
 	if time.Now().After(*offer.EndTime()) {
 		return fmt.Errorf("offer [%s] has expired", offer.ID())
 	}

--- a/pkg/activitypub/service/service_test.go
+++ b/pkg/activitypub/service/service_test.go
@@ -692,6 +692,7 @@ func TestService_Offer(t *testing.T) {
 
 	require.NoError(t, store1.PutActor(actor2))
 	require.NoError(t, store2.PutActor(actor1))
+	require.NoError(t, store2.AddReference(spi.Witnessing, service2IRI, service1IRI))
 
 	service1.Start()
 	service2.Start()

--- a/test/bdd/features/activitypub.feature
+++ b/test/bdd/features/activitypub.feature
@@ -168,6 +168,13 @@ Feature:
 
   @activitypub_offer
   Scenario: offer/like
+    # domain1 invites domain2 to be a witness
+    Given variable "inviteWitnessID" is assigned a unique ID
+    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain2IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
+    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content "${inviteWitnessActivity}" of type "application/json" signed with private key from file "${domain2KeyFile}" using key ID "${domain2KeyID}"
+
+    Then we wait 2 seconds
+
     When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content from file "./fixtures/testdata/offer_activity.json" signed with private key from file "${domain2KeyFile}" using key ID "${domain2KeyID}"
 
     Then we wait 2 seconds

--- a/test/bdd/fixtures/couchdb-config/config.ini
+++ b/test/bdd/fixtures/couchdb-config/config.ini
@@ -6,3 +6,6 @@
 
 [couchdb]
 single_node=true
+
+[log]
+level = warn


### PR DESCRIPTION
If a service receives an 'Offer' from an actor that's not in the service's witnessing collection then the activity is rejected.

closes #247

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>