### PR TITLE
feat: No authentication for activities in outbox addressed to public IRI

### DIFF
--- a/pkg/activitypub/resthandler/authhandler.go
+++ b/pkg/activitypub/resthandler/authhandler.go
@@ -26,6 +26,7 @@ type authHandler struct {
 	verifier       signatureVerifier
 	activityStore  store.Store
 	authorizeActor authorizeActorFunc
+	writeResponse  func(w http.ResponseWriter, status int, body []byte)
 }
 
 func newAuthHandler(cfg *Config, endpoint, method string, s store.Store, verifier signatureVerifier,
@@ -45,6 +46,19 @@ func newAuthHandler(cfg *Config, endpoint, method string, s store.Store, verifie
 		verifier:       verifier,
 		activityStore:  s,
 		authorizeActor: authorizeActor,
+		writeResponse: func(w http.ResponseWriter, status int, body []byte) {
+			w.WriteHeader(status)
+
+			if len(body) > 0 {
+				if _, err := w.Write(body); err != nil {
+					logger.Warnf("[%s] Unable to write response: %s", ep, err)
+
+					return
+				}
+
+				logger.Debugf("[%s] Wrote response: %s", ep, body)
+			}
+		},
 	}
 }
 

--- a/pkg/activitypub/resthandler/outboxhandler_test.go
+++ b/pkg/activitypub/resthandler/outboxhandler_test.go
@@ -292,10 +292,8 @@ func TestOutbox_Handler(t *testing.T) {
 		verifier.VerifyRequestReturns(true, serviceIRI, nil)
 
 		h := NewPostOutbox(cfg, ob, activityStore, verifier)
-		h.writeResponse = func(w http.ResponseWriter, _ []byte) (int, error) {
+		h.writeResponse = func(w http.ResponseWriter, status int, _ []byte) {
 			w.WriteHeader(http.StatusInternalServerError)
-
-			return 0, errors.New("injected error")
 		}
 
 		rw := httptest.NewRecorder()

--- a/pkg/activitypub/resthandler/referencehandler.go
+++ b/pkg/activitypub/resthandler/referencehandler.go
@@ -81,13 +81,13 @@ func (h *Reference) handle(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		logger.Errorf("[%s] Error authorizing request: %s", h.endpoint, err)
 
-		w.WriteHeader(http.StatusInternalServerError)
+		h.writeResponse(w, http.StatusInternalServerError, []byte(internalServerErrorResponse))
 
 		return
 	}
 
 	if !ok {
-		w.WriteHeader(http.StatusUnauthorized)
+		h.writeResponse(w, http.StatusUnauthorized, []byte(unauthorizedResponse))
 
 		return
 	}
@@ -96,7 +96,7 @@ func (h *Reference) handle(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		logger.Errorf("[%s] Error getting object IRI: %s", h.endpoint, err)
 
-		h.writeResponse(w, http.StatusInternalServerError, nil)
+		h.writeResponse(w, http.StatusInternalServerError, []byte(internalServerErrorResponse))
 
 		return
 	}
@@ -105,7 +105,7 @@ func (h *Reference) handle(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		logger.Errorf("[%s] Error generating ID: %s", h.endpoint, err)
 
-		h.writeResponse(w, http.StatusInternalServerError, nil)
+		h.writeResponse(w, http.StatusInternalServerError, []byte(internalServerErrorResponse))
 
 		return
 	}
@@ -117,13 +117,13 @@ func (h *Reference) handle(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
-func (h *Reference) handleReference(rw http.ResponseWriter, objectIRI, id *url.URL) {
+func (h *Reference) handleReference(w http.ResponseWriter, objectIRI, id *url.URL) {
 	coll, err := h.getReference(objectIRI, id)
 	if err != nil {
 		logger.Errorf("[%s] Error retrieving %s for object IRI [%s]: %s",
 			h.endpoint, h.refType, objectIRI, err)
 
-		h.writeResponse(rw, http.StatusInternalServerError, nil)
+		h.writeResponse(w, http.StatusInternalServerError, []byte(internalServerErrorResponse))
 
 		return
 	}
@@ -133,15 +133,15 @@ func (h *Reference) handleReference(rw http.ResponseWriter, objectIRI, id *url.U
 		logger.Errorf("[%s] Unable to marshal %s collection for object IRI [%s]: %s",
 			h.endpoint, h.refType, objectIRI, err)
 
-		h.writeResponse(rw, http.StatusInternalServerError, nil)
+		h.writeResponse(w, http.StatusInternalServerError, []byte(internalServerErrorResponse))
 
 		return
 	}
 
-	h.writeResponse(rw, http.StatusOK, collBytes)
+	h.writeResponse(w, http.StatusOK, collBytes)
 }
 
-func (h *Reference) handleReferencePage(rw http.ResponseWriter, req *http.Request, objectIRI, id *url.URL) {
+func (h *Reference) handleReferencePage(w http.ResponseWriter, req *http.Request, objectIRI, id *url.URL) {
 	var page interface{}
 
 	var err error
@@ -159,7 +159,7 @@ func (h *Reference) handleReferencePage(rw http.ResponseWriter, req *http.Reques
 		logger.Errorf("[%s] Error retrieving page for object IRI [%s]: %s",
 			h.endpoint, objectIRI, err)
 
-		h.writeResponse(rw, http.StatusInternalServerError, nil)
+		h.writeResponse(w, http.StatusInternalServerError, []byte(internalServerErrorResponse))
 
 		return
 	}
@@ -169,15 +169,14 @@ func (h *Reference) handleReferencePage(rw http.ResponseWriter, req *http.Reques
 		logger.Errorf("[%s] Unable to marshal page for object IRI [%s]: %s",
 			h.endpoint, objectIRI, err)
 
-		h.writeResponse(rw, http.StatusInternalServerError, nil)
+		h.writeResponse(w, http.StatusInternalServerError, []byte(internalServerErrorResponse))
 
 		return
 	}
 
-	h.writeResponse(rw, http.StatusOK, pageBytes)
+	h.writeResponse(w, http.StatusOK, pageBytes)
 }
 
-//nolint:dupl
 func (h *Reference) getReference(objectIRI, id *url.URL) (interface{}, error) {
 	it, err := h.activityStore.QueryReferences(h.refType,
 		spi.NewCriteria(

--- a/pkg/activitypub/resthandler/resthandler.go
+++ b/pkg/activitypub/resthandler/resthandler.go
@@ -55,6 +55,11 @@ const (
 
 	authHeader  = "Authorization"
 	tokenPrefix = "Bearer "
+
+	notFoundResponse            = "Not Found.\n"
+	unauthorizedResponse        = "Unauthorized.\n"
+	badRequestResponse          = "Bad Request.\n"
+	internalServerErrorResponse = "Internal Server Error.\n"
 )
 
 // AuthTokenDef contains authorization bearer token configuration.
@@ -78,11 +83,10 @@ type handler struct {
 	*Config
 	*authHandler
 
-	params        map[string]string
-	handler       common.HTTPRequestHandler
-	marshal       func(v interface{}) ([]byte, error)
-	writeResponse func(w http.ResponseWriter, status int, body []byte)
-	getParams     func(req *http.Request) map[string][]string
+	params    map[string]string
+	handler   common.HTTPRequestHandler
+	marshal   func(v interface{}) ([]byte, error)
+	getParams func(req *http.Request) map[string][]string
 }
 
 func newHandler(endpoint string, cfg *Config, s spi.Store, rh common.HTTPRequestHandler,
@@ -94,19 +98,6 @@ func newHandler(endpoint string, cfg *Config, s spi.Store, rh common.HTTPRequest
 		marshal: vocab.Marshal,
 		getParams: func(req *http.Request) map[string][]string {
 			return req.URL.Query()
-		},
-		writeResponse: func(w http.ResponseWriter, status int, body []byte) {
-			w.WriteHeader(status)
-
-			if len(body) > 0 {
-				if _, err := w.Write(body); err != nil {
-					logger.Warnf("[%s] Unable to write response: %s", endpoint, err)
-
-					return
-				}
-
-				logger.Debugf("[%s] Wrote response: %s", endpoint, body)
-			}
 		},
 	}
 

--- a/pkg/activitypub/resthandler/serviceshandler.go
+++ b/pkg/activitypub/resthandler/serviceshandler.go
@@ -49,7 +49,7 @@ func NewPublicKeys(cfg *Config, activityStore spi.Store, publicKey *vocab.Public
 
 func (h *Services) handle(w http.ResponseWriter, req *http.Request) {
 	if !h.authorizeWithBearerToken(req) {
-		w.WriteHeader(http.StatusUnauthorized)
+		h.writeResponse(w, http.StatusUnauthorized, []byte(unauthorizedResponse))
 
 		return
 	}
@@ -58,7 +58,7 @@ func (h *Services) handle(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		logger.Errorf("[%s] Invalid service configuration [%s]: %s", h.endpoint, h.ObjectIRI, err)
 
-		h.writeResponse(w, http.StatusInternalServerError, nil)
+		h.writeResponse(w, http.StatusInternalServerError, []byte(internalServerErrorResponse))
 
 		return
 	}
@@ -67,7 +67,7 @@ func (h *Services) handle(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		logger.Errorf("[%s] Unable to marshal service [%s]: %s", h.endpoint, h.ObjectIRI, err)
 
-		h.writeResponse(w, http.StatusInternalServerError, nil)
+		h.writeResponse(w, http.StatusInternalServerError, []byte(internalServerErrorResponse))
 
 		return
 	}
@@ -77,7 +77,7 @@ func (h *Services) handle(w http.ResponseWriter, req *http.Request) {
 
 func (h *Services) handlePublicKey(w http.ResponseWriter, req *http.Request) {
 	if !h.authorizeWithBearerToken(req) {
-		w.WriteHeader(http.StatusUnauthorized)
+		h.writeResponse(w, http.StatusUnauthorized, []byte(unauthorizedResponse))
 
 		return
 	}
@@ -87,7 +87,7 @@ func (h *Services) handlePublicKey(w http.ResponseWriter, req *http.Request) {
 	if keyID == "" {
 		logger.Infof("[%s] Key ID not specified [%s]", h.endpoint, h.ObjectIRI)
 
-		h.writeResponse(w, http.StatusBadRequest, nil)
+		h.writeResponse(w, http.StatusBadRequest, []byte(badRequestResponse))
 
 		return
 	}
@@ -97,7 +97,7 @@ func (h *Services) handlePublicKey(w http.ResponseWriter, req *http.Request) {
 	if keyID != MainKeyID {
 		logger.Infof("[%s] Public key [%s] not found for [%s]", h.endpoint, h.ObjectIRI, keyID)
 
-		h.writeResponse(w, http.StatusNotFound, nil)
+		h.writeResponse(w, http.StatusNotFound, []byte(notFoundResponse))
 
 		return
 	}
@@ -106,7 +106,7 @@ func (h *Services) handlePublicKey(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		logger.Errorf("[%s] Unable to marshal public key [%s]: %s", h.endpoint, h.ObjectIRI, err)
 
-		h.writeResponse(w, http.StatusInternalServerError, nil)
+		h.writeResponse(w, http.StatusInternalServerError, []byte(internalServerErrorResponse))
 
 		return
 	}

--- a/pkg/activitypub/service/activityhandler/inboxhandler.go
+++ b/pkg/activitypub/service/activityhandler/inboxhandler.go
@@ -433,7 +433,7 @@ func (h *Inbox) handleOfferActivity(offer *vocab.ActivityType) error {
 
 	like := vocab.NewLikeActivity(
 		vocab.NewObjectProperty(vocab.WithIRI(anchorCred.ID().URL())),
-		vocab.WithTo(offer.Actor()),
+		vocab.WithTo(offer.Actor(), vocab.PublicIRI),
 		vocab.WithStartTime(&startTime),
 		vocab.WithEndTime(&endTime),
 		vocab.WithResult(vocab.NewObjectProperty(vocab.WithObject(result))),
@@ -562,7 +562,7 @@ func (h *Inbox) announceAnchorCredential(create *vocab.ActivityType) error {
 				),
 			),
 		),
-		vocab.WithTo(h.followersIRI),
+		vocab.WithTo(h.followersIRI, vocab.PublicIRI),
 		vocab.WithPublishedTime(&published),
 	)
 
@@ -599,7 +599,7 @@ func (h *Inbox) announceAnchorCredentialRef(create *vocab.ActivityType) error {
 				),
 			),
 		),
-		vocab.WithTo(h.followersIRI),
+		vocab.WithTo(h.followersIRI, vocab.PublicIRI),
 		vocab.WithPublishedTime(&published),
 	)
 

--- a/pkg/activitypub/store/ariesstore/ariesstore.go
+++ b/pkg/activitypub/store/ariesstore/ariesstore.go
@@ -429,7 +429,7 @@ func openStores(provider ariesstorage.Provider) (stores, error) {
 
 func openReferenceStores(provider ariesstorage.Provider) (map[spi.ReferenceType]ariesstorage.Store, error) {
 	referenceTypes := []spi.ReferenceType{
-		spi.Inbox, spi.Outbox, spi.Follower, spi.Following, spi.Witness,
+		spi.Inbox, spi.Outbox, spi.PublicOutbox, spi.Follower, spi.Following, spi.Witness,
 		spi.Witnessing, spi.Like, spi.Liked, spi.Share, spi.AnchorCredential,
 	}
 

--- a/pkg/activitypub/store/memstore/memstore.go
+++ b/pkg/activitypub/store/memstore/memstore.go
@@ -38,6 +38,7 @@ func New(serviceName string) *Store {
 		referenceStores: map[spi.ReferenceType]*referenceStore{
 			spi.Inbox:            newReferenceStore(),
 			spi.Outbox:           newReferenceStore(),
+			spi.PublicOutbox:     newReferenceStore(),
 			spi.Follower:         newReferenceStore(),
 			spi.Following:        newReferenceStore(),
 			spi.Witness:          newReferenceStore(),

--- a/pkg/activitypub/store/spi/spi.go
+++ b/pkg/activitypub/store/spi/spi.go
@@ -25,6 +25,10 @@ const (
 	Inbox ReferenceType = "INBOX"
 	// Outbox indicates that the reference is an activity in a service's outbox.
 	Outbox ReferenceType = "OUTBOX"
+	// PublicOutbox indicates that the reference is an activity posted to the service's outbox and was addressed
+	// to 'https://www.w3.org/ns/activitystreams#Public' and therefore may be accessed by anyone without requiring
+	// authentication.
+	PublicOutbox ReferenceType = "PUBLIC_OUTBOX"
 	// Follower indicates that the reference is an actor that's following the local service.
 	Follower ReferenceType = "FOLLOWER"
 	// Following indicates that the reference is an actor that the local service is following.

--- a/pkg/activitypub/vocab/activitytype_test.go
+++ b/pkg/activitypub/vocab/activitytype_test.go
@@ -744,7 +744,6 @@ func TestRejectTypeMarshal(t *testing.T) {
 
 func TestOfferTypeMarshal(t *testing.T) {
 	to := newMockID(service1, "/witnesses")
-	public := testutil.MustParseURL(PublicIRI)
 
 	startTime := getStaticTime()
 	endTime := startTime.Add(1 * time.Minute)
@@ -757,7 +756,7 @@ func TestOfferTypeMarshal(t *testing.T) {
 			NewObjectProperty(WithObject(obj)),
 			WithID(offerActivityID),
 			WithActor(service1),
-			WithTo(to, public),
+			WithTo(to, PublicIRI),
 			WithStartTime(&startTime),
 			WithEndTime(&endTime),
 		)
@@ -782,7 +781,7 @@ func TestOfferTypeMarshal(t *testing.T) {
 
 		require.Len(t, a.To(), 2)
 		require.Equal(t, a.To()[0].String(), to.String())
-		require.Equal(t, a.To()[1].String(), PublicIRI)
+		require.Equal(t, a.To()[1].String(), PublicIRI.String())
 
 		require.Equal(t, service1.String(), a.Actor().String())
 
@@ -808,7 +807,6 @@ func TestOfferTypeMarshal(t *testing.T) {
 
 func TestLikeTypeMarshal(t *testing.T) {
 	actor := testutil.MustParseURL("https://witness1.example.com/services/orb")
-	public := testutil.MustParseURL(PublicIRI)
 	credID := testutil.MustParseURL("http://sally.example.com/transactions/bafkreihwsn")
 
 	startTime := getStaticTime()
@@ -822,7 +820,7 @@ func TestLikeTypeMarshal(t *testing.T) {
 			NewObjectProperty(WithIRI(credID)),
 			WithID(likeActivityID),
 			WithActor(actor),
-			WithTo(service1, public),
+			WithTo(service1, PublicIRI),
 			WithStartTime(&startTime),
 			WithEndTime(&endTime),
 			WithResult(NewObjectProperty(WithObject(result))),
@@ -848,7 +846,7 @@ func TestLikeTypeMarshal(t *testing.T) {
 
 		require.Len(t, a.To(), 2)
 		require.Equal(t, a.To()[0].String(), service1.String())
-		require.Equal(t, a.To()[1].String(), PublicIRI)
+		require.Equal(t, a.To()[1].String(), PublicIRI.String())
 
 		require.Equal(t, actor.String(), a.Actor().String())
 

--- a/pkg/activitypub/vocab/objecttype.go
+++ b/pkg/activitypub/vocab/objecttype.go
@@ -108,9 +108,9 @@ func (t *ObjectType) EndTime() *time.Time {
 type Urls []*url.URL
 
 // Contains returns true if the collection of URLs contains the given URL.
-func (u Urls) Contains(v string) bool {
+func (u Urls) Contains(v fmt.Stringer) bool {
 	for _, iri := range u {
-		if iri.String() == v {
+		if iri.String() == v.String() {
 			return true
 		}
 	}

--- a/pkg/activitypub/vocab/objecttype_test.go
+++ b/pkg/activitypub/vocab/objecttype_test.go
@@ -53,8 +53,8 @@ func TestObjectType_WithoutDocument(t *testing.T) {
 
 		to := obj.To()
 		require.Len(t, to, 2)
-		require.True(t, to.Contains(to1.String()))
-		require.True(t, to.Contains(to2.String()))
+		require.True(t, to.Contains(to1))
+		require.True(t, to.Contains(to2))
 	})
 
 	t.Run("MarshalJSON", func(t *testing.T) {

--- a/pkg/activitypub/vocab/util.go
+++ b/pkg/activitypub/vocab/util.go
@@ -9,6 +9,7 @@ package vocab
 import (
 	"bytes"
 	"encoding/json"
+	"net/url"
 	"strings"
 )
 
@@ -93,4 +94,15 @@ func Marshal(o interface{}) ([]byte, error) {
 	}
 
 	return []byte(strings.TrimSuffix(b.String(), "\n")), nil
+}
+
+// MustParseURL parses the string and returns the URL.
+// This function panics if the string is not a valid URL.
+func MustParseURL(raw string) *url.URL {
+	u, err := url.Parse(raw)
+	if err != nil {
+		panic(err)
+	}
+
+	return u
 }

--- a/pkg/activitypub/vocab/vocab.go
+++ b/pkg/activitypub/vocab/vocab.go
@@ -20,10 +20,9 @@ const (
 	ContextOrb Context = "https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"
 )
 
-const (
-	// PublicIRI indicates that the object is public, i.e. it may be viewed by anyone.
-	PublicIRI = "https://www.w3.org/ns/activitystreams#Public"
-)
+// PublicIRI indicates that the object is public, i.e. it may be viewed by anyone.
+//nolint:gochecknoglobals
+var PublicIRI = MustParseURL("https://www.w3.org/ns/activitystreams#Public")
 
 // Type indicates the type of the object.
 type Type string

--- a/pkg/activitypub/vocab/vocab_test.go
+++ b/pkg/activitypub/vocab/vocab_test.go
@@ -38,6 +38,20 @@ func TestDocument_MergeWith(t *testing.T) {
 	require.Equal(t, 4, doc1[field4])
 }
 
+func TestMustParseURL(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		const iri = "https://example.com"
+
+		require.Equal(t, iri, MustParseURL(iri).String())
+	})
+
+	t.Run("Panic", func(t *testing.T) {
+		require.Panics(t, func() {
+			MustParseURL(string([]byte{0}))
+		})
+	})
+}
+
 func getStaticTime() time.Time {
 	loc, err := time.LoadLocation("UTC")
 	if err != nil {

--- a/pkg/anchor/writer/writer.go
+++ b/pkg/anchor/writer/writer.go
@@ -401,7 +401,7 @@ func (c *Writer) postCreateActivity(vc *verifiable.Credential, cid string) error
 		vocab.NewObjectProperty(vocab.WithObject(obj)),
 		vocab.WithTarget(targetProperty),
 		vocab.WithContext(vocab.ContextOrb),
-		vocab.WithTo(systemFollowers),
+		vocab.WithTo(systemFollowers, vocab.PublicIRI),
 	)
 
 	postID, err := c.Outbox.Post(create)
@@ -433,7 +433,7 @@ func (c *Writer) postOfferActivity(vc *verifiable.Credential, witnesses []string
 
 	// add batch witnesses and system witnesses (activity pub collection)
 	witnessesIRI = append(witnessesIRI, batchWitnessesIRI...)
-	witnessesIRI = append(witnessesIRI, systemWitnessesIRI)
+	witnessesIRI = append(witnessesIRI, vocab.PublicIRI, systemWitnessesIRI)
 
 	bytes, err := vc.MarshalJSON()
 	if err != nil {


### PR DESCRIPTION
Activities in the outbox which are addressed to "https://www.w3.org/ns/activitystreams#Public" are accessible to anyone without authentication.

closes #365

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>