### PR TITLE
feat: Add REST endpoint for updating witness policy

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -71,6 +71,7 @@ import (
 	"github.com/trustbloc/orb/pkg/anchor/handler/proof"
 	anchorinfo "github.com/trustbloc/orb/pkg/anchor/info"
 	"github.com/trustbloc/orb/pkg/anchor/policy"
+	policyhandler "github.com/trustbloc/orb/pkg/anchor/policy/resthandler"
 	"github.com/trustbloc/orb/pkg/anchor/writer"
 	"github.com/trustbloc/orb/pkg/cas/extendedcasclient"
 	ipfscas "github.com/trustbloc/orb/pkg/cas/ipfs"
@@ -657,6 +658,7 @@ func startOrbServices(parameters *orbParameters) error {
 		aphandler.NewPostOutbox(apEndpointCfg, activityPubService.Outbox(), apStore, apSigVerifier),
 		aphandler.NewActivity(apEndpointCfg, apStore, apSigVerifier),
 		webcas.New(apEndpointCfg, apStore, apSigVerifier, coreCasClient),
+		auth.NewHandlerWrapper(authCfg, policyhandler.New(configStore)),
 		ctxRest,
 	)
 

--- a/pkg/anchor/policy/policy.go
+++ b/pkg/anchor/policy/policy.go
@@ -27,9 +27,10 @@ type WitnessPolicy struct {
 }
 
 const (
-	maxPercent = 100
+	// WitnessPolicyKey is witness policy key in config store.
+	WitnessPolicyKey = "witness-policy"
 
-	policyKey = "witness-policy"
+	maxPercent = 100
 
 	defaultCacheSize = 10
 )
@@ -50,12 +51,12 @@ func New(configStore storage.Store, policyCacheExpiry time.Duration) (*WitnessPo
 
 	wp.cache = gcache.New(defaultCacheSize).ARC().LoaderExpireFunc(wp.loadWitnessPolicy).Build()
 
-	policy, _, err := wp.loadWitnessPolicy(policyKey)
+	policy, _, err := wp.loadWitnessPolicy(WitnessPolicyKey)
 	if err != nil {
 		return nil, err
 	}
 
-	err = wp.cache.SetWithExpire(policyKey, policy, policyCacheExpiry)
+	err = wp.cache.SetWithExpire(WitnessPolicyKey, policy, policyCacheExpiry)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set expiry entry in policy cache: %w", err)
 	}
@@ -117,7 +118,7 @@ func (wp *WitnessPolicy) loadWitnessPolicy(key interface{}) (interface{}, *time.
 }
 
 func (wp *WitnessPolicy) getWitnessPolicyConfig() (*config.WitnessPolicyConfig, error) {
-	value, err := wp.cache.Get(policyKey)
+	value, err := wp.cache.Get(WitnessPolicyKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve policy from policy cache: %w", err)
 	}

--- a/pkg/anchor/policy/policy_test.go
+++ b/pkg/anchor/policy/policy_test.go
@@ -41,7 +41,7 @@ func TestNew(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, wp)
 
-		err = configStore.Put(policyKey, []byte("MinPercent(30,system) AND MinPercent(70,batch)"))
+		err = configStore.Put(WitnessPolicyKey, []byte("MinPercent(30,system) AND MinPercent(70,batch)"))
 		require.NoError(t, err)
 
 		time.Sleep(2 * time.Second)
@@ -121,7 +121,7 @@ func TestEvaluate(t *testing.T) {
 		configStore, err := mem.NewProvider().OpenStore(configStoreName)
 		require.NoError(t, err)
 
-		err = configStore.Put(policyKey, []byte("OutOf(1,system)"))
+		err = configStore.Put(WitnessPolicyKey, []byte("OutOf(1,system)"))
 		require.NoError(t, err)
 
 		wp, err := New(configStore, defaultPolicyCacheExpiry)
@@ -158,7 +158,7 @@ func TestEvaluate(t *testing.T) {
 		configStore, err := mem.NewProvider().OpenStore(configStoreName)
 		require.NoError(t, err)
 
-		err = configStore.Put(policyKey, []byte("OutOf(1,system)"))
+		err = configStore.Put(WitnessPolicyKey, []byte("OutOf(1,system)"))
 		require.NoError(t, err)
 
 		wp, err := New(configStore, 1*time.Second)
@@ -196,7 +196,7 @@ func TestEvaluate(t *testing.T) {
 		configStore, err := mem.NewProvider().OpenStore(configStoreName)
 		require.NoError(t, err)
 
-		err = configStore.Put(policyKey, []byte("MinPercent(50,system) AND MinPercent(50,batch)"))
+		err = configStore.Put(WitnessPolicyKey, []byte("MinPercent(50,system) AND MinPercent(50,batch)"))
 		require.NoError(t, err)
 
 		wp, err := New(configStore, defaultPolicyCacheExpiry)
@@ -233,7 +233,7 @@ func TestEvaluate(t *testing.T) {
 		configStore, err := mem.NewProvider().OpenStore(configStoreName)
 		require.NoError(t, err)
 
-		err = configStore.Put(policyKey, []byte("MinPercent(50,system) OR MinPercent(50,batch)"))
+		err = configStore.Put(WitnessPolicyKey, []byte("MinPercent(50,system) OR MinPercent(50,batch)"))
 		require.NoError(t, err)
 
 		wp, err := New(configStore, defaultPolicyCacheExpiry)
@@ -269,7 +269,7 @@ func TestEvaluate(t *testing.T) {
 		configStore, err := mem.NewProvider().OpenStore(configStoreName)
 		require.NoError(t, err)
 
-		err = configStore.Put(policyKey, []byte("MinPercent(50,system) OR MinPercent(50,batch)"))
+		err = configStore.Put(WitnessPolicyKey, []byte("MinPercent(50,system) OR MinPercent(50,batch)"))
 		require.NoError(t, err)
 
 		wp, err := New(configStore, defaultPolicyCacheExpiry)
@@ -301,7 +301,7 @@ func TestEvaluate(t *testing.T) {
 		configStore, err := mem.NewProvider().OpenStore(configStoreName)
 		require.NoError(t, err)
 
-		err = configStore.Put(policyKey, []byte("OutOf(1,system)"))
+		err = configStore.Put(WitnessPolicyKey, []byte("OutOf(1,system)"))
 		require.NoError(t, err)
 
 		wp, err := New(configStore, defaultPolicyCacheExpiry)
@@ -339,7 +339,7 @@ func TestEvaluate(t *testing.T) {
 		configStore, err := mem.NewProvider().OpenStore(configStoreName)
 		require.NoError(t, err)
 
-		err = configStore.Put(policyKey, []byte("MinPercent(50,system) AND MinPercent(50,batch)"))
+		err = configStore.Put(WitnessPolicyKey, []byte("MinPercent(50,system) AND MinPercent(50,batch)"))
 		require.NoError(t, err)
 
 		wp, err := New(configStore, defaultPolicyCacheExpiry)
@@ -363,7 +363,7 @@ func TestEvaluate(t *testing.T) {
 		configStore, err := mem.NewProvider().OpenStore(configStoreName)
 		require.NoError(t, err)
 
-		err = configStore.Put(policyKey, []byte("MinPercent(50,system) AND MinPercent(50,batch)"))
+		err = configStore.Put(WitnessPolicyKey, []byte("MinPercent(50,system) AND MinPercent(50,batch)"))
 		require.NoError(t, err)
 
 		wp, err := New(configStore, defaultPolicyCacheExpiry)
@@ -387,7 +387,7 @@ func TestEvaluate(t *testing.T) {
 		configStore, err := mem.NewProvider().OpenStore(configStoreName)
 		require.NoError(t, err)
 
-		err = configStore.Put(policyKey, []byte("OutOf(0,batch) AND OutOf(1,system)"))
+		err = configStore.Put(WitnessPolicyKey, []byte("OutOf(0,batch) AND OutOf(1,system)"))
 		require.NoError(t, err)
 
 		wp, err := New(configStore, 1*time.Second)
@@ -411,7 +411,7 @@ func TestEvaluate(t *testing.T) {
 		require.Equal(t, true, ok)
 
 		// change policy to 1 system witness and 1 batch witness
-		err = configStore.Put(policyKey, []byte("OutOf(1,batch) AND OutOf(1,system)"))
+		err = configStore.Put(WitnessPolicyKey, []byte("OutOf(1,batch) AND OutOf(1,system)"))
 		require.NoError(t, err)
 
 		// wait for cache to refresh entry

--- a/pkg/anchor/policy/resthandler/configurator.go
+++ b/pkg/anchor/policy/resthandler/configurator.go
@@ -1,0 +1,108 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resthandler
+
+import (
+	"io/ioutil"
+	"net/http"
+
+	"github.com/hyperledger/aries-framework-go/spi/storage"
+	"github.com/trustbloc/edge-core/pkg/log"
+	"github.com/trustbloc/sidetree-core-go/pkg/restapi/common"
+
+	"github.com/trustbloc/orb/pkg/activitypub/resthandler"
+	"github.com/trustbloc/orb/pkg/anchor/policy"
+	"github.com/trustbloc/orb/pkg/anchor/policy/config"
+)
+
+const endpoint = "/policy"
+
+const (
+	badRequestResponse          = "Bad Request."
+	internalServerErrorResponse = "Internal Server Error."
+)
+
+var logger = log.New("policy-rest-handler")
+
+// PolicyConfigurator updates witness policy in config store.
+type PolicyConfigurator struct {
+	*resthandler.AuthHandler
+
+	VerifyActorInSignature bool
+	configStore            storage.Store
+}
+
+// Path returns the HTTP REST endpoint for the PolicyConfigurator service.
+func (pc *PolicyConfigurator) Path() string {
+	return endpoint
+}
+
+// Method returns the HTTP REST method for the configure policy service.
+func (pc *PolicyConfigurator) Method() string {
+	return http.MethodPost
+}
+
+// Handler returns the HTTP REST handle for the PolicyConfigurator service.
+func (pc *PolicyConfigurator) Handler() common.HTTPRequestHandler {
+	return pc.handle
+}
+
+// New returns a new PolicyConfigurator.
+func New(cfgStore storage.Store) *PolicyConfigurator {
+	h := &PolicyConfigurator{
+		configStore: cfgStore,
+	}
+
+	return h
+}
+
+func (pc *PolicyConfigurator) handle(w http.ResponseWriter, req *http.Request) {
+	policyBytes, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		logger.Errorf("[%s] Error reading request body: %s", endpoint, err)
+
+		writeResponse(w, http.StatusBadRequest, []byte(badRequestResponse))
+
+		return
+	}
+
+	_, err = config.Parse(string(policyBytes))
+	if err != nil {
+		logger.Errorf("[%s] Invalid witness policy: %s", endpoint, err)
+
+		writeResponse(w, http.StatusBadRequest, []byte(badRequestResponse))
+
+		return
+	}
+
+	err = pc.configStore.Put(policy.WitnessPolicyKey, policyBytes)
+	if err != nil {
+		logger.Errorf("[%s] Error storing witness policy: %s", endpoint, err)
+
+		writeResponse(w, http.StatusInternalServerError, []byte(internalServerErrorResponse))
+
+		return
+	}
+
+	logger.Debugf("[%s] Stored witness policy %s", endpoint, string(policyBytes))
+
+	writeResponse(w, http.StatusOK, nil)
+}
+
+func writeResponse(w http.ResponseWriter, status int, body []byte) {
+	w.WriteHeader(status)
+
+	if len(body) > 0 {
+		if _, err := w.Write(body); err != nil {
+			logger.Warnf("[%s] Unable to write response: %s", endpoint, err)
+
+			return
+		}
+
+		logger.Debugf("[%s] Wrote response: %s", endpoint, body)
+	}
+}

--- a/pkg/anchor/policy/resthandler/configurator_test.go
+++ b/pkg/anchor/policy/resthandler/configurator_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resthandler
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
+	"github.com/stretchr/testify/require"
+
+	storemocks "github.com/trustbloc/orb/pkg/store/mocks"
+)
+
+const (
+	testPolicy      = "MinPercent(50,system) AND MinPercent(50,batch)"
+	configStoreName = "orb-config"
+)
+
+func TestNew(t *testing.T) {
+	configStore, err := mem.NewProvider().OpenStore(configStoreName)
+	require.NoError(t, err)
+
+	policyConfigurator := New(configStore)
+	require.NotNil(t, policyConfigurator)
+	require.Equal(t, endpoint, policyConfigurator.Path())
+	require.Equal(t, http.MethodPost, policyConfigurator.Method())
+	require.NotNil(t, policyConfigurator.Handler())
+}
+
+func TestHandler(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		configStore, err := mem.NewProvider().OpenStore(configStoreName)
+		require.NoError(t, err)
+
+		policyConfigurator := New(configStore)
+		require.NotNil(t, policyConfigurator)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer([]byte(testPolicy)))
+
+		policyConfigurator.handle(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusOK, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+
+		respBytes, err := ioutil.ReadAll(result.Body)
+		require.NoError(t, err)
+		require.Empty(t, respBytes)
+		require.NoError(t, result.Body.Close())
+	})
+
+	t.Run("error - reader error", func(t *testing.T) {
+		configStore, err := mem.NewProvider().OpenStore(configStoreName)
+		require.NoError(t, err)
+
+		policyConfigurator := New(configStore)
+		require.NotNil(t, policyConfigurator)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, endpoint, errReader(0))
+
+		policyConfigurator.handle(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusBadRequest, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+
+		respBytes, err := ioutil.ReadAll(result.Body)
+		require.NoError(t, err)
+		require.Equal(t, []byte(badRequestResponse), respBytes)
+		require.NoError(t, result.Body.Close())
+	})
+
+	t.Run("error - parse policy error", func(t *testing.T) {
+		configStore, err := mem.NewProvider().OpenStore(configStoreName)
+		require.NoError(t, err)
+
+		policyConfigurator := New(configStore)
+		require.NotNil(t, policyConfigurator)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer([]byte("InvalidPolicy")))
+
+		policyConfigurator.handle(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusBadRequest, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+
+		respBytes, err := ioutil.ReadAll(result.Body)
+		require.NoError(t, err)
+		require.Equal(t, []byte(badRequestResponse), respBytes)
+		require.NoError(t, result.Body.Close())
+	})
+
+	t.Run("error - config store error", func(t *testing.T) {
+		configStore := &storemocks.Store{}
+		configStore.PutReturns(fmt.Errorf("put error"))
+
+		policyConfigurator := New(configStore)
+		require.NotNil(t, policyConfigurator)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer([]byte(testPolicy)))
+
+		policyConfigurator.handle(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusInternalServerError, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+
+		respBytes, err := ioutil.ReadAll(result.Body)
+		require.NoError(t, err)
+		require.Equal(t, []byte(internalServerErrorResponse), respBytes)
+		require.NoError(t, result.Body.Close())
+	})
+}
+
+type errReader int
+
+func (errReader) Read(p []byte) (n int, err error) {
+	return 0, fmt.Errorf("reader error")
+}

--- a/pkg/anchor/writer/writer_test.go
+++ b/pkg/anchor/writer/writer_test.go
@@ -864,6 +864,7 @@ func TestWriter_postOfferActivity(t *testing.T) {
 			Outbox:        &mockOutbox{Err: fmt.Errorf("outbox error")},
 			WitnessStore:  &mockWitnessStore{},
 			ActivityStore: &mockActivityStore{},
+			VCStatusStore: &mockVCStatusStore{},
 		}
 
 		anchorVC, err := verifiable.ParseCredential([]byte(anchorCred),

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -20,6 +20,7 @@ Feature:
     And the authorization bearer token for "GET" requests to path "/services/orb" is set to "READ_TOKEN"
     And the authorization bearer token for "GET" requests to path "/sidetree/v1/identifiers" is set to "READ_TOKEN"
     And the authorization bearer token for "POST" requests to path "/sidetree/v1/operations" is set to "ADMIN_TOKEN"
+    And the authorization bearer token for "POST" requests to path "/policy" is set to "ADMIN_TOKEN"
 
     # domain2 server follows domain1 server
     Given variable "followID" is assigned a unique ID
@@ -45,6 +46,9 @@ Feature:
     Given variable "inviteWitnessID" is assigned a unique ID
     And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain2IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
     When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+
+    # set witness policy for domain1
+    When an HTTP POST is sent to "https://orb.domain1.com/policy" with content "MinPercent(50,batch) AND MinPercent(50,system)" of type "text/plain"
 
     Then we wait 3 seconds
 


### PR DESCRIPTION
Add ability to update witness policy. Create new handler that will validate policy and store it into orb config store.

Closes #469

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>