### PR TITLE
feat: Anchor Credential Witnesses Store

### DIFF
--- a/pkg/activitypub/service/activityhandler/inboxhandler.go
+++ b/pkg/activitypub/service/activityhandler/inboxhandler.go
@@ -467,7 +467,8 @@ func (h *Inbox) handleLikeActivity(like *vocab.ActivityType) error {
 		return fmt.Errorf("marshal error of result in 'Like' activity [%s]: %w", like.ID(), err)
 	}
 
-	err = h.ProofHandler.HandleProof(like.Object().IRI().String(), *like.StartTime(), *like.EndTime(), resultBytes)
+	err = h.ProofHandler.HandleProof(like.Actor(), like.Object().IRI().String(),
+		*like.StartTime(), *like.EndTime(), resultBytes)
 	if err != nil {
 		return fmt.Errorf("proof handler returned error for 'Like' activity [%s]: %w", like.ID(), err)
 	}
@@ -792,6 +793,6 @@ func (a *acceptAllActorsAuth) AuthorizeActor(*vocab.ActorType) (bool, error) {
 
 type noOpProofHandler struct{}
 
-func (p *noOpProofHandler) HandleProof(anchorCredID string, startTime, endTime time.Time, proof []byte) error {
+func (p *noOpProofHandler) HandleProof(witness *url.URL, anchorCredID string, startTime, endTime time.Time, proof []byte) error { //nolint:lll
 	return nil
 }

--- a/pkg/activitypub/service/mocks/mockproofhandler.go
+++ b/pkg/activitypub/service/mocks/mockproofhandler.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package mocks
 
 import (
+	"net/url"
 	"sync"
 	"time"
 )
@@ -33,7 +34,7 @@ func (m *ProofHandler) WithError(err error) *ProofHandler {
 }
 
 // HandleProof store the proof and returns any injected error.
-func (m *ProofHandler) HandleProof(anchorCredID string, startTime, endTime time.Time, proof []byte) error {
+func (m *ProofHandler) HandleProof(witness *url.URL, anchorCredID string, startTime, endTime time.Time, proof []byte) error { //nolint:lll
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 

--- a/pkg/activitypub/service/spi/spi.go
+++ b/pkg/activitypub/service/spi/spi.go
@@ -76,7 +76,7 @@ type WitnessHandler interface {
 
 // ProofHandler handles the given proof for the anchor credential.
 type ProofHandler interface {
-	HandleProof(anchorCredID string, startTime time.Time, endTime time.Time, proof []byte) error
+	HandleProof(witness *url.URL, anchorCredID string, startTime time.Time, endTime time.Time, proof []byte) error
 }
 
 // ActivityHandler defines the functions of an Activity handler.

--- a/pkg/anchor/handler/proof/handler.go
+++ b/pkg/anchor/handler/proof/handler.go
@@ -9,6 +9,7 @@ package proof
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
@@ -47,8 +48,9 @@ type monitoringSvc interface {
 }
 
 // HandleProof handles proof.
-func (h *WitnessProofHandler) HandleProof(anchorCredID string, startTime, endTime time.Time, proof []byte) error {
-	logger.Debugf("received request anchorCredID[%s], proof: %s", anchorCredID, string(proof))
+func (h *WitnessProofHandler) HandleProof(witness *url.URL, anchorCredID string, startTime, endTime time.Time, proof []byte) error { //nolint:lll
+	logger.Debugf("received request anchorCredID[%s] from witness[%s], proof: %s",
+		anchorCredID, witness.String(), string(proof))
 
 	err := h.MonitoringSvc.Watch(anchorCredID, endTime, proof)
 	if err != nil {

--- a/pkg/anchor/proof/proof.go
+++ b/pkg/anchor/proof/proof.go
@@ -1,0 +1,26 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package proof
+
+// WitnessProof contains anchor credential witness proof.
+type WitnessProof struct {
+	Type    Type
+	Witness string
+	Proof   []byte
+}
+
+// Type defines valid values for witness type.
+type Type string
+
+const (
+
+	// TypeBatch captures "batch" witness type.
+	TypeBatch Type = "batch"
+
+	// TypeSystem captures "system" witness type.
+	TypeSystem Type = "witness"
+)

--- a/pkg/store/witness/witness.go
+++ b/pkg/store/witness/witness.go
@@ -1,0 +1,204 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package witness
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/hyperledger/aries-framework-go/spi/storage"
+	"github.com/trustbloc/edge-core/pkg/log"
+
+	"github.com/trustbloc/orb/pkg/anchor/proof"
+)
+
+const (
+	namespace = "witness"
+	vcIndex   = "vcID"
+)
+
+var logger = log.New("witness-store")
+
+// New creates new anchor credential witness store.
+func New(provider storage.Provider) (*Store, error) {
+	store, err := provider.OpenStore(namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open anchor credential witness store: %w", err)
+	}
+
+	err = provider.SetStoreConfig(namespace, storage.StoreConfiguration{TagNames: []string{vcIndex}})
+	if err != nil {
+		return nil, fmt.Errorf("failed to set store configuration: %w", err)
+	}
+
+	return &Store{
+		store: store,
+	}, nil
+}
+
+// Store is db implementation of anchor credential witness store.
+type Store struct {
+	store storage.Store
+}
+
+// Put saves witnesses into anchor credential witness store.
+func (s *Store) Put(vcID string, witnesses []*proof.WitnessProof) error {
+	operations := make([]storage.Operation, len(witnesses))
+
+	for i, w := range witnesses {
+		value, err := json.Marshal(w)
+		if err != nil {
+			return fmt.Errorf("failed to marshal anchor credential witness: %w", err)
+		}
+
+		logger.Debugf("adding witness to storage batch: %s", w.Witness)
+
+		op := storage.Operation{
+			Key:   uuid.New().String(),
+			Value: value,
+			Tags: []storage.Tag{
+				{
+					Name:  vcIndex,
+					Value: vcID,
+				},
+			},
+		}
+
+		operations[i] = op
+	}
+
+	err := s.store.Batch(operations)
+	if err != nil {
+		return fmt.Errorf("failed to store witnesses for vcID[%s]: %w", vcID, err)
+	}
+
+	logger.Debugf("stored %d witnesses for vcID[%s]", vcID, len(witnesses))
+
+	return nil
+}
+
+// Get retrieves witnesses for the given vc id.
+func (s *Store) Get(vcID string) ([]*proof.WitnessProof, error) {
+	var err error
+
+	query := fmt.Sprintf("%s:%s", vcIndex, vcID)
+
+	iter, err := s.store.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get witnesses for[%s]: %w", query, err)
+	}
+
+	defer func() {
+		err = iter.Close()
+		if err != nil {
+			logger.Errorf("failed to close iterator: %s", err.Error())
+		}
+	}()
+
+	ok, err := iter.Next()
+	if err != nil {
+		return nil, fmt.Errorf("iterator error for vcID[%s] : %w", vcID, err)
+	}
+
+	var witnesses []*proof.WitnessProof
+
+	for ok {
+		var value []byte
+
+		value, err = iter.Value()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get iterator value for vcID[%s]: %w", vcID, err)
+		}
+
+		var witness proof.WitnessProof
+
+		err = json.Unmarshal(value, &witness)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal anchor credential witness from store value for vcID[%s]: %w",
+				vcID, err)
+		}
+
+		witnesses = append(witnesses, &witness)
+
+		ok, err = iter.Next()
+		if err != nil {
+			return nil, fmt.Errorf("iterator error for vcID[%s] : %w", vcID, err)
+		}
+	}
+
+	logger.Debugf("retrieved %d witnesses for vcID[%s]", len(witnesses), vcID)
+
+	if len(witnesses) == 0 {
+		return nil, fmt.Errorf("vcID[%s] not found in the store", vcID)
+	}
+
+	return witnesses, nil
+}
+
+// AddProof adds proof for anchor credential id and witness.
+func (s *Store) AddProof(vcID, witness string, p []byte) error {
+	var err error
+
+	query := fmt.Sprintf("%s:%s", vcIndex, vcID)
+
+	iter, err := s.store.Query(query)
+	if err != nil {
+		return fmt.Errorf("failed to get witnesses for[%s]: %w", query, err)
+	}
+
+	defer func() {
+		err = iter.Close()
+		if err != nil {
+			logger.Errorf("failed to close iterator: %s", err.Error())
+		}
+	}()
+
+	ok, err := iter.Next()
+	if err != nil {
+		return fmt.Errorf("iterator error for vcID[%s] : %w", vcID, err)
+	}
+
+	for ok {
+		var value []byte
+
+		value, err = iter.Value()
+		if err != nil {
+			return fmt.Errorf("failed to get iterator value for vcID[%s]: %w", vcID, err)
+		}
+
+		var w proof.WitnessProof
+
+		err = json.Unmarshal(value, &w)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal anchor credential witness from store value for vcID[%s]: %w",
+				vcID, err)
+		}
+
+		if w.Witness == witness {
+			key, err := iter.Key()
+			if err != nil {
+				return fmt.Errorf("failed to get key for anchor credential vcID[%s] and witness[%s]: %w",
+					vcID, witness, err)
+			}
+
+			w.Proof = p
+
+			err = s.store.Put(key, value, storage.Tag{Name: vcIndex, Value: vcID})
+			if err != nil {
+				return fmt.Errorf("failed to add proof for anchor credential vcID[%s] and witness[%s]: %w",
+					vcID, witness, err)
+			}
+
+			logger.Debugf("added proof for anchor credential vcID[%s] and witness[%s]: %s", vcID, witness, string(p))
+
+			return nil
+		}
+	}
+
+	return fmt.Errorf("witness[%s] not found for vcID[%s]", witness, vcID)
+}

--- a/pkg/store/witness/witness_test.go
+++ b/pkg/store/witness/witness_test.go
@@ -1,0 +1,379 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package witness
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/pkg/anchor/proof"
+	"github.com/trustbloc/orb/pkg/store/mocks"
+)
+
+const (
+	vcID    = "vcID"
+	witness = "witness"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		provider := mem.NewProvider()
+
+		s, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, s)
+	})
+
+	t.Run("error - open store fails", func(t *testing.T) {
+		provider := &mocks.Provider{}
+		provider.OpenStoreReturns(nil, fmt.Errorf("open store error"))
+
+		s, err := New(provider)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to open anchor credential witness store: open store error")
+		require.Nil(t, s)
+	})
+
+	t.Run("error - set store config fails", func(t *testing.T) {
+		provider := &mocks.Provider{}
+		provider.SetStoreConfigReturns(fmt.Errorf("set store config error"))
+
+		s, err := New(provider)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to set store configuration: set store config error")
+		require.Nil(t, s)
+	})
+}
+
+func TestStore_Put(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		provider := mem.NewProvider()
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		err = s.Put(vcID, []*proof.WitnessProof{getTestWitness()})
+		require.NoError(t, err)
+	})
+
+	t.Run("error - store error ", func(t *testing.T) {
+		store := &mocks.Store{}
+		store.BatchReturns(fmt.Errorf("batch error"))
+
+		provider := &mocks.Provider{}
+		provider.OpenStoreReturns(store, nil)
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		err = s.Put(vcID, []*proof.WitnessProof{getTestWitness()})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "batch error")
+	})
+}
+
+func TestStore_Get(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		provider := mem.NewProvider()
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		err = s.Put(vcID, []*proof.WitnessProof{getTestWitness()})
+		require.NoError(t, err)
+
+		ops, err := s.Get(vcID)
+		require.NoError(t, err)
+		require.NotEmpty(t, ops)
+	})
+
+	t.Run("success - not found", func(t *testing.T) {
+		provider := mem.NewProvider()
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		ops, err := s.Get(vcID)
+		require.Error(t, err)
+		require.Empty(t, ops)
+		require.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("error - store error ", func(t *testing.T) {
+		store := &mocks.Store{}
+		store.QueryReturns(nil, fmt.Errorf("batch error"))
+
+		provider := &mocks.Provider{}
+		provider.OpenStoreReturns(store, nil)
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		ops, err := s.Get(vcID)
+		require.Error(t, err)
+		require.Nil(t, ops)
+		require.Contains(t, err.Error(), "batch error")
+	})
+
+	t.Run("error - iterator next() error ", func(t *testing.T) {
+		iterator := &mocks.Iterator{}
+		iterator.NextReturns(false, fmt.Errorf("iterator next() error"))
+
+		store := &mocks.Store{}
+		store.QueryReturns(iterator, nil)
+
+		provider := &mocks.Provider{}
+		provider.OpenStoreReturns(store, nil)
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		ops, err := s.Get(vcID)
+		require.Error(t, err)
+		require.Nil(t, ops)
+		require.Contains(t, err.Error(), "iterator next() error")
+	})
+
+	t.Run("error - iterator value() error ", func(t *testing.T) {
+		iterator := &mocks.Iterator{}
+
+		iterator.NextReturns(true, nil)
+		iterator.ValueReturns(nil, fmt.Errorf("iterator value() error"))
+
+		store := &mocks.Store{}
+		store.QueryReturns(iterator, nil)
+
+		provider := &mocks.Provider{}
+		provider.OpenStoreReturns(store, nil)
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		ops, err := s.Get(vcID)
+		require.Error(t, err)
+		require.Nil(t, ops)
+		require.Contains(t, err.Error(), "iterator value() error")
+	})
+
+	t.Run("error - unmarshal anchored credential witness error ", func(t *testing.T) {
+		iterator := &mocks.Iterator{}
+
+		iterator.NextReturns(true, nil)
+		iterator.ValueReturns([]byte("not-json"), nil)
+
+		store := &mocks.Store{}
+		store.QueryReturns(iterator, nil)
+
+		provider := &mocks.Provider{}
+		provider.OpenStoreReturns(store, nil)
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		ops, err := s.Get(vcID)
+		require.Error(t, err)
+		require.Nil(t, ops)
+		require.Contains(t, err.Error(),
+			"failed to unmarshal anchor credential witness from store value for vcID[vcID]")
+	})
+}
+
+func TestStore_AddProof(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		provider := mem.NewProvider()
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		testWitness := &proof.WitnessProof{
+			Type:    proof.TypeBatch,
+			Witness: witness,
+		}
+
+		err = s.Put(vcID, []*proof.WitnessProof{testWitness})
+		require.NoError(t, err)
+
+		wf := []byte(witnessProof)
+
+		err = s.AddProof(vcID, witness, wf)
+		require.NoError(t, err)
+
+		witnesses, err := s.Get(vcID)
+		require.NoError(t, err)
+		require.Equal(t, len(witnesses), 1)
+		bytes.Equal(wf, witnesses[0].Proof)
+	})
+
+	t.Run("error - witness not found", func(t *testing.T) {
+		provider := mem.NewProvider()
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		err = s.AddProof(vcID, witness, []byte(witnessProof))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("error - store error ", func(t *testing.T) {
+		store := &mocks.Store{}
+		store.QueryReturns(nil, fmt.Errorf("batch error"))
+
+		provider := &mocks.Provider{}
+		provider.OpenStoreReturns(store, nil)
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		err = s.AddProof(vcID, witness, []byte(witnessProof))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "batch error")
+	})
+
+	t.Run("error - iterator next() error ", func(t *testing.T) {
+		iterator := &mocks.Iterator{}
+		iterator.NextReturns(false, fmt.Errorf("iterator next() error"))
+
+		store := &mocks.Store{}
+		store.QueryReturns(iterator, nil)
+
+		provider := &mocks.Provider{}
+		provider.OpenStoreReturns(store, nil)
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		err = s.AddProof(vcID, witness, []byte(witnessProof))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "iterator next() error")
+	})
+
+	t.Run("error - iterator value() error ", func(t *testing.T) {
+		iterator := &mocks.Iterator{}
+
+		iterator.NextReturns(true, nil)
+		iterator.ValueReturns(nil, fmt.Errorf("iterator value() error"))
+
+		store := &mocks.Store{}
+		store.QueryReturns(iterator, nil)
+
+		provider := &mocks.Provider{}
+		provider.OpenStoreReturns(store, nil)
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		err = s.AddProof(vcID, witness, []byte(witnessProof))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "iterator value() error")
+	})
+
+	t.Run("error - iterator key() error ", func(t *testing.T) {
+		iterator := &mocks.Iterator{}
+
+		witnessBytes, err := json.Marshal(&proof.WitnessProof{
+			Type:    proof.TypeBatch,
+			Witness: witness,
+		})
+		require.NoError(t, err)
+
+		iterator.NextReturns(true, nil)
+		iterator.ValueReturns(witnessBytes, nil)
+		iterator.KeyReturns("", fmt.Errorf("iterator key() error"))
+
+		store := &mocks.Store{}
+		store.QueryReturns(iterator, nil)
+
+		provider := &mocks.Provider{}
+		provider.OpenStoreReturns(store, nil)
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		err = s.AddProof(vcID, witness, []byte(witnessProof))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "iterator key() error")
+	})
+
+	t.Run("error - store put error ", func(t *testing.T) {
+		iterator := &mocks.Iterator{}
+
+		witnessBytes, err := json.Marshal(&proof.WitnessProof{
+			Type:    proof.TypeBatch,
+			Witness: witness,
+		})
+		require.NoError(t, err)
+
+		iterator.NextReturns(true, nil)
+		iterator.ValueReturns(witnessBytes, nil)
+		iterator.KeyReturns("key", nil)
+
+		store := &mocks.Store{}
+		store.QueryReturns(iterator, nil)
+		store.PutReturns(fmt.Errorf("put error"))
+
+		provider := &mocks.Provider{}
+		provider.OpenStoreReturns(store, nil)
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		err = s.AddProof(vcID, witness, []byte(witnessProof))
+		require.Error(t, err)
+		require.Contains(t, err.Error(),
+			"failed to add proof for anchor credential vcID[vcID] and witness[witness]: put error")
+	})
+
+	t.Run("error - unmarshal anchored credential witness error ", func(t *testing.T) {
+		iterator := &mocks.Iterator{}
+
+		iterator.NextReturns(true, nil)
+		iterator.ValueReturns([]byte("not-json"), nil)
+
+		store := &mocks.Store{}
+		store.QueryReturns(iterator, nil)
+
+		provider := &mocks.Provider{}
+		provider.OpenStoreReturns(store, nil)
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		err = s.AddProof(vcID, witness, []byte(witnessProof))
+		require.Error(t, err)
+		require.Contains(t, err.Error(),
+			"failed to unmarshal anchor credential witness from store value for vcID[vcID]")
+	})
+}
+
+func getTestWitness() *proof.WitnessProof {
+	return &proof.WitnessProof{
+		Type:    proof.TypeBatch,
+		Witness: "witness",
+	}
+}
+
+//nolint:lll
+const witnessProof = `{
+  "@context": [
+    "https://w3id.org/security/v1",
+    "https://w3id.org/jws/v1"
+  ],
+  "proof": {
+    "created": "2021-04-20T20:05:35.055Z",
+    "domain": "http://orb.vct:8077",
+    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..PahivkKT6iKdnZDpkLu6uwDWYSdP7frt4l66AXI8mTsBnjgwrf9Pr-y_BkEFqsOMEuwJ3DSFdmAp1eOdTxMfDQ",
+    "proofPurpose": "assertionMethod",
+    "type": "Ed25519Signature2018",
+    "verificationMethod": "did:web:abc.com#2130bhDAK-2jKsOXJiEDG909Jux4rcYEpFsYzVlqdAY"
+  }
+}`


### PR DESCRIPTION
Implement anchor credential witnesses store.

Also:
- add witness to handle proof handler interface
- store batch witnesses plus system witnesses for anchor credential after post offer activity

Closes #350

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>