### PR TITLE
feat: Add verifiable credential status store

### DIFF
--- a/pkg/anchor/proof/proof.go
+++ b/pkg/anchor/proof/proof.go
@@ -8,19 +8,31 @@ package proof
 
 // WitnessProof contains anchor credential witness proof.
 type WitnessProof struct {
-	Type    Type
+	Type    WitnessType
 	Witness string
 	Proof   []byte
 }
 
-// Type defines valid values for witness type.
-type Type string
+// WitnessType defines valid values for witness type.
+type WitnessType string
 
 const (
 
-	// TypeBatch captures "batch" witness type.
-	TypeBatch Type = "batch"
+	// WitnessTypeBatch captures "batch" witness type.
+	WitnessTypeBatch WitnessType = "batch"
 
-	// TypeSystem captures "system" witness type.
-	TypeSystem Type = "witness"
+	// WitnessTypeSystem captures "system" witness type.
+	WitnessTypeSystem WitnessType = "witness"
+)
+
+// VCStatus defines valid values for verifiable credential proof collection status.
+type VCStatus string
+
+const (
+
+	// VCStatusInProcess defines "in-process" status.
+	VCStatusInProcess VCStatus = "in-process"
+
+	// VCStatusCompleted defines "completed" status.
+	VCStatusCompleted VCStatus = "completed"
 )

