### PR TITLE
feat: Durable message queue for Witnessed Anchor Credentials

### DIFF
--- a/pkg/anchor/graph/graph.go
+++ b/pkg/anchor/graph/graph.go
@@ -15,6 +15,7 @@ import (
 	"github.com/trustbloc/edge-core/pkg/log"
 
 	"github.com/trustbloc/orb/pkg/anchor/util"
+	"github.com/trustbloc/orb/pkg/errors"
 )
 
 var logger = log.New("anchor-graph")
@@ -58,7 +59,7 @@ func (g *Graph) Add(vc *verifiable.Credential) (string, string, error) { //nolin
 
 	cid, hint, err := g.CasWriter.Write(anchorBytes)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to add anchor to graph: %w", err)
+		return "", "", errors.NewTransient(fmt.Errorf("failed to add anchor to graph: %w", err))
 	}
 
 	logger.Debugf("added anchor[%s]: %s", cid, string(anchorBytes))

--- a/pkg/anchor/vcpubsub/publisher.go
+++ b/pkg/anchor/vcpubsub/publisher.go
@@ -1,0 +1,62 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vcpubsub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/ThreeDotsLabs/watermill"
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+	"github.com/trustbloc/edge-core/pkg/log"
+
+	"github.com/trustbloc/orb/pkg/errors"
+)
+
+var logger = log.New("anchor")
+
+const vcTopic = "verifiable-credential"
+
+type pubSub interface {
+	Publish(topic string, messages ...*message.Message) error
+	Subscribe(ctx context.Context, topic string) (<-chan *message.Message, error)
+}
+
+// Publisher implements a publisher that publishes witnessed verifiable credentials to a message queue.
+type Publisher struct {
+	pubSub      pubSub
+	jsonMarshal func(v interface{}) ([]byte, error)
+}
+
+// NewPublisher returns a new verifiable credential publisher.
+func NewPublisher(pubSub pubSub) *Publisher {
+	return &Publisher{
+		pubSub:      pubSub,
+		jsonMarshal: json.Marshal,
+	}
+}
+
+// Publish publishes a verifiable credential to a message queue for processing.
+func (h *Publisher) Publish(vc *verifiable.Credential) error {
+	payload, err := h.jsonMarshal(vc)
+	if err != nil {
+		return fmt.Errorf("publish verifiable credential: %w", err)
+	}
+
+	msg := message.NewMessage(watermill.NewUUID(), payload)
+
+	logger.Debugf("Publishing verifiable credential to topic [%s]: %s", vcTopic, vc)
+
+	err = h.pubSub.Publish(vcTopic, msg)
+	if err != nil {
+		return errors.NewTransient(err)
+	}
+
+	return nil
+}

