### PR TITLE
fix: Deduplicate URLs in outbox

### DIFF
--- a/pkg/activitypub/service/outbox/outbox_test.go
+++ b/pkg/activitypub/service/outbox/outbox_test.go
@@ -497,6 +497,13 @@ func TestOutbox_PostError(t *testing.T) {
 	})
 }
 
+func TestDeduplicate(t *testing.T) {
+	service1URL := testutil.MustParseURL("http://localhost:8002/services/service1")
+	service2URL := testutil.MustParseURL("http://localhost:8002/services/service2")
+
+	require.Len(t, deduplicate([]*url.URL{service1URL, service2URL, service1URL, service2URL}), 2)
+}
+
 type testHandler struct {
 	path    string
 	method  string


### PR DESCRIPTION
Ensure that an activity is sent only once to a URL.

closes #259

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>