### PR TITLE
chore: Move updating did anchor references to observer

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -531,6 +531,7 @@ func startOrbServices(parameters *orbParameters) error {
 		TxnProvider:            mockTxnProvider{registerForAnchor: anchorCh, registerForDID: didCh},
 		ProtocolClientProvider: pcp,
 		AnchorGraph:            anchorGraph,
+		DidAnchors:             didAnchors,
 	}
 
 	observer.New(providers).Start()

--- a/pkg/anchor/proof/proof.go
+++ b/pkg/anchor/proof/proof.go
@@ -22,7 +22,7 @@ const (
 	WitnessTypeBatch WitnessType = "batch"
 
 	// WitnessTypeSystem captures "system" witness type.
-	WitnessTypeSystem WitnessType = "witness"
+	WitnessTypeSystem WitnessType = "system"
 )
 
 // VCStatus defines valid values for verifiable credential proof collection status.

--- a/pkg/anchor/writer/writer.go
+++ b/pkg/anchor/writer/writer.go
@@ -96,7 +96,6 @@ type anchorBuilder interface {
 }
 
 type didAnchors interface {
-	Put(dids []string, cid string) error
 	Get(did []string) ([]string, error)
 }
 
@@ -324,28 +323,6 @@ func (c *Writer) handle(vc *verifiable.Credential) {
 		return
 	}
 
-	anchorSubject, err := util.GetAnchorSubject(vc)
-	if err != nil {
-		logger.Errorf("failed to extract txn payload from witnessed anchor credential[%s]: %s", vc.ID, err.Error())
-
-		return
-	}
-
-	// update global did/anchor references
-	suffixes := getKeys(anchorSubject.PreviousAnchors)
-
-	cidWithHint := cid
-	if hint != "" {
-		cidWithHint = hint + ":" + cid
-	}
-
-	err = c.DidAnchors.Put(suffixes, cidWithHint)
-	if err != nil {
-		logger.Errorf("failed updating did anchor references for anchor credential[%s]: %s", vc.ID, err.Error())
-
-		return
-	}
-
 	fullWebCASURL, err := url.Parse(fmt.Sprintf("%s/%s", c.casIRI.String(), cid))
 	if err != nil {
 		logger.Errorf("failed to construct full WebCAS URL from the following two parts: [%s] and [%s]",
@@ -531,15 +508,6 @@ func (c *Writer) getWitnesses(refs []*operation.Reference) ([]string, error) {
 	}
 
 	return witnesses, nil
-}
-
-func getKeys(m map[string]string) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-
-	return keys
 }
 
 // Read reads transactions since transaction time.

--- a/test/bdd/features/did-sidetree.feature
+++ b/test/bdd/features/did-sidetree.feature
@@ -13,7 +13,7 @@ Feature:
 
     Given domain "orb.domain1.com" is mapped to "localhost:48326"
     And domain "orb.domain2.com" is mapped to "localhost:48426"
-    And domain "orb.domain3.com" is mapped to "orb.domain3.com"
+    And domain "orb.domain3.com" is mapped to "localhost:48626"
 
     Given the authorization bearer token for "POST" requests to path "/services/orb/outbox" is set to "ADMIN_TOKEN"
     And the authorization bearer token for "GET" requests to path "/services/orb" is set to "READ_TOKEN"
@@ -23,10 +23,20 @@ Feature:
     And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain2IRI}/activities/${followID}","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
     When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
 
+    # domain1 server follows domain2 server
+    Given variable "followID" is assigned a unique ID
+    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain1IRI}/activities/${followID}","type":"Follow","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
+    When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
+
     # domain1 invites domain2 to be a witness
     Given variable "inviteWitnessID" is assigned a unique ID
     And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain1IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
     When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+
+    # domain2 invites domain1 to be a witness
+    Given variable "inviteWitnessID" is assigned a unique ID
+    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain2IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
+    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     Then we wait 3 seconds
 
@@ -151,18 +161,18 @@ Feature:
       When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with interim did
       Then check success response contains "#canonicalDID"
 
-      When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to add service endpoint with ID "newService" to DID document
+      When client sends request to "https://orb.domain2.com/sidetree/v1/operations" to add service endpoint with ID "newService" to DID document
       Then check for request success
       Then we wait 2 seconds
 
-      When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+      When client sends request to "https://orb.domain2.com/sidetree/v1/identifiers" to resolve DID document with canonical did
       Then check success response contains "newService"
 
-      When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to remove service endpoint with ID "newService" from DID document
+      When client sends request to "https://orb.domain2.com/sidetree/v1/operations" to remove service endpoint with ID "newService" from DID document
       Then check for request success
       Then we wait 2 seconds
 
-      When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+      When client sends request to "https://orb.domain2.com/sidetree/v1/identifiers" to resolve DID document with canonical did
       Then check success response does NOT contain "newService"
 
   @did_sidetree_auth


### PR DESCRIPTION
Move updating anchor references from writer to observer. This will allow for having up-to-date did anchor references for following domains too so we will be able to send did updates to following domains.

Add test for updating did document in different domain from where it was created. Of course that domain has to follow original domain.

Closes #441

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>