### PR TITLE
feat: Access control with bearer tokens

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -517,12 +517,16 @@ func startOrbServices(parameters *orbParameters) error {
 		ObjectIRI:              apServiceIRI,
 		VerifyActorInSignature: parameters.httpSignaturesEnabled,
 		PageSize:               100, // TODO: Make configurable
+		AuthTokensDef:          parameters.authTokenDefinitions,
+		AuthTokens:             parameters.authTokens,
 	}
 
-	apTxnCfg := &aphandler.Config{
-		BasePath:  activityPubTransactionsPath,
-		ObjectIRI: apTransactionsIRI,
-		PageSize:  100, // TODO: Make configurable
+	apTxnEndpointCfg := &aphandler.Config{
+		BasePath:      activityPubTransactionsPath,
+		ObjectIRI:     apTransactionsIRI,
+		PageSize:      100, // TODO: Make configurable
+		AuthTokensDef: parameters.authTokenDefinitions,
+		AuthTokens:    parameters.authTokens,
 	}
 
 	orbResolver := document.NewResolveHandler(
@@ -561,8 +565,8 @@ func startOrbServices(parameters *orbParameters) error {
 		aphandler.NewWitnesses(apEndpointCfg, apStore, apSigVerifier),
 		aphandler.NewWitnessing(apEndpointCfg, apStore, apSigVerifier),
 		aphandler.NewLiked(apEndpointCfg, apStore, apSigVerifier),
-		aphandler.NewLikes(apTxnCfg, apStore, apSigVerifier),
-		aphandler.NewShares(apTxnCfg, apStore, apSigVerifier),
+		aphandler.NewLikes(apTxnEndpointCfg, apStore, apSigVerifier),
+		aphandler.NewShares(apTxnEndpointCfg, apStore, apSigVerifier),
 		aphandler.NewPostOutbox(apEndpointCfg, activityPubService.Outbox(), apSigVerifier),
 		aphandler.NewActivity(apEndpointCfg, apStore, apSigVerifier),
 		webcas.New(casClient),

--- a/pkg/activitypub/resthandler/activityhandler_test.go
+++ b/pkg/activitypub/resthandler/activityhandler_test.go
@@ -168,6 +168,22 @@ func TestActivities_Handler(t *testing.T) {
 		BasePath:  basePath,
 		ObjectIRI: serviceIRI,
 		PageSize:  4,
+		AuthTokensDef: []*AuthTokenDef{
+			{
+				EndpointExpression: "/services/orb/outbox",
+				ReadTokens:         []string{"admin", "read"},
+				WriteTokens:        []string{"admin"},
+			},
+			{
+				EndpointExpression: "/services/orb/inbox",
+				ReadTokens:         []string{"admin", "read"},
+				WriteTokens:        []string{"admin"},
+			},
+		},
+		AuthTokens: map[string]string{
+			"read":  "READ_TOKEN",
+			"admin": "ADMIN_TOKEN",
+		},
 	}
 
 	verifier := &mocks.SignatureVerifier{}

--- a/pkg/activitypub/resthandler/authhandler.go
+++ b/pkg/activitypub/resthandler/authhandler.go
@@ -1,0 +1,146 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resthandler
+
+import (
+	"crypto/subtle"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+)
+
+type authHandler struct {
+	endpnt     string
+	serviceIRI *url.URL
+	authTokens []string
+	verifier   signatureVerifier
+}
+
+func newAuthHandler(cfg *Config, endpoint, method string, verifier signatureVerifier) *authHandler {
+	ep := fmt.Sprintf("%s%s", cfg.BasePath, endpoint)
+
+	authTokens, err := resolveAuthTokens(ep, method, cfg.AuthTokensDef, cfg.AuthTokens)
+	if err != nil {
+		// This would occur on startup due to bad configuration, so it's better to panic.
+		panic(fmt.Errorf("resolve authorization tokens: %w", err))
+	}
+
+	return &authHandler{
+		endpnt:     ep,
+		serviceIRI: cfg.ObjectIRI,
+		authTokens: authTokens,
+		verifier:   verifier,
+	}
+}
+
+func (h *authHandler) authorize(req *http.Request) (bool, *url.URL, error) {
+	if h.authorizeWithBearerToken(req) {
+		logger.Debugf("[%s] Authorization succeeded using bearer token", h.endpnt)
+
+		// The bearer of the token is assumed to be this service. If it isn't then validation
+		// should fail in subsequent checks.
+		return true, h.serviceIRI, nil
+	}
+
+	logger.Debugf("[%s] Authorization failed using bearer token.", h.endpnt)
+
+	if h.verifier == nil {
+		return false, nil, nil
+	}
+
+	logger.Debugf("[%s] Checking HTTP signature...", h.endpnt)
+
+	// Check HTTP signature.
+	ok, actorIRI, err := h.verifier.VerifyRequest(req)
+	if err != nil {
+		return false, nil, fmt.Errorf("verify HTTP signature: %w", err)
+	}
+
+	return ok, actorIRI, nil
+}
+
+func (h *authHandler) authorizeWithBearerToken(req *http.Request) bool {
+	// Open access.
+	if len(h.authTokens) == 0 {
+		logger.Debugf("[%s] No auth token required.", h.endpnt)
+
+		return true
+	}
+
+	logger.Debugf("[%s] Auth tokens required: %s", h.endpnt, h.authTokens)
+
+	actHdr := req.Header.Get(authHeader)
+	if actHdr == "" {
+		logger.Debugf("[%s] Bearer token not found in header", h.endpnt)
+
+		return false
+	}
+
+	// Compare the header against all tokens. If any match then we allow the request.
+	for _, token := range h.authTokens {
+		logger.Debugf("[%s] Checking token %s", h.endpnt, token)
+
+		if subtle.ConstantTimeCompare([]byte(actHdr), []byte(tokenPrefix+token)) == 1 {
+			logger.Debugf("[%s] Found token %s", h.endpnt, token)
+
+			return true
+		}
+	}
+
+	return false
+}
+
+func resolveAuthTokens(endpoint, method string, authTokensDef []*AuthTokenDef,
+	authTokenMap map[string]string) ([]string, error) {
+	var authTokens []string
+
+	for _, def := range authTokensDef {
+		ok, err := endpointMatches(endpoint, def.EndpointExpression)
+		if err != nil {
+			return nil, err
+		}
+
+		if !ok {
+			continue
+		}
+
+		var tokens []string
+
+		if method == http.MethodPost {
+			tokens = def.WriteTokens
+		} else {
+			tokens = def.ReadTokens
+		}
+
+		for _, tokenID := range tokens {
+			token, ok := authTokenMap[tokenID]
+			if !ok {
+				return nil, fmt.Errorf("token not found: %s", tokenID)
+			}
+
+			authTokens = append(authTokens, token)
+		}
+
+		break
+	}
+
+	logger.Debugf("[%s] Authorization tokens: %s", endpoint, authTokens)
+
+	return authTokens, nil
+}
+
+func endpointMatches(endpoint, pattern string) (bool, error) {
+	ok, err := regexp.MatchString(pattern, endpoint)
+	if err != nil {
+		return false, fmt.Errorf("match endpoint pattern %s: %w", pattern, err)
+	}
+
+	logger.Debugf("[%s] Endpoint matches pattern [%s]: %t", endpoint, pattern, ok)
+
+	return ok, nil
+}

--- a/pkg/activitypub/resthandler/authhandler_test.go
+++ b/pkg/activitypub/resthandler/authhandler_test.go
@@ -1,0 +1,168 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resthandler
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/edge-core/pkg/log"
+
+	"github.com/trustbloc/orb/pkg/activitypub/service/mocks"
+)
+
+func TestNewAuthHandler(t *testing.T) {
+	const inboxURL = "https://example.com/services/orb/inboxbox"
+
+	log.SetLevel("activitypub_resthandler", log.DEBUG)
+
+	cfg := &Config{
+		BasePath:               basePath,
+		ObjectIRI:              serviceIRI,
+		VerifyActorInSignature: true,
+		AuthTokensDef: []*AuthTokenDef{
+			{
+				EndpointExpression: "/services/orb/outbox",
+				ReadTokens:         []string{"admin", "read"},
+				WriteTokens:        []string{"admin"},
+			},
+			{
+				EndpointExpression: "/services/orb/inbox",
+				ReadTokens:         []string{"admin", "read"},
+				WriteTokens:        []string{"admin"},
+			},
+		},
+		AuthTokens: map[string]string{
+			"read":  "READ_TOKEN",
+			"admin": "ADMIN_TOKEN",
+		},
+	}
+
+	t.Run("POST with auth token -> success", func(t *testing.T) {
+		h := newAuthHandler(cfg, InboxPath, http.MethodPost, &mocks.SignatureVerifier{})
+		require.NotNil(t, h)
+
+		req := httptest.NewRequest(http.MethodPost, inboxURL, nil)
+		req.Header[authHeader] = []string{tokenPrefix + "ADMIN_TOKEN"}
+
+		ok, actorIRI, err := h.authorize(req)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, cfg.ObjectIRI.String(), actorIRI.String())
+	})
+
+	t.Run("GET with auth token -> success", func(t *testing.T) {
+		h := newAuthHandler(cfg, InboxPath, http.MethodGet, &mocks.SignatureVerifier{})
+		require.NotNil(t, h)
+
+		req := httptest.NewRequest(http.MethodGet, inboxURL, nil)
+		req.Header[authHeader] = []string{tokenPrefix + "READ_TOKEN"}
+
+		ok, actorIRI, err := h.authorize(req)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, cfg.ObjectIRI.String(), actorIRI.String())
+	})
+
+	t.Run("With invalid auth token -> error", func(t *testing.T) {
+		h := newAuthHandler(cfg, InboxPath, http.MethodPost, &mocks.SignatureVerifier{})
+		require.NotNil(t, h)
+
+		req := httptest.NewRequest(http.MethodPost, inboxURL, nil)
+		req.Header[authHeader] = []string{tokenPrefix + "INVALID_TOKEN"}
+
+		ok, actorIRI, err := h.authorize(req)
+		require.NoError(t, err)
+		require.False(t, ok)
+		require.Nil(t, actorIRI)
+	})
+
+	t.Run("With HTTP signature -> success", func(t *testing.T) {
+		verifier := &mocks.SignatureVerifier{}
+		verifier.VerifyRequestReturns(true, cfg.ObjectIRI, nil)
+
+		h := newAuthHandler(cfg, InboxPath, http.MethodPost, verifier)
+		require.NotNil(t, h)
+
+		req := httptest.NewRequest(http.MethodPost, inboxURL, nil)
+
+		ok, actorIRI, err := h.authorize(req)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, cfg.ObjectIRI.String(), actorIRI.String())
+	})
+
+	t.Run("No auth token definitions -> success", func(t *testing.T) {
+		h := newAuthHandler(
+			&Config{
+				BasePath:  basePath,
+				ObjectIRI: serviceIRI,
+			},
+			InboxPath, http.MethodPost, &mocks.SignatureVerifier{},
+		)
+		require.NotNil(t, h)
+
+		req := httptest.NewRequest(http.MethodPost, inboxURL, nil)
+
+		ok, actorIRI, err := h.authorize(req)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, cfg.ObjectIRI.String(), actorIRI.String())
+	})
+
+	t.Run("Invalid auth token definitions -> panic", func(t *testing.T) {
+		require.Panics(t, func() {
+			h := newAuthHandler(
+				&Config{
+					BasePath:  basePath,
+					ObjectIRI: serviceIRI,
+					AuthTokensDef: []*AuthTokenDef{
+						{
+							EndpointExpression: "/services/orb/inbox",
+							ReadTokens:         []string{"admin", "read"},
+						},
+					},
+				},
+				InboxPath, http.MethodGet, &mocks.SignatureVerifier{},
+			)
+			require.NotNil(t, h)
+		})
+	})
+
+	t.Run("No token and no HTTP signature verifier -> fail", func(t *testing.T) {
+		h := newAuthHandler(cfg, InboxPath, http.MethodPost, nil)
+		require.NotNil(t, h)
+
+		req := httptest.NewRequest(http.MethodGet, inboxURL, nil)
+
+		ok, actorIRI, err := h.authorize(req)
+		require.NoError(t, err)
+		require.False(t, ok)
+		require.Nil(t, actorIRI)
+	})
+
+	t.Run("HTTP signature verifier error -> fail", func(t *testing.T) {
+		errExpected := errors.New("injected verifier error")
+
+		verifier := &mocks.SignatureVerifier{}
+		verifier.VerifyRequestReturns(false, nil, errExpected)
+
+		h := newAuthHandler(cfg, InboxPath, http.MethodPost, verifier)
+		require.NotNil(t, h)
+
+		req := httptest.NewRequest(http.MethodGet, inboxURL, nil)
+
+		ok, actorIRI, err := h.authorize(req)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+		require.False(t, ok)
+		require.Nil(t, actorIRI)
+	})
+}

