### PR TITLE
feat: Added REST endpoint to post to outbox

### DIFF
--- a/cmd/orb-server/go.sum
+++ b/cmd/orb-server/go.sum
@@ -1057,8 +1057,6 @@ github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9 h1:JCWLY91Vp
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9/go.mod h1:BpCeNH2fEH3RX7+C5XfnVIXFQbk7LzBdWdBdgnEb284=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210324191759-951b35003134 h1:cpLmHa6D0PbT6U//yFSQFc6/AW8E4Y2cYzKo7EoxcOs=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210324191759-951b35003134/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
-github.com/trustbloc/vct v0.0.0-20210429132259-eacaec814059 h1:mMnyW3aNuolkNTDMXcqCvGcTyICPcXPSCyJSjPEp/eM=
-github.com/trustbloc/vct v0.0.0-20210429132259-eacaec814059/go.mod h1:wU4hT9o3Vjf4cJlICwHCxkWYGgQsMDLI0+5qx3vzBdE=
 github.com/trustbloc/vct v0.0.0-20210430190325-66a3ac65585a h1:9mTqsQx6P0djpAQPL5zMmTv3hwmwGgSnSSKKc3ixOwM=
 github.com/trustbloc/vct v0.0.0-20210430190325-66a3ac65585a/go.mod h1:wU4hT9o3Vjf4cJlICwHCxkWYGgQsMDLI0+5qx3vzBdE=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -534,7 +534,9 @@ func startOrbServices(parameters *orbParameters) error {
 		aphandler.NewLiked(apServiceCfg, apStore, sigVerifier),
 		aphandler.NewLikes(apTxnCfg, apStore, sigVerifier),
 		aphandler.NewShares(apTxnCfg, apStore, sigVerifier),
-		webcas.New(casClient))
+		aphandler.NewPostOutbox(apServiceCfg, activityPubService.Outbox(), sigVerifier),
+		webcas.New(casClient),
+	)
 
 	handlers = append(handlers,
 		endpointDiscoveryOp.GetRESTHandlers()...)

--- a/go.sum
+++ b/go.sum
@@ -602,7 +602,6 @@ github.com/huaweicloud/golangsdk v0.0.0-20200304081349-45ec0797f2a4/go.mod h1:WQ
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/hyperledger/aries-framework-go v0.1.7-0.20210310014234-cfa8c6d6e2f4/go.mod h1:nKqMfEbn4nAkh/XcBuK6m+4K5IHOIqLfzLyVJC52lJk=
 github.com/hyperledger/aries-framework-go v0.1.7-0.20210409151411-eeeb8508bd87/go.mod h1:9Mz/wkgyzXKxuOZObASCWRprt30P+xSsL08T8VBFRnk=
-github.com/hyperledger/aries-framework-go v0.1.7-0.20210416102014-f347f45b984f/go.mod h1:tBgxVOKcNero3QI21iNf3oxxHkgRMDOby937cqHEvW4=
 github.com/hyperledger/aries-framework-go v0.1.7-0.20210429013345-a595aa0b19c4 h1:7x85byM8VDtA2dOazNRmcsqevgYkDvE9ormdO2o45Pc=
 github.com/hyperledger/aries-framework-go v0.1.7-0.20210429013345-a595aa0b19c4/go.mod h1:NH2lUe2C7kR7agKx3B+qBebALNJWrJVUBpqU2L9hvIM=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20210326155331-14f4ca7d75cb/go.mod h1:zHlYeWY7yvMXtHQ8wTpoZ5UCuUE5WdxHd4D8KEW4DRM=
