### PR TITLE
chore: Disable HTTP signature verification in ActivityPub

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -8,19 +8,14 @@ package startcmd
 
 import (
 	"bytes"
-	"crypto"
 	"crypto/tls"
-	"crypto/x509"
 	"encoding/base64"
-	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -53,9 +48,7 @@ import (
 	restcommon "github.com/trustbloc/sidetree-core-go/pkg/restapi/common"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/diddochandler"
 
-	"github.com/trustbloc/orb/pkg/activitypub/client"
 	"github.com/trustbloc/orb/pkg/activitypub/client/transport"
-	"github.com/trustbloc/orb/pkg/activitypub/httpsig"
 	aphandler "github.com/trustbloc/orb/pkg/activitypub/resthandler"
 	apservice "github.com/trustbloc/orb/pkg/activitypub/service"
 	"github.com/trustbloc/orb/pkg/activitypub/service/monitoring"
@@ -350,19 +343,17 @@ func startOrbServices(parameters *orbParameters) error {
 
 	apStore := apmemstore.New(apConfig.ServiceEndpoint)
 
-	// TODO: Replace with real signing key (from KMS?).
-	pemBytes, privKey, err := loadTestActivityPubKeys()
-	if err != nil {
-		// This should only happen in the start unit test.
-		logger.Errorf("Unable to load signing key: %s", err)
-	}
+	// TODO: Replace with public key from KMS.
+	pemBytes := []byte(publicKeyPem)
 
-	t := transport.New(httpClient, privKey, apServicePublicKeyIRI,
-		httpsig.NewSigner(httpsig.DefaultGetSignerConfig()),
-		httpsig.NewSigner(httpsig.DefaultPostSignerConfig()),
+	// FIXME: Use dummy signer for now until https://github.com/trustbloc/orb/issues/233 is implemented.
+	t := transport.New(httpClient, nil, apServicePublicKeyIRI,
+		&transport.NoOpSigner{},
+		&transport.NoOpSigner{},
 	)
 
-	sigVerifier := httpsig.NewVerifier(httpsig.DefaultVerifierConfig(), client.New(t))
+	// FIXME: Use dummy verifier for now until https://github.com/trustbloc/orb/issues/233 is implemented.
+	sigVerifier := &noOpVerifier{}
 
 	monitoringSvc, err := monitoring.New(storeProviders.provider, vcStore, monitoring.WithHTTPClient(httpClient))
 	if err != nil {
@@ -696,73 +687,13 @@ func mustParseURL(basePath, relativePath string) *url.URL {
 	return u
 }
 
-// TODO: Remove - this is a temporary function.
-func loadTestActivityPubKeys() ([]byte, crypto.PrivateKey, error) {
-	privKey, err := privateKeyFromFile("/etc/orb/activitypub/private-key.pem")
-	if err != nil {
-		return nil, nil, err
-	}
-
-	pubKey, err := publicKeyFromFile("/etc/orb/activitypub/public-key.pem")
-	if err != nil {
-		return nil, nil, err
-	}
-
-	keyBytes, err := x509.MarshalPKIXPublicKey(pubKey)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	pemBytes := pem.EncodeToMemory(&pem.Block{
-		Type:    "PUBLIC KEY",
-		Headers: nil,
-		Bytes:   keyBytes,
-	})
-
-	return pemBytes, privKey, nil
+type noOpVerifier struct {
 }
 
-// TODO: Remove - this is a temporary function.
-func publicKeyFromFile(file string) (crypto.PublicKey, error) {
-	keyBytes, err := ioutil.ReadFile(filepath.Clean(file))
-	if err != nil {
-		return nil, err
-	}
-
-	block, _ := pem.Decode(keyBytes)
-	if block == nil {
-		return nil, fmt.Errorf("public key not found")
-	}
-
-	key, err := x509.ParsePKIXPublicKey(block.Bytes)
-	if err != nil {
-		return nil, err
-	}
-
-	publicKey, ok := key.(crypto.PublicKey)
-	if !ok {
-		return nil, errors.New("invalid public key")
-	}
-
-	return publicKey, nil
+func (v *noOpVerifier) VerifyRequest(_ *http.Request) (*url.URL, error) {
+	return nil, nil
 }
 
-// TODO: Remove - this is a temporary function.
-func privateKeyFromFile(file string) (crypto.PrivateKey, error) {
-	keyBytes, err := ioutil.ReadFile(filepath.Clean(file))
-	if err != nil {
-		return nil, err
-	}
-
-	block, _ := pem.Decode(keyBytes)
-	if block == nil {
-		return nil, fmt.Errorf("private key not found")
-	}
-
-	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
-	if err != nil {
-		return nil, err
-	}
-
-	return key, nil
-}
+const publicKeyPem = `-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEA3FKE2r94LiR0GfqTTT9wttMyUfEQk/7yMtG2JIqzZyI=
+-----END PUBLIC KEY-----`

--- a/pkg/activitypub/service/inbox/httpsubscriber/httpsubscriber.go
+++ b/pkg/activitypub/service/inbox/httpsubscriber/httpsubscriber.go
@@ -123,7 +123,9 @@ func (s *Subscriber) handleMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	msg.Metadata[ActorIRIKey] = actorIRI.String()
+	if actorIRI != nil {
+		msg.Metadata[ActorIRIKey] = actorIRI.String()
+	}
 
 	logger.Debugf("[%s] Handling message [%s] from actor [%s]", s.ServiceEndpoint, msg.UUID, actorIRI)
 

--- a/pkg/activitypub/service/inbox/inbox_test.go
+++ b/pkg/activitypub/service/inbox/inbox_test.go
@@ -499,7 +499,8 @@ func TestInbox_Error(t *testing.T) {
 func TestUnmarshalAndValidateActivity(t *testing.T) {
 	activityID := testutil.MustParseURL("https://example1.com/activities/activity1")
 
-	ib, e := New(&Config{}, memstore.New(""), mocks.NewPubSub(), nil, nil)
+	ib, e := New(&Config{VerifyActorInSignature: true}, memstore.New(""), mocks.NewPubSub(),
+		nil, nil)
 	require.NoError(t, e)
 	require.NotNil(t, ib)
 

--- a/test/bdd/features/activitypub.feature
+++ b/test/bdd/features/activitypub.feature
@@ -57,44 +57,44 @@ Feature:
     # domain2 follows domain1
     Given variable "followID" is assigned a unique ID
     And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain2IRI}/activities/${followID}","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content "${followActivity}" of type "application/json" signed with private key from file "${domain2KeyFile}" using key ID "${domain2KeyID}"
+    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content "${followActivity}" of type "application/json"
 
     Then we wait 3 seconds
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox" signed with private key from file "${domain2KeyFile}" using key ID "${domain2KeyID}"
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox"
     Then the JSON path "type" of the response equals "OrderedCollection"
     And the JSON path "id" of the response equals "${domain1IRI}/inbox"
     And the JSON path "first" of the response equals "${domain1IRI}/inbox?page=true"
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox?page=true" signed with private key from file "${domain2KeyFile}" using key ID "${domain2KeyID}"
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.id" of the response contains "${domain2IRI}/activities/${followID}"
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/followers" signed with private key from file "${domain2KeyFile}" using key ID "${domain2KeyID}"
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/followers"
     Then the JSON path "type" of the response equals "Collection"
     And the JSON path "id" of the response equals "${domain1IRI}/followers"
     And the JSON path "first" of the response equals "${domain1IRI}/followers?page=true"
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/followers?page=true" signed with private key from file "${domain2KeyFile}" using key ID "${domain2KeyID}"
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/followers?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response contains "${domain2IRI}"
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/following" signed with private key from file "${domain2KeyFile}" using key ID "${domain2KeyID}"
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/following"
     Then the JSON path "type" of the response equals "Collection"
     And the JSON path "id" of the response equals "${domain2IRI}/following"
     And the JSON path "first" of the response equals "${domain2IRI}/following?page=true"
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/following?page=true" signed with private key from file "${domain2KeyFile}" using key ID "${domain2KeyID}"
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/following?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response contains "${domain1IRI}"
 
     Given variable "undoID" is assigned a unique ID
     And variable "undoFollowActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain2IRI}/activities/${undoID}","type":"Undo","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain2IRI}/activities/${followID}"}'
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content "${undoFollowActivity}" of type "application/json" signed with private key from file "${domain2KeyFile}" using key ID "${domain2KeyID}"
+    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content "${undoFollowActivity}" of type "application/json"
 
     Then we wait 3 seconds
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/followers?page=true" signed with private key from file "${domain2KeyFile}" using key ID "${domain2KeyID}"
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/followers?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response does not contain "${domain2IRI}"
 
@@ -102,26 +102,26 @@ Feature:
   Scenario: create/announce
     Given variable "followID" is assigned a unique ID
     And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain2IRI}/activities/${followID}","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content "${followActivity}" of type "application/json" signed with private key from file "${domain2KeyFile}" using key ID "${domain2KeyID}"
+    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content "${followActivity}" of type "application/json"
 
     Then we wait 2 seconds
 
     # Post 'Create' activity to domain1
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content from file "./fixtures/testdata/create_activity.json" signed with private key from file "${domain1KeyFile}" using key ID "${domain1KeyID}"
+    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content from file "./fixtures/testdata/create_activity.json"
 
     Then we wait 2 seconds
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox?page=true" signed with private key from file "${domain1KeyFile}" using key ID "${domain1KeyID}"
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.id" of the response contains "${domain1IRI}/activities/77bdd005-bbb6-223d-b889-58bc1de84985"
 
     # An 'Announce' activity should have been posted to domain1's followers (domain2).
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/outbox?page=true" signed with private key from file "${domain1KeyFile}" using key ID "${domain1KeyID}"
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/outbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.type" of the response contains "Announce"
 
     # An 'Announce' activity should have been received by domain2 since it's a follower of domain1.
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/inbox?page=true" signed with private key from file "${domain1KeyFile}" using key ID "${domain1KeyID}"
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.type" of the response contains "Announce"
 
@@ -130,39 +130,39 @@ Feature:
     # domain1 invites domain2 to be a witness
     Given variable "inviteWitnessID" is assigned a unique ID
     And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain1IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/inbox" with content "${inviteWitnessActivity}" of type "application/json" signed with private key from file "${domain1KeyFile}" using key ID "${domain1KeyID}"
+    When an HTTP POST is sent to "https://localhost:48426/services/orb/inbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     Then we wait 3 seconds
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/inbox?page=true" signed with private key from file "${domain2KeyFile}" using key ID "${domain2KeyID}"
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.id" of the response contains "${domain1IRI}/activities/${inviteWitnessID}"
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/witnesses" signed with private key from file "${domain2KeyFile}" using key ID "${domain2KeyID}"
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/witnesses"
     Then the JSON path "type" of the response equals "Collection"
     And the JSON path "id" of the response equals "${domain1IRI}/witnesses"
     And the JSON path "first" of the response equals "${domain1IRI}/witnesses?page=true"
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/witnesses?page=true" signed with private key from file "${domain2KeyFile}" using key ID "${domain2KeyID}"
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/witnesses?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response contains "${domain2IRI}"
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/witnessing" signed with private key from file "${domain2KeyFile}" using key ID "${domain2KeyID}"
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/witnessing"
     Then the JSON path "type" of the response equals "Collection"
     And the JSON path "id" of the response equals "${domain2IRI}/witnessing"
     And the JSON path "first" of the response equals "${domain2IRI}/witnessing?page=true"
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/witnessing?page=true" signed with private key from file "${domain2KeyFile}" using key ID "${domain2KeyID}"
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/witnessing?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response contains "${domain1IRI}"
 
     Given variable "undoWitnessID" is assigned a unique ID
     And variable "undoInviteWitnessActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain1IRI}/activities/${undoWitnessID}","type":"Undo","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain1IRI}/activities/${inviteWitnessID}"}'
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/inbox" with content "${undoInviteWitnessActivity}" of type "application/json" signed with private key from file "${domain1KeyFile}" using key ID "${domain1KeyID}"
+    When an HTTP POST is sent to "https://localhost:48426/services/orb/inbox" with content "${undoInviteWitnessActivity}" of type "application/json"
 
     Then we wait 3 seconds
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/witnessing?page=true" signed with private key from file "${domain2KeyFile}" using key ID "${domain2KeyID}"
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/witnessing?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response does not contain "${domain1IRI}"
 
@@ -171,46 +171,46 @@ Feature:
     # domain1 invites domain2 to be a witness
     Given variable "inviteWitnessID" is assigned a unique ID
     And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain2IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content "${inviteWitnessActivity}" of type "application/json" signed with private key from file "${domain2KeyFile}" using key ID "${domain2KeyID}"
+    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     Then we wait 2 seconds
 
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content from file "./fixtures/testdata/offer_activity.json" signed with private key from file "${domain2KeyFile}" using key ID "${domain2KeyID}"
+    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content from file "./fixtures/testdata/offer_activity.json"
 
     Then we wait 2 seconds
 
     # The 'Offer' activity should be in the inbox of domain1.
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox?page=true" signed with private key from file "${domain1KeyFile}" using key ID "${domain1KeyID}"
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.id" of the response contains "${domain2IRI}/activities/63b3d005-6cb6-673d-6379-18be1ee84973"
 
     # The 'Like' should be in the 'liked' collection of domain1.
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/liked?page=true" signed with private key from file "${domain1KeyFile}" using key ID "${domain1KeyID}"
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/liked?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.type" of the response contains "Like"
     And the JSON path "orderedItems.#.object" of the response contains "http://orb.domain2.com/transactions/bafkreihwsn"
 
     # A 'Like' activity should be in the inbox of domain2.
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/inbox?page=true" signed with private key from file "${domain1KeyFile}" using key ID "${domain1KeyID}"
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.type" of the response contains "Like"
     And the JSON path "orderedItems.#.object" of the response contains "http://orb.domain2.com/transactions/bafkreihwsn"
 
-  @activitypub_httpsig
-  Scenario: Tests HTTP signature verification
-    Given variable "followID" is assigned a unique ID
-    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain2IRI}/activities/${followID}","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-
-    # No signature on POST
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content "${followActivity}" of type "application/json" and the returned status code is 401
-
-    # Invalid signature on POST
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content "${followActivity}" of type "application/json" signed with private key from file "${domain1KeyFile}" using key ID "${domain2KeyID}" and the returned status code is 401
-
-    # No signature on GET
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox" and the returned status code is 401
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/followers" and the returned status code is 401
-
-    # Invalid signature on GET
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox" signed with private key from file "${domain2KeyFile}" using key ID "${domain1KeyID}" and the returned status code is 401
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/followers" signed with private key from file "${domain2KeyFile}" using key ID "${domain1KeyID}" and the returned status code is 401
+#  @activitypub_httpsig
+#  Scenario: Tests HTTP signature verification
+#    Given variable "followID" is assigned a unique ID
+#    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain2IRI}/activities/${followID}","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
+#
+#    # No signature on POST
+#    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content "${followActivity}" of type "application/json" and the returned status code is 401
+#
+#    # Invalid signature on POST
+#    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content "${followActivity}" of type "application/json" signed with private key from file "${domain1KeyFile}" using key ID "${domain2KeyID}" and the returned status code is 401
+#
+#    # No signature on GET
+#    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox" and the returned status code is 401
+#    When an HTTP GET is sent to "https://localhost:48326/services/orb/followers" and the returned status code is 401
+#
+#    # Invalid signature on GET
+#    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox" signed with private key from file "${domain2KeyFile}" using key ID "${domain1KeyID}" and the returned status code is 401
+#    When an HTTP GET is sent to "https://localhost:48326/services/orb/followers" signed with private key from file "${domain2KeyFile}" using key ID "${domain1KeyID}" and the returned status code is 401

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -19,22 +19,22 @@ Feature:
     # domain2 server follows domain1 server
     Given variable "followID" is assigned a unique ID
     And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain2IRI}/activities/${followID}","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content "${followActivity}" of type "application/json" signed with private key from file "${domain2KeyFile}" using key ID "${domain2KeyID}"
+    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content "${followActivity}" of type "application/json"
 
     # domain1 server follows domain2 server
     Given variable "followID" is assigned a unique ID
     And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain1IRI}/activities/${followID}","type":"Follow","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/inbox" with content "${followActivity}" of type "application/json" signed with private key from file "${domain1KeyFile}" using key ID "${domain1KeyID}"
+    When an HTTP POST is sent to "https://localhost:48426/services/orb/inbox" with content "${followActivity}" of type "application/json"
 
     # domain1 invites domain2 to be a witness
     Given variable "inviteWitnessID" is assigned a unique ID
     And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain1IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/inbox" with content "${inviteWitnessActivity}" of type "application/json" signed with private key from file "${domain1KeyFile}" using key ID "${domain1KeyID}"
+    When an HTTP POST is sent to "https://localhost:48426/services/orb/inbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     # domain2 invites domain1 to be a witness
     Given variable "inviteWitnessID" is assigned a unique ID
     And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain2IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content "${inviteWitnessActivity}" of type "application/json" signed with private key from file "${domain2KeyFile}" using key ID "${domain2KeyID}"
+    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     Then we wait 3 seconds
 

--- a/test/bdd/features/did-sidetree.feature
+++ b/test/bdd/features/did-sidetree.feature
@@ -19,12 +19,12 @@ Feature:
     # domain2 server follows domain1 server
     Given variable "followID" is assigned a unique ID
     And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain2IRI}/activities/${followID}","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content "${followActivity}" of type "application/json" signed with private key from file "${domain2KeyFile}" using key ID "${domain2KeyID}"
+    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content "${followActivity}" of type "application/json"
 
     # domain1 invites domain2 to be a witness
     Given variable "inviteWitnessID" is assigned a unique ID
     And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain1IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/inbox" with content "${inviteWitnessActivity}" of type "application/json" signed with private key from file "${domain1KeyFile}" using key ID "${domain1KeyID}"
+    When an HTTP POST is sent to "https://localhost:48426/services/orb/inbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     Then we wait 3 seconds
 


### PR DESCRIPTION
Temporarily disable HTTP signature verification in ActivityPub until https://github.com/trustbloc/orb/issues/233 is implemented.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>