--- a/pkg/activitypub/resthandler/outboxhandler_test.go
+++ b/pkg/activitypub/resthandler/outboxhandler_test.go
@@ -46,6 +46,22 @@ func TestOutbox_Handler(t *testing.T) {
 		BasePath:               "/services/orb",
 		ObjectIRI:              serviceIRI,
 		VerifyActorInSignature: true,
+		AuthTokensDef: []*AuthTokenDef{
+			{
+				EndpointExpression: "/services/orb/outbox",
+				ReadTokens:         []string{"admin", "read"},
+				WriteTokens:        []string{"admin"},
+			},
+			{
+				EndpointExpression: "/services/orb/inbox",
+				ReadTokens:         []string{"admin", "read"},
+				WriteTokens:        []string{"admin"},
+			},
+		},
+		AuthTokens: map[string]string{
+			"read":  "READ_TOKEN",
+			"admin": "ADMIN_TOKEN",
+		},
 	}
 
 	ob := &mocks.Outbox{}

--- a/pkg/activitypub/resthandler/referencehandler_test.go
+++ b/pkg/activitypub/resthandler/referencehandler_test.go
@@ -136,6 +136,22 @@ func TestFollowers_Handler(t *testing.T) {
 		BasePath:  basePath,
 		ObjectIRI: serviceIRI,
 		PageSize:  4,
+		AuthTokensDef: []*AuthTokenDef{
+			{
+				EndpointExpression: "/services/orb/outbox",
+				ReadTokens:         []string{"admin", "read"},
+				WriteTokens:        []string{"admin"},
+			},
+			{
+				EndpointExpression: "/services/orb/.*",
+				ReadTokens:         []string{"admin", "read"},
+				WriteTokens:        []string{"admin"},
+			},
+		},
+		AuthTokens: map[string]string{
+			"read":  "READ_TOKEN",
+			"admin": "ADMIN_TOKEN",
+		},
 	}
 
 	verifier := &mocks.SignatureVerifier{}