@@ -622,7 +621,6 @@ github.com/hyperledger/aries-framework-go/spi v0.0.0-20210320144851-40976de98ccf
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210322152545-e6ebe2c79a2a/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210325221830-6ab3160b7588/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210409151411-eeeb8508bd87/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20210412201938-efffe3eafcd1/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210421165342-de8f911415e3/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210422133815-2ef2d99cb692/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210422144621-1355c6f90b44 h1:X5PSWzGs5s8NQ6WyjXG4Ko3XDKOJsBdTcNlPlTBWm8s=
@@ -1056,10 +1054,6 @@ github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9 h1:JCWLY91Vp
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9/go.mod h1:BpCeNH2fEH3RX7+C5XfnVIXFQbk7LzBdWdBdgnEb284=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210324191759-951b35003134 h1:cpLmHa6D0PbT6U//yFSQFc6/AW8E4Y2cYzKo7EoxcOs=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210324191759-951b35003134/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
-github.com/trustbloc/vct v0.0.0-20210421142540-2e6dc314f272 h1:tYwLg1Md9ywqZeliR1cxr2kPCMgybBAvHtkL/yh0w4w=
-github.com/trustbloc/vct v0.0.0-20210421142540-2e6dc314f272/go.mod h1:iasw5VZKvIspaK2hjo1632lvfxh4UibCrKmuqpJH/TA=
-github.com/trustbloc/vct v0.0.0-20210429132259-eacaec814059 h1:mMnyW3aNuolkNTDMXcqCvGcTyICPcXPSCyJSjPEp/eM=
-github.com/trustbloc/vct v0.0.0-20210429132259-eacaec814059/go.mod h1:wU4hT9o3Vjf4cJlICwHCxkWYGgQsMDLI0+5qx3vzBdE=
 github.com/trustbloc/vct v0.0.0-20210430190325-66a3ac65585a h1:9mTqsQx6P0djpAQPL5zMmTv3hwmwGgSnSSKKc3ixOwM=
 github.com/trustbloc/vct v0.0.0-20210430190325-66a3ac65585a/go.mod h1:wU4hT9o3Vjf4cJlICwHCxkWYGgQsMDLI0+5qx3vzBdE=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/pkg/activitypub/resthandler/outboxhandler.go
+++ b/pkg/activitypub/resthandler/outboxhandler.go
@@ -1,0 +1,118 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resthandler
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/restapi/common"
+
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+)
+
+type outbox interface {
+	Post(activity *vocab.ActivityType) (*url.URL, error)
+}
+
+// Outbox implements a REST handler for posts to a service's outbox.
+type Outbox struct {
+	*Config
+
+	endpoint string
+	ob       outbox
+	verifier signatureVerifier
+}
+
+// NewPostOutbox returns a new REST handler to post activities to the outbox.
+func NewPostOutbox(cfg *Config, ob outbox, verifier signatureVerifier) *Outbox {
+	return &Outbox{
+		Config:   cfg,
+		endpoint: fmt.Sprintf("%s%s", cfg.BasePath, "/outbox"),
+		ob:       ob,
+		verifier: verifier,
+	}
+}
+
+// Method returns the HTTP method, which is always POST.
+func (h *Outbox) Method() string {
+	return http.MethodPost
+}
+
+// Path returns the base path of the target URL for this handler.
+func (h *Outbox) Path() string {
+	return h.endpoint
+}
+
+// Handler returns the handler that should be invoked when an HTTP POST is requested to the target endpoint.
+// This handler must be registered with an HTTP server.
+func (h *Outbox) Handler() common.HTTPRequestHandler {
+	return h.handlePost
+}
+
+func (h *Outbox) handlePost(w http.ResponseWriter, req *http.Request) {
+	_, err := h.verifier.VerifyRequest(req)
+	if err != nil {
+		logger.Errorf("[%s] Error verifying HTTP signature: %s", h.endpoint, err)
+
+		w.WriteHeader(http.StatusUnauthorized)
+
+		return
+	}
+
+	activityBytes, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		logger.Errorf("[%s] Error reading request body: %s", h.endpoint, err)
+
+		w.WriteHeader(http.StatusBadRequest)
+
+		return
+	}
+
+	logger.Debugf("[%s] Posting activity %s", h.endpoint, activityBytes)
+
+	activity, err := h.unmarshalAndValidateActivity(activityBytes)
+	if err != nil {
+		logger.Errorf("[%s] Invalid activity: %s", h.endpoint, err)
+
+		w.WriteHeader(http.StatusUnauthorized)
+
+		return
+	}
+
+	_, err = h.ob.Post(activity)
+	if err != nil {
+		logger.Errorf("[%s] Error posting activity: %s", h.endpoint, err)
+
+		w.WriteHeader(http.StatusInternalServerError)
+
+		return
+	}
+}
+
+func (h *Outbox) unmarshalAndValidateActivity(activityBytes []byte) (*vocab.ActivityType, error) {
+	activity := &vocab.ActivityType{}
+
+	err := json.Unmarshal(activityBytes, activity)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal activity: %w", err)
+	}
+
+	if activity.Actor() == nil {
+		return nil, fmt.Errorf("no actor specified in activity [%s]", activity.ID())
+	}
+
+	if activity.Actor().String() != h.ObjectIRI.String() {
+		return nil, fmt.Errorf("actor in activity [%s] does not match the actor in the HTTP signature [%s]",
+			activity.ID(), h.ObjectIRI)
+	}
+
+	return activity, nil
+}

