### PR TITLE
fix: check for create to be processed before issuing update

### DIFF
--- a/test/bdd/features/did-sidetree.feature
+++ b/test/bdd/features/did-sidetree.feature
@@ -128,6 +128,9 @@ Feature:
       Then check success response contains "#did"
       Then we wait 2 seconds
 
+      When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document
+      Then check success response contains "#did"
+
       When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to add service endpoint with ID "newService" to DID document
       Then we wait 2 seconds
 


### PR DESCRIPTION
We are not waiting enough for create did and that's why update operation fails.
As a follow-up I will add checks for success for did operations. Currently we have it for resolution only.

Closes #289

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>