--- a/pkg/activitypub/resthandler/resthandler_test.go
+++ b/pkg/activitypub/resthandler/resthandler_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/trustbloc/orb/pkg/activitypub/service/mocks"
 	"github.com/trustbloc/orb/pkg/activitypub/store/memstore"
 	"github.com/trustbloc/orb/pkg/activitypub/store/spi"
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
@@ -29,7 +28,7 @@ func TestNewHandler(t *testing.T) {
 
 	h := newHandler("", cfg, memstore.New(""),
 		func(writer http.ResponseWriter, request *http.Request) {},
-		&mocks.SignatureVerifier{}, pageNumParam, pageParam,
+		pageNumParam, pageParam,
 	)
 
 	require.NotNil(t, h)
@@ -71,7 +70,7 @@ func TestGetCurrentPrevNext(t *testing.T) {
 		PageSize:  4,
 	}
 
-	h := newHandler("", cfg, memstore.New(""), nil, &mocks.SignatureVerifier{})
+	h := newHandler("", cfg, memstore.New(""), nil)
 
 	t.Run("Sort ascending", func(t *testing.T) {
 		t.Run("No page-num", func(t *testing.T) {
@@ -163,7 +162,7 @@ func TestGetIDPrevNextURL(t *testing.T) {
 		PageSize:  4,
 	}
 
-	h := newHandler("", cfg, memstore.New(""), nil, &mocks.SignatureVerifier{})
+	h := newHandler("", cfg, memstore.New(""), nil)
 
 	id := testutil.MustParseURL(fmt.Sprintf("%s%s", cfg.ObjectIRI, ""))
 

--- a/test/bdd/features/activitypub.feature
+++ b/test/bdd/features/activitypub.feature
@@ -50,179 +50,194 @@ Feature:
 
   @activitypub_follow
   Scenario: follow/accept/undo
+    Given the authorization bearer token for "POST" requests to path "/services/orb/outbox" is set to "ADMIN_TOKEN"
+    And the authorization bearer token for "GET" requests to path "/services/orb" is set to "READ_TOKEN"
+
     # domain2 follows domain1
     Given variable "followID" is assigned a unique ID
     Given variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain2IRI}/activities/${followID}","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${followActivity}" of type "application/json" signed with KMS key from "domain2"
+    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${followActivity}" of type "application/json"
 
     Then we wait 3 seconds
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/activities/${followID}" signed with KMS key from "domain1"
+    Given the authorization bearer token for "POST" requests to path "/services/orb/outbox" is set to "READ_TOKEN"
+
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/activities/${followID}"
     Then the JSON path "id" of the response equals "${domain2IRI}/activities/${followID}"
     And the JSON path "type" of the response equals "Follow"
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox" signed with KMS key from "domain1"
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox"
     Then the JSON path "type" of the response equals "OrderedCollection"
     And the JSON path "id" of the response equals "${domain1IRI}/inbox"
     And the JSON path "first" of the response equals "${domain1IRI}/inbox?page=true"
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox?page=true" signed with KMS key from "domain1"
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.id" of the response contains "${domain2IRI}/activities/${followID}"
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/followers" signed with KMS key from "domain1"
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/followers"
     Then the JSON path "type" of the response equals "Collection"
     And the JSON path "id" of the response equals "${domain1IRI}/followers"
     And the JSON path "first" of the response equals "${domain1IRI}/followers?page=true"
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/followers?page=true" signed with KMS key from "domain1"
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/followers?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response contains "${domain2IRI}"
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/following" signed with KMS key from "domain1"
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/following"
     Then the JSON path "type" of the response equals "Collection"
     And the JSON path "id" of the response equals "${domain2IRI}/following"
     And the JSON path "first" of the response equals "${domain2IRI}/following?page=true"
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/following?page=true" signed with KMS key from "domain1"
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/following?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response contains "${domain1IRI}"
 
-    Given variable "undoID" is assigned a unique ID
-    And variable "undoFollowActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain2IRI}/activities/${undoID}","type":"Undo","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain2IRI}/activities/${followID}"}'
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${undoFollowActivity}" of type "application/json" signed with KMS key from "domain2"
+    Given the authorization bearer token for "POST" requests to path "/services/orb/outbox" is set to "ADMIN_TOKEN"
+
+    And variable "undoFollowActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain2IRI}/activities/${followID}"}'
+    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${undoFollowActivity}" of type "application/json"
 
     Then we wait 3 seconds
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/following?page=true" signed with KMS key from "domain1"
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/following?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response does not contain "${domain1IRI}"
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/followers?page=true" signed with KMS key from "domain1"
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/followers?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response does not contain "${domain2IRI}"
 
   @activitypub_create
   Scenario: create/announce
+    Given the authorization bearer token for "POST" requests to path "/services/orb/outbox" is set to "ADMIN_TOKEN"
+    And the authorization bearer token for "GET" requests to path "/services/orb" is set to "READ_TOKEN"
+
     # domain2 follows domain1
     Given variable "followDomain1Activity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${followDomain1Activity}" of type "application/json" signed with KMS key from "domain2"
+    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${followDomain1Activity}" of type "application/json"
 
     # domain3 follows domain2
     Given variable "follow2ID" is assigned a unique ID
     And variable "followDomain2Activity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","id":"${domain3IRI}/activities/${follow2ID}","actor":"${domain3IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48626/services/orb/outbox" with content "${followDomain2Activity}" of type "application/json" signed with KMS key from "domain3"
+    When an HTTP POST is sent to "https://localhost:48626/services/orb/outbox" with content "${followDomain2Activity}" of type "application/json"
 
     Then we wait 2 seconds
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/followers?page=true" signed with KMS key from "domain3"
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/followers?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response contains "${domain3IRI}"
 
     # Post 'Create' activity to domain1's outbox
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/outbox" with content from file "./fixtures/testdata/create_activity.json" signed with KMS key from "domain1"
+    When an HTTP POST is sent to "https://localhost:48326/services/orb/outbox" with content from file "./fixtures/testdata/create_activity.json"
 
     Then we wait 2 seconds
 
     # A 'Create' activity should have been posted to domain1's followers (domain2).
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/inbox?page=true" signed with KMS key from "domain1"
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.id" of the response contains "${domain1IRI}/activities/77bdd005-bbb6-223d-b889-58bc1de84985"
 
     # An 'Announce' activity should have been posted to domain2's followers (domain3).
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/outbox?page=true" signed with KMS key from "domain1"
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/outbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.type" of the response contains "Announce"
 
     # An 'Announce' activity should have been received by domain3 since it's a follower of domain2.
-    When an HTTP GET is sent to "https://localhost:48626/services/orb/inbox?page=true" signed with KMS key from "domain1"
+    When an HTTP GET is sent to "https://localhost:48626/services/orb/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.type" of the response contains "Announce"
 
     And variable "undoFollow2Activity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain3IRI}","to":"${domain2IRI}","object":"${domain3IRI}/activities/${follow2ID}"}'
-    When an HTTP POST is sent to "https://localhost:48626/services/orb/outbox" with content "${undoFollow2Activity}" of type "application/json" signed with KMS key from "domain3"
+    When an HTTP POST is sent to "https://localhost:48626/services/orb/outbox" with content "${undoFollow2Activity}" of type "application/json"
 
     Then we wait 2 seconds
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/followers?page=true" signed with KMS key from "domain3"
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/followers?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response does not contain "${domain3IRI}"
 
   @activitypub_invite_witness
   Scenario: invite witness/accept/undo
+    Given the authorization bearer token for "POST" requests to path "/services/orb/outbox" is set to "ADMIN_TOKEN"
+    And the authorization bearer token for "GET" requests to path "/services/orb" is set to "READ_TOKEN"
+
     # domain1 invites domain2 to be a witness
     Given variable "inviteWitnessID" is assigned a unique ID
     And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain1IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json" signed with KMS key from "domain1"
+    When an HTTP POST is sent to "https://localhost:48326/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     Then we wait 3 seconds
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/inbox?page=true" signed with KMS key from "domain1"
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.id" of the response contains "${domain1IRI}/activities/${inviteWitnessID}"
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/witnesses" signed with KMS key from "domain1"
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/witnesses"
     Then the JSON path "type" of the response equals "Collection"
     And the JSON path "id" of the response equals "${domain1IRI}/witnesses"
     And the JSON path "first" of the response equals "${domain1IRI}/witnesses?page=true"
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/witnesses?page=true" signed with KMS key from "domain1"
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/witnesses?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response contains "${domain2IRI}"
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/witnessing" signed with KMS key from "domain1"
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/witnessing"
     Then the JSON path "type" of the response equals "Collection"
     And the JSON path "id" of the response equals "${domain2IRI}/witnessing"
     And the JSON path "first" of the response equals "${domain2IRI}/witnessing?page=true"
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/witnessing?page=true" signed with KMS key from "domain1"
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/witnessing?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response contains "${domain1IRI}"
 
     Given variable "undoWitnessID" is assigned a unique ID
     And variable "undoInviteWitnessActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain1IRI}/activities/${undoWitnessID}","type":"Undo","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain1IRI}/activities/${inviteWitnessID}"}'
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/outbox" with content "${undoInviteWitnessActivity}" of type "application/json" signed with KMS key from "domain1"
+    When an HTTP POST is sent to "https://localhost:48326/services/orb/outbox" with content "${undoInviteWitnessActivity}" of type "application/json"
 
     Then we wait 3 seconds
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/witnesses?page=true" signed with KMS key from "domain1"
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/witnesses?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response does not contain "${domain2IRI}"
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/witnessing?page=true" signed with KMS key from "domain1"
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/witnessing?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response does not contain "${domain1IRI}"
 
   @activitypub_offer
   Scenario: offer/like
