### PR TITLE
feat: Return activity ID from outbox endpoint

### DIFF
--- a/test/bdd/common_steps.go
+++ b/test/bdd/common_steps.go
@@ -309,6 +309,20 @@ func (d *CommonSteps) jsonPathOfArrayResponseNotEmpty(path string) error {
 	return fmt.Errorf("JSON path [%s] resolves to an empty array", path)
 }
 
+func (d *CommonSteps) valueOfJSONStringResponseSavedToVar(varName string) error {
+	var value string
+
+	if err := json.Unmarshal([]byte(d.state.getResponse()), &value); err != nil {
+		return fmt.Errorf("invalid JSON string in response [%s]", d.state.getResponse())
+	}
+
+	logger.Infof("Saving [%s] to variable [%s]", value, varName)
+
+	d.state.setVar(varName, value)
+
+	return nil
+}
+
 func (d *CommonSteps) responseEquals(value string) error {
 	if d.state.getResponse() == value {
 		logger.Infof("Response equals expected value [%s]", value)
@@ -673,6 +687,12 @@ func (d *CommonSteps) setAuthTokenForPath(method, path, token string) error {
 	return nil
 }
 
+func (d *CommonSteps) mapHTTPDomain(domain, mapping string) error {
+	d.httpClient.MapDomain(domain, mapping)
+
+	return nil
+}
+
 func getSignerConfig(domain, pubKeyID string) (*signerConfig, error) {
 	storeProvider, err := newStoreProvider(domain)
 	if err != nil {
@@ -780,6 +800,7 @@ func (d *CommonSteps) RegisterSteps(s *godog.Suite) {
 	s.Step(`^the JSON path "([^"]*)" of the raw response is saved to variable "([^"]*)"$`, d.jsonPathOfRawResponseSavedToVar)
 	s.Step(`^the JSON path "([^"]*)" of the response is not empty$`, d.jsonPathOfResponseNotEmpty)
 	s.Step(`^the JSON path "([^"]*)" of the array response is not empty$`, d.jsonPathOfArrayResponseNotEmpty)
+	s.Step(`^the value of the JSON string response is saved to variable "([^"]*)"$`, d.valueOfJSONStringResponseSavedToVar)
 	s.Step(`^an HTTP GET is sent to "([^"]*)"$`, d.httpGet)
 	s.Step(`^an HTTP GET is sent to "([^"]*)" and the returned status code is (\d+)$`, d.httpGetWithExpectedCode)
 	s.Step(`^an HTTP GET is sent to "([^"]*)" signed with KMS key from "([^"]*)"$`, d.httpGetWithSignature)
@@ -794,4 +815,5 @@ func (d *CommonSteps) RegisterSteps(s *godog.Suite) {
 	s.Step(`^an HTTP POST is sent to "([^"]*)" with content from file "([^"]*)" signed with KMS key from "([^"]*)" and the returned status code is (\d+)$`, d.httpPostFileWithSignatureAndExpectedCode)
 	s.Step(`^the authorization bearer token for "([^"]*)" requests to path "([^"]*)" is set to "([^"]*)"$`, d.setAuthTokenForPath)
 	s.Step(`^variable "([^"]*)" is assigned a unique ID$`, d.setUUIDVariable)
+	s.Step(`^domain "([^"]*)" is mapped to "([^"]*)"$`, d.mapHTTPDomain)
 }

--- a/test/bdd/features/activitypub.feature
+++ b/test/bdd/features/activitypub.feature
@@ -12,9 +12,13 @@ Feature:
     And variable "domain2IRI" is assigned the value "https://orb.domain2.com/services/orb"
     And variable "domain3IRI" is assigned the value "https://orb.domain3.com/services/orb"
 
+    Given domain "orb.domain1.com" is mapped to "localhost:48326"
+    And domain "orb.domain2.com" is mapped to "localhost:48426"
+    And domain "orb.domain3.com" is mapped to "localhost:48626"
+
   @activitypub_service
   Scenario: Get ActivityPub service
-    When an HTTP GET is sent to "https://localhost:48326/services/orb"
+    When an HTTP GET is sent to "https://orb.domain1.com/services/orb"
     Then the JSON path "type" of the response equals "Service"
     And the JSON path "inbox" of the response equals "${domain1IRI}/inbox"
     And the JSON path "outbox" of the response equals "${domain1IRI}/outbox"
@@ -25,7 +29,7 @@ Feature:
     And the JSON path "witnessing" of the response equals "${domain1IRI}/witnessing"
     And the JSON path "publicKey.id" of the response equals "${domain1IRI}/keys/main-key"
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb"
+    When an HTTP GET is sent to "https://orb.domain2.com/services/orb"
     Then the JSON path "type" of the response equals "Service"
     And the JSON path "inbox" of the response equals "${domain2IRI}/inbox"
     And the JSON path "outbox" of the response equals "${domain2IRI}/outbox"
@@ -38,12 +42,12 @@ Feature:
 
   @activitypub_pubkey
   Scenario: Get service public key
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/keys/main-key"
+    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/keys/main-key"
     Then the JSON path "id" of the response equals "https://orb.domain1.com/services/orb/keys/main-key"
     Then the JSON path "owner" of the response equals "https://orb.domain1.com/services/orb"
     Then the JSON path "publicKeyPem" of the response is not empty
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/keys/main-key"
+    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/keys/main-key"
     Then the JSON path "id" of the response equals "https://orb.domain2.com/services/orb/keys/main-key"
     Then the JSON path "owner" of the response equals "https://orb.domain2.com/services/orb"
     Then the JSON path "publicKeyPem" of the response is not empty
@@ -54,57 +58,57 @@ Feature:
     And the authorization bearer token for "GET" requests to path "/services/orb" is set to "READ_TOKEN"
 
     # domain2 follows domain1
-    Given variable "followID" is assigned a unique ID
-    Given variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain2IRI}/activities/${followID}","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${followActivity}" of type "application/json"
+    Given variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
+    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
+    Then the value of the JSON string response is saved to variable "followID"
 
     Then we wait 3 seconds
 
     Given the authorization bearer token for "POST" requests to path "/services/orb/outbox" is set to "READ_TOKEN"
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/activities/${followID}"
-    Then the JSON path "id" of the response equals "${domain2IRI}/activities/${followID}"
+    When an HTTP GET is sent to "${followID}"
+    Then the JSON path "id" of the response equals "${followID}"
     And the JSON path "type" of the response equals "Follow"
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox"
+    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/inbox"
     Then the JSON path "type" of the response equals "OrderedCollection"
     And the JSON path "id" of the response equals "${domain1IRI}/inbox"
     And the JSON path "first" of the response equals "${domain1IRI}/inbox?page=true"
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox?page=true"
+    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
-    And the JSON path "orderedItems.#.id" of the response contains "${domain2IRI}/activities/${followID}"
+    And the JSON path "orderedItems.#.id" of the response contains "${followID}"
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/followers"
+    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/followers"
     Then the JSON path "type" of the response equals "Collection"
     And the JSON path "id" of the response equals "${domain1IRI}/followers"
     And the JSON path "first" of the response equals "${domain1IRI}/followers?page=true"
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/followers?page=true"
+    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/followers?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response contains "${domain2IRI}"
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/following"
+    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/following"
     Then the JSON path "type" of the response equals "Collection"
     And the JSON path "id" of the response equals "${domain2IRI}/following"
     And the JSON path "first" of the response equals "${domain2IRI}/following?page=true"
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/following?page=true"
+    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/following?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response contains "${domain1IRI}"
 
     Given the authorization bearer token for "POST" requests to path "/services/orb/outbox" is set to "ADMIN_TOKEN"
 
-    And variable "undoFollowActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain2IRI}/activities/${followID}"}'
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${undoFollowActivity}" of type "application/json"
+    And variable "undoFollowActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${followID}"}'
+    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${undoFollowActivity}" of type "application/json"
 
     Then we wait 3 seconds
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/following?page=true"
+    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/following?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response does not contain "${domain1IRI}"
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/followers?page=true"
+    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/followers?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response does not contain "${domain2IRI}"
 
@@ -115,45 +119,49 @@ Feature:
 
     # domain2 follows domain1
     Given variable "followDomain1Activity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${followDomain1Activity}" of type "application/json"
+    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${followDomain1Activity}" of type "application/json"
+    Then the value of the JSON string response is saved to variable "follow1ID"
 
     # domain3 follows domain2
-    Given variable "follow2ID" is assigned a unique ID
-    And variable "followDomain2Activity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","id":"${domain3IRI}/activities/${follow2ID}","actor":"${domain3IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48626/services/orb/outbox" with content "${followDomain2Activity}" of type "application/json"
+    And variable "followDomain2Activity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain3IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
+    When an HTTP POST is sent to "https://orb.domain3.com/services/orb/outbox" with content "${followDomain2Activity}" of type "application/json"
+    Then the value of the JSON string response is saved to variable "follow2ID"
 
     Then we wait 2 seconds
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/followers?page=true"
+    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/followers?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response contains "${domain3IRI}"
 
     # Post 'Create' activity to domain1's outbox
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/outbox" with content from file "./fixtures/testdata/create_activity.json"
+    When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content from file "./fixtures/testdata/create_activity.json"
 
     Then we wait 2 seconds
 
     # A 'Create' activity should have been posted to domain1's followers (domain2).
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/inbox?page=true"
+    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.id" of the response contains "${domain1IRI}/activities/77bdd005-bbb6-223d-b889-58bc1de84985"
 
     # An 'Announce' activity should have been posted to domain2's followers (domain3).
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/outbox?page=true"
+    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/outbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.type" of the response contains "Announce"
 
     # An 'Announce' activity should have been received by domain3 since it's a follower of domain2.
-    When an HTTP GET is sent to "https://localhost:48626/services/orb/inbox?page=true"
+    When an HTTP GET is sent to "https://orb.domain3.com/services/orb/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.type" of the response contains "Announce"
 
-    And variable "undoFollow2Activity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain3IRI}","to":"${domain2IRI}","object":"${domain3IRI}/activities/${follow2ID}"}'
-    When an HTTP POST is sent to "https://localhost:48626/services/orb/outbox" with content "${undoFollow2Activity}" of type "application/json"
+    And variable "undoFollow1Activity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${follow1ID}"}'
+    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${undoFollow1Activity}" of type "application/json"
+
+    And variable "undoFollow2Activity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain3IRI}","to":"${domain2IRI}","object":"${follow2ID}"}'
+    When an HTTP POST is sent to "https://orb.domain3.com/services/orb/outbox" with content "${undoFollow2Activity}" of type "application/json"
 
     Then we wait 2 seconds
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/followers?page=true"
+    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/followers?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response does not contain "${domain3IRI}"
 
