### PR TITLE
feat: Add bearer token authorization for /cas endpoint

### DIFF
--- a/pkg/activitypub/client/transport/transport_test.go
+++ b/pkg/activitypub/client/transport/transport_test.go
@@ -29,7 +29,12 @@ func TestNew(t *testing.T) {
 }
 
 func TestNewRequest(t *testing.T) {
-	require.NotNil(t, NewRequest(testutil.MustParseURL("https://someurl")))
+	req := NewRequest(
+		testutil.MustParseURL("https://someurl"),
+		WithHeader(AcceptHeader, ActivityStreamsContentType),
+	)
+	require.NotNil(t, req)
+	require.Equal(t, []string{ActivityStreamsContentType}, req.Header[AcceptHeader])
 }
 
 func TestDefault(t *testing.T) {

--- a/pkg/activitypub/httpsig/signer.go
+++ b/pkg/activitypub/httpsig/signer.go
@@ -73,9 +73,9 @@ func NewSigner(cfg SignerConfig, cr crypto.Crypto, km kms.KeyManager, keyID stri
 
 // SignRequest signs an HTTP request.
 func (s *Signer) SignRequest(pubKeyID string, req *http.Request) error {
-	logger.Debugf("Signing request for %s. Public key ID [%s]", req.RequestURI, pubKeyID)
-
 	req.Header.Add(dateHeader, date())
+
+	logger.Debugf("Signing request for %s. Public key ID [%s]. Headers: %s", req.RequestURI, pubKeyID, req.Header)
 
 	if err := s.signer().Sign(pubKeyID, req); err != nil {
 		return fmt.Errorf("sign request with public key ID [%s]: %w", pubKeyID, err)

--- a/pkg/activitypub/resthandler/activityhandler.go
+++ b/pkg/activitypub/resthandler/activityhandler.go
@@ -93,7 +93,7 @@ func NewActivities(path string, refType spi.ReferenceType, cfg *Config, activity
 }
 
 func (h *Activities) handle(w http.ResponseWriter, req *http.Request) {
-	ok, _, err := h.authorize(req)
+	ok, _, err := h.Authorize(req)
 	if err != nil {
 		logger.Errorf("[%s] Error authorizing request: %s", h.endpoint, err)
 
@@ -293,7 +293,7 @@ type Activity struct {
 }
 
 func (h *Activity) handle(w http.ResponseWriter, req *http.Request) {
-	authorized, _, err := h.authorize(req)
+	authorized, _, err := h.Authorize(req)
 	if err != nil {
 		logger.Errorf("[%s] Error authorizing request: %s", h.endpoint, err)
 
@@ -376,7 +376,7 @@ type ReadOutbox struct {
 }
 
 func (h *ReadOutbox) handleOutbox(w http.ResponseWriter, req *http.Request) {
-	ok, _, err := h.authorize(req)
+	ok, _, err := h.Authorize(req)
 	if err != nil {
 		logger.Errorf("[%s] Error authorizing request: %s", h.endpoint, err)
 

--- a/pkg/activitypub/resthandler/authhandler.go
+++ b/pkg/activitypub/resthandler/authhandler.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package resthandler
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -17,10 +18,12 @@ import (
 
 type authorizeActorFunc func(actorIRI *url.URL) (bool, error)
 
-type authHandler struct {
+// AuthHandler handles authorization of an HTTP request. Both bearer token and HTTP signature authorization
+// are performed.
+type AuthHandler struct {
 	*Config
-	tokenVerifier *auth.TokenVerifier
 
+	tokenVerifier  *auth.TokenVerifier
 	endpoint       string
 	verifier       signatureVerifier
 	activityStore  store.Store
@@ -28,11 +31,12 @@ type authHandler struct {
 	writeResponse  func(w http.ResponseWriter, status int, body []byte)
 }
 
-func newAuthHandler(cfg *Config, endpoint, method string, s store.Store, verifier signatureVerifier,
-	authorizeActor authorizeActorFunc) *authHandler {
+// NewAuthHandler returns a new authorization handler.
+func NewAuthHandler(cfg *Config, endpoint, method string, s store.Store, verifier signatureVerifier,
+	authorizeActor authorizeActorFunc) *AuthHandler {
 	ep := fmt.Sprintf("%s%s", cfg.BasePath, endpoint)
 
-	return &authHandler{
+	h := &AuthHandler{
 		Config:         cfg,
 		tokenVerifier:  auth.NewTokenVerifier(cfg.Config, ep, method),
 		endpoint:       ep,
@@ -53,24 +57,32 @@ func newAuthHandler(cfg *Config, endpoint, method string, s store.Store, verifie
 			}
 		},
 	}
+
+	if h.authorizeActor == nil {
+		h.authorizeActor = h.ensureActorIsWitnessOrFollower
+	}
+
+	return h
 }
 
-func (h *authHandler) authorize(req *http.Request) (bool, *url.URL, error) {
+// Authorize authorizes the request, first checking the required bearer token and then, if the bearer token was not
+// provided, the HTTP signature.
+func (h *AuthHandler) Authorize(req *http.Request) (bool, *url.URL, error) {
 	if h.tokenVerifier.Verify(req) {
-		logger.Debugf("[%s] Authorization succeeded using bearer token", h.endpoint)
+		logger.Debugf("[%s] Authorization succeeded using bearer token for request %s", h.endpoint, req.URL)
 
 		// The bearer of the token is assumed to be this service. If it isn't then validation
 		// should fail in subsequent checks.
 		return true, h.ObjectIRI, nil
 	}
 
-	logger.Debugf("[%s] Authorization failed using bearer token.", h.endpoint)
+	logger.Debugf("[%s] Authorization failed using bearer token for request %s.", h.endpoint, req.URL)
 
 	if h.verifier == nil {
 		return false, nil, nil
 	}
 
-	logger.Debugf("[%s] Checking HTTP signature...", h.endpoint)
+	logger.Debugf("[%s] Checking HTTP signature for request %s...", h.endpoint, req.URL)
 
 	// Check HTTP signature.
 	ok, actorIRI, err := h.verifier.VerifyRequest(req)
@@ -79,7 +91,7 @@ func (h *authHandler) authorize(req *http.Request) (bool, *url.URL, error) {
 	}
 
 	if !ok {
-		logger.Debugf("[%s] Authorization failed using HTTP signature.", h.endpoint)
+		logger.Debugf("[%s] Authorization failed using HTTP signature for request %s.", h.endpoint, req.URL)
 
 		return false, nil, nil
 	}
@@ -89,5 +101,64 @@ func (h *authHandler) authorize(req *http.Request) (bool, *url.URL, error) {
 		return false, nil, fmt.Errorf("authorize actor [%s]: %w", actorIRI, err)
 	}
 
+	logger.Debugf("[%s] Authorization succeeded using HTTP signature for request %s.", h.endpoint, req.URL)
+
 	return ok, actorIRI, nil
+}
+
+func (h *AuthHandler) ensureActorIsWitnessOrFollower(actorIRI *url.URL) (bool, error) {
+	if !h.VerifyActorInSignature {
+		return true, nil
+	}
+
+	// Ensure that the actor is a follower or a witness, otherwise deny access.
+	isFollower, err := h.hasReference(store.Follower, actorIRI)
+	if err != nil {
+		return false, fmt.Errorf("check follower: %w", err)
+	}
+
+	if !isFollower {
+		isWitness, err := h.hasReference(store.Witness, actorIRI)
+		if err != nil {
+			return false, fmt.Errorf("check witness: %w", err)
+		}
+
+		if !isWitness {
+			logger.Infof("[%s] Denying access since actor [%s] is neither a follower or a witness.", h.endpoint, actorIRI)
+
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func (h *AuthHandler) hasReference(refType store.ReferenceType, refIRI *url.URL) (bool, error) {
+	it, err := h.activityStore.QueryReferences(refType,
+		store.NewCriteria(
+			store.WithObjectIRI(h.ObjectIRI),
+			store.WithReferenceIRI(refIRI),
+		),
+	)
+	if err != nil {
+		return false, fmt.Errorf("query references: %w", err)
+	}
+
+	defer func() {
+		err = it.Close()
+		if err != nil {
+			logger.Errorf("failed to close iterator: %s", err.Error())
+		}
+	}()
+
+	_, err = it.Next()
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("get next reference: %w", err)
+	}
+
+	return true, nil
 }

--- a/pkg/activitypub/resthandler/authhandler_test.go
+++ b/pkg/activitypub/resthandler/authhandler_test.go
@@ -53,7 +53,7 @@ func TestNewAuthHandler(t *testing.T) {
 	activityStore := memstore.New("")
 
 	t.Run("POST with auth token -> success", func(t *testing.T) {
-		h := newAuthHandler(cfg, InboxPath, http.MethodPost, activityStore, &mocks.SignatureVerifier{},
+		h := NewAuthHandler(cfg, InboxPath, http.MethodPost, activityStore, &mocks.SignatureVerifier{},
 			func(actorIRI *url.URL) (bool, error) {
 				return true, nil
 			},
@@ -63,14 +63,14 @@ func TestNewAuthHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, inboxURL, nil)
 		req.Header[authHeader] = []string{tokenPrefix + "ADMIN_TOKEN"}
 
-		ok, actorIRI, err := h.authorize(req)
+		ok, actorIRI, err := h.Authorize(req)
 		require.NoError(t, err)
 		require.True(t, ok)
 		require.Equal(t, cfg.ObjectIRI.String(), actorIRI.String())
 	})
 
 	t.Run("GET with auth token -> success", func(t *testing.T) {
-		h := newAuthHandler(cfg, InboxPath, http.MethodGet, activityStore, &mocks.SignatureVerifier{},
+		h := NewAuthHandler(cfg, InboxPath, http.MethodGet, activityStore, &mocks.SignatureVerifier{},
 			func(actorIRI *url.URL) (bool, error) {
 				return true, nil
 			},
@@ -80,14 +80,14 @@ func TestNewAuthHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, inboxURL, nil)
 		req.Header[authHeader] = []string{tokenPrefix + "READ_TOKEN"}
 
-		ok, actorIRI, err := h.authorize(req)
+		ok, actorIRI, err := h.Authorize(req)
 		require.NoError(t, err)
 		require.True(t, ok)
 		require.Equal(t, cfg.ObjectIRI.String(), actorIRI.String())
 	})
 
 	t.Run("With invalid auth token -> error", func(t *testing.T) {
-		h := newAuthHandler(cfg, InboxPath, http.MethodPost, activityStore, &mocks.SignatureVerifier{},
+		h := NewAuthHandler(cfg, InboxPath, http.MethodPost, activityStore, &mocks.SignatureVerifier{},
 			func(actorIRI *url.URL) (bool, error) {
 				return true, nil
 			},
@@ -97,7 +97,7 @@ func TestNewAuthHandler(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, inboxURL, nil)
 		req.Header[authHeader] = []string{tokenPrefix + "INVALID_TOKEN"}
 
-		ok, actorIRI, err := h.authorize(req)
+		ok, actorIRI, err := h.Authorize(req)
 		require.NoError(t, err)
 		require.False(t, ok)
 		require.Nil(t, actorIRI)
@@ -107,7 +107,7 @@ func TestNewAuthHandler(t *testing.T) {
 		verifier := &mocks.SignatureVerifier{}
 		verifier.VerifyRequestReturns(true, cfg.ObjectIRI, nil)
 
-		h := newAuthHandler(cfg, InboxPath, http.MethodPost, activityStore, verifier,
+		h := NewAuthHandler(cfg, InboxPath, http.MethodPost, activityStore, verifier,
 			func(actorIRI *url.URL) (bool, error) {
 				return true, nil
 			},
@@ -116,14 +116,14 @@ func TestNewAuthHandler(t *testing.T) {
 
 		req := httptest.NewRequest(http.MethodPost, inboxURL, nil)
 
-		ok, actorIRI, err := h.authorize(req)
+		ok, actorIRI, err := h.Authorize(req)
 		require.NoError(t, err)
 		require.True(t, ok)
 		require.Equal(t, cfg.ObjectIRI.String(), actorIRI.String())
 	})
 
 	t.Run("No auth token definitions -> success", func(t *testing.T) {
-		h := newAuthHandler(
+		h := NewAuthHandler(
 			&Config{
 				BasePath:  basePath,
 				ObjectIRI: serviceIRI,
@@ -137,7 +137,7 @@ func TestNewAuthHandler(t *testing.T) {
 
 		req := httptest.NewRequest(http.MethodPost, inboxURL, nil)
 
-		ok, actorIRI, err := h.authorize(req)
+		ok, actorIRI, err := h.Authorize(req)
 		require.NoError(t, err)
 		require.True(t, ok)
 		require.Equal(t, cfg.ObjectIRI.String(), actorIRI.String())
@@ -145,7 +145,7 @@ func TestNewAuthHandler(t *testing.T) {
 
 	t.Run("Invalid auth token definitions -> panic", func(t *testing.T) {
 		require.Panics(t, func() {
-			h := newAuthHandler(
+			h := NewAuthHandler(
 				&Config{
 					BasePath:  basePath,
 					ObjectIRI: serviceIRI,
@@ -168,7 +168,7 @@ func TestNewAuthHandler(t *testing.T) {
 	})
 
 	t.Run("No token and no HTTP signature verifier -> fail", func(t *testing.T) {
-		h := newAuthHandler(cfg, InboxPath, http.MethodPost, activityStore, nil,
+		h := NewAuthHandler(cfg, InboxPath, http.MethodPost, activityStore, nil,
 			func(actorIRI *url.URL) (bool, error) {
 				return true, nil
 			},
@@ -177,7 +177,7 @@ func TestNewAuthHandler(t *testing.T) {
 
 		req := httptest.NewRequest(http.MethodGet, inboxURL, nil)
 
-		ok, actorIRI, err := h.authorize(req)
+		ok, actorIRI, err := h.Authorize(req)
 		require.NoError(t, err)
 		require.False(t, ok)
 		require.Nil(t, actorIRI)
@@ -189,7 +189,7 @@ func TestNewAuthHandler(t *testing.T) {
 		verifier := &mocks.SignatureVerifier{}
 		verifier.VerifyRequestReturns(false, nil, errExpected)
 
-		h := newAuthHandler(cfg, InboxPath, http.MethodPost, activityStore, verifier,
+		h := NewAuthHandler(cfg, InboxPath, http.MethodPost, activityStore, verifier,
 			func(actorIRI *url.URL) (bool, error) {
 				return true, nil
 			},
@@ -198,7 +198,7 @@ func TestNewAuthHandler(t *testing.T) {
 
 		req := httptest.NewRequest(http.MethodGet, inboxURL, nil)
 
-		ok, actorIRI, err := h.authorize(req)
+		ok, actorIRI, err := h.Authorize(req)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errExpected.Error())
 		require.False(t, ok)
@@ -206,12 +206,12 @@ func TestNewAuthHandler(t *testing.T) {
 	})
 
 	t.Run("Authorize actor error -> fail", func(t *testing.T) {
-		errExpected := errors.New("injected authorize error")
+		errExpected := errors.New("injected Authorize error")
 
 		verifier := &mocks.SignatureVerifier{}
 		verifier.VerifyRequestReturns(true, cfg.ObjectIRI, nil)
 
-		h := newAuthHandler(cfg, InboxPath, http.MethodPost, activityStore, verifier,
+		h := NewAuthHandler(cfg, InboxPath, http.MethodPost, activityStore, verifier,
 			func(actorIRI *url.URL) (bool, error) {
 				return false, errExpected
 			},
@@ -220,7 +220,7 @@ func TestNewAuthHandler(t *testing.T) {
 
 		req := httptest.NewRequest(http.MethodGet, inboxURL, nil)
 
-		ok, actorIRI, err := h.authorize(req)
+		ok, actorIRI, err := h.Authorize(req)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errExpected.Error())
 		require.False(t, ok)

--- a/pkg/activitypub/resthandler/outboxhandler.go
+++ b/pkg/activitypub/resthandler/outboxhandler.go
@@ -26,7 +26,7 @@ type outbox interface {
 // Outbox implements a REST handler for posts to a service's outbox.
 type Outbox struct {
 	*Config
-	*authHandler
+	*AuthHandler
 
 	endpoint string
 	ob       outbox
@@ -42,7 +42,7 @@ func NewPostOutbox(cfg *Config, ob outbox, s store.Store, verifier signatureVeri
 		marshal:  json.Marshal,
 	}
 
-	h.authHandler = newAuthHandler(cfg, "/outbox", http.MethodPost, s, verifier, h.authorizeActor)
+	h.AuthHandler = NewAuthHandler(cfg, "/outbox", http.MethodPost, s, verifier, h.authorizeActor)
 
 	return h
 }
@@ -64,7 +64,7 @@ func (h *Outbox) Handler() common.HTTPRequestHandler {
 }
 
 func (h *Outbox) handlePost(w http.ResponseWriter, req *http.Request) {
-	ok, _, err := h.authorize(req)
+	ok, _, err := h.Authorize(req)
 	if err != nil {
 		logger.Errorf("[%s] Error authorizing request: %s", h.endpoint, err)
 

--- a/pkg/activitypub/resthandler/referencehandler.go
+++ b/pkg/activitypub/resthandler/referencehandler.go
@@ -77,7 +77,7 @@ func NewReference(path string, refType spi.ReferenceType, sortOrder spi.SortOrde
 }
 
 func (h *Reference) handle(w http.ResponseWriter, req *http.Request) {
-	ok, _, err := h.authorize(req)
+	ok, _, err := h.Authorize(req)
 	if err != nil {
 		logger.Errorf("[%s] Error authorizing request: %s", h.endpoint, err)
 

--- a/pkg/activitypub/service/outbox/httppublisher/httppublisher.go
+++ b/pkg/activitypub/service/outbox/httppublisher/httppublisher.go
@@ -116,16 +116,14 @@ func (p *Publisher) newRequest(_ string, msg *message.Message) (*transport.Reque
 		return nil, fmt.Errorf("parse URL %s: %w", to, err)
 	}
 
-	req := transport.NewRequest(toURL)
-
-	req.Header.Set(wmhttp.HeaderUUID, msg.UUID)
-
 	metadataBytes, err := p.jsonMarshal(msg.Metadata)
 	if err != nil {
 		return nil, fmt.Errorf("marshal metadata to JSON: %w", err)
 	}
 
-	req.Header.Set(wmhttp.HeaderMetadata, string(metadataBytes))
-
-	return req, nil
+	return transport.NewRequest(toURL,
+		transport.WithHeader(transport.AcceptHeader, transport.ActivityStreamsContentType),
+		transport.WithHeader(wmhttp.HeaderUUID, msg.UUID),
+		transport.WithHeader(wmhttp.HeaderMetadata, string(metadataBytes)),
+	), nil
 }

--- a/pkg/anchor/graph/graph_test.go
+++ b/pkg/anchor/graph/graph_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package graph
 
 import (
-	"net/http"
 	"testing"
 	"time"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
 
+	apmocks "github.com/trustbloc/orb/pkg/activitypub/mocks"
 	"github.com/trustbloc/orb/pkg/anchor/subject"
 	vcutil "github.com/trustbloc/orb/pkg/anchor/util"
 	casresolver "github.com/trustbloc/orb/pkg/cas/resolver"
@@ -36,7 +36,7 @@ func TestGraph_Add(t *testing.T) {
 
 	providers := &Providers{
 		CasWriter:   caswriter.New(casClient, "webcas:domain.com"),
-		CasResolver: casresolver.New(casClient, nil, &http.Client{}),
+		CasResolver: casresolver.New(casClient, nil, &apmocks.HTTPTransport{}),
 		Pkf:         pubKeyFetcherFnc,
 		DocLoader:   testutil.GetLoader(t),
 	}
@@ -63,7 +63,7 @@ func TestGraph_Read(t *testing.T) {
 
 	providers := &Providers{
 		CasWriter:   caswriter.New(casClient, "ipfs"),
-		CasResolver: casresolver.New(casClient, nil, &http.Client{}),
+		CasResolver: casresolver.New(casClient, nil, &apmocks.HTTPTransport{}),
 		Pkf:         pubKeyFetcherFnc,
 		DocLoader:   testutil.GetLoader(t),
 	}
@@ -106,7 +106,7 @@ func TestGraph_GetDidAnchors(t *testing.T) {
 
 	providers := &Providers{
 		CasWriter:   caswriter.New(casClient, "webcas:domain.com"),
-		CasResolver: casresolver.New(casClient, nil, &http.Client{}),
+		CasResolver: casresolver.New(casClient, nil, &apmocks.HTTPTransport{}),
 		Pkf:         pubKeyFetcherFnc,
 		DocLoader:   testutil.GetLoader(t),
 	}

--- a/pkg/anchor/writer/writer_test.go
+++ b/pkg/anchor/writer/writer_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
 
+	"github.com/trustbloc/orb/pkg/activitypub/client/transport"
 	apmocks "github.com/trustbloc/orb/pkg/activitypub/store/mocks"
 	"github.com/trustbloc/orb/pkg/activitypub/store/spi"
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
@@ -79,9 +80,12 @@ func TestWriter_WriteAnchor(t *testing.T) {
 	casClient := mocks.NewMockCasClient(nil)
 
 	graphProviders := &graph.Providers{
-		CasWriter:   caswriter.New(casClient, "webcas:domain.com"),
-		CasResolver: casresolver.New(casClient, nil, &http.Client{}),
-		Pkf:         pubKeyFetcherFnc,
+		CasWriter: caswriter.New(casClient, "webcas:domain.com"),
+		CasResolver: casresolver.New(casClient, nil, transport.New(&http.Client{},
+			testutil.MustParseURL("https://example.com/keys/public-key"),
+			transport.DefaultSigner(), transport.DefaultSigner()),
+		),
+		Pkf: pubKeyFetcherFnc,
 	}
 
 	apServiceIRI, err := url.Parse(activityPubURL)
@@ -482,9 +486,12 @@ func TestWriter_handle(t *testing.T) {
 	casClient := mocks.NewMockCasClient(nil)
 
 	graphProviders := &graph.Providers{
-		CasWriter:   caswriter.New(casClient, "webcas:domain.com"),
-		CasResolver: casresolver.New(casClient, nil, &http.Client{}),
-		Pkf:         pubKeyFetcherFnc,
+		CasWriter: caswriter.New(casClient, "webcas:domain.com"),
+		CasResolver: casresolver.New(casClient, nil, transport.New(&http.Client{},
+			testutil.MustParseURL("https://example.com/keys/public-key"),
+			transport.DefaultSigner(), transport.DefaultSigner()),
+		),
+		Pkf: pubKeyFetcherFnc,
 	}
 
 	apServiceIRI, err := url.Parse(activityPubURL)
@@ -941,9 +948,12 @@ func TestWriter_Read(t *testing.T) {
 	casClient := mocks.NewMockCasClient(nil)
 
 	graphProviders := &graph.Providers{
-		CasWriter:   caswriter.New(casClient, "webcas:domain.com"),
-		CasResolver: casresolver.New(casClient, nil, &http.Client{}),
-		Pkf:         pubKeyFetcherFnc,
+		CasWriter: caswriter.New(casClient, "webcas:domain.com"),
+		CasResolver: casresolver.New(casClient, nil, transport.New(&http.Client{},
+			testutil.MustParseURL("https://example.com/keys/public-key"),
+			transport.DefaultSigner(), transport.DefaultSigner()),
+		),
+		Pkf: pubKeyFetcherFnc,
 	}
 
 	providers := &Providers{

--- a/pkg/cas/resolver/resolver_test.go
+++ b/pkg/cas/resolver/resolver_test.go
@@ -22,8 +22,13 @@ import (
 	"github.com/stretchr/testify/require"
 	casapi "github.com/trustbloc/sidetree-core-go/pkg/api/cas"
 
+	"github.com/trustbloc/orb/pkg/activitypub/client/transport"
+	"github.com/trustbloc/orb/pkg/activitypub/resthandler"
+	"github.com/trustbloc/orb/pkg/activitypub/service/mocks"
+	"github.com/trustbloc/orb/pkg/activitypub/store/memstore"
 	"github.com/trustbloc/orb/pkg/cas/ipfs"
 	"github.com/trustbloc/orb/pkg/discovery/endpoint/restapi"
+	"github.com/trustbloc/orb/pkg/internal/testutil"
 	"github.com/trustbloc/orb/pkg/store/cas"
 	"github.com/trustbloc/orb/pkg/webcas"
 )
@@ -125,7 +130,7 @@ func TestResolver_Resolve(t *testing.T) {
 			require.NoError(t, err)
 			require.NotEmpty(t, cid)
 
-			webCAS := webcas.New(casClient)
+			webCAS := webcas.New(&resthandler.Config{}, memstore.New(""), &mocks.SignatureVerifier{}, casClient)
 			require.NotNil(t, webCAS)
 
 			router := mux.NewRouter()
@@ -156,7 +161,7 @@ func TestResolver_Resolve(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, cid)
 
-		webCAS := webcas.New(casClient)
+		webCAS := webcas.New(&resthandler.Config{}, memstore.New(""), &mocks.SignatureVerifier{}, casClient)
 		require.NotNil(t, webCAS)
 
 		router := mux.NewRouter()
@@ -195,7 +200,7 @@ func TestResolver_Resolve(t *testing.T) {
 		require.NotEmpty(t, cid)
 
 		// remote server doesn't have cid (clean CAS)
-		webCAS := webcas.New(createInMemoryCAS(t))
+		webCAS := webcas.New(&resthandler.Config{}, memstore.New(""), &mocks.SignatureVerifier{}, createInMemoryCAS(t))
 		require.NotNil(t, webCAS)
 
 		router := mux.NewRouter()
@@ -305,7 +310,7 @@ func TestResolver_Resolve(t *testing.T) {
 		require.Nil(t, data)
 	})
 	t.Run("Neither local nor remote CAS has the data", func(t *testing.T) {
-		webCAS := webcas.New(createInMemoryCAS(t))
+		webCAS := webcas.New(&resthandler.Config{}, memstore.New(""), &mocks.SignatureVerifier{}, createInMemoryCAS(t))
 		require.NotNil(t, webCAS)
 
 		router := mux.NewRouter()
@@ -338,7 +343,7 @@ func TestResolver_Resolve(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, cid)
 
-		webCAS := webcas.New(casClient)
+		webCAS := webcas.New(&resthandler.Config{}, memstore.New(""), &mocks.SignatureVerifier{}, casClient)
 		require.NotNil(t, webCAS)
 
 		router := mux.NewRouter()
@@ -436,7 +441,7 @@ func TestResolver_Resolve(t *testing.T) {
 			require.NoError(t, err)
 			require.NotEmpty(t, cid)
 
-			webCAS := webcas.New(casClient)
+			webCAS := webcas.New(&resthandler.Config{}, memstore.New(""), &mocks.SignatureVerifier{}, casClient)
 			require.NotNil(t, webCAS)
 
 			router := mux.NewRouter()
@@ -473,7 +478,7 @@ func TestResolver_Resolve(t *testing.T) {
 			require.NoError(t, err)
 			require.NotEmpty(t, cid)
 
-			webCAS := webcas.New(casClient)
+			webCAS := webcas.New(&resthandler.Config{}, memstore.New(""), &mocks.SignatureVerifier{}, casClient)
 			require.NotNil(t, webCAS)
 
 			router := mux.NewRouter()
@@ -509,7 +514,7 @@ func TestResolver_Resolve(t *testing.T) {
 			require.NoError(t, err)
 			require.NotEmpty(t, cid)
 
-			webCAS := webcas.New(casClient)
+			webCAS := webcas.New(&resthandler.Config{}, memstore.New(""), &mocks.SignatureVerifier{}, casClient)
 			require.NotNil(t, webCAS)
 
 			router := mux.NewRouter()
@@ -550,7 +555,9 @@ func TestResolver_Resolve(t *testing.T) {
 func createNewResolver(t *testing.T, casClient casapi.Client, ipfsReader ipfsReader) *Resolver {
 	t.Helper()
 
-	casResolver := New(casClient, ipfsReader, http.DefaultClient)
+	casResolver := New(casClient, ipfsReader,
+		transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
+			transport.DefaultSigner(), transport.DefaultSigner()))
 	require.NotNil(t, casResolver)
 
 	return casResolver

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
 
+	"github.com/trustbloc/orb/pkg/activitypub/client/transport"
 	"github.com/trustbloc/orb/pkg/anchor/graph"
 	anchorinfo "github.com/trustbloc/orb/pkg/anchor/info"
 	"github.com/trustbloc/orb/pkg/anchor/subject"
@@ -67,10 +68,13 @@ func TestStartObserver(t *testing.T) {
 		casClient := mocks.NewMockCasClient(nil)
 
 		graphProviders := &graph.Providers{
-			CasWriter:   caswriter.New(casClient, ""),
-			CasResolver: casresolver.New(casClient, nil, &http.Client{}),
-			Pkf:         pubKeyFetcherFnc,
-			DocLoader:   testutil.GetLoader(t),
+			CasWriter: caswriter.New(casClient, ""),
+			CasResolver: casresolver.New(casClient, nil, transport.New(&http.Client{},
+				testutil.MustParseURL("https://example.com/keys/public-key"),
+				transport.DefaultSigner(), transport.DefaultSigner()),
+			),
+			Pkf:       pubKeyFetcherFnc,
+			DocLoader: testutil.GetLoader(t),
 		}
 
 		anchorGraph := graph.New(graphProviders)
@@ -121,10 +125,13 @@ func TestStartObserver(t *testing.T) {
 		casClient := mocks.NewMockCasClient(nil)
 
 		graphProviders := &graph.Providers{
-			CasWriter:   caswriter.New(casClient, ""),
-			CasResolver: casresolver.New(casClient, nil, &http.Client{}),
-			Pkf:         pubKeyFetcherFnc,
-			DocLoader:   testutil.GetLoader(t),
+			CasWriter: caswriter.New(casClient, ""),
+			CasResolver: casresolver.New(casClient, nil, transport.New(&http.Client{},
+				testutil.MustParseURL("https://example.com/keys/public-key"),
+				transport.DefaultSigner(), transport.DefaultSigner()),
+			),
+			Pkf:       pubKeyFetcherFnc,
+			DocLoader: testutil.GetLoader(t),
 		}
 
 		anchorGraph := graph.New(graphProviders)
@@ -174,10 +181,13 @@ func TestStartObserver(t *testing.T) {
 		casClient := mocks.NewMockCasClient(nil)
 
 		graphProviders := &graph.Providers{
-			CasWriter:   caswriter.New(casClient, ""),
-			CasResolver: casresolver.New(casClient, nil, &http.Client{}),
-			Pkf:         pubKeyFetcherFnc,
-			DocLoader:   testutil.GetLoader(t),
+			CasWriter: caswriter.New(casClient, ""),
+			CasResolver: casresolver.New(casClient, nil, transport.New(&http.Client{},
+				testutil.MustParseURL("https://example.com/keys/public-key"),
+				transport.DefaultSigner(), transport.DefaultSigner()),
+			),
+			Pkf:       pubKeyFetcherFnc,
+			DocLoader: testutil.GetLoader(t),
 		}
 
 		anchorGraph := graph.New(graphProviders)
@@ -235,10 +245,13 @@ func TestStartObserver(t *testing.T) {
 		casClient := mocks.NewMockCasClient(nil)
 
 		graphProviders := &graph.Providers{
-			CasWriter:   caswriter.New(casClient, ""),
-			CasResolver: casresolver.New(casClient, nil, &http.Client{}),
-			Pkf:         pubKeyFetcherFnc,
-			DocLoader:   testutil.GetLoader(t),
+			CasWriter: caswriter.New(casClient, ""),
+			CasResolver: casresolver.New(casClient, nil, transport.New(&http.Client{},
+				testutil.MustParseURL("https://example.com/keys/public-key"),
+				transport.DefaultSigner(), transport.DefaultSigner()),
+			),
+			Pkf:       pubKeyFetcherFnc,
+			DocLoader: testutil.GetLoader(t),
 		}
 		anchorGraph := graph.New(graphProviders)
 
@@ -294,10 +307,13 @@ func TestStartObserver(t *testing.T) {
 		casClient := mocks.NewMockCasClient(nil)
 
 		graphProviders := &graph.Providers{
-			CasWriter:   caswriter.New(casClient, "webcas:domain.com"),
-			CasResolver: casresolver.New(casClient, nil, &http.Client{}),
-			Pkf:         pubKeyFetcherFnc,
-			DocLoader:   testutil.GetLoader(t),
+			CasWriter: caswriter.New(casClient, "webcas:domain.com"),
+			CasResolver: casresolver.New(casClient, nil, transport.New(&http.Client{},
+				testutil.MustParseURL("https://example.com/keys/public-key"),
+				transport.DefaultSigner(), transport.DefaultSigner()),
+			),
+			Pkf:       pubKeyFetcherFnc,
+			DocLoader: testutil.GetLoader(t),
 		}
 
 		anchorGraph := graph.New(graphProviders)
@@ -349,10 +365,13 @@ func TestStartObserver(t *testing.T) {
 		casClient := mocks.NewMockCasClient(nil)
 
 		graphProviders := &graph.Providers{
-			CasWriter:   caswriter.New(casClient, ""),
-			CasResolver: casresolver.New(casClient, nil, &http.Client{}),
-			Pkf:         pubKeyFetcherFnc,
-			DocLoader:   testutil.GetLoader(t),
+			CasWriter: caswriter.New(casClient, ""),
+			CasResolver: casresolver.New(casClient, nil, transport.New(&http.Client{},
+				testutil.MustParseURL("https://example.com/keys/public-key"),
+				transport.DefaultSigner(), transport.DefaultSigner()),
+			),
+			Pkf:       pubKeyFetcherFnc,
+			DocLoader: testutil.GetLoader(t),
 		}
 
 		anchorGraph := graph.New(graphProviders)
@@ -401,10 +420,13 @@ func TestStartObserver(t *testing.T) {
 		casClient := mocks.NewMockCasClient(nil)
 
 		graphProviders := &graph.Providers{
-			CasWriter:   caswriter.New(casClient, ""),
-			CasResolver: casresolver.New(casClient, nil, &http.Client{}),
-			Pkf:         pubKeyFetcherFnc,
-			DocLoader:   testutil.GetLoader(t),
+			CasWriter: caswriter.New(casClient, ""),
+			CasResolver: casresolver.New(casClient, nil, transport.New(&http.Client{},
+				testutil.MustParseURL("https://example.com/keys/public-key"),
+				transport.DefaultSigner(), transport.DefaultSigner()),
+			),
+			Pkf:       pubKeyFetcherFnc,
+			DocLoader: testutil.GetLoader(t),
 		}
 
 		anchorGraph := graph.New(graphProviders)

--- a/pkg/protocolversion/versions/v1_0/factory/factory_test.go
+++ b/pkg/protocolversion/versions/v1_0/factory/factory_test.go
@@ -18,8 +18,10 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/compression"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/1_0/operationparser"
 
+	"github.com/trustbloc/orb/pkg/activitypub/client/transport"
 	casresolver "github.com/trustbloc/orb/pkg/cas/resolver"
 	"github.com/trustbloc/orb/pkg/config"
+	"github.com/trustbloc/orb/pkg/internal/testutil"
 	"github.com/trustbloc/orb/pkg/protocolversion/mocks"
 	"github.com/trustbloc/orb/pkg/store/cas"
 )
@@ -93,7 +95,10 @@ func TestCasClientWrapper_Read(t *testing.T) {
 func createNewResolver(t *testing.T, casClient casapi.Client) *casresolver.Resolver {
 	t.Helper()
 
-	casResolver := casresolver.New(casClient, nil, &http.Client{})
+	casResolver := casresolver.New(casClient, nil, transport.New(&http.Client{},
+		testutil.MustParseURL("https://example.com/keys/public-key"),
+		transport.DefaultSigner(), transport.DefaultSigner()),
+	)
 	require.NotNil(t, casResolver)
 
 	return casResolver

--- a/pkg/webcas/webcas_internal_test.go
+++ b/pkg/webcas/webcas_internal_test.go
@@ -18,6 +18,9 @@ import (
 	ariesstorage "github.com/hyperledger/aries-framework-go/spi/storage"
 	"github.com/stretchr/testify/require"
 
+	"github.com/trustbloc/orb/pkg/activitypub/resthandler"
+	"github.com/trustbloc/orb/pkg/activitypub/service/mocks"
+	"github.com/trustbloc/orb/pkg/activitypub/store/memstore"
 	"github.com/trustbloc/orb/pkg/store/cas"
 )
 
@@ -41,6 +44,14 @@ func (s *stringLogger) Errorf(msg string, args ...interface{}) {
 	s.log = fmt.Sprintf(msg, args...)
 }
 
+func (s *stringLogger) Infof(msg string, args ...interface{}) {
+	s.log = fmt.Sprintf(msg, args...)
+}
+
+func (s *stringLogger) Debugf(msg string, args ...interface{}) {
+	s.log = fmt.Sprintf(msg, args...)
+}
+
 func TestWriteResponseFailures(t *testing.T) {
 	t.Run("Fail to write failure response", func(t *testing.T) {
 		t.Run("Status not found", func(t *testing.T) {
@@ -51,10 +62,8 @@ func TestWriteResponseFailures(t *testing.T) {
 
 			testLogger := &stringLogger{}
 
-			webCAS := WebCAS{
-				casClient: casClient,
-				logger:    testLogger,
-			}
+			webCAS := New(&resthandler.Config{}, memstore.New(""), &mocks.SignatureVerifier{}, casClient)
+			webCAS.logger = testLogger
 
 			rw := &failingResponseWriter{}
 			req := httptest.NewRequest(http.MethodGet, "/cas", nil)
@@ -70,10 +79,8 @@ func TestWriteResponseFailures(t *testing.T) {
 
 			testLogger := &stringLogger{}
 
-			webCAS := WebCAS{
-				casClient: casClient,
-				logger:    testLogger,
-			}
+			webCAS := New(&resthandler.Config{}, memstore.New(""), &mocks.SignatureVerifier{}, casClient)
+			webCAS.logger = testLogger
 
 			rw := &failingResponseWriter{}
 			req := httptest.NewRequest(http.MethodGet, "/cas", nil)
@@ -91,10 +98,8 @@ func TestWriteResponseFailures(t *testing.T) {
 
 		testLogger := &stringLogger{}
 
-		webCAS := WebCAS{
-			casClient: casClient,
-			logger:    testLogger,
-		}
+		webCAS := New(&resthandler.Config{}, memstore.New(""), &mocks.SignatureVerifier{}, casClient)
+		webCAS.logger = testLogger
 
 		rw := &failingResponseWriter{}
 		req := httptest.NewRequest(http.MethodGet, "/cas", nil)

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -10,6 +10,7 @@ Feature:
   Background: Setup
     Given variable "domain1IRI" is assigned the value "https://orb.domain1.com/services/orb"
     And variable "domain2IRI" is assigned the value "https://orb.domain2.com/services/orb"
+    And variable "domain3IRI" is assigned the value "https://orb.domain3.com/services/orb"
 
     Given domain "orb.domain1.com" is mapped to "localhost:48326"
     And domain "orb.domain2.com" is mapped to "localhost:48426"
@@ -30,6 +31,11 @@ Feature:
     And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain1IRI}/activities/${followID}","type":"Follow","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
     When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
 
+    # domain3 server follows domain1 server. Domain3 needs to be a follower of domain1 so that HTTP signature validation succeeds when
+    # the /cas endpoint is invoked on domain1 (since only followers and witnesses are authorized).
+    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain3IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
+    When an HTTP POST is sent to "https://orb.domain3.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
+
     # domain1 invites domain2 to be a witness
     Given variable "inviteWitnessID" is assigned a unique ID
     And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain1IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
@@ -46,6 +52,8 @@ Feature:
     Scenario: discover did
       When client discover orb endpoints
 
+      # Stop domain3 so that it will miss an anchor credential from domain1. This tests WebCAS resolution
+      # when domain3 is asked for the unknown DID.
       Then container "orb-domain3" is stopped
       Then we wait 3 seconds
 
@@ -67,6 +75,9 @@ Feature:
       When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with canonical did
       Then check success response contains "recoveryKey"
       Then check success response contains "#canonicalDID"
+
+      # Wait long enough so that domain1 gives up attempting to deliver the anchor credential to domain3
+      Then we wait 5 seconds
 
       Then container "orb-domain3" is started
       Then we wait 10 seconds

--- a/test/bdd/features/did-sidetree.feature
+++ b/test/bdd/features/did-sidetree.feature
@@ -182,4 +182,10 @@ Feature:
     When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to create DID document
     Then check error response contains "Unauthorized"
 
-    When an HTTP GET is sent to "https://orb.domain1.com/sidetree/v1/identifiers/EiAYGECupFQNyJsFXQiTIAkGIoxC4qKpXFWeRHjWVkah2A" and the returned status code is 401
+    # Unauthorized
+    When an HTTP GET is sent to "https://orb.domain1.com/sidetree/v1/identifiers/did:orb:QmSvg9rNRDGADLoTsNVt56vCuyYxuf1uernuAWoPcm5oiS:EiDahnXxu4l4iSUXgZKW6nUnSF7_y6QIaY4ePuWEE4bz0Q" and the returned status code is 401
+    When an HTTP GET is sent to "https://orb.domain1.com/cas/bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y" and the returned status code is 401
+
+    # Domain3 is open for reads
+    When an HTTP GET is sent to "https://orb.domain3.com/sidetree/v1/identifiers/did:orb:QmSvg9rNRDGADLoTsNVt56vCuyYxuf1uernuAWoPcm5oiS:EiDahnXxu4l4iSUXgZKW6nUnSF7_y6QIaY4ePuWEE4bz0Q" and the returned status code is 404
+    When an HTTP GET is sent to "https://orb.domain3.com/cas/bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y" and the returned status code is 404

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       # - The client requires a 'read' or 'admin' token in order to view the outbox's contents
       # - The client requires an 'admin' token in order to post to the outbox
       # - The client requires a 'read' or 'admin' token in order to perform a GET on any endpoint starting with /services/orb/
-      - ORB_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/.*|read&admin,/transactions|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin
+      - ORB_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/.*|read&admin,/transactions|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin
       # ORB_AUTH_TOKENS specifies the actual values of the tokens defined in ORB_AUTH_TOKENS_DEF.
       - ORB_AUTH_TOKENS=admin=ADMIN_TOKEN,read=READ_TOKEN
     ports:
@@ -126,7 +126,7 @@ services:
       # - The client requires a 'read' or 'admin' token in order to view the outbox's contents
       # - The client requires an 'admin' token in order to post to the outbox
       # - The client requires a 'read' or 'admin' token in order to perform a GET on any endpoint starting with /services/orb/
-      - ORB_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/.*|read&admin,/transactions|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin
+      - ORB_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/.*|read&admin,/transactions|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin
       # ORB_AUTH_TOKENS specifies the actual values of the tokens defined in ORB_AUTH_TOKENS_DEF.
       - ORB_AUTH_TOKENS=admin=ADMIN_TOKEN,read=READ_TOKEN
     ports:
@@ -194,7 +194,7 @@ services:
       # - The client requires a 'read' or 'admin' token in order to view the outbox's contents
       # - The client requires an 'admin' token in order to post to the outbox
       # - The client requires a 'read' or 'admin' token in order to perform a GET on any endpoint starting with /services/orb/
-      - ORB_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/.*|read&admin,/transactions|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin
+      - ORB_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/.*|read&admin,/transactions|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin
       # ORB_AUTH_TOKENS specifies the actual values of the tokens defined in ORB_AUTH_TOKENS_DEF.
       - ORB_AUTH_TOKENS=admin=ADMIN_TOKEN,read=READ_TOKEN
     ports:


### PR DESCRIPTION
If a bearer token is defined for the /cas endpoint then the client must provide a valid token in the header. If a token is not found in the header then the HTTP signature in the header is verified and the actor of the signature is verified to be either a follower or witness.

closes #408

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>