--- a/pkg/anchor/vcpubsub/subscriber.go
+++ b/pkg/anchor/vcpubsub/subscriber.go
@@ -1,0 +1,117 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vcpubsub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+	"github.com/piprate/json-gold/ld"
+
+	"github.com/trustbloc/orb/pkg/errors"
+	"github.com/trustbloc/orb/pkg/lifecycle"
+)
+
+type (
+	vcProcessor func(vc *verifiable.Credential) error
+)
+
+type documentLoader interface {
+	LoadDocument(u string) (*ld.RemoteDocument, error)
+}
+
+// Subscriber implements a subscriber that processes witnessed verifiable credentials from a message queue.
+type Subscriber struct {
+	*lifecycle.Lifecycle
+
+	vcChan                      <-chan *message.Message
+	processVerifiableCredential vcProcessor
+	documentLoader              documentLoader
+	jsonUnmarshal               func(data []byte, v interface{}) error
+}
+
+// NewSubscriber returns a new verifiable credential subscriber.
+func NewSubscriber(pubSub pubSub, vcProcessor vcProcessor, documentLoader documentLoader) (*Subscriber, error) {
+	h := &Subscriber{
+		processVerifiableCredential: vcProcessor,
+		documentLoader:              documentLoader,
+		jsonUnmarshal:               json.Unmarshal,
+	}
+
+	h.Lifecycle = lifecycle.New("vcsubscriber",
+		lifecycle.WithStart(h.start),
+	)
+
+	logger.Infof("Subscribing to topic [%s]", vcTopic)
+
+	vcChan, err := pubSub.Subscribe(context.Background(), vcTopic)
+	if err != nil {
+		return nil, fmt.Errorf("subscribe to topic [%s]: %w", vcTopic, err)
+	}
+
+	h.vcChan = vcChan
+
+	return h, nil
+}
+
+func (h *Subscriber) start() {
+	// Start the message listener
+	go h.listen()
+}
+
+func (h *Subscriber) listen() {
+	logger.Debugf("Starting message listener")
+
+	for msg := range h.vcChan {
+		logger.Debugf("Got new verifiable credential message: %s: %s", msg.UUID, msg.Payload)
+
+		h.handleVerifiableCredentialMessage(msg)
+	}
+
+	logger.Infof("Listener stopped.")
+}
+
+func (h *Subscriber) handleVerifiableCredentialMessage(msg *message.Message) {
+	logger.Debugf("Handling message [%s]: %s", msg.UUID, msg.Payload)
+
+	vc, err := verifiable.ParseCredential(msg.Payload,
+		verifiable.WithDisabledProofCheck(),
+		verifiable.WithJSONLDDocumentLoader(h.documentLoader),
+	)
+	if err != nil {
+		logger.Errorf("Error parsing verifiable credential [%s]: %s", msg.UUID, err)
+
+		// Ack the message to indicate that it should not be redelivered since this is a persistent error.
+		msg.Ack()
+
+		return
+	}
+
+	err = h.processVerifiableCredential(vc)
+
+	switch {
+	case err == nil:
+		logger.Debugf("Acking verifiable credential message. MsgID [%s], VC ID [%s]", msg.UUID, vc.ID)
+
+		msg.Ack()
+	case errors.IsTransient(err):
+		// The message should be redelivered to (potentially) another server instance.
+		logger.Warnf("Nacking verifiable credential message since it could not be delivered due"+
+			"to a transient error. MsgID [%s], VC ID [%s]: %s", msg.UUID, vc.ID, err)
+
+		msg.Nack()
+	default:
+		// A persistent message should not be retried.
+		logger.Warnf("Acking verifiable credential message since it could not be delivered due"+
+			"to a persistent error. MsgID [%s], VC ID [%s]: %s", msg.UUID, vc.ID, err)
+
+		msg.Ack()
+	}
+}