+    Given the authorization bearer token for "POST" requests to path "/services/orb/outbox" is set to "ADMIN_TOKEN"
+    And the authorization bearer token for "GET" requests to path "/services/orb" is set to "READ_TOKEN"
+
     # domain2 invites domain1 to be a witness
     Given variable "inviteWitnessID" is assigned a unique ID
     Given variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain2IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json" signed with KMS key from "domain2"
+    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     Then we wait 2 seconds
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox?page=true" signed with KMS key from "domain1"
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.id" of the response contains "${domain2IRI}/activities/${inviteWitnessID}"
 
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content from file "./fixtures/testdata/offer_activity.json" signed with KMS key from "domain2"
+    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content from file "./fixtures/testdata/offer_activity.json"
 
     Then we wait 2 seconds
 
     # The 'Offer' activity should be in the inbox of domain1.
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox?page=true" signed with KMS key from "domain1"
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.id" of the response contains "${domain2IRI}/activities/63b3d005-6cb6-673d-6379-18be1ee84973"
 
     # The 'Like' should be in the 'liked' collection of domain1.
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/liked?page=true" signed with KMS key from "domain1"
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/liked?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.type" of the response contains "Like"
     And the JSON path "orderedItems.#.object" of the response contains "http://orb.domain2.com/transactions/bafkreihwsn"
 
     # A 'Like' activity should be in the inbox of domain2.
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/inbox?page=true" signed with KMS key from "domain1"
+    When an HTTP GET is sent to "https://localhost:48426/services/orb/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.type" of the response contains "Like"
     And the JSON path "orderedItems.#.object" of the response contains "http://orb.domain2.com/transactions/bafkreihwsn"
