### PR TITLE
feat: Support for AMQP message queue in ActivityPub

### DIFF
--- a/cmd/orb-driver/go.sum
+++ b/cmd/orb-driver/go.sum
@@ -124,8 +124,10 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/Stebalien/go-bitfield v0.0.1/go.mod h1:GNjFpasyUVkHMsfEOk8EFLJ9syQ6SI+XWrX9Wf2XH0s=
+github.com/ThreeDotsLabs/watermill v1.0.2/go.mod h1:vZCPh7eN0P7r2qKau4SfmcUZ83+3JXWkRl4BiWUlqFw=
 github.com/ThreeDotsLabs/watermill v1.1.0/go.mod h1:Qd1xNFxolCAHCzcMrm6RnjW0manbvN+DJVWc1MWRFlI=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.4/go.mod h1:sl2PSceOQJ8BreN60hCnU2WixFNOYJOQDY1J3hvyVCs=
+github.com/ThreeDotsLabs/watermill-amqp v1.1.1/go.mod h1:Qbu3JDlr6vIOxHJjhfsSHsrdF/ToJLYoaYek8X5Wnto=
 github.com/ThreeDotsLabs/watermill-http v1.1.3/go.mod h1:mkQ9CC0pxTZerNwr281rBoOy355vYt/lePkmYSX/BRg=
 github.com/VictoriaMetrics/fastcache v1.5.7/go.mod h1:ptDBkNMQI4RtmVo8VS/XwRY6RoTu1dAWCbrk+6WsEM8=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=

--- a/cmd/orb-server/go.sum
+++ b/cmd/orb-server/go.sum
@@ -130,9 +130,12 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/Stebalien/go-bitfield v0.0.1/go.mod h1:GNjFpasyUVkHMsfEOk8EFLJ9syQ6SI+XWrX9Wf2XH0s=
+github.com/ThreeDotsLabs/watermill v1.0.2/go.mod h1:vZCPh7eN0P7r2qKau4SfmcUZ83+3JXWkRl4BiWUlqFw=
 github.com/ThreeDotsLabs/watermill v1.1.0/go.mod h1:Qd1xNFxolCAHCzcMrm6RnjW0manbvN+DJVWc1MWRFlI=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.4 h1:hX8toeERHfnrZFvCXdWRQCYgoNExQoi5vtf5+rbGaA8=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.4/go.mod h1:sl2PSceOQJ8BreN60hCnU2WixFNOYJOQDY1J3hvyVCs=
+github.com/ThreeDotsLabs/watermill-amqp v1.1.1 h1:wlrYlQDf6ZgdYoVPbrBaOnSMqxkQJZXDS6qugIin4o0=
+github.com/ThreeDotsLabs/watermill-amqp v1.1.1/go.mod h1:Qbu3JDlr6vIOxHJjhfsSHsrdF/ToJLYoaYek8X5Wnto=
 github.com/ThreeDotsLabs/watermill-http v1.1.3 h1:2jHbbE+gbq7pKWBCtOxeHTWSBNrS44Oh7QOzuAeHH/g=
 github.com/ThreeDotsLabs/watermill-http v1.1.3/go.mod h1:mkQ9CC0pxTZerNwr281rBoOy355vYt/lePkmYSX/BRg=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=
@@ -1354,6 +1357,7 @@ github.com/square/go-jose/v3 v3.0.0-20200630053402-0a67ce9b0693 h1:wD1IWQwAhdWcl
 github.com/square/go-jose/v3 v3.0.0-20200630053402-0a67ce9b0693/go.mod h1:6hSY48PjDm4UObWmGLyJE9DxYVKTgR9kbCspXXJEhcU=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