--- a/pkg/anchor/vcpubsub/vcpubsub_test.go
+++ b/pkg/anchor/vcpubsub/vcpubsub_test.go
@@ -1,0 +1,254 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vcpubsub
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+	"github.com/stretchr/testify/require"
+
+	orberrors "github.com/trustbloc/orb/pkg/errors"
+	"github.com/trustbloc/orb/pkg/internal/testutil"
+	"github.com/trustbloc/orb/pkg/mocks"
+	"github.com/trustbloc/orb/pkg/pubsub/mempubsub"
+)
+
+func TestNewSubscriber(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		s, err := NewSubscriber(&mocks.PubSub{}, nil, testutil.GetLoader(t))
+		require.NoError(t, err)
+		require.NotNil(t, s)
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		errExpected := errors.New("injected subscribe error")
+
+		ps := &mocks.PubSub{}
+		ps.SubscribeReturns(nil, errExpected)
+
+		s, err := NewSubscriber(ps, nil, testutil.GetLoader(t))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+		require.Nil(t, s)
+	})
+}
+
+func TestPubSub(t *testing.T) {
+	ps := mempubsub.New(mempubsub.Config{})
+	defer ps.Stop()
+
+	p := NewPublisher(ps)
+	require.NotNil(t, p)
+
+	var mutex sync.RWMutex
+
+	var gotVCs []*verifiable.Credential
+
+	s, err := NewSubscriber(ps,
+		func(vc *verifiable.Credential) error {
+			mutex.Lock()
+			gotVCs = append(gotVCs, vc)
+			mutex.Unlock()
+
+			return nil
+		},
+		testutil.GetLoader(t),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, s)
+
+	s.Start()
+
+	vc, err := verifiable.ParseCredential([]byte(anchorCred),
+		verifiable.WithDisabledProofCheck(),
+		verifiable.WithJSONLDDocumentLoader(testutil.GetLoader(t)),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, p.Publish(vc))
+
+	time.Sleep(100 * time.Millisecond)
+
+	mutex.RLock()
+	require.Len(t, gotVCs, 1)
+	require.Equal(t, vc.ID, gotVCs[0].ID)
+	mutex.RUnlock()
+}
+
+func TestPublisherError(t *testing.T) {
+	vc, err := verifiable.ParseCredential([]byte(anchorCred),
+		verifiable.WithDisabledProofCheck(),
+		verifiable.WithJSONLDDocumentLoader(testutil.GetLoader(t)),
+	)
+	require.NoError(t, err)
+
+	t.Run("Marshal error", func(t *testing.T) {
+		p := NewPublisher(&mocks.PubSub{})
+		require.NotNil(t, p)
+
+		errExpected := errors.New("injected marshal error")
+
+		p.jsonMarshal = func(v interface{}) ([]byte, error) {
+			return nil, errExpected
+		}
+
+		err = p.Publish(vc)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+	})
+
+	t.Run("Publish error", func(t *testing.T) {
+		errExpected := errors.New("injected publish error")
+
+		ps := &mocks.PubSub{}
+		ps.PublishReturns(errExpected)
+
+		p := NewPublisher(ps)
+		require.NotNil(t, p)
+
+		err = p.Publish(vc)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+		require.True(t, orberrors.IsTransient(err))
+	})
+}
+
+func TestSubscriberError(t *testing.T) {
+	ps := mempubsub.New(mempubsub.Config{})
+	defer ps.Stop()
+
+	p := NewPublisher(ps)
+	require.NotNil(t, p)
+
+	t.Run("Invalid verifiable credential", func(t *testing.T) {
+		var mutex sync.RWMutex
+
+		var gotVCs []*verifiable.Credential
+
+		s, err := NewSubscriber(ps,
+			func(vc *verifiable.Credential) error {
+				mutex.Lock()
+				gotVCs = append(gotVCs, vc)
+				mutex.Unlock()
+
+				return nil
+			},
+			testutil.GetLoader(t),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, s)
+
+		s.Start()
+
+		require.NoError(t, p.Publish(&verifiable.Credential{}))
+
+		time.Sleep(100 * time.Millisecond)
+
+		mutex.RLock()
+		require.Empty(t, gotVCs)
+		mutex.RUnlock()
+	})
+
+	t.Run("Process error", func(t *testing.T) {
+		vc, err := verifiable.ParseCredential([]byte(anchorCred),
+			verifiable.WithDisabledProofCheck(),
+			verifiable.WithJSONLDDocumentLoader(testutil.GetLoader(t)),
+		)
+		require.NoError(t, err)
+
+		t.Run("Transient error", func(t *testing.T) {
+			var mutex sync.RWMutex
+
+			var gotVCs []*verifiable.Credential
+
+			s, err := NewSubscriber(ps,
+				func(vc *verifiable.Credential) error {
+					mutex.Lock()
+					gotVCs = append(gotVCs, vc)
+					mutex.Unlock()
+
+					return orberrors.NewTransient(errors.New("injected transient error"))
+				},
+				testutil.GetLoader(t),
+			)
+			require.NoError(t, err)
+			require.NotNil(t, s)
+
+			s.Start()
+
+			require.NoError(t, p.Publish(vc))
+
+			time.Sleep(100 * time.Millisecond)
+
+			mutex.RLock()
+			require.Len(t, gotVCs, 1)
+			mutex.RUnlock()
+		})
+
+		t.Run("Persistent error", func(t *testing.T) {
+			var mutex sync.RWMutex
+
+			var gotVCs []*verifiable.Credential
+
+			s, err := NewSubscriber(ps,
+				func(vc *verifiable.Credential) error {
+					mutex.Lock()
+					gotVCs = append(gotVCs, vc)
+					mutex.Unlock()
+
+					return errors.New("injected persistent error")
+				},
+				testutil.GetLoader(t),
+			)
+			require.NoError(t, err)
+			require.NotNil(t, s)
+
+			s.Start()
+
+			require.NoError(t, p.Publish(vc))
+
+			time.Sleep(100 * time.Millisecond)
+
+			mutex.RLock()
+			require.Len(t, gotVCs, 1)
+			mutex.RUnlock()
+		})
+	})
+}
+
+//nolint: lll
+var anchorCred = `
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1"
+  ],
+  "credentialSubject": {
+    "coreIndex": "QmZzPwGc3JEMQDiJu21YZcdpEPam7qCoXPLEUQXn34sMhB",
+    "namespace": "did:sidetree",
+    "operationCount": 1,
+    "previousAnchors": {
+      "EiBjG9z921eyj8wI4j-LAqsJBRC_GalIUWPJeXGekxFQ-w": ""
+    },
+    "version": 0
+  },
+  "id": "http://peer1.com/vc/62c153d1-a6be-400e-a6a6-5b700b596d9d",
+  "issuanceDate": "2021-03-17T20:01:10.4002903Z",
+  "issuer": "http://peer1.com",
+  "proof": {
+    "created": "2021-03-17T20:01:10.4024292Z",
+    "domain": "domain.com",
+    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..pHA1rMSsHBJLbDwRpNY0FrgSgoLzBw4S7VP7d5bkYW-JwU8qc_4CmPfQctR8kycQHSa2Jh8LNBqNKMeVWsAwDA",
+    "proofPurpose": "assertionMethod",
+    "type": "Ed25519Signature2018",
+    "verificationMethod": "did:web:abc#CvSyX0VxMCbg-UiYpAVd9OmhaFBXBr5ISpv2RZ2c9DY"
+  },
+  "type": "VerifiableCredential"
+}`

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -140,20 +140,16 @@ Feature:
 
      # write batch of DIDs to multiple servers and check them
      When client sends request to "https://orb2.domain1.com/sidetree/v1/operations,https://orb.domain2.com/sidetree/v1/operations" to create 50 DID documents using 10 concurrent requests
