### PR TITLE
chore: Do not store already processed operation

### DIFF
--- a/pkg/mocks/protocol.go
+++ b/pkg/mocks/protocol.go
@@ -186,7 +186,6 @@ func (m *MockProtocolClientProvider) create() *MockProtocolClient {
 		&txnprocessor.Providers{
 			OpStore:                   m.opStore,
 			OperationProtocolProvider: op,
-			AnchorGraph:               m.anchorGraph,
 		},
 	)
 

--- a/pkg/protocolversion/versions/v1_0/factory/factory.go
+++ b/pkg/protocolversion/versions/v1_0/factory/factory.go
@@ -85,7 +85,6 @@ func (v *Factory) Create(version string, casClient cas.Client, casResolver ctxco
 		&txnprocessor.Providers{
 			OpStore:                   opStore,
 			OperationProtocolProvider: op,
-			AnchorGraph:               anchorGraph,
 		},
 	)
 


### PR DESCRIPTION
In order to be able to retry anchor processing/did discovery we should ignore already processed operations.

Closes #475

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>