### PR TITLE
feat: Reuse the same message queue for all services

### DIFF
--- a/cmd/orb-server/go.mod
+++ b/cmd/orb-server/go.mod
@@ -5,6 +5,7 @@
 module github.com/trustbloc/orb/cmd/orb-server
 
 require (
+	github.com/ThreeDotsLabs/watermill v1.2.0-rc.4
 	github.com/cenkalti/backoff/v4 v4.1.0
 	github.com/google/uuid v1.2.0
 	github.com/hyperledger/aries-framework-go v0.1.7-0.20210604191029-fce55e13c101

--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -23,6 +23,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/google/uuid"
 	ariescouchdbstorage "github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb"
 	ariesmysqlstorage "github.com/hyperledger/aries-framework-go-ext/component/storage/mysql"
@@ -138,8 +139,10 @@ const (
 	kidKey         = "kid"
 )
 
-type server interface {
-	Start(srv *httpserver.Server) error
+type pubSub interface {
+	Subscribe(ctx context.Context, topic string) (<-chan *message.Message, error)
+	Publish(topic string, messages ...*message.Message) error
+	Close() error
 }
 
 // HTTPServer represents an actual HTTP server implementation.
@@ -440,12 +443,12 @@ func startOrbServices(parameters *orbParameters) error {
 		VerifyActorInSignature: parameters.httpSignaturesEnabled,
 	}
 
-	if parameters.mqURL != "" {
-		apConfig.PubSubFactory = func(serviceName string) apservice.PubSub {
-			logger.Infof("[%s] Creating new AMQP publisher/subscriber at URL [%s]", serviceName, parameters.mqURL)
+	var pubSub pubSub
 
-			return amqp.New(serviceName, amqp.Config{URI: parameters.mqURL})
-		}
+	if parameters.mqURL != "" {
+		pubSub = amqp.New(amqp.Config{URI: parameters.mqURL})
+	} else {
+		pubSub = mempubsub.New(mempubsub.DefaultConfig())
 	}
 
 	var apStore activitypubspi.Store
@@ -514,14 +517,7 @@ func startOrbServices(parameters *orbParameters) error {
 		ProtocolClientProvider: pcp,
 		AnchorGraph:            anchorGraph,
 		DidAnchors:             didAnchors,
-	}
-
-	if parameters.mqURL != "" {
-		// FIXME: Should reuse the same AMQP client as in ActivityPub (issue #473).
-
-		providers.PubSub = amqp.New("observer", amqp.Config{URI: parameters.mqURL})
-	} else {
-		providers.PubSub = mempubsub.New("observer", mempubsub.DefaultConfig())
+		PubSub:                 pubSub,
 	}
 
 	o, err := observer.New(providers)
@@ -532,7 +528,7 @@ func startOrbServices(parameters *orbParameters) error {
 	o.Start()
 
 	activityPubService, err := apservice.New(apConfig,
-		apStore, t, apSigVerifier,
+		apStore, t, apSigVerifier, pubSub,
 		apspi.WithProofHandler(proofHandler),
 		apspi.WithWitness(witness),
 		apspi.WithAnchorCredentialHandler(credential.New(

--- a/pkg/activitypub/service/service_test.go
+++ b/pkg/activitypub/service/service_test.go
@@ -55,15 +55,12 @@ func TestNewService(t *testing.T) {
 	cfg1 := &Config{
 		ServiceEndpoint: "/services/service1",
 		ServiceIRI:      testutil.MustParseURL("http://localhost:8301/services/service1"),
-		PubSubFactory: func(serviceName string) PubSub {
-			return mocks.NewPubSub()
-		},
 	}
 
 	store1 := memstore.New(cfg1.ServiceEndpoint)
 	undeliverableHandler1 := mocks.NewUndeliverableHandler()
 
-	service1, err := New(cfg1, store1, transport.Default(), &mocks.SignatureVerifier{},
+	service1, err := New(cfg1, store1, transport.Default(), &mocks.SignatureVerifier{}, mocks.NewPubSub(),
 		service.WithUndeliverableHandler(undeliverableHandler1))
 	require.NoError(t, err)
 
@@ -1037,7 +1034,7 @@ func newServiceWithMocks(t *testing.T, endpoint string,
 
 	activityStore := memstore.New(cfg.ServiceEndpoint)
 
-	s, err := New(cfg, activityStore, trnspt, httpsig.NewVerifier(providers.actorRetriever, cr, km),
+	s, err := New(cfg, activityStore, trnspt, httpsig.NewVerifier(providers.actorRetriever, cr, km), mocks.NewPubSub(),
 		service.WithUndeliverableHandler(providers.undeliverableHandler),
 		service.WithAnchorCredentialHandler(providers.anchorCredentialHandler),
 		service.WithFollowerAuth(providers.followerAuth),

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -62,7 +62,7 @@ func TestStartObserver(t *testing.T) {
 	t.Run("test channel close", func(t *testing.T) {
 		providers := &Providers{
 			DidAnchors: memdidanchor.New(),
-			PubSub:     mempubsub.New("observer", mempubsub.DefaultConfig()),
+			PubSub:     mempubsub.New(mempubsub.DefaultConfig()),
 		}
 
 		o, err := New(providers)
@@ -115,7 +115,7 @@ func TestStartObserver(t *testing.T) {
 			ProtocolClientProvider: mocks.NewMockProtocolClientProvider().WithProtocolClient(namespace1, pc),
 			AnchorGraph:            anchorGraph,
 			DidAnchors:             memdidanchor.New(),
-			PubSub:                 mempubsub.New("observer", mempubsub.DefaultConfig()),
+			PubSub:                 mempubsub.New(mempubsub.DefaultConfig()),
 		}
 
 		o, err := New(providers)
@@ -172,7 +172,7 @@ func TestStartObserver(t *testing.T) {
 			ProtocolClientProvider: mocks.NewMockProtocolClientProvider().WithProtocolClient(namespace1, pc),
 			AnchorGraph:            anchorGraph,
 			DidAnchors:             memdidanchor.New(),
-			PubSub:                 mempubsub.New("observer", mempubsub.DefaultConfig()),
+			PubSub:                 mempubsub.New(mempubsub.DefaultConfig()),
 		}
 
 		o, err := New(providers)
@@ -234,7 +234,7 @@ func TestStartObserver(t *testing.T) {
 			ProtocolClientProvider: mocks.NewMockProtocolClientProvider().WithProtocolClient(namespace1, pc),
 			AnchorGraph:            anchorGraph,
 			DidAnchors:             memdidanchor.New(),
-			PubSub:                 mempubsub.New("observer", mempubsub.DefaultConfig()),
+			PubSub:                 mempubsub.New(mempubsub.DefaultConfig()),
 		}
 
 		o, err := New(providers)
@@ -292,7 +292,7 @@ func TestStartObserver(t *testing.T) {
 			ProtocolClientProvider: mocks.NewMockProtocolClientProvider().WithProtocolClient(namespace1, pc),
 			AnchorGraph:            anchorGraph,
 			DidAnchors:             memdidanchor.New(),
-			PubSub:                 mempubsub.New("observer", mempubsub.DefaultConfig()),
+			PubSub:                 mempubsub.New(mempubsub.DefaultConfig()),
 		}
 
 		o, err := New(providers)
@@ -348,7 +348,7 @@ func TestStartObserver(t *testing.T) {
 			ProtocolClientProvider: mocks.NewMockProtocolClientProvider().WithProtocolClient(namespace1, pc),
 			AnchorGraph:            anchorGraph,
 			DidAnchors:             memdidanchor.New(),
-			PubSub:                 mempubsub.New("observer", mempubsub.DefaultConfig()),
+			PubSub:                 mempubsub.New(mempubsub.DefaultConfig()),
 		}
 
 		o, err := New(providers)
@@ -405,7 +405,7 @@ func TestStartObserver(t *testing.T) {
 			ProtocolClientProvider: mocks.NewMockProtocolClientProvider().WithProtocolClient(namespace1, pc),
 			AnchorGraph:            anchorGraph,
 			DidAnchors:             &mockDidAnchor{Err: fmt.Errorf("did anchor error")},
-			PubSub:                 mempubsub.New("observer", mempubsub.DefaultConfig()),
+			PubSub:                 mempubsub.New(mempubsub.DefaultConfig()),
 		}
 
 		o, err := New(providers)
@@ -450,7 +450,7 @@ func TestStartObserver(t *testing.T) {
 			ProtocolClientProvider: mocks.NewMockProtocolClientProvider().WithProtocolClient(namespace1, pc),
 			AnchorGraph:            anchorGraph,
 			DidAnchors:             memdidanchor.New(),
-			PubSub:                 mempubsub.New("observer", mempubsub.DefaultConfig()),
+			PubSub:                 mempubsub.New(mempubsub.DefaultConfig()),
 		}
 
 		o, err := New(providers)
@@ -477,7 +477,7 @@ func TestStartObserver(t *testing.T) {
 		providers := &Providers{
 			ProtocolClientProvider: mocks.NewMockProtocolClientProvider().WithProtocolClient(namespace1, pc),
 			DidAnchors:             memdidanchor.New(),
-			PubSub:                 mempubsub.New("observer", mempubsub.DefaultConfig()),
+			PubSub:                 mempubsub.New(mempubsub.DefaultConfig()),
 		}
 
 		o, err := New(providers)
@@ -508,7 +508,7 @@ func TestStartObserver(t *testing.T) {
 			ProtocolClientProvider: mocks.NewMockProtocolClientProvider().WithProtocolClient(namespace1, pc),
 			AnchorGraph:            anchorGraph,
 			DidAnchors:             memdidanchor.New(),
-			PubSub:                 mempubsub.New("observer", mempubsub.DefaultConfig()),
+			PubSub:                 mempubsub.New(mempubsub.DefaultConfig()),
 		}
 
 		o, err := New(providers)

--- a/pkg/observer/pubsub_test.go
+++ b/pkg/observer/pubsub_test.go
@@ -23,7 +23,7 @@ import (
 //go:generate counterfeiter -o ../mocks/pubsub.gen.go --fake-name PubSub . pubSub
 
 func TestPubSub(t *testing.T) {
-	p := mempubsub.New("observer", mempubsub.DefaultConfig())
+	p := mempubsub.New(mempubsub.DefaultConfig())
 	require.NotNil(t, p)
 
 	var mutex sync.RWMutex
@@ -103,7 +103,7 @@ func TestPubSub_Error(t *testing.T) {
 	})
 
 	t.Run("Marshal error", func(t *testing.T) {
-		p := mempubsub.New("observer", mempubsub.DefaultConfig())
+		p := mempubsub.New(mempubsub.DefaultConfig())
 		require.NotNil(t, p)
 
 		ps, err := NewPubSub(p,
@@ -130,7 +130,7 @@ func TestPubSub_Error(t *testing.T) {
 	})
 
 	t.Run("Unmarshal error", func(t *testing.T) {
-		p := mempubsub.New("observer", mempubsub.DefaultConfig())
+		p := mempubsub.New(mempubsub.DefaultConfig())
 		require.NotNil(t, p)
 
 		var mutex sync.RWMutex
@@ -177,7 +177,7 @@ func TestPubSub_Error(t *testing.T) {
 	})
 
 	t.Run("Transient error", func(t *testing.T) {
-		p := mempubsub.New("observer", mempubsub.DefaultConfig())
+		p := mempubsub.New(mempubsub.DefaultConfig())
 		require.NotNil(t, p)
 
 		errExpected := errors.New("injected unmarshal error")

--- a/pkg/pubsub/amqp/amqppubsub_test.go
+++ b/pkg/pubsub/amqp/amqppubsub_test.go
@@ -32,7 +32,7 @@ func TestAMQP(t *testing.T) {
 	const topic = "some-topic"
 
 	t.Run("Success", func(t *testing.T) {
-		p := New("", Config{URI: "amqp://guest:guest@localhost:5672/"})
+		p := New(Config{URI: "amqp://guest:guest@localhost:5672/"})
 		require.NotNil(t, p)
 
 		msgChan, err := p.Subscribe(context.Background(), topic)
@@ -57,7 +57,7 @@ func TestAMQP(t *testing.T) {
 
 	t.Run("Connection failure", func(t *testing.T) {
 		require.Panics(t, func() {
-			p := New("", Config{URI: "amqp://guest:guest@localhost:9999/", MaxConnectRetries: 3})
+			p := New(Config{URI: "amqp://guest:guest@localhost:9999/", MaxConnectRetries: 3})
 			require.NotNil(t, p)
 		})
 	})

--- a/test/bdd/features/did-sidetree.feature
+++ b/test/bdd/features/did-sidetree.feature
@@ -184,8 +184,8 @@ Feature:
 
     # Unauthorized
     When an HTTP GET is sent to "https://orb.domain1.com/sidetree/v1/identifiers/did:orb:QmSvg9rNRDGADLoTsNVt56vCuyYxuf1uernuAWoPcm5oiS:EiDahnXxu4l4iSUXgZKW6nUnSF7_y6QIaY4ePuWEE4bz0Q" and the returned status code is 401
-    When an HTTP GET is sent to "https://orb.domain1.com/cas/bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y" and the returned status code is 401
+    When an HTTP GET is sent to "https://orb.domain1.com/cas/bafkreiatkubvbkdidscmqynkyls3iqaweqvthi7e6mbky2amuw3inxsi3y" and the returned status code is 401
 
     # Domain3 is open for reads
     When an HTTP GET is sent to "https://orb.domain3.com/sidetree/v1/identifiers/did:orb:QmSvg9rNRDGADLoTsNVt56vCuyYxuf1uernuAWoPcm5oiS:EiDahnXxu4l4iSUXgZKW6nUnSF7_y6QIaY4ePuWEE4bz0Q" and the returned status code is 404
-    When an HTTP GET is sent to "https://orb.domain3.com/cas/bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y" and the returned status code is 404
+    When an HTTP GET is sent to "https://orb.domain3.com/cas/bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6nbky2amuw3inxsi3y" and the returned status code is 404


### PR DESCRIPTION
The same message queue instance is now used for ActivityPub (inbox/outbox) and Observer.

closes #473

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>