-     And we wait 5 seconds
+     And we wait 2 seconds
 
-     # Enable the following code after #477 has been implemented since, currently the witnessed anchor credential queue
-     # has no retry mechanism and messages may be lost.
-#     And we wait 2 seconds
-#     # Stop orb2.domain1. The other instance in the domain should process any pending operations since
-#     # we're using a durable operation queue.
-#     Then container "orb2-domain1" is stopped
-#     And we wait 10 seconds
+     # Stop orb2.domain1. The other instance in the domain should process any pending operations since
+     # we're using a durable operation queue.
+     Then container "orb2-domain1" is stopped
+     And we wait 10 seconds
 
      Then client sends request to "https://orb.domain1.com/sidetree/v1/identifiers,https://orb.domain2.com/sidetree/v1/identifiers" to verify the DID documents that were created
 
      Then container "orb-domain1" is stopped
-     Then container "orb2-domain1" is stopped
      Then container "orb-domain2" is stopped
      Then container "ipfs" is stopped
 

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -173,6 +173,9 @@ services:
       - BATCH_WRITER_TIMEOUT=1000
       - CAS_TYPE=${CAS_TYPE}
       - IPFS_URL=ipfs:5001
+      - MQ_URL=amqp://guest:guest@orb.mq.domain2.com:5672/
+      # MQ_OP_POOL specifies the number of subscribers that concurrently process messages in the operation queue.
+      - MQ_OP_POOL=20
       - CID_VERSION=${CID_VERSION_DOMAIN2}
       - ANCHOR_CREDENTIAL_ISSUER=http://orb.domain2.com
       - ANCHOR_CREDENTIAL_URL=http://orb.domain2.com/vc
@@ -215,6 +218,7 @@ services:
       - orb.kms
       - couchdb.kms.com
       - couchdb.shared.com
+      - orb.mq.domain2.com
     networks:
       - orb_net
 
@@ -240,6 +244,9 @@ services:
       - BATCH_WRITER_TIMEOUT=1000
       - CAS_TYPE=${CAS_TYPE}
       - IPFS_URL=ipfs:5001
+      - MQ_URL=amqp://guest:guest@orb.mq.domain3.com:5672/
+      # MQ_OP_POOL specifies the number of subscribers that concurrently process messages in the operation queue.
+      - MQ_OP_POOL=20
       - CID_VERSION=${CID_VERSION_DOMAIN3}
       - ANCHOR_CREDENTIAL_ISSUER=http://orb.domain3.com
       - ANCHOR_CREDENTIAL_URL=http://orb.domain3.com/vc
@@ -282,6 +289,7 @@ services:
       - orb.kms
       - couchdb.kms.com
       - couchdb.shared.com
+      - orb.mq.domain3.com
     networks:
       - orb_net
 
@@ -470,6 +478,24 @@ services:
     image: rabbitmq:3.8.16
     ports:
       - 5672:5672
+    restart: unless-stopped
+    networks:
+      - orb_net
+
+  orb.mq.domain2.com:
+    container_name: orb.mq.domain2.com
+    image: rabbitmq:3.8.16
+    ports:
+      - 5682:5672
+    restart: unless-stopped
+    networks:
+      - orb_net
+
+  orb.mq.domain3.com:
+    container_name: orb.mq.domain3.com
+    image: rabbitmq:3.8.16
+    ports:
+      - 5692:5672
     restart: unless-stopped
     networks:
       - orb_net


### PR DESCRIPTION
Changed the witnessed anchored credential processor to use a publisher/subscriber instead of a Go channel. This allows for a durable message queue to be used.

Also changed the BDD test to use RabbitMQ for all domains.

closes #477

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>