@@ -238,6 +253,29 @@ Feature:
     # Invalid signature on POST
     When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${followActivity}" of type "application/json" signed with KMS key from "domain1" and the returned status code is 401
 
+    # Valid signature on POST
+    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${followActivity}" of type "application/json" signed with KMS key from "domain2"
+
+    Then we wait 2 seconds
+
+    And variable "undoFollowActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain2IRI}/activities/${followID}"}'
+    Then an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${undoFollowActivity}" of type "application/json" signed with KMS key from "domain2"
+
     # No signature on GET
     When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox" and the returned status code is 401
     When an HTTP GET is sent to "https://localhost:48326/services/orb/followers" and the returned status code is 401
+
+    # Valid signature on GET
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox" signed with KMS key from "domain2"
+    Then the JSON path "type" of the response equals "OrderedCollection"
+
+  @activitypub_auth_token
+  Scenario: Tests authorization tokens
+    # No auth token or signature on GET
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox" and the returned status code is 401
+
+    # Set auth token
+    Given the authorization bearer token for "GET" requests to path "/services/orb/inbox" is set to "READ_TOKEN"
+
+    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox"
+    Then the JSON path "type" of the response equals "OrderedCollection"

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -11,25 +11,28 @@ Feature:
     Given variable "domain1IRI" is assigned the value "https://orb.domain1.com/services/orb"
     And variable "domain2IRI" is assigned the value "https://orb.domain2.com/services/orb"
 
