### PR TITLE
feat: CAS resolver ability to switch between v0 and v1 CIDs dynamically

### DIFF
--- a/cmd/orb-server/startcmd/params.go
+++ b/cmd/orb-server/startcmd/params.go
@@ -226,7 +226,7 @@ type orbParameters struct {
 	batchWriterTimeout        time.Duration
 	casType                   string
 	ipfsURL                   string
-	useV0CIDs                 bool
+	cidVersion                int
 	dbParameters              *dbParameters
 	logLevel                  string
 	methodContext             []string
@@ -314,12 +314,18 @@ func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 		return nil, err
 	}
 
-	var useV0CIDs bool
+	var cidVersion int
 
-	if cidVersionString == "0" {
-		useV0CIDs = true
-	} else if cidVersionString != "1" && cidVersionString != "" { // default to v1 if no version specified
+	if cidVersionString == "" {
+		// default to v1 if no version specified
+		cidVersion = 1
+	} else if cidVersionString != "0" && cidVersionString != "1" {
 		return nil, fmt.Errorf("invalid CID version specified. Must be either 0 or 1")
+	} else {
+		cidVersion, err = strconv.Atoi(cidVersionString)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert CID version string to an integer: %w", err)
+		}
 	}
 
 	batchWriterTimeoutStr, err := cmdutils.GetUserSetVarFromString(cmd, batchWriterTimeoutFlagName, batchWriterTimeoutEnvKey, true)
@@ -461,7 +467,7 @@ func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 		allowedOrigins:            allowedOrigins,
 		casType:                   casType,
 		ipfsURL:                   ipfsURL,
-		useV0CIDs:                 useV0CIDs,
+		cidVersion:                cidVersion,
 		batchWriterTimeout:        batchWriterTimeout,
 		anchorCredentialParams:    anchorCredentialParams,
 		dbParameters:              dbParams,