--- a/pkg/activitypub/resthandler/outboxhandler_test.go
+++ b/pkg/activitypub/resthandler/outboxhandler_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resthandler
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/pkg/activitypub/service/mocks"
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+	"github.com/trustbloc/orb/pkg/internal/testutil"
+)
+
+func TestNewOutboxAdmin(t *testing.T) {
+	cfg := &Config{
+		BasePath:  "/services/orb",
+		ObjectIRI: serviceIRI,
+	}
+
+	ob := &mocks.Outbox{}
+	verifier := &mocks.SignatureVerifier{}
+
+	h := NewPostOutbox(cfg, ob, verifier)
+
+	require.NotNil(t, h.Handler())
+	require.Equal(t, http.MethodPost, h.Method())
+	require.Equal(t, "/services/orb/outbox", h.Path())
+}
+
+func TestOutbox_Handler(t *testing.T) {
+	const outboxURL = "https://example1.com/services/orb/outbox"
+
+	service2IRI := testutil.MustParseURL("https://example2.com/services/orb")
+
+	cfg := &Config{
+		BasePath:  "/services/orb",
+		ObjectIRI: serviceIRI,
+	}
+
+	ob := &mocks.Outbox{}
+
+	activity := vocab.NewFollowActivity(
+		vocab.NewObjectProperty(vocab.WithIRI(service2IRI)),
+		vocab.WithActor(serviceIRI),
+		vocab.WithTo(service2IRI),
+	)
+
+	activityBytes, err := json.Marshal(activity)
+	require.NoError(t, err)
+
+	t.Run("Success", func(t *testing.T) {
+		verifier := &mocks.SignatureVerifier{}
+		verifier.VerifyRequestReturns(serviceIRI, nil)
+
+		h := NewPostOutbox(cfg, ob, verifier)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, outboxURL, bytes.NewBuffer(activityBytes))
+
+		h.handlePost(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusOK, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+	})
+
+	t.Run("HTTP signature verifier error", func(t *testing.T) {
+		errExpected := errors.New("injected signature verifier error")
+
+		verifier := &mocks.SignatureVerifier{}
+		verifier.VerifyRequestReturns(nil, errExpected)
+
+		h := NewPostOutbox(cfg, ob, verifier)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, outboxURL, bytes.NewBuffer(activityBytes))
+
+		h.handlePost(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusUnauthorized, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+	})
+
+	t.Run("No activity in request -> error", func(t *testing.T) {
+		verifier := &mocks.SignatureVerifier{}
+		verifier.VerifyRequestReturns(serviceIRI, nil)
+
+		h := NewPostOutbox(cfg, ob, verifier)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, outboxURL, nil)
+
+		h.handlePost(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusUnauthorized, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+	})
+
+	t.Run("Outbox Post error", func(t *testing.T) {
+		verifier := &mocks.SignatureVerifier{}
+		verifier.VerifyRequestReturns(serviceIRI, nil)
+
+		errExpected := errors.New("injected outbox error")
+
+		outb := &mocks.Outbox{}
+		outb.WithError(errExpected)
+
+		h := NewPostOutbox(cfg, outb, verifier)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, outboxURL, bytes.NewBuffer(activityBytes))
+
+		h.handlePost(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusInternalServerError, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+	})
+
+	t.Run("Nil actor in activity", func(t *testing.T) {
+		verifier := &mocks.SignatureVerifier{}
+		verifier.VerifyRequestReturns(serviceIRI, nil)
+
+		h := NewPostOutbox(cfg, ob, verifier)
+
+		a := vocab.NewFollowActivity(
+			vocab.NewObjectProperty(vocab.WithIRI(service2IRI)),
+			vocab.WithTo(service2IRI),
+		)
+
+		aBytes, err := json.Marshal(a)
+		require.NoError(t, err)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, outboxURL, bytes.NewBuffer(aBytes))
+
+		h.handlePost(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusUnauthorized, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+	})
+
+	t.Run("Invalid actor in activity", func(t *testing.T) {
+		verifier := &mocks.SignatureVerifier{}
+		verifier.VerifyRequestReturns(serviceIRI, nil)
+
+		h := NewPostOutbox(cfg, ob, verifier)
+
+		a := vocab.NewFollowActivity(
+			vocab.NewObjectProperty(vocab.WithIRI(service2IRI)),
+			vocab.WithActor(service2IRI),
+			vocab.WithTo(service2IRI),
+		)
+
+		aBytes, err := json.Marshal(a)
+		require.NoError(t, err)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, outboxURL, bytes.NewBuffer(aBytes))
+
+		h.handlePost(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusUnauthorized, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+	})
+}

