### PR TITLE
feat: Configure witness policy: storage and caching

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -112,6 +112,8 @@ const (
 	defaulthttpSignaturesEnabled = true
 
 	unpublishedDIDLabel = "interim"
+
+	defaultPolicyCacheExpiry = 30 * time.Second
 )
 
 var logger = log.New("orb-server")
@@ -486,9 +488,7 @@ func startOrbServices(parameters *orbParameters) error {
 
 	defer monitoringSvc.Close()
 
-	// TODO: Make witness policy configurable (issue-448)
-	// For now use default 100% batch and 100% system witnesses
-	witnessPolicy, err := policy.New("")
+	witnessPolicy, err := policy.New(configStore, defaultPolicyCacheExpiry)
 	if err != nil {
 		return fmt.Errorf("failed to create witness policy: %s", err.Error())
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/ThreeDotsLabs/watermill v1.2.0-rc.4
 	github.com/ThreeDotsLabs/watermill-amqp v1.1.1
 	github.com/ThreeDotsLabs/watermill-http v1.1.3
+	github.com/bluele/gcache v0.0.0-20190518031135-bc40bd653833
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cenkalti/backoff/v4 v4.1.0
 	github.com/go-kivik/couchdb/v3 v3.2.7 // indirect

--- a/pkg/anchor/handler/proof/handler_test.go
+++ b/pkg/anchor/handler/proof/handler_test.go
@@ -30,8 +30,10 @@ import (
 //go:generate counterfeiter -o ../mocks/vcstatus.gen.go --fake-name VCStatusStore . vcStatusStore
 
 const (
-	vcID       = "http://peer1.com/vc/62c153d1-a6be-400e-a6a6-5b700b596d9d"
-	witnessURL = "http://example.com/orb/services"
+	vcID                     = "http://peer1.com/vc/62c153d1-a6be-400e-a6a6-5b700b596d9d"
+	witnessURL               = "http://example.com/orb/services"
+	configStoreName          = "orb-config"
+	defaultPolicyCacheExpiry = 5 * time.Second
 )
 
 func TestNew(t *testing.T) {
@@ -50,6 +52,9 @@ func TestNew(t *testing.T) {
 
 func TestWitnessProofHandler(t *testing.T) {
 	witnessIRI, err := url.Parse(witnessURL)
+	require.NoError(t, err)
+
+	configStore, err := mem.NewProvider().OpenStore(configStoreName)
 	require.NoError(t, err)
 
 	t.Run("success - witness policy not satisfied", func(t *testing.T) {
@@ -124,7 +129,7 @@ func TestWitnessProofHandler(t *testing.T) {
 		err = witnessStore.Put(anchorVC.ID, emptyWitnessProofs)
 		require.NoError(t, err)
 
-		witnessPolicy, err := policy.New("")
+		witnessPolicy, err := policy.New(configStore, defaultPolicyCacheExpiry)
 		require.NoError(t, err)
 
 		providers := &Providers{
@@ -233,7 +238,7 @@ func TestWitnessProofHandler(t *testing.T) {
 		err = witnessStore.Put(anchorVC.ID, emptyWitnessProofs)
 		require.NoError(t, err)
 
-		witnessPolicy, err := policy.New("")
+		witnessPolicy, err := policy.New(configStore, defaultPolicyCacheExpiry)
 		require.NoError(t, err)
 
 		mockVCStatusStore := &mocks.VCStatusStore{}
@@ -279,7 +284,7 @@ func TestWitnessProofHandler(t *testing.T) {
 		err = witnessStore.Put(anchorVC.ID, emptyWitnessProofs)
 		require.NoError(t, err)
 
-		witnessPolicy, err := policy.New("")
+		witnessPolicy, err := policy.New(configStore, defaultPolicyCacheExpiry)
 		require.NoError(t, err)
 
 		mockVCStatusStore := &mocks.VCStatusStore{}
@@ -326,7 +331,7 @@ func TestWitnessProofHandler(t *testing.T) {
 		err = witnessStore.Put(anchorVC.ID, emptyWitnessProofs)
 		require.NoError(t, err)
 
-		witnessPolicy, err := policy.New("")
+		witnessPolicy, err := policy.New(configStore, defaultPolicyCacheExpiry)
 		require.NoError(t, err)
 
 		mockVCStatusStore := &mocks.VCStatusStore{}

--- a/pkg/anchor/policy/config/parser.go
+++ b/pkg/anchor/policy/config/parser.go
@@ -1,0 +1,172 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// WitnessPolicyConfig parses witness policy.
+type WitnessPolicyConfig struct {
+	MinNumberSystem int
+	MinNumberBatch  int
+
+	MinPercentSystem int
+	MinPercentBatch  int
+
+	Operator operatorFnc
+}
+
+// Gate values.
+const (
+	OutOf      = "OutOf"
+	MinPercent = "MinPercent"
+
+	AND = "AND"
+	OR  = "OR"
+)
+
+// Role values.
+const (
+	RoleBatch  = "batch"
+	RoleSystem = "system"
+)
+
+const maxPercent = 100
+
+type operatorFnc func(a, b bool) bool
+
+// Parse parses witness policy from policy string.
+func Parse(policy string) (*WitnessPolicyConfig, error) {
+	// default policy is 100% batch and 100% system witnesses
+	wp := &WitnessPolicyConfig{
+		MinPercentBatch:  maxPercent,
+		MinPercentSystem: maxPercent,
+		Operator:         and,
+	}
+
+	if policy == "" {
+		return wp, nil
+	}
+
+	tokens := strings.Split(policy, " ")
+
+	for _, token := range tokens {
+		err := wp.processToken(token)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return wp, nil
+}
+
+func (wp *WitnessPolicyConfig) processToken(token string) error {
+	switch t := token; {
+	case strings.HasPrefix(t, OutOf):
+		err := wp.processOutOf(token)
+		if err != nil {
+			return err
+		}
+	case strings.HasPrefix(t, MinPercent):
+		err := wp.processMinPercent(token)
+		if err != nil {
+			return err
+		}
+	case t == AND:
+		wp.Operator = and
+	case t == OR:
+		wp.Operator = or
+	default:
+		return fmt.Errorf("rule not supported: %s", token)
+	}
+
+	return nil
+}
+
+// processOutOf rule (e.g. OutOf(2,system) rule means that proofs from at least 2 system witnesses are required.
+func (wp *WitnessPolicyConfig) processOutOf(token string) error {
+	insideBrackets := token[len(OutOf)+1 : len(token)-1]
+
+	outOfArgs := strings.Split(insideBrackets, ",")
+
+	const outOfArgsNo = 2
+	if len(outOfArgs) != outOfArgsNo {
+		return fmt.Errorf("expected 2 but got %d arguments for OutOf policy", len(outOfArgs))
+	}
+
+	minNo, err := strconv.Atoi(outOfArgs[0])
+	if err != nil {
+		return fmt.Errorf("first argument for OutOf policy must be an integer: %w", err)
+	}
+
+	switch outOfArgs[1] {
+	case RoleSystem:
+		wp.MinNumberSystem = minNo
+
+		if wp.MinNumberSystem == 0 {
+			wp.MinPercentSystem = 0
+		}
+
+	case RoleBatch:
+		wp.MinNumberBatch = minNo
+
+		if wp.MinNumberBatch == 0 {
+			wp.MinPercentBatch = 0
+		}
+
+	default:
+		return fmt.Errorf("role '%s' not supported for OutOf policy", outOfArgs[1])
+	}
+
+	return nil
+}
+
+// processMinPercent will process minimum percent rule.
+// e.g. MinPercent(0.2,system) rule means that proofs from at least 20% of system witnesses are required.
+func (wp *WitnessPolicyConfig) processMinPercent(token string) error {
+	insideBrackets := token[len(MinPercent)+1 : len(token)-1]
+
+	minPercentArgs := strings.Split(insideBrackets, ",")
+
+	const minPercentArgsNo = 2
+	if len(minPercentArgs) != minPercentArgsNo {
+		return fmt.Errorf("expected 2 but got %d arguments for MinPercent policy", len(minPercentArgs))
+	}
+
+	minPercent, err := strconv.Atoi(minPercentArgs[0])
+	if err != nil {
+		return fmt.Errorf("first argument for OutOf policy must be an integer between 0 and 100: %w", err)
+	}
+
+	if minPercent < 0 || minPercent > 100 {
+		return fmt.Errorf("first argument for OutOf policy must be an integer between 0 and 100")
+	}
+
+	switch minPercentArgs[1] {
+	case RoleSystem:
+		wp.MinPercentSystem = minPercent
+
+	case RoleBatch:
+		wp.MinPercentBatch = minPercent
+
+	default:
+		return fmt.Errorf("role '%s' not supported for MinPercent policy", minPercentArgs[1])
+	}
+
+	return nil
+}
+
+func and(a, b bool) bool {
+	return a && b
+}
+
+func or(a, b bool) bool {
+	return a || b
+}

--- a/pkg/anchor/policy/config/parser_test.go
+++ b/pkg/anchor/policy/config/parser_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	t.Run("success - default policy (100% batch and 100% system witnesses)", func(t *testing.T) {
+		wp, err := Parse("")
+		require.NoError(t, err)
+		require.NotNil(t, wp)
+
+		require.Equal(t, 0, wp.MinNumberBatch)
+		require.Equal(t, 0, wp.MinNumberSystem)
+		require.Equal(t, 100, wp.MinPercentBatch)
+		require.Equal(t, 100, wp.MinPercentSystem)
+		require.Equal(t, and(true, false), wp.Operator(true, false))
+	})
+
+	t.Run("error - rule not supported ", func(t *testing.T) {
+		wp, err := Parse("Test(2,3)")
+		require.Error(t, err)
+		require.Nil(t, wp)
+		require.Contains(t, err.Error(), "rule not supported: Test(2,3)")
+	})
+}
+
+func TestParse_OutOf(t *testing.T) {
+	t.Run("success - OutOf policy for system", func(t *testing.T) {
+		wp, err := Parse("OutOf(2,system)")
+		require.NoError(t, err)
+		require.NotNil(t, wp)
+
+		require.Equal(t, 0, wp.MinNumberBatch)
+		require.Equal(t, 2, wp.MinNumberSystem)
+		require.Equal(t, 100, wp.MinPercentBatch)
+		require.Equal(t, 100, wp.MinPercentSystem)
+		require.Equal(t, and(true, false), wp.Operator(true, false))
+	})
+
+	t.Run("success - OutOf policy for batch", func(t *testing.T) {
+		wp, err := Parse("OutOf(2,batch)")
+		require.NoError(t, err)
+		require.NotNil(t, wp)
+
+		require.Equal(t, 2, wp.MinNumberBatch)
+		require.Equal(t, 0, wp.MinNumberSystem)
+		require.Equal(t, 100, wp.MinPercentBatch)
+		require.Equal(t, 100, wp.MinPercentSystem)
+		require.Equal(t, and(true, false), wp.Operator(true, false))
+	})
+
+	t.Run("success - OutOf policy for batch", func(t *testing.T) {
+		wp, err := Parse("OutOf(3,system) AND OutOf(1,batch)")
+		require.NoError(t, err)
+		require.NotNil(t, wp)
+
+		require.Equal(t, 1, wp.MinNumberBatch)
+		require.Equal(t, 3, wp.MinNumberSystem)
+		require.Equal(t, 100, wp.MinPercentBatch)
+		require.Equal(t, 100, wp.MinPercentSystem)
+		require.Equal(t, and(true, false), wp.Operator(true, false))
+	})
+
+	t.Run("error - first argument for OutOf policy must be an integer", func(t *testing.T) {
+		wp, err := Parse("OutOf(a,system)")
+		require.Error(t, err)
+		require.Nil(t, wp)
+		require.Contains(t, err.Error(), "first argument for OutOf policy must be an integer")
+	})
+
+	t.Run("error - role 'invalid' not supported for OutOf policy", func(t *testing.T) {
+		wp, err := Parse("OutOf(2,invalid)")
+		require.Error(t, err)
+		require.Nil(t, wp)
+		require.Contains(t, err.Error(), "role 'invalid' not supported for OutOf policy")
+	})
+
+	t.Run("error - expected 2 but got 3 arguments for OutOf", func(t *testing.T) {
+		wp, err := Parse("OutOf(2,system,other)")
+		require.Error(t, err)
+		require.Nil(t, wp)
+		require.Contains(t, err.Error(), "expected 2 but got 3 arguments for OutOf")
+	})
+}
+
+func TestParse_MinPercent(t *testing.T) {
+	t.Run("success - MinPercent policy for batch", func(t *testing.T) {
+		wp, err := Parse("MinPercent(70,batch)")
+		require.NoError(t, err)
+		require.NotNil(t, wp)
+
+		require.Equal(t, 0, wp.MinNumberBatch)
+		require.Equal(t, 0, wp.MinNumberSystem)
+		require.Equal(t, 70, wp.MinPercentBatch)
+		require.Equal(t, 100, wp.MinPercentSystem)
+		require.Equal(t, and(true, false), wp.Operator(true, false))
+	})
+
+	t.Run("success - MinPercent policy for batch and system", func(t *testing.T) {
+		wp, err := Parse("MinPercent(30,system) OR MinPercent(70,batch)")
+		require.NoError(t, err)
+		require.NotNil(t, wp)
+
+		require.Equal(t, 0, wp.MinNumberBatch)
+		require.Equal(t, 0, wp.MinNumberSystem)
+		require.Equal(t, 70, wp.MinPercentBatch)
+		require.Equal(t, 30, wp.MinPercentSystem)
+		require.Equal(t, or(true, false), wp.Operator(true, false))
+	})
+
+	t.Run("error - role 'invalid' not supported for MinPercent policy", func(t *testing.T) {
+		wp, err := Parse("MinPercent(70,invalid)")
+		require.Error(t, err)
+		require.Nil(t, wp)
+		require.Contains(t, err.Error(), "role 'invalid' not supported for MinPercent policy")
+	})
+
+	t.Run("error - first argument not an integer", func(t *testing.T) {
+		wp, err := Parse("MinPercent(invalid,batch)")
+		require.Error(t, err)
+		require.Nil(t, wp)
+		require.Contains(t, err.Error(), "first argument for OutOf policy must be an integer between 0 and 100: strconv.Atoi")
+	})
+
+	t.Run("error - first argument for OutOf policy must be an integer between 0 and 100", func(t *testing.T) {
+		wp, err := Parse("MinPercent(150,batch)")
+		require.Error(t, err)
+		require.Nil(t, wp)
+		require.Contains(t, err.Error(), "first argument for OutOf policy must be an integer between 0 and 100")
+	})
+
+	t.Run("error - expected 2 but got 3 arguments for MinPercent", func(t *testing.T) {
+		wp, err := Parse("MinPercent(20,system,other)")
+		require.Error(t, err)
+		require.Nil(t, wp)
+		require.Contains(t, err.Error(), "expected 2 but got 3 arguments for MinPercent")
+	})
+}


### PR DESCRIPTION
Retrieve witness policy from storage and add cache in front of witness policy storage.

Also, move witness policy parsing to separate package so it can be reused for validating witness policy in upcoming REST handler for updating witness policy. 

Closes #448

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>