### PR TITLE
fix: Publish Announce activity to followers

### DIFF
--- a/pkg/activitypub/service/service_test.go
+++ b/pkg/activitypub/service/service_test.go
@@ -53,6 +53,7 @@ var (
 func TestNewService(t *testing.T) {
 	cfg1 := &Config{
 		ServiceEndpoint: "/services/service1",
+		ServiceIRI:      testutil.MustParseURL("http://localhost:8301/services/service1"),
 		PubSubFactory: func(serviceName string) PubSub {
 			return mocks.NewPubSub()
 		},

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - DATABASE_URL=${COUCHDB_USERNAME}:${COUCHDB_PASSWORD}@couchdb.shared.com:5984
       - DATABASE_PREFIX=domain1
       - DISCOVERY_DOMAINS=https://orb.domain2.com
-      - ENABLE_HTTP_SIGNATURES=true
+      - HTTP_SIGNATURES_ENABLED=true
     ports:
       - 48326:443
     command: start
@@ -86,7 +86,7 @@ services:
       - DATABASE_URL=${COUCHDB_USERNAME}:${COUCHDB_PASSWORD}@couchdb.shared.com:5984
       - DATABASE_PREFIX=domain1
       - DISCOVERY_DOMAINS=https://orb.domain2.com
-      - ENABLE_HTTP_SIGNATURES=true
+      - HTTP_SIGNATURES_ENABLED=true
     ports:
       - 48526:443
     command: start
@@ -133,7 +133,7 @@ services:
       - DATABASE_URL=${COUCHDB_USERNAME}:${COUCHDB_PASSWORD}@couchdb.shared.com:5984
       - DATABASE_PREFIX=domain2
       - DISCOVERY_DOMAINS=https://orb.domain1.com
-      - ENABLE_HTTP_SIGNATURES=true
+      - HTTP_SIGNATURES_ENABLED=true
     ports:
       - 48426:443
     command: start
@@ -179,7 +179,7 @@ services:
       - DATABASE_URL=${COUCHDB_USERNAME}:${COUCHDB_PASSWORD}@couchdb.shared.com:5984
       - DATABASE_PREFIX=domain3
       - DISCOVERY_DOMAINS=https://orb.domain1.com
-      - ENABLE_HTTP_SIGNATURES=true
+      - HTTP_SIGNATURES_ENABLED=true
     ports:
       - 48626:443
     command: start


### PR DESCRIPTION
The 'to' field of the 'Announce' activity is now set to the actor's '/followers' collection as opposed to setting it to the IRIs of each individual follower. This may result in an 'Announce' activity being posted back to the originator of the 'Create', but there is already handling for duplicate anchor credential at the originator, so this will not be a problem.

closes #347

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>