--- a/pkg/activitypub/service/outbox/outbox.go
+++ b/pkg/activitypub/service/outbox/outbox.go
@@ -454,7 +454,7 @@ func (h *Outbox) resolveIRIs(toIRIs []*url.URL, resolve func(iri *url.URL) ([]*u
 }
 
 func (h *Outbox) newActivityID() *url.URL {
-	id, err := url.Parse(fmt.Sprintf("%s/%s", h.ServiceIRI, uuid.New()))
+	id, err := url.Parse(fmt.Sprintf("%s/activities/%s", h.ServiceIRI, uuid.New()))
 	if err != nil {
 		// Should never happen since we've already validated the URLs
 		panic(err)

--- a/test/bdd/did_orb_steps.go
+++ b/test/bdd/did_orb_steps.go
@@ -394,7 +394,7 @@ func (d *DIDOrbSteps) checkSuccessResp(msg string, contains bool) error {
 			return err
 		}
 
-		time.Sleep(time.Second)
+		time.Sleep(2 * time.Second)
 		logger.Infof("retrying check success response - attempt %d", i)
 
 		resolveErr := d.resolveDIDDocumentWithID(d.sidetreeURL, did)

--- a/test/bdd/features/activitypub.feature
+++ b/test/bdd/features/activitypub.feature
@@ -9,12 +9,8 @@
 Feature:
   Background: Setup
     Given variable "domain1IRI" is assigned the value "https://orb.domain1.com/services/orb"
-    And variable "domain1KeyID" is assigned the value "${domain1IRI}/keys/main-key"
-    And variable "domain1KeyFile" is assigned the value "./fixtures/testdata/keys/domain1/private-key.pem"
-
     And variable "domain2IRI" is assigned the value "https://orb.domain2.com/services/orb"
-    And variable "domain2KeyID" is assigned the value "${domain2IRI}/keys/main-key"
-    And variable "domain2KeyFile" is assigned the value "./fixtures/testdata/keys/domain2/private-key.pem"
+    And variable "domain3IRI" is assigned the value "https://orb.domain3.com/services/orb"
 
   @activitypub_service
   Scenario: Get ActivityPub service
@@ -56,8 +52,8 @@ Feature:
   Scenario: follow/accept/undo
     # domain2 follows domain1
     Given variable "followID" is assigned a unique ID
-    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain2IRI}/activities/${followID}","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content "${followActivity}" of type "application/json"
+    Given variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain2IRI}/activities/${followID}","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
+    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${followActivity}" of type "application/json"
 
     Then we wait 3 seconds
 
@@ -90,9 +86,13 @@ Feature:
 
     Given variable "undoID" is assigned a unique ID
     And variable "undoFollowActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain2IRI}/activities/${undoID}","type":"Undo","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain2IRI}/activities/${followID}"}'
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content "${undoFollowActivity}" of type "application/json"
+    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${undoFollowActivity}" of type "application/json"
 
     Then we wait 3 seconds
