### PR TITLE
fix: Anchor Origin MUST be provided for Create and Recover

### DIFF
--- a/pkg/versions/1_0/operationparser/validators/anchororigin/validator.go
+++ b/pkg/versions/1_0/operationparser/validators/anchororigin/validator.go
@@ -21,7 +21,7 @@ type Validator struct {
 // Validate validates anchor origin object.
 func (v *Validator) Validate(obj interface{}) error {
 	if obj == nil {
-		return nil
+		return fmt.Errorf("anchor origin must be specified")
 	}
 
 	// if allowed origins contains wild-card '*' any origin is allowed

--- a/pkg/versions/1_0/operationparser/validators/anchororigin/validator_test.go
+++ b/pkg/versions/1_0/operationparser/validators/anchororigin/validator_test.go
@@ -1,3 +1,9 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package anchororigin
 
 import (
@@ -9,9 +15,10 @@ import (
 func TestValidator_Validate(t *testing.T) {
 	v := New([]string{"*"})
 
-	t.Run("success - no anchor origin specified", func(t *testing.T) {
+	t.Run("error - no anchor origin specified", func(t *testing.T) {
 		err := v.Validate(nil)
-		require.NoError(t, err)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "anchor origin must be specified")
 	})
 
 	t.Run("success - allow all origins", func(t *testing.T) {

--- a/pkg/versions/1_0/operationparser/validators/anchortime/validator_test.go
+++ b/pkg/versions/1_0/operationparser/validators/anchortime/validator_test.go
@@ -1,3 +1,9 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package anchortime
 
 import (


### PR DESCRIPTION
Currently anchor origin is checked against allowed list  if it is provided. However if it is not (nil) it will go through. During early drafts of Orb spec there was an idea about filling in anchor origin if not provided. This requirement got dropped (evolved) later on and anchor origin validator never got updated.

Closes #403

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>