@@ -163,45 +171,44 @@ Feature:
     And the authorization bearer token for "GET" requests to path "/services/orb" is set to "READ_TOKEN"
 
     # domain1 invites domain2 to be a witness
-    Given variable "inviteWitnessID" is assigned a unique ID
-    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain1IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"type":"InviteWitness","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
+    When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    Then the value of the JSON string response is saved to variable "inviteWitnessID"
 
     Then we wait 3 seconds
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/inbox?page=true"
+    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
-    And the JSON path "orderedItems.#.id" of the response contains "${domain1IRI}/activities/${inviteWitnessID}"
+    And the JSON path "orderedItems.#.id" of the response contains "${inviteWitnessID}"
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/witnesses"
+    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/witnesses"
     Then the JSON path "type" of the response equals "Collection"
     And the JSON path "id" of the response equals "${domain1IRI}/witnesses"
     And the JSON path "first" of the response equals "${domain1IRI}/witnesses?page=true"
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/witnesses?page=true"
+    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/witnesses?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response contains "${domain2IRI}"
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/witnessing"
+    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/witnessing"
     Then the JSON path "type" of the response equals "Collection"
     And the JSON path "id" of the response equals "${domain2IRI}/witnessing"
     And the JSON path "first" of the response equals "${domain2IRI}/witnessing?page=true"
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/witnessing?page=true"
+    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/witnessing?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response contains "${domain1IRI}"
 
