### PR TITLE
feat: CAS based on Aries storage provider

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -64,7 +64,7 @@ import (
 	"github.com/trustbloc/orb/pkg/anchor/writer"
 	"github.com/trustbloc/orb/pkg/config"
 	sidetreecontext "github.com/trustbloc/orb/pkg/context"
-	"github.com/trustbloc/orb/pkg/context/cas"
+	ipfscas "github.com/trustbloc/orb/pkg/context/cas/ipfs"
 	"github.com/trustbloc/orb/pkg/context/common"
 	orbpc "github.com/trustbloc/orb/pkg/context/protocol/client"
 	orbpcp "github.com/trustbloc/orb/pkg/context/protocol/provider"
@@ -261,7 +261,7 @@ func startOrbServices(parameters *orbParameters) error {
 	}
 
 	// basic providers (CAS + operation store)
-	casClient := cas.New(parameters.casURL)
+	casClient := ipfscas.New(parameters.casURL)
 
 	didAnchors, err := didanchorstore.New(storeProviders.provider)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,10 @@ require (
 	github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20210426192704-553740e279e5
 	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210409151411-eeeb8508bd87
 	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210422144621-1355c6f90b44
+	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-ipfs-api v0.2.0
 	github.com/mr-tron/base58 v1.2.0
+	github.com/multiformats/go-multihash v0.0.14
 	github.com/ory/dockertest/v3 v3.6.3
 	github.com/piprate/json-gold v0.4.0
 	github.com/rs/cors v1.7.0

--- a/pkg/context/cas/ipfs/ipfs.go
+++ b/pkg/context/cas/ipfs/ipfs.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package cas
+package ipfs
 
 import (
 	"bytes"

--- a/pkg/context/cas/ipfs/ipfs_test.go
+++ b/pkg/context/cas/ipfs/ipfs_test.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package cas
+package ipfs
 
 import (
 	"fmt"

--- a/pkg/store/cas/cas.go
+++ b/pkg/store/cas/cas.go
@@ -1,0 +1,64 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cas
+
+import (
+	"fmt"
+
+	ariesstorage "github.com/hyperledger/aries-framework-go/spi/storage"
+	"github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+)
+
+// CAS represents a content-addressable storage provider.
+type CAS struct {
+	cas ariesstorage.Store
+}
+
+// New returns a new CAS that uses the passed in provider as a backing store.
+func New(provider ariesstorage.Provider) (*CAS, error) {
+	cas, err := provider.OpenStore("cas_store")
+	if err != nil {
+		return nil, fmt.Errorf("failed to open store in underlying storage provider: %w", err)
+	}
+
+	return &CAS{cas: cas}, nil
+}
+
+// Write writes the given content to the underlying storage provider.
+// Returns the address of the content.
+func (p *CAS) Write(content []byte) (string, error) {
+	// TODO #318 figure out why the CIDs produced here differ from the ones that IPFS generates.
+	prefix := cid.Prefix{
+		Version:  0,
+		MhType:   mh.SHA2_256,
+		MhLength: -1, // default length
+	}
+
+	contentID, err := prefix.Sum(content)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate CID: %w", err)
+	}
+
+	err = p.cas.Put(contentID.String(), content)
+	if err != nil {
+		return "", fmt.Errorf("failed to put content into underlying storage provider: %w", err)
+	}
+
+	return contentID.String(), nil
+}
+
+// Read reads the content of the given address from the underlying storage provider.
+// Returns the content at the given address.
+func (p *CAS) Read(address string) ([]byte, error) {
+	content, err := p.cas.Get(address)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get content from the underlying storage provider: %w", err)
+	}
+
+	return content, nil
+}

--- a/pkg/store/cas/cas_test.go
+++ b/pkg/store/cas/cas_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cas_test
+
+import (
+	"errors"
+	"testing"
+
+	ariesmemstorage "github.com/hyperledger/aries-framework-go/component/storageutil/mem"
+	ariesmockstorage "github.com/hyperledger/aries-framework-go/component/storageutil/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/pkg/store/cas"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		provider, err := cas.New(ariesmemstorage.NewProvider())
+		require.NoError(t, err)
+		require.NotNil(t, provider)
+	})
+	t.Run("Fail to store in underlying storage provider", func(t *testing.T) {
+		provider, err := cas.New(&ariesmockstorage.Provider{ErrOpenStore: errors.New("open store error")})
+		require.EqualError(t, err, "failed to open store in underlying storage provider: open store error")
+		require.Nil(t, provider)
+	})
+}
+
+func TestProvider_Write_Read(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		provider, err := cas.New(ariesmemstorage.NewProvider())
+		require.NoError(t, err)
+
+		address, err := provider.Write([]byte("content"))
+		require.NoError(t, err)
+		require.Equal(t, "QmeKWPxUJP9M3WJgBuj8ykLtGU37iqur5gZ8cDCi49WJVG", address)
+
+		content, err := provider.Read(address)
+		require.NoError(t, err)
+		require.Equal(t, "content", string(content))
+	})
+	t.Run("Fail to put content bytes into underlying storage provider", func(t *testing.T) {
+		provider, err := cas.New(&ariesmockstorage.Provider{
+			OpenStoreReturn: &ariesmockstorage.Store{
+				ErrPut: errors.New("put error"),
+			},
+		})
+		require.NoError(t, err)
+
+		address, err := provider.Write([]byte("content"))
+		require.EqualError(t, err, "failed to put content into underlying storage provider: put error")
+		require.Equal(t, "", address)
+	})
+	t.Run("Fail to get content bytes from underlying storage provider", func(t *testing.T) {
+		provider, err := cas.New(&ariesmockstorage.Provider{
+			OpenStoreReturn: &ariesmockstorage.Store{
+				ErrGet: errors.New("put error"),
+			},
+		})
+		require.NoError(t, err)
+
+		content, err := provider.Read("AVUSIO1wArQ56ayEXyI1fYIrrBREcw-9tgFtPslDIpe57J9z")
+		require.EqualError(t, err, "failed to get content from the underlying storage provider: put error")
+		require.Nil(t, content)
+	})
+}


### PR DESCRIPTION
- Added a CAS implementation that can use any Aries provider implementation as a backing store.
- Moved the existing IPFS CAS implementation to a separate folder.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>