+    Given the authorization bearer token for "POST" requests to path "/services/orb/outbox" is set to "ADMIN_TOKEN"
+    And the authorization bearer token for "GET" requests to path "/services/orb" is set to "READ_TOKEN"
+
     # domain2 server follows domain1 server
     Given variable "followID" is assigned a unique ID
     And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain2IRI}/activities/${followID}","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${followActivity}" of type "application/json" signed with KMS key from "domain2"
+    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${followActivity}" of type "application/json"
 
     # domain1 server follows domain2 server
     Given variable "followID" is assigned a unique ID
     And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain1IRI}/activities/${followID}","type":"Follow","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/outbox" with content "${followActivity}" of type "application/json" signed with KMS key from "domain1"
+    When an HTTP POST is sent to "https://localhost:48326/services/orb/outbox" with content "${followActivity}" of type "application/json"
 
     # domain1 invites domain2 to be a witness
     Given variable "inviteWitnessID" is assigned a unique ID
     And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain1IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json" signed with KMS key from "domain1"
+    When an HTTP POST is sent to "https://localhost:48326/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     # domain2 invites domain1 to be a witness
     Given variable "inviteWitnessID" is assigned a unique ID
     And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain2IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json" signed with KMS key from "domain2"
+    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     Then we wait 3 seconds
 