--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -71,6 +71,7 @@ import (
 	"github.com/trustbloc/orb/pkg/anchor/handler/proof"
 	anchorinfo "github.com/trustbloc/orb/pkg/anchor/info"
 	"github.com/trustbloc/orb/pkg/anchor/writer"
+	"github.com/trustbloc/orb/pkg/cas/extendedcasclient"
 	ipfscas "github.com/trustbloc/orb/pkg/cas/ipfs"
 	"github.com/trustbloc/orb/pkg/cas/resolver"
 	orbcaswriter "github.com/trustbloc/orb/pkg/cas/writer"
@@ -281,17 +282,18 @@ func startOrbServices(parameters *orbParameters) error {
 		return err
 	}
 
-	var coreCasClient casapi.Client
+	var coreCasClient extendedcasclient.Client
 	var anchorCasWriter *orbcaswriter.CasWriter
 
 	switch parameters.casType {
 	case "ipfs":
-		coreCasClient = ipfscas.New(parameters.ipfsURL, parameters.useV0CIDs)
+		coreCasClient = ipfscas.New(parameters.ipfsURL, extendedcasclient.WithCIDVersion(parameters.cidVersion))
 		anchorCasWriter = orbcaswriter.New(coreCasClient, "ipfs")
 	case "local":
 		var err error
 
-		coreCasClient, err = casstore.New(storeProviders.provider, parameters.useV0CIDs)
+		coreCasClient, err = casstore.New(storeProviders.provider,
+			extendedcasclient.WithCIDVersion(parameters.cidVersion))
 		if err != nil {
 			return err
 		}
@@ -338,7 +340,7 @@ func startOrbServices(parameters *orbParameters) error {
 
 	var ipfsReader *ipfscas.Client
 	if parameters.ipfsURL != "" {
-		ipfsReader = ipfscas.New(parameters.ipfsURL, false)
+		ipfsReader = ipfscas.New(parameters.ipfsURL, extendedcasclient.WithCIDVersion(parameters.cidVersion))
 	}
 
 	casResolver := resolver.New(coreCasClient, ipfsReader, t)

--- a/pkg/anchor/graph/graph_test.go
+++ b/pkg/anchor/graph/graph_test.go
@@ -10,11 +10,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/util"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	"github.com/stretchr/testify/require"
-	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
 
 	apmocks "github.com/trustbloc/orb/pkg/activitypub/mocks"
 	"github.com/trustbloc/orb/pkg/anchor/subject"
@@ -22,6 +22,7 @@ import (
 	casresolver "github.com/trustbloc/orb/pkg/cas/resolver"
 	caswriter "github.com/trustbloc/orb/pkg/cas/writer"
 	"github.com/trustbloc/orb/pkg/internal/testutil"
+	"github.com/trustbloc/orb/pkg/store/cas"
 )
 
 const testDID = "abc"
@@ -32,7 +33,8 @@ func TestNew(t *testing.T) {
 }
 
 func TestGraph_Add(t *testing.T) {
-	casClient := mocks.NewMockCasClient(nil)
+	casClient, err := cas.New(mem.NewProvider())
+	require.NoError(t, err)
 
 	providers := &Providers{
 		CasWriter:   caswriter.New(casClient, "webcas:domain.com"),
@@ -59,7 +61,8 @@ func TestGraph_Add(t *testing.T) {
 }
 
 func TestGraph_Read(t *testing.T) {
-	casClient := mocks.NewMockCasClient(nil)
+	casClient, err := cas.New(mem.NewProvider())
+	require.NoError(t, err)
 
 	providers := &Providers{
 		CasWriter:   caswriter.New(casClient, "ipfs"),
@@ -102,7 +105,8 @@ func TestGraph_Read(t *testing.T) {
 }
 
 func TestGraph_GetDidAnchors(t *testing.T) {
-	casClient := mocks.NewMockCasClient(nil)
+	casClient, err := cas.New(mem.NewProvider())
+	require.NoError(t, err)
 
 	providers := &Providers{
 		CasWriter:   caswriter.New(casClient, "webcas:domain.com"),

--- a/pkg/anchor/handler/credential/handler_test.go
+++ b/pkg/anchor/handler/credential/handler_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
 	"github.com/stretchr/testify/require"
-	casapi "github.com/trustbloc/sidetree-core-go/pkg/api/cas"
 
 	"github.com/trustbloc/orb/pkg/activitypub/client/transport"
 	"github.com/trustbloc/orb/pkg/activitypub/resthandler"
@@ -26,6 +25,7 @@ import (
 	"github.com/trustbloc/orb/pkg/activitypub/store/memstore"
 	"github.com/trustbloc/orb/pkg/anchor/handler/mocks"
 	anchorinfo "github.com/trustbloc/orb/pkg/anchor/info"
+	"github.com/trustbloc/orb/pkg/cas/extendedcasclient"
 	casresolver "github.com/trustbloc/orb/pkg/cas/resolver"
 	"github.com/trustbloc/orb/pkg/internal/testutil"
 	"github.com/trustbloc/orb/pkg/store/cas"
@@ -169,7 +169,8 @@ func TestAnchorCredentialHandler(t *testing.T) {
 	})
 }
 
-func createNewAnchorCredentialHandler(t *testing.T, client casapi.Client) *AnchorCredentialHandler {
+func createNewAnchorCredentialHandler(t *testing.T,
+	client extendedcasclient.Client) *AnchorCredentialHandler {
 	t.Helper()
 
 	anchorCh := make(chan []anchorinfo.AnchorInfo, 100)
@@ -184,10 +185,10 @@ func createNewAnchorCredentialHandler(t *testing.T, client casapi.Client) *Ancho
 	return anchorCredentialHandler
 }
 
-func createInMemoryCAS(t *testing.T) casapi.Client {
+func createInMemoryCAS(t *testing.T) extendedcasclient.Client {
 	t.Helper()
 
-	casClient, err := cas.New(mem.NewProvider(), false)
+	casClient, err := cas.New(mem.NewProvider())
 	require.NoError(t, err)
 
 	return casClient

--- a/pkg/anchor/writer/writer_test.go
+++ b/pkg/anchor/writer/writer_test.go
@@ -14,13 +14,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	mockstore "github.com/hyperledger/aries-framework-go/pkg/mock/storage"
 	"github.com/stretchr/testify/require"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
-	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
 
 	"github.com/trustbloc/orb/pkg/activitypub/client/transport"
 	apmocks "github.com/trustbloc/orb/pkg/activitypub/store/mocks"
@@ -34,6 +34,7 @@ import (
 	caswriter "github.com/trustbloc/orb/pkg/cas/writer"
 	"github.com/trustbloc/orb/pkg/didanchor/memdidanchor"
 	"github.com/trustbloc/orb/pkg/internal/testutil"
+	"github.com/trustbloc/orb/pkg/store/cas"
 	vcstore "github.com/trustbloc/orb/pkg/store/verifiable"
 	"github.com/trustbloc/orb/pkg/vcsigner"
 )
@@ -77,7 +78,8 @@ func TestNew(t *testing.T) {
 }
 
 func TestWriter_WriteAnchor(t *testing.T) {
-	casClient := mocks.NewMockCasClient(nil)
+	casClient, err := cas.New(mem.NewProvider())
+	require.NoError(t, err)
 
 	graphProviders := &graph.Providers{
 		CasWriter: caswriter.New(casClient, "webcas:domain.com"),
@@ -483,7 +485,8 @@ func TestWriter_WriteAnchor(t *testing.T) {
 }
 
 func TestWriter_handle(t *testing.T) {
-	casClient := mocks.NewMockCasClient(nil)
+	casClient, err := cas.New(mem.NewProvider())
+	require.NoError(t, err)
 
 	graphProviders := &graph.Providers{
 		CasWriter: caswriter.New(casClient, "webcas:domain.com"),
@@ -945,7 +948,8 @@ func TestWriter_getBatchWitnessesIRI(t *testing.T) {
 }
 
 func TestWriter_Read(t *testing.T) {
-	casClient := mocks.NewMockCasClient(nil)
+	casClient, err := cas.New(mem.NewProvider())
+	require.NoError(t, err)
 
 	graphProviders := &graph.Providers{
 		CasWriter: caswriter.New(casClient, "webcas:domain.com"),

--- a/pkg/cas/extendedcasclient/extendedcasclient.go
+++ b/pkg/cas/extendedcasclient/extendedcasclient.go
@@ -1,0 +1,32 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package extendedcasclient
+
+import casapi "github.com/trustbloc/sidetree-core-go/pkg/api/cas"
+
+// CIDFormatOption is an option for specifying the CID format used in a WriteWithCIDFormat call.
+type CIDFormatOption func(opts *CIDFormatOptions)
+
+// CIDFormatOptions represent CID format options for use in a Client.WriteWithCIDFormat call.
+type CIDFormatOptions struct {
+	CIDVersion int
+}
+
+// WithCIDVersion sets the CID version to be used in a WriteWithCIDFormat call.
+// Currently, 0 and 1 are the only valid options.
+func WithCIDVersion(cidVersion int) CIDFormatOption {
+	return func(opts *CIDFormatOptions) {
+		opts.CIDVersion = cidVersion
+	}
+}
+
+// Client represents a CAS client with an additional method that allows the CID format
+// to be specified for a specific write.
+type Client interface {
+	casapi.Client
+	WriteWithCIDFormat(content []byte, opts ...CIDFormatOption) (string, error)
+}

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/util"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
@@ -27,6 +28,7 @@ import (
 	caswriter "github.com/trustbloc/orb/pkg/cas/writer"
 	"github.com/trustbloc/orb/pkg/didanchor/memdidanchor"
 	"github.com/trustbloc/orb/pkg/internal/testutil"
+	"github.com/trustbloc/orb/pkg/store/cas"
 )
 
 func TestStartObserver(t *testing.T) {
@@ -65,7 +67,8 @@ func TestStartObserver(t *testing.T) {
 
 		var anchors []anchorinfo.AnchorInfo
 
-		casClient := mocks.NewMockCasClient(nil)
+		casClient, err := cas.New(mem.NewProvider())
+		require.NoError(t, err)
 
 		graphProviders := &graph.Providers{
 			CasWriter: caswriter.New(casClient, ""),
@@ -122,7 +125,8 @@ func TestStartObserver(t *testing.T) {
 
 		var dids []string
 
-		casClient := mocks.NewMockCasClient(nil)
+		casClient, err := cas.New(mem.NewProvider())
+		require.NoError(t, err)
 
 		graphProviders := &graph.Providers{
 			CasWriter: caswriter.New(casClient, ""),
@@ -178,7 +182,8 @@ func TestStartObserver(t *testing.T) {
 		pc.Versions[0].TransactionProcessorReturns(tp)
 		pc.Versions[0].ProtocolReturns(pc.Protocol)
 
-		casClient := mocks.NewMockCasClient(nil)
+		casClient, err := cas.New(mem.NewProvider())
+		require.NoError(t, err)
 
 		graphProviders := &graph.Providers{
 			CasWriter: caswriter.New(casClient, ""),
@@ -242,7 +247,8 @@ func TestStartObserver(t *testing.T) {
 		var dids []string
 		var anchors []anchorinfo.AnchorInfo
 
-		casClient := mocks.NewMockCasClient(nil)
+		casClient, err := cas.New(mem.NewProvider())
+		require.NoError(t, err)
 
 		graphProviders := &graph.Providers{
 			CasWriter: caswriter.New(casClient, ""),
@@ -304,7 +310,8 @@ func TestStartObserver(t *testing.T) {
 
 		var dids []string
 
-		casClient := mocks.NewMockCasClient(nil)
+		casClient, err := cas.New(mem.NewProvider())
+		require.NoError(t, err)
 
 		graphProviders := &graph.Providers{
 			CasWriter: caswriter.New(casClient, "webcas:domain.com"),
@@ -362,7 +369,8 @@ func TestStartObserver(t *testing.T) {
 
 		var anchors []anchorinfo.AnchorInfo
 
-		casClient := mocks.NewMockCasClient(nil)
+		casClient, err := cas.New(mem.NewProvider())
+		require.NoError(t, err)
 
 		graphProviders := &graph.Providers{
 			CasWriter: caswriter.New(casClient, ""),
@@ -417,7 +425,8 @@ func TestStartObserver(t *testing.T) {
 		pc.Versions[0].TransactionProcessorReturns(tp)
 		pc.Versions[0].ProtocolReturns(pc.Protocol)
 
-		casClient := mocks.NewMockCasClient(nil)
+		casClient, err := cas.New(mem.NewProvider())
+		require.NoError(t, err)
 
 		graphProviders := &graph.Providers{
 			CasWriter: caswriter.New(casClient, ""),

--- a/pkg/protocolversion/versions/v1_0/factory/factory_test.go
+++ b/pkg/protocolversion/versions/v1_0/factory/factory_test.go
@@ -12,13 +12,13 @@ import (
 
 	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
 	"github.com/stretchr/testify/require"
-	casapi "github.com/trustbloc/sidetree-core-go/pkg/api/cas"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/txn"
 	"github.com/trustbloc/sidetree-core-go/pkg/compression"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/1_0/operationparser"
 
 	"github.com/trustbloc/orb/pkg/activitypub/client/transport"
+	"github.com/trustbloc/orb/pkg/cas/extendedcasclient"
 	casresolver "github.com/trustbloc/orb/pkg/cas/resolver"
 	"github.com/trustbloc/orb/pkg/config"
 	"github.com/trustbloc/orb/pkg/internal/testutil"
@@ -92,7 +92,7 @@ func TestCasClientWrapper_Read(t *testing.T) {
 	})
 }
 
-func createNewResolver(t *testing.T, casClient casapi.Client) *casresolver.Resolver {
+func createNewResolver(t *testing.T, casClient extendedcasclient.Client) *casresolver.Resolver {
 	t.Helper()
 
 	casResolver := casresolver.New(casClient, nil, transport.New(&http.Client{},
@@ -104,10 +104,10 @@ func createNewResolver(t *testing.T, casClient casapi.Client) *casresolver.Resol
 	return casResolver
 }
 
-func createInMemoryCAS(t *testing.T) casapi.Client {
+func createInMemoryCAS(t *testing.T) extendedcasclient.Client {
 	t.Helper()
 
-	casClient, err := cas.New(mem.NewProvider(), false)
+	casClient, err := cas.New(mem.NewProvider())
 	require.NoError(t, err)
 
 	return casClient

--- a/pkg/store/cas/cas.go
+++ b/pkg/store/cas/cas.go
@@ -15,34 +15,50 @@ import (
 	"github.com/ipfs/go-merkledag"
 	"github.com/ipfs/go-unixfs"
 	mh "github.com/multiformats/go-multihash"
+
+	"github.com/trustbloc/orb/pkg/cas/extendedcasclient"
 )
 
 // ErrContentNotFound is used to indicate that content as a given address could not be found.
 var ErrContentNotFound = errors.New("content not found")
 
 // CAS represents a content-addressable storage provider.
-// TODO (#344) Support writing and reading both v0 and v1 CIDs.
 type CAS struct {
-	cas       ariesstorage.Store
-	useV0CIDs bool
+	cas  ariesstorage.Store
+	opts []extendedcasclient.CIDFormatOption
 }
 
 // New returns a new CAS that uses the passed in provider as a backing store.
-func New(provider ariesstorage.Provider, useV0CIDs bool) (*CAS, error) {
+// If no CID version is specified, then v1 will be used by default.
+func New(provider ariesstorage.Provider, opts ...extendedcasclient.CIDFormatOption) (*CAS, error) {
 	cas, err := provider.OpenStore("cas_store")
 	if err != nil {
 		return nil, fmt.Errorf("failed to open store in underlying storage provider: %w", err)
 	}
 
-	return &CAS{cas: cas, useV0CIDs: useV0CIDs}, nil
+	return &CAS{cas: cas, opts: opts}, nil
 }
 
-// Write writes the given content to the underlying storage provider.
+// Write writes the given content to the underlying storage provider using this CAS' default CID version.
+// Returns the address of the content.
+func (p *CAS) Write(content []byte) (string, error) {
+	return p.WriteWithCIDFormat(content, p.opts...)
+}
+
+// WriteWithCIDFormat writes the given content to the underlying storage provider.
+// If useV0CID is true, then the older v0 CID version will be used for calculating the address of the content instead
+// of the newer v1 version.
 // Returns the address of the content.
 // TODO (#418): Support creating IPFS-compatible CIDs when content is > 256KB.
-func (p *CAS) Write(content []byte) (string, error) {
+// TODO (#443): Support v1 CID formats (different multibases and multicodecs) other than just the IPFS default.
+func (p *CAS) WriteWithCIDFormat(content []byte, opts ...extendedcasclient.CIDFormatOption) (string, error) {
+	options, err := getOptions(opts)
+	if err != nil {
+		return "", err
+	}
+
 	var cid string
-	if p.useV0CIDs {
+	if options.CIDVersion == 0 {
 		// The v0 CID produced below is equal to what an IPFS node would produce, assuming that:
 		// 1. The IPFS node is running with default settings, and
 		// 2. The size of the content passed in here is less than 256KB (the default chunk size).
@@ -85,4 +101,21 @@ func (p *CAS) Read(address string) ([]byte, error) {
 	}
 
 	return content, nil
+}
+
+func getOptions(opts []extendedcasclient.CIDFormatOption) (extendedcasclient.CIDFormatOptions, error) {
+	options := extendedcasclient.CIDFormatOptions{CIDVersion: 1}
+
+	for _, option := range opts {
+		if option != nil {
+			option(&options)
+		}
+	}
+
+	if options.CIDVersion != 0 && options.CIDVersion != 1 {
+		return extendedcasclient.CIDFormatOptions{},
+			fmt.Errorf("%d is not a supported CID version. It must be either 0 or 1", options.CIDVersion)
+	}
+
+	return options, nil
 }

--- a/pkg/webcas/webcas_internal_test.go
+++ b/pkg/webcas/webcas_internal_test.go
@@ -57,7 +57,7 @@ func TestWriteResponseFailures(t *testing.T) {
 		t.Run("Status not found", func(t *testing.T) {
 			casClient, err := cas.New(&mock.Provider{OpenStoreReturn: &mock.Store{
 				ErrGet: ariesstorage.ErrDataNotFound,
-			}}, false)
+			}})
 			require.NoError(t, err)
 
 			testLogger := &stringLogger{}
@@ -74,7 +74,7 @@ func TestWriteResponseFailures(t *testing.T) {
 				"content not found. Response write error: response write failure", testLogger.log)
 		})
 		t.Run("Internal server error", func(t *testing.T) {
-			casClient, err := cas.New(mem.NewProvider(), false)
+			casClient, err := cas.New(mem.NewProvider())
 			require.NoError(t, err)
 
 			testLogger := &stringLogger{}
@@ -93,7 +93,7 @@ func TestWriteResponseFailures(t *testing.T) {
 		})
 	})
 	t.Run("Fail to write success response", func(t *testing.T) {
-		casClient, err := cas.New(&mock.Provider{OpenStoreReturn: &mock.Store{}}, false)
+		casClient, err := cas.New(&mock.Provider{OpenStoreReturn: &mock.Store{}})
 		require.NoError(t, err)
 
 		testLogger := &stringLogger{}

--- a/pkg/webcas/webcas_test.go
+++ b/pkg/webcas/webcas_test.go
@@ -76,7 +76,7 @@ const sampleAnchorCredential = `{
 }`
 
 func TestNew(t *testing.T) {
-	casClient, err := cas.New(mem.NewProvider(), false)
+	casClient, err := cas.New(mem.NewProvider())
 	require.NoError(t, err)
 
 	webCAS := webcas.New(&resthandler.Config{}, memstore.New(""), &mocks.SignatureVerifier{}, casClient)
@@ -88,7 +88,7 @@ func TestNew(t *testing.T) {
 
 func TestHandler(t *testing.T) {
 	t.Run("Content found", func(t *testing.T) {
-		casClient, err := cas.New(mem.NewProvider(), false)
+		casClient, err := cas.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		cid, err := casClient.Write([]byte(sampleAnchorCredential))
@@ -119,7 +119,7 @@ func TestHandler(t *testing.T) {
 		require.Equal(t, sampleAnchorCredential, string(responseBody))
 	})
 	t.Run("Content not found", func(t *testing.T) {
-		casClient, err := cas.New(mem.NewProvider(), false)
+		casClient, err := cas.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		webCAS := webcas.New(&resthandler.Config{}, memstore.New(""), &mocks.SignatureVerifier{}, casClient)
@@ -148,7 +148,7 @@ func TestHandler(t *testing.T) {
 	})
 
 	t.Run("Authorization", func(t *testing.T) {
-		casClient, err := cas.New(mem.NewProvider(), false)
+		casClient, err := cas.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		cfg := &resthandler.Config{

--- a/test/bdd/fixtures/.env
+++ b/test/bdd/fixtures/.env
@@ -27,7 +27,7 @@ COUCHDB_KMS_PORT=5984
 COUCHDB_SHARED_PORT=5986
 
 CAS_TYPE=ipfs
-# If using CID_VERSION=0, then in create_activity.json
-# you have to change all occurances of bafkreiduenhjrl7hjgh3lwxr6nvmfv4kzqzzizhzkbydxdabtcjptavzbm to QmbF6AKvzZ2fV7GubWq9v2P6qLMXyL6Y4ebZY8hrBng7QU
-# for the BDD tests to pass
-CID_VERSION=1
+
+CID_VERSION_DOMAIN1=1
+CID_VERSION_DOMAIN2=0
+CID_VERSION_DOMAIN3=1

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - BATCH_WRITER_TIMEOUT=200
       - CAS_TYPE=${CAS_TYPE}
       - IPFS_URL=ipfs:5001
-      - CID_VERSION=${CID_VERSION}
+      - CID_VERSION=${CID_VERSION_DOMAIN1}
       - ANCHOR_CREDENTIAL_ISSUER=http://orb.domain1.com
       - ANCHOR_CREDENTIAL_URL=http://orb.domain1.com/vc
       - ANCHOR_CREDENTIAL_SIGNATURE_SUITE=Ed25519Signature2018
@@ -98,7 +98,7 @@ services:
       - BATCH_WRITER_TIMEOUT=200
       - CAS_TYPE=${CAS_TYPE}
       - IPFS_URL=ipfs:5001
-      - CID_VERSION=${CID_VERSION}
+      - CID_VERSION=${CID_VERSION_DOMAIN1}
       - ANCHOR_CREDENTIAL_ISSUER=http://orb2.domain1.com
       - ANCHOR_CREDENTIAL_URL=http://orb2.domain1.com/vc
       - ANCHOR_CREDENTIAL_SIGNATURE_SUITE=Ed25519Signature2018
@@ -166,7 +166,7 @@ services:
       - BATCH_WRITER_TIMEOUT=200
       - CAS_TYPE=${CAS_TYPE}
       - IPFS_URL=ipfs:5001
-      - CID_VERSION=${CID_VERSION}
+      - CID_VERSION=${CID_VERSION_DOMAIN2}
       - ANCHOR_CREDENTIAL_ISSUER=http://orb.domain2.com
       - ANCHOR_CREDENTIAL_URL=http://orb.domain2.com/vc
       - ANCHOR_CREDENTIAL_SIGNATURE_SUITE=Ed25519Signature2018
@@ -233,7 +233,7 @@ services:
       - BATCH_WRITER_TIMEOUT=200
       - CAS_TYPE=${CAS_TYPE}
       - IPFS_URL=ipfs:5001
-      - CID_VERSION=${CID_VERSION}
+      - CID_VERSION=${CID_VERSION_DOMAIN3}
       - ANCHOR_CREDENTIAL_ISSUER=http://orb.domain3.com
       - ANCHOR_CREDENTIAL_URL=http://orb.domain3.com/vc
       - ANCHOR_CREDENTIAL_SIGNATURE_SUITE=Ed25519Signature2018


### PR DESCRIPTION
The CAS resolver is now able to accept either v0 and v1 CIDs and react appropriately (i.e. if v0 received, then v0 used for storage. If v1 received, then v1 used for storage). This means that two Orb servers using different CID versions can now work together.

The BDD tests can now be configured to use either CID format without needing to change the create_activity.json sample data.

Also updated the BDD tests to make one of the Orb domains use v0 while the others use v1 for the sake of proving their compatibility.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>

closes #344