### PR TITLE
fix: Add proof in witness proof storage

### DIFF
--- a/pkg/store/witness/witness.go
+++ b/pkg/store/witness/witness.go
@@ -146,7 +146,7 @@ func (s *Store) Get(vcID string) ([]*proof.WitnessProof, error) {
 }
 
 // AddProof adds proof for anchor credential id and witness.
-func (s *Store) AddProof(vcID, witness string, p []byte) error {
+func (s *Store) AddProof(vcID, witness string, p []byte) error { //nolint:funlen,gocyclo,cyclop
 	vcIDEncoded := base64.RawURLEncoding.EncodeToString([]byte(vcID))
 
 	query := fmt.Sprintf("%s:%s", vcIndex, vcIDEncoded)
@@ -185,7 +185,9 @@ func (s *Store) AddProof(vcID, witness string, p []byte) error {
 		}
 
 		if w.Witness == witness {
-			key, err := iter.Key()
+			var key string
+
+			key, err = iter.Key()
 			if err != nil {
 				return fmt.Errorf("failed to get key for anchor credential vcID[%s] and witness[%s]: %w",
 					vcID, witness, err)
@@ -202,6 +204,11 @@ func (s *Store) AddProof(vcID, witness string, p []byte) error {
 			logger.Debugf("added proof for anchor credential vcID[%s] and witness[%s]: %s", vcID, witness, string(p))
 
 			return nil
+		}
+
+		ok, err = iter.Next()
+		if err != nil {
+			return fmt.Errorf("iterator error for vcID[%s] : %w", vcID, err)
 		}
 	}
 

--- a/pkg/store/witness/witness_test.go
+++ b/pkg/store/witness/witness_test.go
@@ -213,7 +213,69 @@ func TestStore_AddProof(t *testing.T) {
 		bytes.Equal(wf, witnesses[0].Proof)
 	})
 
+	t.Run("success - multiple witnesses were recorded", func(t *testing.T) {
+		provider := mem.NewProvider()
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		witnessProofs := []*proof.WitnessProof{
+			{
+				Type:    proof.TypeBatch,
+				Witness: "witness-1",
+			},
+			{
+				Type:    proof.TypeBatch,
+				Witness: "witness-2",
+			},
+		}
+
+		err = s.Put(vcID, witnessProofs)
+		require.NoError(t, err)
+
+		wf := []byte(witnessProof)
+
+		err = s.AddProof(vcID, "witness-1", wf)
+		require.NoError(t, err)
+
+		err = s.AddProof(vcID, "witness-2", wf)
+		require.NoError(t, err)
+
+		witnesses, err := s.Get(vcID)
+		require.NoError(t, err)
+		require.Equal(t, len(witnesses), 2)
+		bytes.Equal(wf, witnesses[0].Proof)
+		bytes.Equal(wf, witnesses[1].Proof)
+	})
+
 	t.Run("error - witness not found", func(t *testing.T) {
+		provider := mem.NewProvider()
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		witnessProofs := []*proof.WitnessProof{
+			{
+				Type:    proof.TypeBatch,
+				Witness: "witness-1",
+			},
+			{
+				Type:    proof.TypeBatch,
+				Witness: "witness-2",
+			},
+		}
+
+		err = s.Put(vcID, witnessProofs)
+		require.NoError(t, err)
+
+		wf := []byte(witnessProof)
+
+		err = s.AddProof(vcID, "witness-3", wf)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "witness[witness-3] not found for vcID[vcID]")
+	})
+
+	t.Run("error - witness not found (no witnesses for VC)", func(t *testing.T) {
 		provider := mem.NewProvider()
 
 		s, err := New(provider)


### PR DESCRIPTION
Fix add proof in witness proof storage for multiple witnesses.

Closes #401

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>