--- a/test/bdd/features/did-sidetree.feature
+++ b/test/bdd/features/did-sidetree.feature
@@ -11,15 +11,18 @@ Feature:
     Given variable "domain1IRI" is assigned the value "https://orb.domain1.com/services/orb"
     And variable "domain2IRI" is assigned the value "https://orb.domain2.com/services/orb"
 
+    Given the authorization bearer token for "POST" requests to path "/services/orb/outbox" is set to "ADMIN_TOKEN"
+    And the authorization bearer token for "GET" requests to path "/services/orb" is set to "READ_TOKEN"
+
     # domain2 server follows domain1 server
     Given variable "followID" is assigned a unique ID
     And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain2IRI}/activities/${followID}","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${followActivity}" of type "application/json" signed with KMS key from "domain2"
+    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${followActivity}" of type "application/json"
 
     # domain1 invites domain2 to be a witness
     Given variable "inviteWitnessID" is assigned a unique ID
     And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain1IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json" signed with KMS key from "domain1"
+    When an HTTP POST is sent to "https://localhost:48326/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     Then we wait 3 seconds
 

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -39,6 +39,27 @@ services:
       - DATABASE_PREFIX=domain1
       - DISCOVERY_DOMAINS=https://orb.domain2.com
       - HTTP_SIGNATURES_ENABLED=true
+
+      # ORB_AUTH_TOKENS_DEF contains the authorization definition for each of the REST endpoints. Format:
+      #
+      # <path-expr>|<read-token1>&<read-token2>&...>|<write-token1>&<write-token2>&...>,<path-expr> ...
+      #
+      # Where:
+      # - path-expr contains a regular expression for a path. Path expressions are processed in the order they are specified.
+      # - read-token defines a token for a read (GET) operation. If not specified then authorization is not performed.
+      # - write-token defines a token for a write (POST) operation. If not specified then authorization is not performed.
+      #
+      # If no definition is included for an endpoint then authorization is NOT performed for that endpoint.
+      #
+      # Example:
+      #
+      # ORB_AUTH_TOKENS_DEF=/services/orb/outbox|admin&read|admin,/services/orb/.*|read&admin
+      # - The client requires a 'read' or 'admin' token in order to view the outbox's contents
+      # - The client requires an 'admin' token in order to post to the outbox
+      # - The client requires a 'read' or 'admin' token in order to perform a GET on any endpoint starting with /services/orb/
+      - ORB_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read&admin|admin,/services/orb/.*|read&admin,/transactions|read&admin
+      # ORB_AUTH_TOKENS specifies the actual values of the tokens defined in ORB_AUTH_TOKENS_DEF.
+      - ORB_AUTH_TOKENS=admin=ADMIN_TOKEN,read=READ_TOKEN
     ports:
       - 48326:443
     command: start
@@ -87,6 +108,27 @@ services:
       - DATABASE_PREFIX=domain1
       - DISCOVERY_DOMAINS=https://orb.domain2.com
       - HTTP_SIGNATURES_ENABLED=true