-    Given variable "undoWitnessID" is assigned a unique ID
-    And variable "undoInviteWitnessActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain1IRI}/activities/${undoWitnessID}","type":"Undo","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain1IRI}/activities/${inviteWitnessID}"}'
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/outbox" with content "${undoInviteWitnessActivity}" of type "application/json"
+    And variable "undoInviteWitnessActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${inviteWitnessID}"}'
+    When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${undoInviteWitnessActivity}" of type "application/json"
 
     Then we wait 3 seconds
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/witnesses?page=true"
+    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/witnesses?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response does not contain "${domain2IRI}"
 
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/witnessing?page=true"
+    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/witnessing?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response does not contain "${domain1IRI}"
 
@@ -211,71 +218,78 @@ Feature:
     And the authorization bearer token for "GET" requests to path "/services/orb" is set to "READ_TOKEN"
 
     # domain2 invites domain1 to be a witness
-    Given variable "inviteWitnessID" is assigned a unique ID
-    Given variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain2IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    Given variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"type":"InviteWitness","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
+    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    Then the value of the JSON string response is saved to variable "inviteWitnessID"
 
     Then we wait 2 seconds
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox?page=true"
+    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
-    And the JSON path "orderedItems.#.id" of the response contains "${domain2IRI}/activities/${inviteWitnessID}"
+    And the JSON path "orderedItems.#.id" of the response contains "${inviteWitnessID}"
 
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content from file "./fixtures/testdata/offer_activity.json"
+    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content from file "./fixtures/testdata/offer_activity.json"
 
     Then we wait 2 seconds
 
     # The 'Offer' activity should be in the inbox of domain1.
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox?page=true"
+    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.id" of the response contains "${domain2IRI}/activities/63b3d005-6cb6-673d-6379-18be1ee84973"
 
     # The 'Like' should be in the 'liked' collection of domain1.
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/liked?page=true"
+    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/liked?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.type" of the response contains "Like"
     And the JSON path "orderedItems.#.object" of the response contains "http://orb.domain2.com/transactions/bafkreihwsn"
 
     # A 'Like' activity should be in the inbox of domain2.