+
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/following?page=true"
+    Then the JSON path "type" of the response equals "CollectionPage"
+    And the JSON path "items" of the response does not contain "${domain1IRI}"
 
     When an HTTP GET is sent to "https://localhost:48326/services/orb/followers?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
@@ -100,28 +100,33 @@ Feature:
 
   @activitypub_create
   Scenario: create/announce
-    Given variable "followID" is assigned a unique ID
-    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain2IRI}/activities/${followID}","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content "${followActivity}" of type "application/json"
+    # domain2 follows domain1
+    Given variable "followDomain1Activity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
+    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${followDomain1Activity}" of type "application/json"
+
+    # domain3 follows domain2
+    Given variable "followDomain2Activity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain3IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
+    When an HTTP POST is sent to "https://localhost:48626/services/orb/outbox" with content "${followDomain2Activity}" of type "application/json"
 
     Then we wait 2 seconds
 
-    # Post 'Create' activity to domain1
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content from file "./fixtures/testdata/create_activity.json"
+    # Post 'Create' activity to domain1's outbox
+    When an HTTP POST is sent to "https://localhost:48326/services/orb/outbox" with content from file "./fixtures/testdata/create_activity.json"
 
     Then we wait 2 seconds
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox?page=true"
+    # A 'Create' activity should have been posted to domain1's followers (domain2).
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.id" of the response contains "${domain1IRI}/activities/77bdd005-bbb6-223d-b889-58bc1de84985"
 
-    # An 'Announce' activity should have been posted to domain1's followers (domain2).
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/outbox?page=true"
+    # An 'Announce' activity should have been posted to domain2's followers (domain3).
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/outbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.type" of the response contains "Announce"
 
-    # An 'Announce' activity should have been received by domain2 since it's a follower of domain1.
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/inbox?page=true"
+    # An 'Announce' activity should have been received by domain3 since it's a follower of domain2.
+    When an HTTP GET is sent to "https://localhost:48626/services/orb/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.type" of the response contains "Announce"
 
@@ -130,7 +135,7 @@ Feature:
     # domain1 invites domain2 to be a witness
     Given variable "inviteWitnessID" is assigned a unique ID
     And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain1IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/inbox" with content "${inviteWitnessActivity}" of type "application/json"
+    When an HTTP POST is sent to "https://localhost:48326/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     Then we wait 3 seconds
 
@@ -158,9 +163,13 @@ Feature:
 
     Given variable "undoWitnessID" is assigned a unique ID
     And variable "undoInviteWitnessActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain1IRI}/activities/${undoWitnessID}","type":"Undo","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain1IRI}/activities/${inviteWitnessID}"}'
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/inbox" with content "${undoInviteWitnessActivity}" of type "application/json"
+    When an HTTP POST is sent to "https://localhost:48326/services/orb/outbox" with content "${undoInviteWitnessActivity}" of type "application/json"
 
     Then we wait 3 seconds
+
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/witnesses?page=true"
+    Then the JSON path "type" of the response equals "CollectionPage"
+    And the JSON path "items" of the response does not contain "${domain2IRI}"
 
     When an HTTP GET is sent to "https://localhost:48426/services/orb/witnessing?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
@@ -168,14 +177,18 @@ Feature:
 
   @activitypub_offer
   Scenario: offer/like
-    # domain1 invites domain2 to be a witness
+    # domain2 invites domain1 to be a witness
     Given variable "inviteWitnessID" is assigned a unique ID