+
+      # ORB_AUTH_TOKENS_DEF contains the authorization definition for each of the REST endpoints. Format:
+      #
+      # <path-expr>|<read-token1>&<read-token2>&...>|<write-token1>&<write-token2>&...>,<path-expr> ...
+      #
+      # Where:
+      # - path-expr contains a regular expression for a path. Path expressions are processed in the order they are specified.
+      # - read-token defines a token for a read (GET) operation. If not specified then authorization is not performed.
+      # - write-token defines a token for a write (POST) operation. If not specified then authorization is not performed.
+      #
+      # If no definition is included for an endpoint then authorization is NOT performed for that endpoint.
+      #
+      # Example:
+      #
+      # ORB_AUTH_TOKENS_DEF=/services/orb/outbox|admin&read|admin,/services/orb/.*|read&admin
+      # - The client requires a 'read' or 'admin' token in order to view the outbox's contents
+      # - The client requires an 'admin' token in order to post to the outbox
+      # - The client requires a 'read' or 'admin' token in order to perform a GET on any endpoint starting with /services/orb/
+      - ORB_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read&admin|admin,/services/orb/.*|read&admin,/transactions|read&admin
+      # ORB_AUTH_TOKENS specifies the actual values of the tokens defined in ORB_AUTH_TOKENS_DEF.
+      - ORB_AUTH_TOKENS=admin=ADMIN_TOKEN,read=READ_TOKEN
     ports:
       - 48526:443
     command: start
@@ -134,6 +176,27 @@ services:
       - DATABASE_PREFIX=domain2
       - DISCOVERY_DOMAINS=https://orb.domain1.com
       - HTTP_SIGNATURES_ENABLED=true
+
+      # ORB_AUTH_TOKENS_DEF contains the authorization definition for each of the REST endpoints. Format:
+      #
+      # <path-expr>|<read-token1>&<read-token2>&...>|<write-token1>&<write-token2>&...>,<path-expr> ...
+      #
+      # Where:
+      # - path-expr contains a regular expression for a path. Path expressions are processed in the order they are specified.
+      # - read-token defines a token for a read (GET) operation. If not specified then authorization is not performed.
+      # - write-token defines a token for a write (POST) operation. If not specified then authorization is not performed.
+      #
+      # If no definition is included for an endpoint then authorization is NOT performed for that endpoint.
+      #
+      # Example:
+      #
+      # ORB_AUTH_TOKENS_DEF=/services/orb/outbox|admin&read|admin,/services/orb/.*|read&admin
+      # - The client requires a 'read' or 'admin' token in order to view the outbox's contents
+      # - The client requires an 'admin' token in order to post to the outbox
+      # - The client requires a 'read' or 'admin' token in order to perform a GET on any endpoint starting with /services/orb/
+      - ORB_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read&admin|admin,/services/orb/.*|read&admin,/transactions|read&admin
+      # ORB_AUTH_TOKENS specifies the actual values of the tokens defined in ORB_AUTH_TOKENS_DEF.
+      - ORB_AUTH_TOKENS=admin=ADMIN_TOKEN,read=READ_TOKEN
     ports:
       - 48426:443
     command: start
@@ -180,6 +243,27 @@ services:
       - DATABASE_PREFIX=domain3
       - DISCOVERY_DOMAINS=https://orb.domain1.com
       - HTTP_SIGNATURES_ENABLED=true
+
+      # ORB_AUTH_TOKENS_DEF contains the authorization definition for each of the REST endpoints. Format:
+      #
+      # <path-expr>|<read-token1>&<read-token2>&...>|<write-token1>&<write-token2>&...>,<path-expr> ...
+      #
+      # Where:
+      # - path-expr contains a regular expression for a path. Path expressions are processed in the order they are specified.
+      # - read-token defines a token for a read (GET) operation. If not specified then authorization is not performed.
+      # - write-token defines a token for a write (POST) operation. If not specified then authorization is not performed.
+      #
+      # If no definition is included for an endpoint then authorization is NOT performed for that endpoint.
+      #
+      # Example:
+      #
+      # ORB_AUTH_TOKENS_DEF=/services/orb/outbox|admin&read|admin,/services/orb/.*|read&admin
+      # - The client requires a 'read' or 'admin' token in order to view the outbox's contents
+      # - The client requires an 'admin' token in order to post to the outbox
+      # - The client requires a 'read' or 'admin' token in order to perform a GET on any endpoint starting with /services/orb/
+      - ORB_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read&admin|admin,/services/orb/.*|read&admin,/transactions|read&admin
+      # ORB_AUTH_TOKENS specifies the actual values of the tokens defined in ORB_AUTH_TOKENS_DEF.
+      - ORB_AUTH_TOKENS=admin=ADMIN_TOKEN,read=READ_TOKEN
     ports:
       - 48626:443
     command: start


### PR DESCRIPTION
Use authorization bearer tokens to authorize ActivityPub requests. If a token is required but not provided then the HTTP signature is verified (if provided).

closes #358

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>