### PR TITLE
feat: Restrict server-to-server GETs on certain endpoints

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -567,7 +567,7 @@ func startOrbServices(parameters *orbParameters) error {
 		aphandler.NewLiked(apEndpointCfg, apStore, apSigVerifier),
 		aphandler.NewLikes(apTxnEndpointCfg, apStore, apSigVerifier),
 		aphandler.NewShares(apTxnEndpointCfg, apStore, apSigVerifier),
-		aphandler.NewPostOutbox(apEndpointCfg, activityPubService.Outbox(), apSigVerifier),
+		aphandler.NewPostOutbox(apEndpointCfg, activityPubService.Outbox(), apStore, apSigVerifier),
 		aphandler.NewActivity(apEndpointCfg, apStore, apSigVerifier),
 		webcas.New(casClient),
 	)

--- a/pkg/activitypub/resthandler/activityhandler.go
+++ b/pkg/activitypub/resthandler/activityhandler.go
@@ -19,11 +19,9 @@ import (
 
 // NewActivity returns a new 'activities/{id}' REST handler that retrieves a single activity by ID.
 func NewActivity(cfg *Config, activityStore spi.Store, verifier signatureVerifier) *Activity {
-	h := &Activity{
-		authHandler: newAuthHandler(cfg, ActivitiesPath, http.MethodGet, verifier),
-	}
+	h := &Activity{}
 
-	h.handler = newHandler(ActivitiesPath, cfg, activityStore, h.handle)
+	h.handler = newHandler(ActivitiesPath, cfg, activityStore, h.handle, verifier)
 
 	return h
 }
@@ -66,7 +64,6 @@ type getObjectIRIFunc func(req *http.Request) (*url.URL, error)
 // Activities implements a REST handler that retrieves activities.
 type Activities struct {
 	*handler
-	*authHandler
 
 	refType      spi.ReferenceType
 	getID        getIDFunc
@@ -77,13 +74,12 @@ type Activities struct {
 func NewActivities(path string, refType spi.ReferenceType, cfg *Config, activityStore spi.Store,
 	getObjectIRI getObjectIRIFunc, getID getIDFunc, verifier signatureVerifier) *Activities {
 	h := &Activities{
-		authHandler:  newAuthHandler(cfg, path, http.MethodGet, verifier),
 		refType:      refType,
 		getID:        getID,
 		getObjectIRI: getObjectIRI,
 	}
 
-	h.handler = newHandler(path, cfg, activityStore, h.handle)
+	h.handler = newHandler(path, cfg, activityStore, h.handle, verifier)
 
 	return h
 }
@@ -279,7 +275,6 @@ func (h *Activities) getPage(objectIRI, id *url.URL, opts ...spi.QueryOpt) (*voc
 // Activity implements a REST handler that retrieves a single activity by ID.
 type Activity struct {
 	*handler
-	*authHandler
 }
 
 func (h *Activity) handle(w http.ResponseWriter, req *http.Request) {

--- a/pkg/activitypub/resthandler/activityhandler_test.go
+++ b/pkg/activitypub/resthandler/activityhandler_test.go
@@ -164,6 +164,8 @@ func TestActivities_Handler(t *testing.T) {
 		require.NoError(t, activityStore.AddReference(spi.Outbox, serviceIRI, activity.ID().URL()))
 	}
 
+	require.NoError(t, activityStore.AddReference(spi.Follower, serviceIRI, service2IRI))
+
 	cfg := &Config{
 		BasePath:  basePath,
 		ObjectIRI: serviceIRI,
@@ -187,7 +189,7 @@ func TestActivities_Handler(t *testing.T) {
 	}
 
 	verifier := &mocks.SignatureVerifier{}
-	verifier.VerifyRequestReturns(true, serviceIRI, nil)
+	verifier.VerifyRequestReturns(true, service2IRI, nil)
 
 	t.Run("Success", func(t *testing.T) {
 		h := NewOutbox(cfg, activityStore, verifier)

--- a/pkg/activitypub/resthandler/referencehandler.go
+++ b/pkg/activitypub/resthandler/referencehandler.go
@@ -49,7 +49,6 @@ type signatureVerifier interface {
 // Reference implements a REST handler that retrieves references as a collection of IRIs.
 type Reference struct {
 	*handler
-	*authHandler
 
 	refType              spi.ReferenceType
 	sortOrder            spi.SortOrder
@@ -64,7 +63,6 @@ func NewReference(path string, refType spi.ReferenceType, sortOrder spi.SortOrde
 	cfg *Config, activityStore spi.Store, getObjectIRI getObjectIRIFunc, getID getIDFunc,
 	verifier signatureVerifier) *Reference {
 	h := &Reference{
-		authHandler:          newAuthHandler(cfg, path, http.MethodGet, verifier),
 		refType:              refType,
 		sortOrder:            sortOrder,
 		createCollection:     createCollection(ordered),
@@ -73,7 +71,7 @@ func NewReference(path string, refType spi.ReferenceType, sortOrder spi.SortOrde
 		getObjectIRI:         getObjectIRI,
 	}
 
-	h.handler = newHandler(path, cfg, activityStore, h.handle)
+	h.handler = newHandler(path, cfg, activityStore, h.handle, verifier)
 
 	return h
 }

--- a/pkg/activitypub/resthandler/serviceshandler.go
+++ b/pkg/activitypub/resthandler/serviceshandler.go
@@ -21,7 +21,6 @@ const MainKeyID = "main-key"
 // Services implements the 'services' REST handler to retrieve a given ActivityPub service (actor).
 type Services struct {
 	*handler
-	*authHandler
 
 	publicKey *vocab.PublicKeyType
 }
@@ -29,11 +28,10 @@ type Services struct {
 // NewServices returns a new 'services' REST handler.
 func NewServices(cfg *Config, activityStore spi.Store, publicKey *vocab.PublicKeyType) *Services {
 	h := &Services{
-		authHandler: newAuthHandler(cfg, "", http.MethodGet, nil),
-		publicKey:   publicKey,
+		publicKey: publicKey,
 	}
 
-	h.handler = newHandler("", cfg, activityStore, h.handle)
+	h.handler = newHandler("", cfg, activityStore, h.handle, nil)
 
 	return h
 }
@@ -41,11 +39,10 @@ func NewServices(cfg *Config, activityStore spi.Store, publicKey *vocab.PublicKe
 // NewPublicKeys returns a new public keys REST handler.
 func NewPublicKeys(cfg *Config, activityStore spi.Store, publicKey *vocab.PublicKeyType) *Services {
 	h := &Services{
-		authHandler: newAuthHandler(cfg, "/keys", http.MethodGet, nil),
-		publicKey:   publicKey,
+		publicKey: publicKey,
 	}
 
-	h.handler = newHandler(PublicKeysPath, cfg, activityStore, h.handlePublicKey)
+	h.handler = newHandler(PublicKeysPath, cfg, activityStore, h.handlePublicKey, nil)
 
 	return h
 }

--- a/pkg/activitypub/resthandler/serviceshandler_test.go
+++ b/pkg/activitypub/resthandler/serviceshandler_test.go
@@ -28,6 +28,7 @@ const (
 
 var (
 	serviceIRI   = testutil.MustParseURL("https://example1.com/services/orb")
+	service2IRI  = testutil.MustParseURL("https://example2.com/services/orb")
 	publicKeyIRI = testutil.NewMockID(serviceIRI, "/keys/main-key")
 )
 

--- a/test/bdd/features/activitypub.feature
+++ b/test/bdd/features/activitypub.feature
@@ -272,16 +272,19 @@ Feature:
 
     Then we wait 2 seconds
 
-    And variable "undoFollowActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${followID}"}'
-    Then an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${undoFollowActivity}" of type "application/json" signed with KMS key from "domain2"
-
     # No signature on GET
     When an HTTP GET is sent to "https://orb.domain1.com/services/orb/inbox" and the returned status code is 401
     When an HTTP GET is sent to "https://orb.domain1.com/services/orb/followers" and the returned status code is 401
 
-    # Valid signature on GET
+    # Valid signature on GET with actor as a follower - should be allowed
     When an HTTP GET is sent to "https://orb.domain1.com/services/orb/inbox" signed with KMS key from "domain2"
     Then the JSON path "type" of the response equals "OrderedCollection"
+
+    # Valid signature on GET with actor as non-follower/non-witness - should be denied
+    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/inbox" signed with KMS key from "domain3" and the returned status code is 401
+
+    And variable "undoFollowActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${followID}"}'
+    Then an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${undoFollowActivity}" of type "application/json" signed with KMS key from "domain2"
 
   @activitypub_auth_token
   Scenario: Tests authorization tokens


### PR DESCRIPTION
For server-to-server interactions, access is restricted to witnesses and followers to perform GETs on the following endpoints:

- /followers
- /following
- /outbox
- /inbox
- /witnesses
- /witnessing
- /likes
- /shares
- /activities

Posts to /outbox are restricted to the owner of the outbox.
Posts to /inbox are open to anyone with a valid HTTP signature.

closes #388

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>