### PR TITLE
feat: Implement /activities REST endpoint

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -555,6 +555,7 @@ func startOrbServices(parameters *orbParameters) error {
 		aphandler.NewLikes(apTxnCfg, apStore, apSigVerifier),
 		aphandler.NewShares(apTxnCfg, apStore, apSigVerifier),
 		aphandler.NewPostOutbox(apEndpointCfg, activityPubService.Outbox(), apSigVerifier),
+		aphandler.NewActivity(apEndpointCfg, apStore, apSigVerifier),
 		webcas.New(casClient),
 	)
 

--- a/pkg/activitypub/resthandler/resthandler.go
+++ b/pkg/activitypub/resthandler/resthandler.go
@@ -43,6 +43,8 @@ const (
 	SharesPath = "/{id}/shares"
 	// LikesPath specifies the object's 'likes' endpoint.
 	LikesPath = "/{id}/likes"
+	// ActivitiesPath specifies the object's 'activities' endpoint.
+	ActivitiesPath = "/activities/{id}"
 )
 
 const (

--- a/test/bdd/features/activitypub.feature
+++ b/test/bdd/features/activitypub.feature
@@ -57,6 +57,10 @@ Feature:
 
     Then we wait 3 seconds
 
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/activities/${followID}" signed with KMS key from "domain1"
+    Then the JSON path "id" of the response equals "${domain2IRI}/activities/${followID}"
+    And the JSON path "type" of the response equals "Follow"
+
     When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox" signed with KMS key from "domain1"
     Then the JSON path "type" of the response equals "OrderedCollection"
     And the JSON path "id" of the response equals "${domain1IRI}/inbox"


### PR DESCRIPTION
The /activities/{id} REST endpoint returns a single activity by ID.

closes #308

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>