-    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain2IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content "${inviteWitnessActivity}" of type "application/json"
+    Given variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain2IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
+    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     Then we wait 2 seconds
 
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content from file "./fixtures/testdata/offer_activity.json"
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox?page=true"
+    Then the JSON path "type" of the response equals "OrderedCollectionPage"
+    And the JSON path "orderedItems.#.id" of the response contains "${domain2IRI}/activities/${inviteWitnessID}"
+
+    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content from file "./fixtures/testdata/offer_activity.json"
 
     Then we wait 2 seconds
 

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -9,32 +9,27 @@
 Feature:
   Background: Setup
     Given variable "domain1IRI" is assigned the value "https://orb.domain1.com/services/orb"
-    And variable "domain1KeyID" is assigned the value "${domain1IRI}/keys/main-key"
-    And variable "domain1KeyFile" is assigned the value "./fixtures/testdata/keys/domain1/private-key.pem"
-
     And variable "domain2IRI" is assigned the value "https://orb.domain2.com/services/orb"
-    And variable "domain2KeyID" is assigned the value "${domain2IRI}/keys/main-key"
-    And variable "domain2KeyFile" is assigned the value "./fixtures/testdata/keys/domain2/private-key.pem"
 
     # domain2 server follows domain1 server
     Given variable "followID" is assigned a unique ID
     And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain2IRI}/activities/${followID}","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content "${followActivity}" of type "application/json"
+    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${followActivity}" of type "application/json"
 
     # domain1 server follows domain2 server
     Given variable "followID" is assigned a unique ID
     And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain1IRI}/activities/${followID}","type":"Follow","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/inbox" with content "${followActivity}" of type "application/json"
+    When an HTTP POST is sent to "https://localhost:48326/services/orb/outbox" with content "${followActivity}" of type "application/json"
 
     # domain1 invites domain2 to be a witness
     Given variable "inviteWitnessID" is assigned a unique ID
     And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain1IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/inbox" with content "${inviteWitnessActivity}" of type "application/json"
+    When an HTTP POST is sent to "https://localhost:48326/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     # domain2 invites domain1 to be a witness
     Given variable "inviteWitnessID" is assigned a unique ID
     And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain2IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content "${inviteWitnessActivity}" of type "application/json"
+    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     Then we wait 3 seconds
 

--- a/test/bdd/features/did-sidetree.feature
+++ b/test/bdd/features/did-sidetree.feature
@@ -9,22 +9,17 @@
 Feature:
   Background: Setup
     Given variable "domain1IRI" is assigned the value "https://orb.domain1.com/services/orb"
-    And variable "domain1KeyID" is assigned the value "${domain1IRI}/keys/main-key"
-    And variable "domain1KeyFile" is assigned the value "./fixtures/testdata/keys/domain1/private-key.pem"
-
     And variable "domain2IRI" is assigned the value "https://orb.domain2.com/services/orb"
-    And variable "domain2KeyID" is assigned the value "${domain2IRI}/keys/main-key"
-    And variable "domain2KeyFile" is assigned the value "./fixtures/testdata/keys/domain2/private-key.pem"
 
     # domain2 server follows domain1 server
     Given variable "followID" is assigned a unique ID
     And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain2IRI}/activities/${followID}","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/inbox" with content "${followActivity}" of type "application/json"
+    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${followActivity}" of type "application/json"
 
     # domain1 invites domain2 to be a witness
     Given variable "inviteWitnessID" is assigned a unique ID
     And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain1IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/inbox" with content "${inviteWitnessActivity}" of type "application/json"
+    When an HTTP POST is sent to "https://localhost:48326/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     Then we wait 3 seconds
 

--- a/test/bdd/fixtures/testdata/offer_activity.json
+++ b/test/bdd/fixtures/testdata/offer_activity.json
@@ -27,6 +27,6 @@
       "AnchorCredential"
     ]
   },