-    When an HTTP GET is sent to "https://localhost:48426/services/orb/inbox?page=true"
+    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.type" of the response contains "Like"
     And the JSON path "orderedItems.#.object" of the response contains "http://orb.domain2.com/transactions/bafkreihwsn"
 
+    And variable "undoInviteWitnessActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${inviteWitnessID}"}'
+    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${undoInviteWitnessActivity}" of type "application/json"
+
+    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/witnessing?page=true"
+    Then the JSON path "type" of the response equals "CollectionPage"
+    And the JSON path "items" of the response does not contain "${domain1IRI}"
+
   @activitypub_httpsig
   Scenario: Tests HTTP signature verification
-    Given variable "followID" is assigned a unique ID
-    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain2IRI}/activities/${followID}","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
+    Given variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
 
     # No signature on POST
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${followActivity}" of type "application/json" and the returned status code is 401
+    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${followActivity}" of type "application/json" and the returned status code is 401
 
     # Invalid signature on POST
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${followActivity}" of type "application/json" signed with KMS key from "domain1" and the returned status code is 401
+    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${followActivity}" of type "application/json" signed with KMS key from "domain1" and the returned status code is 401
 
     # Valid signature on POST
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${followActivity}" of type "application/json" signed with KMS key from "domain2"
+    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${followActivity}" of type "application/json" signed with KMS key from "domain2"
+    Then the value of the JSON string response is saved to variable "followID"
 
     Then we wait 2 seconds
 
-    And variable "undoFollowActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain2IRI}/activities/${followID}"}'
-    Then an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${undoFollowActivity}" of type "application/json" signed with KMS key from "domain2"
+    And variable "undoFollowActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${followID}"}'
+    Then an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${undoFollowActivity}" of type "application/json" signed with KMS key from "domain2"
 
     # No signature on GET
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox" and the returned status code is 401
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/followers" and the returned status code is 401
+    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/inbox" and the returned status code is 401
+    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/followers" and the returned status code is 401
 
     # Valid signature on GET
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox" signed with KMS key from "domain2"
+    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/inbox" signed with KMS key from "domain2"
     Then the JSON path "type" of the response equals "OrderedCollection"
 
   @activitypub_auth_token
   Scenario: Tests authorization tokens
     # No auth token or signature on GET
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox" and the returned status code is 401
+    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/inbox" and the returned status code is 401
 
     # Set auth token
     Given the authorization bearer token for "GET" requests to path "/services/orb/inbox" is set to "READ_TOKEN"
 
