### PR TITLE
chore: Enable domain self-referencing in allowed anchor origin list

### DIFF
--- a/pkg/anchor/handler/proof/handler.go
+++ b/pkg/anchor/handler/proof/handler.go
@@ -67,6 +67,13 @@ func (h *WitnessProofHandler) HandleProof(anchorCredID string, startTime, endTim
 		return fmt.Errorf("failed to retrieve anchor credential[%s]: %w", anchorCredID, err)
 	}
 
+	if len(vc.Proofs) > 1 {
+		// TODO: issue-322 (handle multiple proofs - our witness policy is currently 1)
+		logger.Debugf("Credential[%s] has already been witnessed, nothing to do", vc.ID)
+
+		return nil
+	}
+
 	vc.Proofs = append(vc.Proofs, witnessProof.Proof)
 
 	h.vcCh <- vc

--- a/pkg/anchor/handler/proof/handler_test.go
+++ b/pkg/anchor/handler/proof/handler_test.go
@@ -65,6 +65,33 @@ func TestWitnessProofHandler(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("success - ignore if already witnessed", func(t *testing.T) {
+		vcCh := make(chan *verifiable.Credential, 100)
+
+		store, err := vcstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		require.NoError(t, err)
+
+		anchorVC, err := verifiable.ParseCredential(
+			[]byte(anchorCredTwoProofs),
+			verifiable.WithJSONLDDocumentLoader(testutil.GetLoader(t)),
+			verifiable.WithDisabledProofCheck())
+		require.NoError(t, err)
+
+		err = store.Put(anchorVC)
+		require.NoError(t, err)
+
+		providers := &Providers{
+			Store:         store,
+			MonitoringSvc: &mocks.MonitoringService{},
+		}
+
+		proofHandler := New(providers, vcCh)
+
+		err = proofHandler.HandleProof("http://orb.domain1.com/vc/9ac66b40-bcc6-4ca8-a9c7-d1fd3eaebafd",
+			time.Now(), time.Now(), []byte(witnessProof))
+		require.NoError(t, err)
+	})
+
 	t.Run("error - store error", func(t *testing.T) {
 		vcCh := make(chan *verifiable.Credential, 100)
 
@@ -168,6 +195,50 @@ const anchorCred = `
     "verificationMethod": "did:web:abc#CvSyX0VxMCbg-UiYpAVd9OmhaFBXBr5ISpv2RZ2c9DY"
   },
   "type": "VerifiableCredential"
+}`
+
+//nolint:lll
+const anchorCredTwoProofs = `
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://trustbloc.github.io/did-method-orb/contexts/anchor/v1",
+    "https://w3id.org/jws/v1"
+  ],
+  "credentialSubject": {
+    "coreIndex": "QmTTXin1m7Afk3mQJPMZQdCQAafid7eUNsUDYVcLdSRU2s",
+    "namespace": "did:orb",
+    "operationCount": 1,
+    "previousAnchors": {
+      "EiAhqN-B6kLoWMqKkqwxeLB5ppo0gOYWhZYA-BmptZ0Tqw": ""
+    },
+    "version": 0
+  },
+  "id": "http://orb.domain1.com/vc/9ac66b40-bcc6-4ca8-a9c7-d1fd3eaebafd",
+  "issuanceDate": "2021-04-20T20:07:19.873389246Z",
+  "issuer": "http://orb.domain1.com",
+  "proof": [
+    {
+      "created": "2021-04-20T20:07:19.875087637Z",
+      "domain": "domain1.com",
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..kIg1Z2DpPwY-0njcMRtc8uEmZqewVSmsTqwFSy97ppU7eubGfwGmu_L5nErfn4OCRkPdlDxZRkXhqW1VY329AA",
+      "proofPurpose": "assertionMethod",
+      "type": "Ed25519Signature2018",
+      "verificationMethod": "did:web:abc.com#2130bhDAK-2jKsOXJiEDG909Jux4rcYEpFsYzVlqdAY"
+    },
+    {
+      "created": "2021-04-20T20:07:20.956Z",
+      "domain": "http://orb.vct:8077",
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..khSPSqvqDHhOFWzGe7UoyHhr6-RSEPNZwXjOFk31WOWByRwGZMDuaWpDbbe6QYo89lR0dqVQCxs2N7xprqwgAA",
+      "proofPurpose": "assertionMethod",
+      "type": "Ed25519Signature2018",
+      "verificationMethod": "did:web:abc.com#3e2Fq05s-jEYa5BOW0uQKuNOU8nOTzR3-IIQqE5KmPo"
+    }
+  ],
+  "type": [
+    "VerifiableCredential",
+    "AnchorCredential"
+  ]
 }`
 
 //nolint:lll

--- a/pkg/anchor/writer/writer.go
+++ b/pkg/anchor/writer/writer.go
@@ -391,7 +391,10 @@ func (c *Writer) getWitnesses(refs []*operation.Reference) ([]string, error) {
 		}
 
 		_, ok = uniqueWitnesses[anchorOrigin]
-		if !ok {
+
+		// TODO: Clarify if orb server can witness itself
+		// Remove requesting domain from witness list
+		if !ok && anchorOrigin != c.apServiceIRI.String() {
 			witnesses = append(witnesses, anchorOrigin)
 			uniqueWitnesses[anchorOrigin] = true
 		}

--- a/pkg/anchor/writer/writer_test.go
+++ b/pkg/anchor/writer/writer_test.go
@@ -478,6 +478,29 @@ func TestWriter_getWitnesses(t *testing.T) {
 		require.Equal(t, expected, witnesses)
 	})
 
+	t.Run("success - exclude current domain from witness list", func(t *testing.T) {
+		anchorCh := make(chan []string, 100)
+		vcCh := make(chan *verifiable.Credential, 100)
+
+		providers := &Providers{
+			OpProcessor: &mockOpProcessor{},
+		}
+
+		c := New(namespace, apServiceIRI, casIRI, providers, anchorCh, vcCh)
+
+		opRefs := []*operation.Reference{
+			{
+				UniqueSuffix: "did-1",
+				Type:         operation.TypeCreate,
+				AnchorOrigin: activityPubURL,
+			},
+		}
+
+		witnesses, err := c.getWitnesses(opRefs)
+		require.NoError(t, err)
+		require.Equal(t, 0, len(witnesses))
+	})
+
 	t.Run("error - operation type not supported", func(t *testing.T) {
 		anchorCh := make(chan []string, 100)
 		vcCh := make(chan *verifiable.Credential, 100)

--- a/test/bdd/did_orb_steps.go
+++ b/test/bdd/did_orb_steps.go
@@ -59,8 +59,8 @@ var localURLs = map[string]string{
 }
 
 var anchorOriginURLs = map[string]string{
-	"https://localhost:48326/sidetree/v1/operations": "https://orb.domain2.com/services/orb",
-	"https://localhost:48526/sidetree/v1/operations": "https://orb.domain2.com/services/orb",
+	"https://localhost:48326/sidetree/v1/operations": "https://orb.domain1.com/services/orb",
+	"https://localhost:48526/sidetree/v1/operations": "https://orb.domain1.com/services/orb",
 	"https://localhost:48426/sidetree/v1/operations": "https://orb.domain1.com/services/orb",
 	"https://localhost:48626/sidetree/v1/operations": "https://orb.domain1.com/services/orb",
 }

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - ORB_TLS_KEY=/etc/orb/tls/ec-key.pem
       - DID_NAMESPACE=did:orb
       - DID_ALIASES=did:alias.com
-      - ALLOWED_ORIGINS=https://orb.domain2.com/services/orb
+      - ALLOWED_ORIGINS=https://orb.domain1.com/services/orb,https://orb.domain2.com/services/orb
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
       - BATCH_WRITER_TIMEOUT=200
       - CAS_URL=ipfs:5001
@@ -69,7 +69,7 @@ services:
       - ORB_TLS_KEY=/etc/orb/tls/ec-key.pem
       - DID_NAMESPACE=did:orb
       - DID_ALIASES=did:alias.com
-      - ALLOWED_ORIGINS=https://orb.domain2.com/services/orb
+      - ALLOWED_ORIGINS=https://orb.domain1.com/services/orb,https://orb.domain2.com/services/orb
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
       - BATCH_WRITER_TIMEOUT=200
       - CAS_URL=ipfs:5001
@@ -114,7 +114,7 @@ services:
       - ORB_TLS_KEY=/etc/orb/tls/ec-key.pem
       - DID_NAMESPACE=did:orb
       - DID_ALIASES=did:alias.com
-      - ALLOWED_ORIGINS=https://orb.domain1.com/services/orb
+      - ALLOWED_ORIGINS=https://orb.domain1.com/services/orb,https://orb.domain2.com/services/orb
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
       - BATCH_WRITER_TIMEOUT=200
       - CAS_URL=ipfs:5001


### PR DESCRIPTION
Included:
- disable domain witnessing itself (clarify requirement with @troyronda)
- ignore handling/propagating witness proof if anchor credential has been witnessed already (witness policy = 1 for phase 1)

Closes #323

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>