--- a/pkg/anchor/writer/writer.go
+++ b/pkg/anchor/writer/writer.go
@@ -556,7 +556,7 @@ func (c *Writer) storeWitnesses(vcID string, batchWitnesses []*url.URL) error {
 	for _, w := range batchWitnesses {
 		witnesses = append(witnesses,
 			&proof.WitnessProof{
-				Type:    proof.TypeBatch,
+				Type:    proof.WitnessTypeBatch,
 				Witness: w.String(),
 			})
 	}
@@ -570,7 +570,7 @@ func (c *Writer) storeWitnesses(vcID string, batchWitnesses []*url.URL) error {
 		if !containsURI(batchWitnesses, systemWitnessURI) {
 			witnesses = append(witnesses,
 				&proof.WitnessProof{
-					Type:    proof.TypeSystem,
+					Type:    proof.WitnessTypeSystem,
 					Witness: systemWitnessURI.String(),
 				})
 		}

--- a/pkg/store/vcstatus/store.go
+++ b/pkg/store/vcstatus/store.go
@@ -1,0 +1,113 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vcstatus
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/hyperledger/aries-framework-go/spi/storage"
+	"github.com/trustbloc/edge-core/pkg/log"
+
+	"github.com/trustbloc/orb/pkg/anchor/proof"
+)
+
+const (
+	namespace = "vcstatus"
+	index     = "vcID"
+)
+
+var logger = log.New("vc-status")
+
+// New creates new vc status store.
+func New(provider storage.Provider) (*Store, error) {
+	store, err := provider.OpenStore(namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open vc-status store: %w", err)
+	}
+
+	err = provider.SetStoreConfig(namespace, storage.StoreConfiguration{TagNames: []string{index}})
+	if err != nil {
+		return nil, fmt.Errorf("failed to set store configuration: %w", err)
+	}
+
+	return &Store{
+		store: store,
+	}, nil
+}
+
+// Store is db implementation of vc status store.
+type Store struct {
+	store storage.Store
+}
+
+// AddStatus adds verifiable credential proof collecting status.
+func (s *Store) AddStatus(vcID string, status proof.VCStatus) error {
+	vcIDEncoded := base64.RawURLEncoding.EncodeToString([]byte(vcID))
+
+	tag := storage.Tag{
+		Name:  index,
+		Value: vcIDEncoded,
+	}
+
+	err := s.store.Put(uuid.New().String(), []byte(status), tag)
+	if err != nil {
+		return fmt.Errorf("failed to store vcID[%s] status '%s': %w", vcID, status, err)
+	}
+
+	logger.Debugf("stored vcID[%s] status '%s'", vcID, status)
+
+	return nil
+}
+
+// GetStatus retrieves proof collection status for the given verifiable credential.
+func (s *Store) GetStatus(vcID string) (proof.VCStatus, error) {
+	var err error
+
+	vcIDEncoded := base64.RawURLEncoding.EncodeToString([]byte(vcID))
+
+	query := fmt.Sprintf("%s:%s", index, vcIDEncoded)
+
+	iter, err := s.store.Query(query)
+	if err != nil {
+		return "", fmt.Errorf("failed to get statuses for vcID[%s] query[%s]: %w", vcID, query, err)
+	}
+
+	ok, err := iter.Next()
+	if err != nil {
+		return "", fmt.Errorf("iterator error for vcID[%s] statuses: %w", vcID, err)
+	}
+
+	if !ok {
+		return "", fmt.Errorf("status not found for vcID: %s", vcID)
+	}
+
+	var value []byte
+
+	for ok {
+		value, err = iter.Value()
+		if err != nil {
+			return "", fmt.Errorf("failed to get iterator value for vcID[%s]: %w", vcID, err)
+		}
+
+		if proof.VCStatus(value) == proof.VCStatusCompleted {
+			return proof.VCStatusCompleted, nil
+		}
+
+		ok, err = iter.Next()
+		if err != nil {
+			return "", fmt.Errorf("iterator error for vcID[%s]: %w", vcID, err)
+		}
+	}
+
+	status := proof.VCStatus(value)
+
+	logger.Debugf("status for vcID[%s]: %s", vcID, status)
+
+	return status, nil
+}

--- a/pkg/store/vcstatus/store_test.go
+++ b/pkg/store/vcstatus/store_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vcstatus
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/pkg/anchor/proof"
+	"github.com/trustbloc/orb/pkg/store/mocks"
+)
+
+const vcID = "vcID"
+
+func TestNew(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		provider := mem.NewProvider()
+
+		s, err := New(provider)
+		require.NoError(t, err)
+		require.NotNil(t, s)
+	})
+
+	t.Run("error - open store fails", func(t *testing.T) {
+		provider := &mocks.Provider{}
+		provider.OpenStoreReturns(nil, fmt.Errorf("open store error"))
+
+		s, err := New(provider)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to open vc-status store: open store error")
+		require.Nil(t, s)
+	})
+
+	t.Run("error - set store config fails", func(t *testing.T) {
+		provider := &mocks.Provider{}
+		provider.SetStoreConfigReturns(fmt.Errorf("set store config error"))
+
+		s, err := New(provider)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to set store configuration: set store config error")
+		require.Nil(t, s)
+	})
+}
+
+func TestStore_Put(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		provider := mem.NewProvider()
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		err = s.AddStatus(vcID, proof.VCStatusInProcess)
+		require.NoError(t, err)
+	})
+
+	t.Run("error - store error ", func(t *testing.T) {
+		store := &mocks.Store{}
+		store.PutReturns(fmt.Errorf("put error"))
+
+		provider := &mocks.Provider{}
+		provider.OpenStoreReturns(store, nil)
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		err = s.AddStatus(vcID, proof.VCStatusInProcess)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "put error")
+	})
+}
+
+func TestStore_Get(t *testing.T) {
+	t.Run("success - in process", func(t *testing.T) {
+		provider := mem.NewProvider()
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		err = s.AddStatus(vcID, proof.VCStatusInProcess)
+		require.NoError(t, err)
+
+		status, err := s.GetStatus(vcID)
+		require.NoError(t, err)
+		require.Equal(t, proof.VCStatusInProcess, status)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		provider := mem.NewProvider()
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		err = s.AddStatus(vcID, proof.VCStatusInProcess)
+		require.NoError(t, err)
+
+		err = s.AddStatus(vcID, proof.VCStatusCompleted)
+		require.NoError(t, err)
+
+		status, err := s.GetStatus(vcID)
+		require.NoError(t, err)
+		require.Equal(t, proof.VCStatusCompleted, status)
+	})
+
+	t.Run("error - not found", func(t *testing.T) {
+		provider := mem.NewProvider()
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		status, err := s.GetStatus(vcID)
+		require.Error(t, err)
+		require.Empty(t, status)
+		require.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("error - store error ", func(t *testing.T) {
+		store := &mocks.Store{}
+		store.QueryReturns(nil, fmt.Errorf("get error"))
+
+		provider := &mocks.Provider{}
+		provider.OpenStoreReturns(store, nil)
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		status, err := s.GetStatus(vcID)
+		require.Error(t, err)
+		require.Empty(t, status)
+		require.Contains(t, err.Error(), "get error")
+	})
+
+	t.Run("error - iterator next() error ", func(t *testing.T) {
+		iterator := &mocks.Iterator{}
+		iterator.NextReturns(false, fmt.Errorf("iterator next() error"))
+
+		store := &mocks.Store{}
+		store.QueryReturns(iterator, nil)
+
+		provider := &mocks.Provider{}
+		provider.OpenStoreReturns(store, nil)
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		status, err := s.GetStatus(vcID)
+		require.Error(t, err)
+		require.Empty(t, status)
+		require.Contains(t, err.Error(), "iterator next() error")
+	})
+
+	t.Run("error - iterator value() error ", func(t *testing.T) {
+		iterator := &mocks.Iterator{}
+
+		iterator.NextReturns(true, nil)
+		iterator.ValueReturns(nil, fmt.Errorf("iterator value() error"))
+
+		store := &mocks.Store{}
+		store.QueryReturns(iterator, nil)
+
+		provider := &mocks.Provider{}
+		provider.OpenStoreReturns(store, nil)
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		status, err := s.GetStatus(vcID)
+		require.Error(t, err)
+		require.Empty(t, status)
+		require.Contains(t, err.Error(), "iterator value() error")
+	})
+}

--- a/pkg/store/witness/witness_test.go
+++ b/pkg/store/witness/witness_test.go
@@ -195,7 +195,7 @@ func TestStore_AddProof(t *testing.T) {
 		require.NoError(t, err)
 
 		testWitness := &proof.WitnessProof{
-			Type:    proof.TypeBatch,
+			Type:    proof.WitnessTypeBatch,
 			Witness: witness,
 		}
 
@@ -221,11 +221,11 @@ func TestStore_AddProof(t *testing.T) {
 
 		witnessProofs := []*proof.WitnessProof{
 			{
-				Type:    proof.TypeBatch,
+				Type:    proof.WitnessTypeBatch,
 				Witness: "witness-1",
 			},
 			{
-				Type:    proof.TypeBatch,
+				Type:    proof.WitnessTypeBatch,
 				Witness: "witness-2",
 			},
 		}
@@ -256,11 +256,11 @@ func TestStore_AddProof(t *testing.T) {
 
 		witnessProofs := []*proof.WitnessProof{
 			{
-				Type:    proof.TypeBatch,
+				Type:    proof.WitnessTypeBatch,
 				Witness: "witness-1",
 			},
 			{
-				Type:    proof.TypeBatch,
+				Type:    proof.WitnessTypeBatch,
 				Witness: "witness-2",
 			},
 		}
@@ -343,7 +343,7 @@ func TestStore_AddProof(t *testing.T) {
 		iterator := &mocks.Iterator{}
 
 		witnessBytes, err := json.Marshal(&proof.WitnessProof{
-			Type:    proof.TypeBatch,
+			Type:    proof.WitnessTypeBatch,
 			Witness: witness,
 		})
 		require.NoError(t, err)
@@ -370,7 +370,7 @@ func TestStore_AddProof(t *testing.T) {
 		iterator := &mocks.Iterator{}
 
 		witnessBytes, err := json.Marshal(&proof.WitnessProof{
-			Type:    proof.TypeBatch,
+			Type:    proof.WitnessTypeBatch,
 			Witness: witness,
 		})
 		require.NoError(t, err)
@@ -419,7 +419,7 @@ func TestStore_AddProof(t *testing.T) {
 
 func getTestWitness() *proof.WitnessProof {
 	return &proof.WitnessProof{
-		Type:    proof.TypeBatch,
+		Type:    proof.WitnessTypeBatch,
 		Witness: "witness",
 	}
 }


### PR DESCRIPTION
Add verifiable credential proof status store.
When verifiable credentials is sent for witnesssing "in-process" status will be added. Upon satisfying proof policy "completed" status will be added.

Closes #378

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>