### PR TITLE
chore: Add option to disable signing with local witness log

### DIFF
--- a/cmd/orb-server/startcmd/params.go
+++ b/cmd/orb-server/startcmd/params.go
@@ -172,6 +172,11 @@ const (
 	maxWitnessDelayFlagShorthand = "w"
 	maxWitnessDelayFlagUsage     = "Maximum witness response time (in seconds). " + commonEnvVarUsageText + maxWitnessDelayEnvKey
 
+	signWithLocalWitnessFlagName      = "sign-with-local-witness"
+	signWithLocalWitnessEnvKey        = "SIGN_WITH_LOCAL_WITNESS"
+	signWithLocalWitnessFlagShorthand = "f"
+	signWithLocalWitnessFlagUsage     = "Always sign with local witness flag (default true). " + commonEnvVarUsageText + signWithLocalWitnessEnvKey
+
 	discoveryDomainsFlagName  = "discovery-domains"
 	discoveryDomainsEnvKey    = "DISCOVERY_DOMAINS"
 	discoveryDomainsFlagUsage = "Discovery domains. " + commonEnvVarUsageText + discoveryDomainsEnvKey
@@ -210,6 +215,7 @@ type orbParameters struct {
 	discoveryMinimumResolvers int
 	maxWitnessDelay           time.Duration
 	startupDelay              time.Duration
+	signWithLocalWitness      bool
 }
 
 type anchorCredentialParams struct {
@@ -301,6 +307,20 @@ func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 		maxWitnessDelay = time.Duration(delay) * time.Second
 	}
 
+	signWithLocalWitnessStr, err := cmdutils.GetUserSetVarFromString(cmd, signWithLocalWitnessFlagName, signWithLocalWitnessEnvKey, true)
+	if err != nil {
+		return nil, err
+	}
+
+	// default behaviour is to always sign with local witness
+	signWithLocalWitness := true
+	if signWithLocalWitnessStr != "" {
+		signWithLocalWitness, err = strconv.ParseBool(signWithLocalWitnessStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid sign with local witness flag value: %s", err.Error())
+		}
+	}
+
 	startupDelayStr, err := cmdutils.GetUserSetVarFromString(cmd, startupDelayFlagName, startupDelayEnvKey, true)
 	if err != nil {
 		return nil, err
@@ -384,6 +404,7 @@ func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 		discoveryMinimumResolvers: discoveryMinimumResolvers,
 		maxWitnessDelay:           maxWitnessDelay,
 		startupDelay:              startupDelay,
+		signWithLocalWitness:      signWithLocalWitness,
 	}, nil
 }
 
@@ -478,6 +499,7 @@ func createFlags(startCmd *cobra.Command) {
 	startCmd.Flags().StringP(tlsKeyFlagName, tlsKeyFlagShorthand, "", tlsKeyFlagUsage)
 	startCmd.Flags().StringP(batchWriterTimeoutFlagName, batchWriterTimeoutFlagShorthand, "", batchWriterTimeoutFlagUsage)
 	startCmd.Flags().StringP(maxWitnessDelayFlagName, maxWitnessDelayFlagShorthand, "", maxWitnessDelayFlagUsage)
+	startCmd.Flags().StringP(signWithLocalWitnessFlagName, signWithLocalWitnessFlagShorthand, "", signWithLocalWitnessFlagUsage)
 	startCmd.Flags().StringP(casURLFlagName, casURLFlagShorthand, "", casURLFlagUsage)
 	startCmd.Flags().StringP(didNamespaceFlagName, didNamespaceFlagShorthand, "", didNamespaceFlagUsage)
 	startCmd.Flags().StringArrayP(didAliasesFlagName, didAliasesFlagShorthand, []string{}, didAliasesFlagUsage)

--- a/cmd/orb-server/startcmd/params_test.go
+++ b/cmd/orb-server/startcmd/params_test.go
@@ -260,6 +260,33 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 		require.Contains(t, err.Error(), "invalid max witness delay format")
 	})
 
+	t.Run("test invalid sign with local witness flag", func(t *testing.T) {
+		startCmd := GetStartCmd()
+
+		args := []string{
+			"--" + hostURLFlagName, "localhost:8247",
+			"--" + vctURLFlagName, "localhost:8081",
+			"--" + externalEndpointFlagName, "orb.example.com",
+			"--" + casURLFlagName, "localhost:8081",
+			"--" + maxWitnessDelayFlagName, "5",
+			"--" + signWithLocalWitnessFlagName, "abc",
+			"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
+			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption, "--" + tokenFlagName, "tk1",
+			"--" + anchorCredentialSignatureSuiteFlagName, "suite",
+			"--" + anchorCredentialDomainFlagName, "domain.com",
+			"--" + anchorCredentialIssuerFlagName, "issuer.com",
+			"--" + anchorCredentialURLFlagName, "peer.com",
+			"--" + LogLevelFlagName, log.ParseString(log.ERROR),
+		}
+
+		startCmd.SetArgs(args)
+
+		err := startCmd.Execute()
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid sign with local witness flag value")
+	})
+
 	t.Run("test invalid startup delay format", func(t *testing.T) {
 		startCmd := GetStartCmd()
 
@@ -416,6 +443,7 @@ func TestStartCmdValidArgs(t *testing.T) {
 		"--" + casURLFlagName, "localhost:8081",
 		"--" + batchWriterTimeoutFlagName, "700",
 		"--" + maxWitnessDelayFlagName, "600",
+		"--" + signWithLocalWitnessFlagName, "false",
 		"--" + startupDelayFlagName, "1",
 		"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
 		"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption, "--" + tokenFlagName, "tk1",
@@ -452,6 +480,9 @@ func setEnvVars(t *testing.T, databaseType string) {
 	require.NoError(t, err)
 
 	err = os.Setenv(maxWitnessDelayEnvKey, "600")
+	require.NoError(t, err)
+
+	err = os.Setenv(signWithLocalWitnessEnvKey, "true")
 	require.NoError(t, err)
 
 	err = os.Setenv(startupDelayEnvKey, "1")

--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -456,7 +456,8 @@ func startOrbServices(parameters *orbParameters) error {
 		apServiceIRI, casIRI,
 		anchorWriterProviders,
 		anchorCh, vcCh,
-		parameters.maxWitnessDelay)
+		parameters.maxWitnessDelay,
+		parameters.signWithLocalWitness)
 
 	// create new batch writer
 	batchWriter, err := batch.New(parameters.didNamespace,


### PR DESCRIPTION
Currently we always sign anchor credential with local witness log if available. We should add an option to disable this default behaviour in case that anchor origin (for local witness log) is not referenced in Sidetree batch.

Closes #332

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>