### PR TITLE
feat: Witness anchor credential with local witness log

### DIFF
--- a/cmd/orb-server/startcmd/params_test.go
+++ b/cmd/orb-server/startcmd/params_test.go
@@ -233,6 +233,33 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid batch writer timeout format")
 	})
+
+	t.Run("test invalid max witness delay", func(t *testing.T) {
+		startCmd := GetStartCmd()
+
+		args := []string{
+			"--" + hostURLFlagName, "localhost:8247",
+			"--" + vctURLFlagName, "localhost:8081",
+			"--" + externalEndpointFlagName, "orb.example.com",
+			"--" + casURLFlagName, "localhost:8081",
+			"--" + maxWitnessDelayFlagName, "abc",
+			"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
+			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption, "--" + tokenFlagName, "tk1",
+			"--" + anchorCredentialSignatureSuiteFlagName, "suite",
+			"--" + anchorCredentialDomainFlagName, "domain.com",
+			"--" + anchorCredentialIssuerFlagName, "issuer.com",
+			"--" + anchorCredentialURLFlagName, "peer.com",
+			"--" + LogLevelFlagName, log.ParseString(log.ERROR),
+		}
+
+		startCmd.SetArgs(args)
+
+		err := startCmd.Execute()
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid max witness delay format")
+	})
+
 }
 
 func TestStartCmdWithBlankEnvVar(t *testing.T) {
@@ -363,6 +390,7 @@ func TestStartCmdValidArgs(t *testing.T) {
 		"--" + externalEndpointFlagName, "orb.example.com",
 		"--" + casURLFlagName, "localhost:8081",
 		"--" + batchWriterTimeoutFlagName, "700",
+		"--" + maxWitnessDelayFlagName, "600",
 		"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
 		"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption, "--" + tokenFlagName, "tk1",
 		"--" + anchorCredentialSignatureSuiteFlagName, "suite",
@@ -395,6 +423,9 @@ func setEnvVars(t *testing.T, databaseType string) {
 	require.NoError(t, err)
 
 	err = os.Setenv(batchWriterTimeoutEnvKey, "2000")
+	require.NoError(t, err)
+
+	err = os.Setenv(maxWitnessDelayEnvKey, "600")
 	require.NoError(t, err)
 
 	err = os.Setenv(didNamespaceEnvKey, "namespace")

--- a/pkg/anchor/builder/builder.go
+++ b/pkg/anchor/builder/builder.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/trustbloc/orb/pkg/anchor/subject"
 	"github.com/trustbloc/orb/pkg/context/loader"
-	"github.com/trustbloc/orb/pkg/vcsigner"
 )
 
 const (
@@ -32,24 +31,18 @@ type Params struct {
 }
 
 // New returns new instance of anchor credential builder.
-func New(signer vcSigner, params Params) (*Builder, error) {
+func New(params Params) (*Builder, error) {
 	if err := verifyBuilderParams(params); err != nil {
 		return nil, fmt.Errorf("failed to verify builder parameters: %w", err)
 	}
 
 	return &Builder{
-		signer: signer,
 		params: params,
 	}, nil
 }
 
-type vcSigner interface {
-	Sign(vc *verifiable.Credential, opts ...vcsigner.Opt) (*verifiable.Credential, error)
-}
-
 // Builder implements building of anchor credential.
 type Builder struct {
-	signer vcSigner
 	params Params
 }
 
@@ -68,12 +61,7 @@ func (b *Builder) Build(payload *subject.Payload) (*verifiable.Credential, error
 		ID:     id,
 	}
 
-	signedVC, err := b.signer.Sign(vc)
-	if err != nil {
-		return nil, fmt.Errorf("failed to sign credential: %w", err)
-	}
-
-	return signedVC, nil
+	return vc, nil
 }
 
 func verifyBuilderParams(params Params) error {

--- a/pkg/anchor/builder/builder_test.go
+++ b/pkg/anchor/builder/builder_test.go
@@ -7,14 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 package builder
 
 import (
-	"errors"
 	"testing"
 
-	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	"github.com/stretchr/testify/require"
 
 	"github.com/trustbloc/orb/pkg/anchor/subject"
-	"github.com/trustbloc/orb/pkg/vcsigner"
 )
 
 func TestSigner_New(t *testing.T) {
@@ -24,20 +21,20 @@ func TestSigner_New(t *testing.T) {
 			URL:    "url",
 		}
 
-		b, err := New(&mockSigner{}, builderParams)
+		b, err := New(builderParams)
 		require.NoError(t, err)
 		require.NotNil(t, b)
 	})
 
 	t.Run("error - missing issuer", func(t *testing.T) {
-		s, err := New(&mockSigner{}, Params{})
+		s, err := New(Params{})
 		require.Error(t, err)
 		require.Nil(t, s)
 		require.Contains(t, err.Error(), "failed to verify builder parameters: missing issuer")
 	})
 
 	t.Run("error - missing URL", func(t *testing.T) {
-		s, err := New(&mockSigner{}, Params{Issuer: "issuer"})
+		s, err := New(Params{Issuer: "issuer"})
 		require.Error(t, err)
 		require.Nil(t, s)
 		require.Contains(t, err.Error(), "failed to verify builder parameters: missing URL")
@@ -51,23 +48,12 @@ func TestBuilder_Build(t *testing.T) {
 	}
 
 	t.Run("success", func(t *testing.T) {
-		b, err := New(&mockSigner{}, builderParams)
+		b, err := New(builderParams)
 		require.NoError(t, err)
 
 		vc, err := b.Build(&subject.Payload{})
 		require.NoError(t, err)
 		require.NotEmpty(t, vc)
-	})
-
-	t.Run("error - error from signer", func(t *testing.T) {
-		b, err := New(&mockSigner{Err: errors.New("signer error")},
-			builderParams)
-		require.NoError(t, err)
-
-		vc, err := b.Build(&subject.Payload{})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to sign credential: signer error")
-		require.Nil(t, vc)
 	})
 }
 
@@ -87,16 +73,4 @@ func TestSigner_verifyBuilderParams(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "missing issuer")
 	})
-}
-
-type mockSigner struct {
-	Err error
-}
-
-func (m *mockSigner) Sign(vc *verifiable.Credential, opts ...vcsigner.Opt) (*verifiable.Credential, error) {
-	if m.Err != nil {
-		return nil, m.Err
-	}
-
-	return vc, nil
 }

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -32,7 +32,8 @@ services:
       - ANCHOR_CREDENTIAL_ISSUER=http://orb.domain1.com
       - ANCHOR_CREDENTIAL_URL=http://orb.domain1.com/vc
       - ANCHOR_CREDENTIAL_SIGNATURE_SUITE=Ed25519Signature2018
-      - ANCHOR_CREDENTIAL_DOMAIN=domain1.com
+      # used in case that orb server signs anchor credential (there is no local witness log)
+      - ANCHOR_CREDENTIAL_DOMAIN=https://orb.domain1.com
       - DATABASE_TYPE=couchdb
       - DATABASE_URL=${COUCHDB_USERNAME}:${COUCHDB_PASSWORD}@couchdb.shared.com:5984
       - DATABASE_PREFIX=domain1
@@ -76,7 +77,8 @@ services:
       - ANCHOR_CREDENTIAL_ISSUER=http://orb2.domain1.com
       - ANCHOR_CREDENTIAL_URL=http://orb2.domain1.com/vc
       - ANCHOR_CREDENTIAL_SIGNATURE_SUITE=Ed25519Signature2018
-      - ANCHOR_CREDENTIAL_DOMAIN=domain1.com
+      # used in case that orb server signs anchor credential (there is no local witness log)
+      - ANCHOR_CREDENTIAL_DOMAIN=https://orb.domain1.com
       - DATABASE_TYPE=couchdb
       - DATABASE_URL=${COUCHDB_USERNAME}:${COUCHDB_PASSWORD}@couchdb.shared.com:5984
       - DATABASE_PREFIX=domain1
@@ -121,7 +123,8 @@ services:
       - ANCHOR_CREDENTIAL_ISSUER=http://orb.domain2.com
       - ANCHOR_CREDENTIAL_URL=http://orb.domain2.com/vc
       - ANCHOR_CREDENTIAL_SIGNATURE_SUITE=Ed25519Signature2018
-      - ANCHOR_CREDENTIAL_DOMAIN=domain2.com
+      # used in case that orb server signs anchor credential (there is no local witness log)
+      - ANCHOR_CREDENTIAL_DOMAIN=https://orb.domain2.com
       - DATABASE_TYPE=couchdb
       - DATABASE_URL=${COUCHDB_USERNAME}:${COUCHDB_PASSWORD}@couchdb.shared.com:5984
       - DATABASE_PREFIX=domain2
@@ -165,7 +168,8 @@ services:
       - ANCHOR_CREDENTIAL_ISSUER=http://orb.domain3.com
       - ANCHOR_CREDENTIAL_URL=http://orb.domain3.com/vc
       - ANCHOR_CREDENTIAL_SIGNATURE_SUITE=Ed25519Signature2018
-      - ANCHOR_CREDENTIAL_DOMAIN=domain3.com
+      # used in case that orb server signs anchor credential (there is no local witness log)
+      - ANCHOR_CREDENTIAL_DOMAIN=https://orb.domain3.com
       - DATABASE_TYPE=couchdb
       - DATABASE_URL=${COUCHDB_USERNAME}:${COUCHDB_PASSWORD}@couchdb.shared.com:5984
       - DATABASE_PREFIX=domain3


### PR DESCRIPTION
If domain has local witness log then Orb server should witness anchor credential (instead of just signing it) before sending it to other witness logs for witnessing. This is default behaviour. An option to disable this default behaviour (#332) will be added later.

Also, added maximum witness delay configuration.

Closes #328

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>