### PR TITLE
fix: Set content type and accept headers on ActivityPub requests

### DIFF
--- a/pkg/activitypub/client/transport/transport.go
+++ b/pkg/activitypub/client/transport/transport.go
@@ -20,6 +20,12 @@ import (
 
 var logger = log.New("activitypub_client")
 
+const (
+	contentTypeHeader          = "Content-Type"
+	acceptHeader               = "Accept"
+	activityStreamsContentType = `application/ld+json; profile="https://www.w3.org/ns/activitystreams"`
+)
+
 // Signer signs an HTTP request and adds the signature to the header of the request.
 type Signer interface {
 	SignRequest(pKey crypto.PrivateKey, pubKeyID string, r *http.Request, body []byte) error
@@ -87,7 +93,11 @@ func (t *Transport) Post(ctx context.Context, r *Request, payload []byte) (*http
 		return nil, fmt.Errorf("new request to %s: %w", r.URL, err)
 	}
 
-	req.Header = r.Header
+	req.Header.Set(contentTypeHeader, activityStreamsContentType)
+
+	for k, v := range r.Header {
+		req.Header[k] = v
+	}
 
 	err = t.postSigner.SignRequest(t.privateKey, t.publicKeyID.String(), req, payload)
 	if err != nil {
@@ -106,7 +116,11 @@ func (t *Transport) Get(ctx context.Context, r *Request) (*http.Response, error)
 		return nil, fmt.Errorf("get from %s: %w", r.URL, err)
 	}
 
-	req.Header = r.Header
+	req.Header.Set(acceptHeader, activityStreamsContentType)
+
+	for k, v := range r.Header {
+		req.Header[k] = v
+	}
 
 	logger.Debugf("Signed HTTP GET to %s. Headers: %s", r.URL, req.Header)
 

--- a/pkg/activitypub/client/transport/transport_test.go
+++ b/pkg/activitypub/client/transport/transport_test.go
@@ -46,9 +46,11 @@ func TestTransport_Post(t *testing.T) {
 		tp := New(httpClient, nil, testutil.MustParseURL(publicKeyID), DefaultSigner(), DefaultSigner())
 		require.NotNil(t, tp)
 
+		req := NewRequest(testutil.MustParseURL("https://domain1.com"))
+		req.Header["some-header"] = []string{"some value"}
+
 		//nolint:bodyclose
-		resp, err := tp.Post(context.Background(),
-			NewRequest(testutil.MustParseURL("https://domain1.com")), []byte("payload"))
+		resp, err := tp.Post(context.Background(), req, []byte("payload"))
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 	})
@@ -81,8 +83,11 @@ func TestTransport_Get(t *testing.T) {
 		tp := New(httpClient, nil, testutil.MustParseURL(publicKeyID), DefaultSigner(), DefaultSigner())
 		require.NotNil(t, tp)
 
+		req := NewRequest(testutil.MustParseURL("https://domain1.com"))
+		req.Header["some-header"] = []string{"some value"}
+
 		//nolint:bodyclose
-		resp, err := tp.Get(context.Background(), NewRequest(testutil.MustParseURL("https://domain1.com")))
+		resp, err := tp.Get(context.Background(), req)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 	})


### PR DESCRIPTION
Content-Type on POST and Accept on GET are set to 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"' for ActivityPub requests.

closes #224

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>