-  "to": ["https://orb.domain1.com/services/orb/witnesses","https://www.w3.org/ns/activitystreams#Public"],
+  "to": ["https://orb.domain2.com/services/orb/witnesses","https://www.w3.org/ns/activitystreams#Public"],
   "type": "Offer"
 }

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -586,8 +586,6 @@ github.com/huaweicloud/golangsdk v0.0.0-20200304081349-45ec0797f2a4/go.mod h1:WQ
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/hyperledger/aries-framework-go v0.1.7-0.20210310014234-cfa8c6d6e2f4/go.mod h1:nKqMfEbn4nAkh/XcBuK6m+4K5IHOIqLfzLyVJC52lJk=
 github.com/hyperledger/aries-framework-go v0.1.7-0.20210409151411-eeeb8508bd87/go.mod h1:9Mz/wkgyzXKxuOZObASCWRprt30P+xSsL08T8VBFRnk=
-github.com/hyperledger/aries-framework-go v0.1.7-0.20210416102014-f347f45b984f/go.mod h1:tBgxVOKcNero3QI21iNf3oxxHkgRMDOby937cqHEvW4=
-github.com/hyperledger/aries-framework-go v0.1.7-0.20210429013345-a595aa0b19c4 h1:7x85byM8VDtA2dOazNRmcsqevgYkDvE9ormdO2o45Pc=
 github.com/hyperledger/aries-framework-go v0.1.7-0.20210429013345-a595aa0b19c4/go.mod h1:NH2lUe2C7kR7agKx3B+qBebALNJWrJVUBpqU2L9hvIM=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20210326155331-14f4ca7d75cb/go.mod h1:zHlYeWY7yvMXtHQ8wTpoZ5UCuUE5WdxHd4D8KEW4DRM=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20210426192704-553740e279e5/go.mod h1:+16+LT5k4eulqgc7CsWqHFjKX7cphw1GRHBk8V4jGTk=
@@ -604,7 +602,6 @@ github.com/hyperledger/aries-framework-go/spi v0.0.0-20210320144851-40976de98ccf
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210322152545-e6ebe2c79a2a/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210325221830-6ab3160b7588/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210409151411-eeeb8508bd87/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20210412201938-efffe3eafcd1/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210421165342-de8f911415e3/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210422133815-2ef2d99cb692/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210422144621-1355c6f90b44/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
@@ -1011,9 +1008,6 @@ github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9 h1:JCWLY91Vp
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9/go.mod h1:BpCeNH2fEH3RX7+C5XfnVIXFQbk7LzBdWdBdgnEb284=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210324191759-951b35003134 h1:cpLmHa6D0PbT6U//yFSQFc6/AW8E4Y2cYzKo7EoxcOs=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210324191759-951b35003134/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
-github.com/trustbloc/vct v0.0.0-20210421142540-2e6dc314f272/go.mod h1:iasw5VZKvIspaK2hjo1632lvfxh4UibCrKmuqpJH/TA=
-github.com/trustbloc/vct v0.0.0-20210429132259-eacaec814059/go.mod h1:wU4hT9o3Vjf4cJlICwHCxkWYGgQsMDLI0+5qx3vzBdE=
-github.com/trustbloc/vct v0.0.0-20210430190325-66a3ac65585a h1:9mTqsQx6P0djpAQPL5zMmTv3hwmwGgSnSSKKc3ixOwM=
 github.com/trustbloc/vct v0.0.0-20210430190325-66a3ac65585a/go.mod h1:wU4hT9o3Vjf4cJlICwHCxkWYGgQsMDLI0+5qx3vzBdE=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/test/bdd/restclient/sender.go
+++ b/test/bdd/restclient/sender.go
@@ -106,7 +106,7 @@ func SendResolveRequestWithRetry(url string, attempts uint8, retryableCode int, 
 			break
 		}
 
-		time.Sleep(time.Second)
+		time.Sleep(2 * time.Second)
 	}
 
 	return resp, nil


### PR DESCRIPTION
Added an endpoint that allows a client to post to it's own service outbox in order to perform admin activities such as add/remove followers and witnesses. A future PR will add access control using HTTP signatures.

closes #117

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>