### PR TITLE
feat: Subscriber pool for AMQP broker

### DIFF
--- a/pkg/activitypub/service/inbox/inbox.go
+++ b/pkg/activitypub/service/inbox/inbox.go
@@ -56,7 +56,6 @@ type Inbox struct {
 
 	router          *message.Router
 	httpSubscriber  *httpsubscriber.Subscriber
-	pubSub          pubSub
 	msgChannel      <-chan *message.Message
 	activityHandler service.ActivityHandler
 	activityStore   store.Store
@@ -70,7 +69,6 @@ func New(cfg *Config, s store.Store, pubSub pubSub, activityHandler service.Acti
 		Config:          cfg,
 		activityHandler: activityHandler,
 		activityStore:   s,
-		pubSub:          pubSub,
 		jsonUnmarshal:   json.Unmarshal,
 	}
 

--- a/pkg/pubsub/amqp/pooledsubscriber.go
+++ b/pkg/pubsub/amqp/pooledsubscriber.go
@@ -1,0 +1,91 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package amqp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+)
+
+// pooledSubscriber manages a pool of subscriptions. Each subscription listens on a topic and forwards
+// the message to a Go channel that is consumed by the subscriber.
+type pooledSubscriber struct {
+	topic       string
+	subscribers []*poolSubscriber
+	msgChan     chan *message.Message
+}
+
+func newPooledSubscriber(ctx context.Context, size uint, subscriber subscriber,
+	topic string) (*pooledSubscriber, error) {
+	p := &pooledSubscriber{
+		topic:   topic,
+		msgChan: make(chan *message.Message, size),
+	}
+
+	for i := uint(0); i < size; i++ {
+		ps, err := newPoolSubscriber(ctx, i, topic, subscriber, p.msgChan)
+		if err != nil {
+			return nil, fmt.Errorf("create pool subscriber: %w", err)
+		}
+
+		p.subscribers = append(p.subscribers, ps)
+	}
+
+	return p, nil
+}
+
+func (s *pooledSubscriber) start() {
+	logger.Infof("[%s] Starting pooled subscriber with %d listeners", s.topic, len(s.subscribers))
+
+	for _, subscriber := range s.subscribers {
+		go subscriber.listen()
+	}
+}
+
+func (s *pooledSubscriber) stop() {
+	logger.Infof("[%s] Closing pooled subscriber", s.topic)
+
+	close(s.msgChan)
+}
+
+type poolSubscriber struct {
+	n           uint
+	topic       string
+	msgChan     <-chan *message.Message
+	poolMsgChan chan<- *message.Message
+}
+
+func newPoolSubscriber(ctx context.Context, n uint, topic string, s subscriber,
+	poolMsgChan chan<- *message.Message) (*poolSubscriber, error) {
+	logger.Debugf("[%s-%d] Subscribing...", topic, n)
+
+	msgChan, err := s.Subscribe(ctx, topic)
+	if err != nil {
+		return nil, fmt.Errorf("subscribe to topic [%s]: %w", topic, err)
+	}
+
+	return &poolSubscriber{
+		n:           n,
+		topic:       topic,
+		msgChan:     msgChan,
+		poolMsgChan: poolMsgChan,
+	}, nil
+}
+
+func (s *poolSubscriber) listen() {
+	logger.Debugf("[%s-%d] Pool subscriber started", s.topic, s.n)
+
+	for msg := range s.msgChan {
+		logger.Debugf("[%s-%d] Pool subscriber got message [%s]", s.topic, s.n, msg.UUID)
+
+		s.poolMsgChan <- msg
+	}
+
+	logger.Debugf("[%s-%d] Pool subscriber stopped", s.topic, s.n)
+}

--- a/pkg/pubsub/amqp/pooledsubscriber_test.go
+++ b/pkg/pubsub/amqp/pooledsubscriber_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package amqp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/pkg/mocks"
+)
+
+func TestPooledSubscriber(t *testing.T) {
+	t.Run("Subscriber -> error", func(t *testing.T) {
+		const (
+			n     = 100
+			topic = "pooled"
+		)
+
+		p := New(Config{
+			URI: "amqp://guest:guest@localhost:5672/",
+		})
+		require.NotNil(t, p)
+		defer func() {
+			require.NoError(t, p.Close())
+		}()
+
+		s := &mocks.PubSub{}
+
+		errExpected := errors.New("injected subscriber error")
+
+		s.SubscribeReturns(nil, errExpected)
+
+		_, err := newPooledSubscriber(context.Background(), 10, s, topic)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+	})
+}

--- a/pkg/pubsub/mempubsub/mempubsub.go
+++ b/pkg/pubsub/mempubsub/mempubsub.go
@@ -124,7 +124,13 @@ func (p *PubSub) stop() {
 
 // Subscribe subscribes to a topic and returns the Go channel over which messages
 // are sent. The returned channel will be closed when Close() is called on this struct.
-func (p *PubSub) Subscribe(_ context.Context, topic string) (<-chan *message.Message, error) {
+func (p *PubSub) Subscribe(ctx context.Context, topic string) (<-chan *message.Message, error) {
+	return p.SubscribeWithOpts(ctx, topic)
+}
+
+// SubscribeWithOpts subscribes to a topic and returns the Go channel over which messages
+// are sent. The returned channel will be closed when Close() is called on this struct.
+func (p *PubSub) SubscribeWithOpts(_ context.Context, topic string, _ ...spi.Option) (<-chan *message.Message, error) {
 	if p.State() != lifecycle.StateStarted {
 		return nil, lifecycle.ErrNotStarted
 	}

--- a/pkg/pubsub/spi/spi.go
+++ b/pkg/pubsub/spi/spi.go
@@ -6,19 +6,20 @@ SPDX-License-Identifier: Apache-2.0
 
 package spi
 
-import (
-	"github.com/trustbloc/orb/pkg/lifecycle"
-)
-
 // UndeliverableTopic is the topic to which to post undeliverable messages.
 const UndeliverableTopic = "undeliverable_activities"
 
-// ServiceLifecycle defines the functions of a service lifecycle.
-type ServiceLifecycle interface {
-	// Start starts the service.
-	Start()
-	// Stop stops the service.
-	Stop()
-	// State returns the state of the service.
-	State() lifecycle.State
+// Options contains publisher/subscriber options.
+type Options struct {
+	PoolSize uint
+}
+
+// Option specifies a publisher/subscriber option.
+type Option func(option *Options)
+
+// WithPool sets the pool size.
+func WithPool(size uint) Option {
+	return func(option *Options) {
+		option.PoolSize = size
+	}
 }


### PR DESCRIPTION
An AMQP subscriber is handled synchronously and therefore each message in the queue needs to be acknowledged before the next message may be processed. Multiple subscribers are able to handle messages concurrently. The AMQP publisher/subscriber now provides an option for a subscriber pool of a given size allowing messages to be processed concurrently.

closes # 488

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>