-    When an HTTP GET is sent to "https://localhost:48326/services/orb/inbox"
+    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/inbox"
     Then the JSON path "type" of the response equals "OrderedCollection"

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -11,28 +11,32 @@ Feature:
     Given variable "domain1IRI" is assigned the value "https://orb.domain1.com/services/orb"
     And variable "domain2IRI" is assigned the value "https://orb.domain2.com/services/orb"
 
+    Given domain "orb.domain1.com" is mapped to "localhost:48326"
+    And domain "orb.domain2.com" is mapped to "localhost:48426"
+    And domain "orb.domain3.com" is mapped to "localhost:48626"
+
     Given the authorization bearer token for "POST" requests to path "/services/orb/outbox" is set to "ADMIN_TOKEN"
     And the authorization bearer token for "GET" requests to path "/services/orb" is set to "READ_TOKEN"
 
     # domain2 server follows domain1 server
     Given variable "followID" is assigned a unique ID
     And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain2IRI}/activities/${followID}","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${followActivity}" of type "application/json"
+    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
 
     # domain1 server follows domain2 server
     Given variable "followID" is assigned a unique ID
     And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain1IRI}/activities/${followID}","type":"Follow","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/outbox" with content "${followActivity}" of type "application/json"
+    When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
 
     # domain1 invites domain2 to be a witness
     Given variable "inviteWitnessID" is assigned a unique ID
     And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain1IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     # domain2 invites domain1 to be a witness
     Given variable "inviteWitnessID" is assigned a unique ID
     And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain2IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     Then we wait 3 seconds
 

--- a/test/bdd/features/did-sidetree.feature
+++ b/test/bdd/features/did-sidetree.feature
@@ -11,18 +11,22 @@ Feature:
     Given variable "domain1IRI" is assigned the value "https://orb.domain1.com/services/orb"
     And variable "domain2IRI" is assigned the value "https://orb.domain2.com/services/orb"
 
+    Given domain "orb.domain1.com" is mapped to "localhost:48326"
+    And domain "orb.domain2.com" is mapped to "localhost:48426"
+    And domain "orb.domain3.com" is mapped to "orb.domain3.com"
+
     Given the authorization bearer token for "POST" requests to path "/services/orb/outbox" is set to "ADMIN_TOKEN"
     And the authorization bearer token for "GET" requests to path "/services/orb" is set to "READ_TOKEN"
 
     # domain2 server follows domain1 server
     Given variable "followID" is assigned a unique ID
     And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain2IRI}/activities/${followID}","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${followActivity}" of type "application/json"
+    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
 
     # domain1 invites domain2 to be a witness
     Given variable "inviteWitnessID" is assigned a unique ID
     And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain1IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     Then we wait 3 seconds
 

--- a/test/bdd/features/orb-cli.feature
+++ b/test/bdd/features/orb-cli.feature
@@ -12,15 +12,19 @@ Feature: Using Orb CLI
     Given variable "domain1IRI" is assigned the value "https://orb.domain1.com/services/orb"
     And variable "domain2IRI" is assigned the value "https://orb.domain2.com/services/orb"
 
+    Given domain "orb.domain1.com" is mapped to "localhost:48326"
+    And domain "orb.domain2.com" is mapped to "localhost:48426"
+    And domain "orb.domain3.com" is mapped to "localhost:48626"
+
     # domain2 server follows domain1 server
     Given variable "followID" is assigned a unique ID
     And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain2IRI}/activities/${followID}","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48426/services/orb/outbox" with content "${followActivity}" of type "application/json" signed with KMS key from "domain2"
+    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${followActivity}" of type "application/json" signed with KMS key from "domain2"
 
     # domain1 invites domain2 to be a witness
     Given variable "inviteWitnessID" is assigned a unique ID
     And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain1IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://localhost:48326/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json" signed with KMS key from "domain1"
+    When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json" signed with KMS key from "domain1"
 
     Then we wait 3 seconds
 


### PR DESCRIPTION
When an activity is posted to the /outbox REST endpoint then the ID of the activity is returned in the response.

closes #384

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>