### PR TITLE
chore: Enable key contexts in did documents

### DIFF
--- a/cmd/orb-cli/common/common_test.go
+++ b/cmd/orb-cli/common/common_test.go
@@ -48,7 +48,7 @@ const (
  },
  {
   "id": "key2",
-  "type": "JwsVerificationKey2020",
+  "type": "JsonWebKey2020",
   "purposes": ["authentication"],
   "jwkPath": "%s"
  }

--- a/cmd/orb-cli/createdidcmd/createdid_test.go
+++ b/cmd/orb-cli/createdidcmd/createdid_test.go
@@ -30,7 +30,7 @@ const (
  },
  {
   "id": "key2",
-  "type": "JwsVerificationKey2020",
+  "type": "JsonWebKey2020",
   "purposes": ["authentication"],
   "jwkPath": "%s"
  }

--- a/cmd/orb-cli/recoverdidcmd/recoverdid_test.go
+++ b/cmd/orb-cli/recoverdidcmd/recoverdid_test.go
@@ -28,7 +28,7 @@ const (
  },
  {
   "id": "key2",
-  "type": "JwsVerificationKey2020",
+  "type": "JsonWebKey2020",
   "purposes": ["authentication"],
   "jwkPath": "%s"
  }

--- a/cmd/orb-cli/updatedidcmd/updatedid_test.go
+++ b/cmd/orb-cli/updatedidcmd/updatedid_test.go
@@ -28,7 +28,7 @@ const (
  },
  {
   "id": "key2",
-  "type": "JwsVerificationKey2020",
+  "type": "JsonWebKey2020",
   "purposes": ["authentication"],
   "jwkPath": "%s"
  }

--- a/cmd/orb-server/go.mod
+++ b/cmd/orb-server/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9
 	github.com/trustbloc/orb v0.0.0
-	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210519143310-f0606b30b35b
+	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210520185648-ad6fce89b352
 	golang.org/x/net v0.0.0-20210423184538-5f58ad60dda6 // indirect
 )
 

--- a/cmd/orb-server/go.sum
+++ b/cmd/orb-server/go.sum
@@ -1055,8 +1055,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9 h1:JCWLY91Vp1qf19IFDSYUmHyPSfnYWZ5/fN6I5s+jq0M=
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9/go.mod h1:BpCeNH2fEH3RX7+C5XfnVIXFQbk7LzBdWdBdgnEb284=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210519143310-f0606b30b35b h1:ZgkOSMPh005/5jRuKeKNjZUgyQ4I1IqHbGakwgr9kQ4=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210519143310-f0606b30b35b/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210520185648-ad6fce89b352 h1:Uk78yCqB3CgziTLTggTK4J4RsgbYQzUFzcvVCDyVXL8=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210520185648-ad6fce89b352/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/trustbloc/vct v0.1.0 h1:hG5oBXUjzaTY+tIJZBDsCyb1lHoNFgsJc6ObfgJkI8A=
 github.com/trustbloc/vct v0.1.0/go.mod h1:wU4hT9o3Vjf4cJlICwHCxkWYGgQsMDLI0+5qx3vzBdE=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9
-	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210519143310-f0606b30b35b
+	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210520185648-ad6fce89b352
 	github.com/trustbloc/vct v0.1.0
 	golang.org/x/net v0.0.0-20210421230115-4e50805a0758 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1052,8 +1052,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9 h1:JCWLY91Vp1qf19IFDSYUmHyPSfnYWZ5/fN6I5s+jq0M=
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9/go.mod h1:BpCeNH2fEH3RX7+C5XfnVIXFQbk7LzBdWdBdgnEb284=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210519143310-f0606b30b35b h1:ZgkOSMPh005/5jRuKeKNjZUgyQ4I1IqHbGakwgr9kQ4=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210519143310-f0606b30b35b/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210520185648-ad6fce89b352 h1:Uk78yCqB3CgziTLTggTK4J4RsgbYQzUFzcvVCDyVXL8=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210520185648-ad6fce89b352/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/trustbloc/vct v0.1.0 h1:hG5oBXUjzaTY+tIJZBDsCyb1lHoNFgsJc6ObfgJkI8A=
 github.com/trustbloc/vct v0.1.0/go.mod h1:wU4hT9o3Vjf4cJlICwHCxkWYGgQsMDLI0+5qx3vzBdE=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/test/bdd/fixtures/did-keys/create/publickeys.json
+++ b/test/bdd/fixtures/did-keys/create/publickeys.json
@@ -7,7 +7,7 @@
  },
  {
   "id": "key2",
-  "type": "JwsVerificationKey2020",
+  "type": "JsonWebKey2020",
   "purposes": ["capabilityInvocation"],
   "jwkPath": "./fixtures/did-keys/create/key2_jwk.json"
  }

--- a/test/bdd/fixtures/did-keys/update/publickeys.json
+++ b/test/bdd/fixtures/did-keys/update/publickeys.json
@@ -1,7 +1,7 @@
 [
  {
  "id": "key2",
- "type": "JwsVerificationKey2020",
+ "type": "JsonWebKey2020",
  "purposes": ["capabilityInvocation"],
  "jwkPath": "./fixtures/did-keys/update/key2_jwk.json"
  },

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/tidwall/gjson v1.7.4
 	github.com/trustbloc/orb v0.0.0
-	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210519143310-f0606b30b35b
+	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210520185648-ad6fce89b352
 )
 
 replace github.com/trustbloc/orb => ../../

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -1035,8 +1035,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9 h1:JCWLY91Vp1qf19IFDSYUmHyPSfnYWZ5/fN6I5s+jq0M=
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9/go.mod h1:BpCeNH2fEH3RX7+C5XfnVIXFQbk7LzBdWdBdgnEb284=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210519143310-f0606b30b35b h1:ZgkOSMPh005/5jRuKeKNjZUgyQ4I1IqHbGakwgr9kQ4=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210519143310-f0606b30b35b/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210520185648-ad6fce89b352 h1:Uk78yCqB3CgziTLTggTK4J4RsgbYQzUFzcvVCDyVXL8=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210520185648-ad6fce89b352/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/trustbloc/vct v0.1.0/go.mod h1:wU4hT9o3Vjf4cJlICwHCxkWYGgQsMDLI0+5qx3vzBdE=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=


### PR DESCRIPTION
Update sidetree-core: enable key contexts in did documents

Closes #416

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>