+github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271 h1:WhxRHzgeVGETMlmVfqhRn8RIeeNoPr2Czh33I4Zdccw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/cmd/orb-server/startcmd/params.go
+++ b/cmd/orb-server/startcmd/params.go
@@ -94,6 +94,11 @@ const (
 	ipfsURLEnvKey        = "IPFS_URL"
 	ipfsURLFlagUsage     = "The URL of the IPFS Content Addressable Storage(CAS). " + commonEnvVarUsageText + ipfsURLEnvKey
 
+	mqURLFlagName      = "mq-url"
+	mqURLFlagShorthand = "q"
+	mqURLEnvKey        = "MQ_URL"
+	mqURLFlagUsage     = "The URL of the message broker. " + commonEnvVarUsageText + mqURLEnvKey
+
 	cidVersionFlagName  = "cid-version"
 	cidVersionEnvKey    = "CID_VERSION"
 	cidVersionFlagUsage = "The version of the CID format to use for generating CIDs. " +
@@ -227,6 +232,7 @@ type orbParameters struct {
 	casType                   string
 	ipfsURL                   string
 	cidVersion                int
+	mqURL                     string
 	dbParameters              *dbParameters
 	logLevel                  string
 	methodContext             []string
@@ -305,6 +311,11 @@ func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 	}
 
 	ipfsURL, err := cmdutils.GetUserSetVarFromString(cmd, ipfsURLFlagName, ipfsURLEnvKey, true)
+	if err != nil {
+		return nil, err
+	}
+
+	mqURL, err := cmdutils.GetUserSetVarFromString(cmd, mqURLFlagName, mqURLEnvKey, true)
 	if err != nil {
 		return nil, err
 	}
@@ -468,6 +479,7 @@ func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 		casType:                   casType,
 		ipfsURL:                   ipfsURL,
 		cidVersion:                cidVersion,
+		mqURL:                     mqURL,
 		batchWriterTimeout:        batchWriterTimeout,
 		anchorCredentialParams:    anchorCredentialParams,
 		dbParameters:              dbParams,
@@ -655,6 +667,7 @@ func createFlags(startCmd *cobra.Command) {
 	startCmd.Flags().StringP(httpSignaturesEnabledFlagName, httpSignaturesEnabledShorthand, "", httpSignaturesEnabledUsage)
 	startCmd.Flags().StringP(casTypeFlagName, casTypeFlagShorthand, "", casTypeFlagUsage)
 	startCmd.Flags().StringP(ipfsURLFlagName, ipfsURLFlagShorthand, "", ipfsURLFlagUsage)
+	startCmd.Flags().StringP(mqURLFlagName, mqURLFlagShorthand, "", mqURLFlagUsage)
 	startCmd.Flags().String(cidVersionFlagName, "1", cidVersionFlagUsage)
 	startCmd.Flags().StringP(didNamespaceFlagName, didNamespaceFlagShorthand, "", didNamespaceFlagUsage)
 	startCmd.Flags().StringArrayP(didAliasesFlagName, didAliasesFlagShorthand, []string{}, didAliasesFlagUsage)

--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -58,6 +58,7 @@ import (
 	"github.com/trustbloc/orb/pkg/activitypub/httpsig"
 	aphandler "github.com/trustbloc/orb/pkg/activitypub/resthandler"
 	apservice "github.com/trustbloc/orb/pkg/activitypub/service"
+	"github.com/trustbloc/orb/pkg/activitypub/service/amqp"
 	"github.com/trustbloc/orb/pkg/activitypub/service/monitoring"
 	apspi "github.com/trustbloc/orb/pkg/activitypub/service/spi"
 	"github.com/trustbloc/orb/pkg/activitypub/service/vct"
@@ -438,6 +439,14 @@ func startOrbServices(parameters *orbParameters) error {
 		ServiceIRI:             apServiceIRI,
 		MaxWitnessDelay:        parameters.maxWitnessDelay,
 		VerifyActorInSignature: parameters.httpSignaturesEnabled,
+	}
+
+	if parameters.mqURL != "" {
+		apConfig.PubSubFactory = func(serviceName string) apservice.PubSub {
+			logger.Infof("[%s] Creating new AMQP publisher/subscriber at URL [%s]", serviceName, parameters.mqURL)
+
+			return amqp.New(serviceName, amqp.Config{URI: parameters.mqURL})
+		}
 	}
 
 	var apStore activitypubspi.Store

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ module github.com/trustbloc/orb
 
 require (
 	github.com/ThreeDotsLabs/watermill v1.2.0-rc.4
+	github.com/ThreeDotsLabs/watermill-amqp v1.1.1
 	github.com/ThreeDotsLabs/watermill-http v1.1.3
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cenkalti/backoff/v4 v4.1.0

--- a/go.sum
+++ b/go.sum
@@ -130,9 +130,12 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/Stebalien/go-bitfield v0.0.1/go.mod h1:GNjFpasyUVkHMsfEOk8EFLJ9syQ6SI+XWrX9Wf2XH0s=
+github.com/ThreeDotsLabs/watermill v1.0.2/go.mod h1:vZCPh7eN0P7r2qKau4SfmcUZ83+3JXWkRl4BiWUlqFw=
 github.com/ThreeDotsLabs/watermill v1.1.0/go.mod h1:Qd1xNFxolCAHCzcMrm6RnjW0manbvN+DJVWc1MWRFlI=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.4 h1:hX8toeERHfnrZFvCXdWRQCYgoNExQoi5vtf5+rbGaA8=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.4/go.mod h1:sl2PSceOQJ8BreN60hCnU2WixFNOYJOQDY1J3hvyVCs=
+github.com/ThreeDotsLabs/watermill-amqp v1.1.1 h1:wlrYlQDf6ZgdYoVPbrBaOnSMqxkQJZXDS6qugIin4o0=
+github.com/ThreeDotsLabs/watermill-amqp v1.1.1/go.mod h1:Qbu3JDlr6vIOxHJjhfsSHsrdF/ToJLYoaYek8X5Wnto=
 github.com/ThreeDotsLabs/watermill-http v1.1.3 h1:2jHbbE+gbq7pKWBCtOxeHTWSBNrS44Oh7QOzuAeHH/g=
 github.com/ThreeDotsLabs/watermill-http v1.1.3/go.mod h1:mkQ9CC0pxTZerNwr281rBoOy355vYt/lePkmYSX/BRg=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=
@@ -1376,6 +1379,7 @@ github.com/square/go-jose/v3 v3.0.0-20200630053402-0a67ce9b0693 h1:wD1IWQwAhdWcl
 github.com/square/go-jose/v3 v3.0.0-20200630053402-0a67ce9b0693/go.mod h1:6hSY48PjDm4UObWmGLyJE9DxYVKTgR9kbCspXXJEhcU=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
+github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271 h1:WhxRHzgeVGETMlmVfqhRn8RIeeNoPr2Czh33I4Zdccw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/pkg/activitypub/errors/errors.go
+++ b/pkg/activitypub/errors/errors.go
@@ -1,0 +1,36 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package errors
+
+import (
+	"errors"
+)
+
+var transientType = &transient{} //nolint:gochecknoglobals
+
+// NewTransient returns a transient error that wraps the given error in order to indicate to the caller that a retry may
+// resolve the problem, whereas a non-transient (persistent) error will always fail with the same outcome if retried.
+func NewTransient(err error) error {
+	return &transient{err: err}
+}
+
+// IsTransient returns true if the given error is a 'transient' error.
+func IsTransient(err error) bool {
+	return errors.As(err, &transientType)
+}
+
+type transient struct {
+	err error
+}
+
+func (e *transient) Error() string {
+	return e.err.Error()
+}
+
+func (e *transient) Unwrap() error {
+	return e.err
+}

--- a/pkg/activitypub/errors/errors_test.go
+++ b/pkg/activitypub/errors/errors_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package errors
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransientError(t *testing.T) {
+	et := errors.New("some transient error")
+	ep := errors.New("some persistent error")
+
+	err := NewTransient(et)
+
+	require.True(t, IsTransient(err))
+	require.True(t, errors.Is(err, et))
+	require.False(t, IsTransient(ep))
+	require.EqualError(t, err, et.Error())
+}

--- a/pkg/activitypub/service/activityhandler/inboxhandler.go
+++ b/pkg/activitypub/service/activityhandler/inboxhandler.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"time"
 
+	aperrors "github.com/trustbloc/orb/pkg/activitypub/errors"
 	"github.com/trustbloc/orb/pkg/activitypub/resthandler"
 	service "github.com/trustbloc/orb/pkg/activitypub/service/spi"
 	store "github.com/trustbloc/orb/pkg/activitypub/store/spi"
@@ -202,7 +203,7 @@ func (h *Inbox) validateActivity(activity *vocab.ActivityType) error {
 
 func (h *Inbox) acceptActor(activity *vocab.ActivityType, actor *vocab.ActorType, refType store.ReferenceType) error {
 	if err := h.store.AddReference(refType, h.ServiceIRI, actor.ID().URL()); err != nil {
-		return fmt.Errorf("unable to store reference: %w", err)
+		return aperrors.NewTransient(fmt.Errorf("unable to store reference: %w", err))
 	}
 
 	if err := h.store.PutActor(actor); err != nil {
@@ -262,7 +263,7 @@ func (h *Inbox) handleAccept(accept *vocab.ActivityType, refType store.Reference
 
 	err = h.store.AddReference(refType, h.ServiceIRI, accept.Actor())
 	if err != nil {
-		return fmt.Errorf("handle accept '%s' activity %s: %w", refType, accept.ID(), err)
+		return aperrors.NewTransient(fmt.Errorf("handle accept '%s' activity %s: %w", refType, accept.ID(), err))
 	}
 
 	return nil
@@ -321,7 +322,7 @@ func (h *Inbox) postAccept(activity *vocab.ActivityType, toIRI *url.URL) error {
 	logger.Debugf("[%s] Publishing 'Accept' activity to %s", h.ServiceName, toIRI)
 
 	if _, err := h.outbox.Post(acceptActivity); err != nil {
-		return fmt.Errorf("unable to reply with 'Accept' to %s: %w", toIRI, err)
+		return aperrors.NewTransient(fmt.Errorf("unable to reply with 'Accept' to %s: %w", toIRI, err))
 	}
 
 	return nil
@@ -336,7 +337,7 @@ func (h *Inbox) postReject(activity *vocab.ActivityType, toIRI *url.URL) error {
 	logger.Debugf("[%s] Publishing 'Reject' activity to %s", h.ServiceName, toIRI)
 
 	if _, err := h.outbox.Post(reject); err != nil {
-		return fmt.Errorf("unable to reply with 'Accept' to %s: %w", toIRI, err)
+		return aperrors.NewTransient(fmt.Errorf("unable to reply with 'Accept' to %s: %w", toIRI, err))
 	}
 
 	return nil
@@ -350,7 +351,7 @@ func (h *Inbox) hasReference(objectIRI, refIRI *url.URL, refType store.Reference
 		),
 	)
 	if err != nil {
-		return false, fmt.Errorf("query references: %w", err)
+		return false, aperrors.NewTransient(fmt.Errorf("query references: %w", err))
 	}
 
 	defer func() {
@@ -366,7 +367,7 @@ func (h *Inbox) hasReference(objectIRI, refIRI *url.URL, refType store.Reference
 			return false, nil
 		}
 
-		return false, fmt.Errorf("get next reference: %w", err)
+		return false, aperrors.NewTransient(fmt.Errorf("get next reference: %w", err))
 	}
 
 	return true, nil
@@ -441,12 +442,13 @@ func (h *Inbox) handleOfferActivity(offer *vocab.ActivityType) error {
 
 	activityID, err := h.outbox.Post(like)
 	if err != nil {
-		return fmt.Errorf("unable to reply with 'Like' to %s for offer [%s]: %w", offer.Actor(), offer.ID(), err)
+		return aperrors.NewTransient(fmt.Errorf("unable to reply with 'Like' to %s for offer [%s]: %w",
+			offer.Actor(), offer.ID(), err))
 	}
 
 	err = h.store.AddReference(store.Liked, h.ServiceIRI, activityID)
 	if err != nil {
-		return fmt.Errorf("unable to store 'Like' activity for offer [%s]: %w", offer.ID(), err)
+		return aperrors.NewTransient(fmt.Errorf("unable to store 'Like' activity for offer [%s]: %w", offer.ID(), err))
 	}
 
 	h.notify(offer)
@@ -474,7 +476,7 @@ func (h *Inbox) handleLikeActivity(like *vocab.ActivityType) error {
 
 	err = h.store.AddReference(store.Like, h.ServiceIRI, like.ID().URL())
 	if err != nil {
-		return fmt.Errorf("unable to store 'Like' activity [%s]: %w", like.ID(), err)
+		return aperrors.NewTransient(fmt.Errorf("unable to store 'Like' activity [%s]: %w", like.ID(), err))
 	}
 
 	h.notify(like)
@@ -491,7 +493,7 @@ func (h *Inbox) handleAnchorCredential(target *vocab.ObjectProperty, obj *vocab.
 
 	ok, err := h.hasReference(targetIRI, h.ServiceIRI, store.AnchorCredential)
 	if err != nil {
-		return fmt.Errorf("has anchor credential [%s]: %w", targetIRI, err)
+		return aperrors.NewTransient(fmt.Errorf("has anchor credential [%s]: %w", targetIRI, err))
 	}
 
 	if ok {
@@ -512,7 +514,7 @@ func (h *Inbox) handleAnchorCredential(target *vocab.ObjectProperty, obj *vocab.
 
 	err = h.store.AddReference(store.AnchorCredential, targetIRI, h.ServiceIRI)
 	if err != nil {
-		return fmt.Errorf("store anchor credential reference: %w", err)
+		return aperrors.NewTransient(fmt.Errorf("store anchor credential reference: %w", err))
 	}
 
 	return nil
@@ -567,7 +569,7 @@ func (h *Inbox) announceAnchorCredential(create *vocab.ActivityType) error {
 
 	activityID, err := h.outbox.Post(announce)
 	if err != nil {
-		return err
+		return aperrors.NewTransient(err)
 	}
 
 	logger.Debugf("[%s] Adding 'Announce' %s to shares of %s", h.ServiceIRI, announce.ID(), ref.ID())
@@ -604,7 +606,7 @@ func (h *Inbox) announceAnchorCredentialRef(create *vocab.ActivityType) error {
 
 	activityID, err := h.outbox.Post(announce)
 	if err != nil {
-		return err
+		return aperrors.NewTransient(err)
 	}
 
 	anchorCredID := ref.Target().Object().ID()
@@ -701,7 +703,8 @@ func (h *Inbox) undoAddReference(activity *vocab.ActivityType, refType store.Ref
 
 	err := h.store.DeleteReference(refType, h.ServiceIRI, actorIRI)
 	if err != nil {
-		return fmt.Errorf("unable to delete %s from %s's collection of %s", actorIRI, h.ServiceIRI, refType)
+		return aperrors.NewTransient(fmt.Errorf("unable to delete %s from %s's collection of %s",
+			actorIRI, h.ServiceIRI, refType))
 	}
 
 	logger.Debugf("[%s] %s (if found) was successfully deleted from %s's collection of %s",
@@ -713,7 +716,11 @@ func (h *Inbox) undoAddReference(activity *vocab.ActivityType, refType store.Ref
 func (h *Inbox) ensureActivityInOutbox(activity *vocab.ActivityType) error {
 	obActivity, err := h.getActivityFromOutbox(activity.ID().URL())
 	if err != nil {
-		return fmt.Errorf("get activity from outbox: %w", err)
+		if errors.Is(err, store.ErrNotFound) {
+			return fmt.Errorf("get activity from outbox: %w", err)
+		}
+
+		return aperrors.NewTransient(fmt.Errorf("get activity from outbox: %w", err))
 	}
 
 	// Ensure the activity in the outbox is the same as the given activity.

--- a/pkg/activitypub/service/activityhandler/outboxhandler.go
+++ b/pkg/activitypub/service/activityhandler/outboxhandler.go
@@ -9,6 +9,7 @@ package activityhandler
 import (
 	"fmt"
 
+	"github.com/trustbloc/orb/pkg/activitypub/errors"
 	store "github.com/trustbloc/orb/pkg/activitypub/store/spi"
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
 )
@@ -71,7 +72,7 @@ func (h *handler) handleCreateActivity(create *vocab.ActivityType) error {
 
 	err := h.store.AddReference(store.AnchorCredential, target.Object().ID().URL(), h.ServiceIRI)
 	if err != nil {
-		return fmt.Errorf("store anchor credential reference: %w", err)
+		return errors.NewTransient(fmt.Errorf("store anchor credential reference: %w", err))
 	}
 
 	return nil
@@ -88,7 +89,7 @@ func (h *Outbox) undoAddReference(activity *vocab.ActivityType, refType store.Re
 	}
 
 	if err := h.store.DeleteReference(refType, h.ServiceIRI, iri); err != nil {
-		return fmt.Errorf("unable to delete %s from %s's collection of %s", iri, h.ServiceIRI, refType)
+		return errors.NewTransient(fmt.Errorf("unable to delete %s from %s's collection of %s", iri, h.ServiceIRI, refType))
 	}
 
 	logger.Debugf("[%s] %s (if found) was successfully deleted from %s's collection of %s",

--- a/pkg/activitypub/service/amqp/amqppubsub.go
+++ b/pkg/activitypub/service/amqp/amqppubsub.go
@@ -1,0 +1,157 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package amqp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ThreeDotsLabs/watermill-amqp/pkg/amqp"
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/cenkalti/backoff"
+	"github.com/trustbloc/edge-core/pkg/log"
+
+	"github.com/trustbloc/orb/pkg/activitypub/service/lifecycle"
+	service "github.com/trustbloc/orb/pkg/activitypub/service/spi"
+	"github.com/trustbloc/orb/pkg/activitypub/service/wmlogger"
+)
+
+var logger = log.New("activitypub_service")
+
+const defaultMaxConnectRetries = 15
+
+// Config holds the configuration for the publisher/subscriber.
+type Config struct {
+	URI               string
+	MaxConnectRetries uint64
+}
+
+type closeable interface {
+	Close() error
+}
+
+type subscriber interface {
+	closeable
+	Subscribe(ctx context.Context, topic string) (<-chan *message.Message, error)
+}
+
+type publisher interface {
+	closeable
+	Publish(topic string, messages ...*message.Message) error
+}
+
+// PubSub implements a publisher/subscriber that connects to an AMQP-compatible message queue.
+type PubSub struct {
+	*lifecycle.Lifecycle
+	Config
+
+	serviceName string
+	config      amqp.Config
+	subscriber  subscriber
+	publisher   publisher
+}
+
+// New returns a new AMQP publisher/subscriber.
+func New(name string, cfg Config) *PubSub {
+	p := &PubSub{
+		Config:      cfg,
+		serviceName: name,
+		config:      amqp.NewDurableQueueConfig(cfg.URI),
+	}
+
+	p.Lifecycle = lifecycle.New("amqp-"+name, lifecycle.WithStart(p.start))
+
+	// Start the service immediately.
+	p.Start()
+
+	return p
+}
+
+// Subscribe subscribes to a topic and returns the Go channel over which messages
+// are sent. The returned channel will be closed when Close() is called on this struct.
+func (p *PubSub) Subscribe(ctx context.Context, topic string) (<-chan *message.Message, error) {
+	if p.State() != service.StateStarted {
+		return nil, service.ErrNotStarted
+	}
+
+	logger.Debugf("[%s] Subscribing to topic [%s]", p.serviceName, topic)
+
+	return p.subscriber.Subscribe(ctx, topic)
+}
+
+// Publish publishes the given messages to the given topic.
+func (p *PubSub) Publish(topic string, messages ...*message.Message) error {
+	if p.State() != service.StateStarted {
+		return service.ErrNotStarted
+	}
+
+	logger.Debugf("[%s] Publishing messages to topic [%s]", p.serviceName, topic)
+
+	return p.publisher.Publish(topic, messages...)
+}
+
+// Close stops the publisher/subscriber.
+func (p *PubSub) Close() error {
+	p.Stop()
+
+	logger.Debugf("[%s] Closing publisher...", p.serviceName)
+
+	if err := p.publisher.Close(); err != nil {
+		logger.Warnf("[%s] Error closing publisher: %s", err)
+	}
+
+	logger.Debugf("[%s] Closing subscriber...", p.serviceName)
+
+	if err := p.subscriber.Close(); err != nil {
+		logger.Warnf("[%s] Error closing subscriber: %s", err)
+	}
+
+	return nil
+}
+
+func (p *PubSub) start() {
+	logger.Infof("[%s] Connecting to message queue at %s", p.serviceName, p.config.Connection.AmqpURI)
+
+	maxRetries := p.MaxConnectRetries
+	if maxRetries == 0 {
+		maxRetries = defaultMaxConnectRetries
+	}
+
+	err := backoff.RetryNotify(
+		func() error {
+			return p.connect()
+		},
+		backoff.WithMaxRetries(backoff.NewExponentialBackOff(), maxRetries),
+		func(err error, duration time.Duration) {
+			logger.Infof("[%s] Error connecting to AMQP service %s after %s: %s",
+				p.serviceName, p.config.Connection.AmqpURI, duration, err)
+		},
+	)
+	if err != nil {
+		panic(fmt.Sprintf("[%s] Unable to connect to message queue after %d attempts", p.serviceName, maxRetries))
+	}
+
+	logger.Warnf("[%s] Successfully connected to message queue: %s", p.serviceName, p.config.Connection.AmqpURI)
+}
+
+func (p *PubSub) connect() error {
+	subscriber, err := amqp.NewSubscriber(p.config, wmlogger.New())
+	if err != nil {
+		return err
+	}
+
+	publisher, err := amqp.NewPublisher(p.config, wmlogger.New())
+	if err != nil {
+		return err
+	}
+
+	p.subscriber = subscriber
+	p.publisher = publisher
+
+	return nil
+}

--- a/pkg/activitypub/service/amqp/amqppubsub_test.go
+++ b/pkg/activitypub/service/amqp/amqppubsub_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package amqp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ThreeDotsLabs/watermill"
+	"github.com/ThreeDotsLabs/watermill/message"
+	dctest "github.com/ory/dockertest/v3"
+	dc "github.com/ory/dockertest/v3/docker"
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/pkg/activitypub/service/spi"
+)
+
+const (
+	dockerImage = "rabbitmq"
+	dockerTag   = "3.8.16"
+)
+
+func TestAMQP(t *testing.T) {
+	const topic = "some-topic"
+
+	t.Run("Success", func(t *testing.T) {
+		p := New("", Config{URI: "amqp://guest:guest@localhost:5672/"})
+		require.NotNil(t, p)
+
+		msgChan, err := p.Subscribe(context.Background(), topic)
+		require.NoError(t, err)
+
+		msg := message.NewMessage(watermill.NewUUID(), []byte("some payload"))
+		require.NoError(t, p.Publish(topic, msg))
+
+		select {
+		case m := <-msgChan:
+			require.Equal(t, msg.UUID, m.UUID)
+		case <-time.After(200 * time.Millisecond):
+			t.Fatal("timed out waiting for message")
+		}
+
+		require.NoError(t, p.Close())
+
+		_, err = p.Subscribe(context.Background(), topic)
+		require.True(t, errors.Is(err, spi.ErrNotStarted))
+		require.True(t, errors.Is(p.Publish(topic, msg), spi.ErrNotStarted))
+	})
+
+	t.Run("Connection failure", func(t *testing.T) {
+		require.Panics(t, func() {
+			p := New("", Config{URI: "amqp://guest:guest@localhost:9999/", MaxConnectRetries: 3})
+			require.NotNil(t, p)
+		})
+	})
+}
+
+func TestMain(m *testing.M) {
+	code := 1
+
+	defer func() { os.Exit(code) }()
+
+	pool, err := dctest.NewPool("")
+	if err != nil {
+		panic(fmt.Sprintf("pool: %v", err))
+	}
+
+	resource, err := pool.RunWithOptions(&dctest.RunOptions{
+		Repository: dockerImage,
+		Tag:        dockerTag,
+		PortBindings: map[dc.Port][]dc.PortBinding{
+			"5672/tcp": {{HostIP: "", HostPort: "5672"}},
+		},
+	})
+	if err != nil {
+		logger.Errorf(`Failed to start RabbitMQ Docker image.`)
+
+		panic(fmt.Sprintf("run with options: %v", err))
+	}
+
+	defer func() {
+		if err := pool.Purge(resource); err != nil {
+			panic(fmt.Sprintf("purge: %v", err))
+		}
+	}()
+
+	code = m.Run()
+}

--- a/pkg/activitypub/service/service.go
+++ b/pkg/activitypub/service/service.go
@@ -29,7 +29,10 @@ import (
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
 )
 
-const activitiesTopic = "activities"
+const (
+	inboxActivitiesTopic  = "inbox_activities"
+	outboxActivitiesTopic = "outbox_activities"
+)
 
 // PubSub defines the functions for a publisher/subscriber.
 type PubSub interface {
@@ -88,7 +91,7 @@ func New(cfg *Config, activityStore store.Store, t httpTransport, sigVerifier si
 		&outbox.Config{
 			ServiceName:      cfg.ServiceEndpoint,
 			ServiceIRI:       cfg.ServiceIRI,
-			Topic:            activitiesTopic,
+			Topic:            outboxActivitiesTopic,
 			RedeliveryConfig: cfg.RetryOpts,
 		},
 		activityStore, newPubSub(cfg, cfg.ServiceEndpoint+resthandler.OutboxPath),
@@ -111,7 +114,7 @@ func New(cfg *Config, activityStore store.Store, t httpTransport, sigVerifier si
 		&inbox.Config{
 			ServiceEndpoint:        cfg.ServiceEndpoint + resthandler.InboxPath,
 			ServiceIRI:             cfg.ServiceIRI,
-			Topic:                  activitiesTopic,
+			Topic:                  inboxActivitiesTopic,
 			VerifyActorInSignature: cfg.VerifyActorInSignature,
 		},
 		activityStore,

--- a/pkg/activitypub/service/spi/spi.go
+++ b/pkg/activitypub/service/spi/spi.go
@@ -15,7 +15,7 @@ import (
 )
 
 // UndeliverableTopic is the topic to which to post undeliverable messages.
-const UndeliverableTopic = "undeliverable"
+const UndeliverableTopic = "undeliverable_activities"
 
 // ErrNotStarted indicates that an attempt was made to invoke a service that has not been started
 // or is still in the process of starting.

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - BATCH_WRITER_TIMEOUT=200
       - CAS_TYPE=${CAS_TYPE}
       - IPFS_URL=ipfs:5001
+      - MQ_URL=amqp://guest:guest@orb.mq.domain1.com:5672/
       - CID_VERSION=${CID_VERSION_DOMAIN1}
       - ANCHOR_CREDENTIAL_ISSUER=http://orb.domain1.com
       - ANCHOR_CREDENTIAL_URL=http://orb.domain1.com/vc
@@ -71,6 +72,7 @@ services:
       - orb.kms
       - couchdb.kms.com
       - couchdb.shared.com
+      - orb.mq.domain1.com
     networks:
       - orb_net
 
@@ -98,6 +100,7 @@ services:
       - BATCH_WRITER_TIMEOUT=200
       - CAS_TYPE=${CAS_TYPE}
       - IPFS_URL=ipfs:5001
+      - MQ_URL=amqp://guest:guest@orb.mq.domain1.com:5672/
       - CID_VERSION=${CID_VERSION_DOMAIN1}
       - ANCHOR_CREDENTIAL_ISSUER=http://orb2.domain1.com
       - ANCHOR_CREDENTIAL_URL=http://orb2.domain1.com/vc
@@ -141,6 +144,7 @@ services:
       - couchdb.kms.com
       - couchdb.shared.com
       - orb-domain1
+      - orb.mq.domain1.com
     networks:
       - orb_net
 
@@ -453,6 +457,15 @@ services:
       - "8080:8080"
     volumes:
       - ./uni-resolver-web/config.json:/opt/uni-resolver-java/uni-resolver-web/config.json
+    networks:
+      - orb_net
+
+  orb.mq.domain1.com:
+    container_name: orb.mq.domain1.com
+    image: rabbitmq:3.8.16
+    ports:
+      - 5672:5672
+    restart: unless-stopped
     networks:
       - orb_net
 

--- a/test/bdd/fixtures/testdata/undo_follow_activity.json
+++ b/test/bdd/fixtures/testdata/undo_follow_activity.json
@@ -1,8 +1,0 @@
-{
-  "@context": "https://www.w3.org/ns/activitystreams",
-  "id": "https://orb.domain2.com/services/orb/activities/77bcd005-bbb6-233d-c889-98bc1ce64983",
-  "type": "Undo",
-  "actor": "https://orb.domain2.com/services/orb",
-  "to": "https://orb.domain1.com/services/orb",
-  "object": "https://orb.domain2.com/services/orb/activities/97b3d005-abb6-422d-a889-18bc1ee84988"
-}

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -130,8 +130,10 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/Stebalien/go-bitfield v0.0.1/go.mod h1:GNjFpasyUVkHMsfEOk8EFLJ9syQ6SI+XWrX9Wf2XH0s=
+github.com/ThreeDotsLabs/watermill v1.0.2/go.mod h1:vZCPh7eN0P7r2qKau4SfmcUZ83+3JXWkRl4BiWUlqFw=
 github.com/ThreeDotsLabs/watermill v1.1.0/go.mod h1:Qd1xNFxolCAHCzcMrm6RnjW0manbvN+DJVWc1MWRFlI=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.4/go.mod h1:sl2PSceOQJ8BreN60hCnU2WixFNOYJOQDY1J3hvyVCs=
+github.com/ThreeDotsLabs/watermill-amqp v1.1.1/go.mod h1:Qbu3JDlr6vIOxHJjhfsSHsrdF/ToJLYoaYek8X5Wnto=
 github.com/ThreeDotsLabs/watermill-http v1.1.3/go.mod h1:mkQ9CC0pxTZerNwr281rBoOy355vYt/lePkmYSX/BRg=
 github.com/VictoriaMetrics/fastcache v1.5.7/go.mod h1:ptDBkNMQI4RtmVo8VS/XwRY6RoTu1dAWCbrk+6WsEM8=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=


### PR DESCRIPTION
Added support for AMQP-compatible message queue for the publisher/subscriber in ActivityPub. Modified the BDD test to use RabbitMQ for Domain1.

closes #369

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>