### PR TITLE
fix: Authorize /activities endpoint

### DIFF
--- a/pkg/activitypub/vocab/objecttype.go
+++ b/pkg/activitypub/vocab/objecttype.go
@@ -104,8 +104,22 @@ func (t *ObjectType) EndTime() *time.Time {
 	return t.object.EndTime
 }
 
+// Urls holds a collection of URLs.
+type Urls []*url.URL
+
+// Contains returns true if the collection of URLs contains the given URL.
+func (u Urls) Contains(v string) bool {
+	for _, iri := range u {
+		if iri.String() == v {
+			return true
+		}
+	}
+
+	return false
+}
+
 // To returns a set of URLs to which the object should be sent.
-func (t *ObjectType) To() []*url.URL {
+func (t *ObjectType) To() Urls {
 	if t.object.To == nil {
 		return nil
 	}

--- a/pkg/activitypub/vocab/objecttype_test.go
+++ b/pkg/activitypub/vocab/objecttype_test.go
@@ -53,8 +53,8 @@ func TestObjectType_WithoutDocument(t *testing.T) {
 
 		to := obj.To()
 		require.Len(t, to, 2)
-		require.Equal(t, to1.String(), to[0].String())
-		require.Equal(t, to2.String(), to[1].String())
+		require.True(t, to.Contains(to1.String()))
+		require.True(t, to.Contains(to2.String()))
 	})
 
 	t.Run("MarshalJSON", func(t *testing.T) {


### PR DESCRIPTION
No authentication is required for activities sent to "https://www.w3.org/ns/activitystreams#Public".

closes #392

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>