### PR TITLE
fix: Add new domain for did discovery test

### DIFF
--- a/pkg/anchor/handler/proof/handler.go
+++ b/pkg/anchor/handler/proof/handler.go
@@ -156,7 +156,7 @@ func (h *WitnessProofHandler) handleWitnessPolicy(vc *verifiable.Credential) err
 
 	vc, err = addProofs(vc, witnessProofs)
 	if err != nil {
-		return fmt.Errorf("failed to add witness proofs to credential[%s]: %w", vc.ID, err)
+		return fmt.Errorf("failed to add witness proofs: %w", err)
 	}
 
 	status, err := h.VCStatusStore.GetStatus(vc.ID)

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -199,8 +199,6 @@ func (o *Observer) processAnchor(anchor *anchorinfo.AnchorInfo, info *verifiable
 	equivalentRef := anchor.CID
 	if anchor.Hint != "" {
 		equivalentRef = anchor.Hint + ":" + equivalentRef
-	} else {
-		logger.Errorf("investigate: no hint provided for anchor[%s]", anchor.CID)
 	}
 
 	sidetreeTxn := txnapi.SidetreeTxn{

--- a/test/bdd/bddtests_test.go
+++ b/test/bdd/bddtests_test.go
@@ -61,7 +61,7 @@ func TestMain(m *testing.M) {
 					panic(fmt.Sprintf("Error composing system in BDD context: %s", err))
 				}
 
-				testSleep := 60
+				testSleep := 80
 				if os.Getenv("TEST_SLEEP") != "" {
 					testSleep, _ = strconv.Atoi(os.Getenv("TEST_SLEEP"))
 				}

--- a/test/bdd/did_orb_steps.go
+++ b/test/bdd/did_orb_steps.go
@@ -60,6 +60,7 @@ var localURLs = map[string]string{
 	"https://orb2.domain1.com": "https://localhost:48526",
 	"https://orb.domain2.com":  "https://localhost:48426",
 	"https://orb.domain3.com":  "https://localhost:48626",
+	"https://orb.domain4.com":  "https://localhost:48726",
 }
 
 var anchorOriginURLs = map[string]string{
@@ -67,6 +68,7 @@ var anchorOriginURLs = map[string]string{
 	"https://localhost:48526/sidetree/v1/operations": "https://orb.domain1.com/services/orb",
 	"https://localhost:48426/sidetree/v1/operations": "https://orb.domain1.com/services/orb",
 	"https://localhost:48626/sidetree/v1/operations": "https://orb.domain1.com/services/orb",
+	"https://localhost:48726/sidetree/v1/operations": "https://orb.domain4.com/services/orb",
 }
 
 const addPublicKeysTemplate = `[

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -11,10 +11,12 @@ Feature:
     Given variable "domain1IRI" is assigned the value "https://orb.domain1.com/services/orb"
     And variable "domain2IRI" is assigned the value "https://orb.domain2.com/services/orb"
     And variable "domain3IRI" is assigned the value "https://orb.domain3.com/services/orb"
+    And variable "domain4IRI" is assigned the value "https://orb.domain4.com/services/orb"
 
     Given domain "orb.domain1.com" is mapped to "localhost:48326"
     And domain "orb.domain2.com" is mapped to "localhost:48426"
     And domain "orb.domain3.com" is mapped to "localhost:48626"
+    And domain "orb.domain4.com" is mapped to "localhost:48726"
 
     Given the authorization bearer token for "POST" requests to path "/services/orb/outbox" is set to "ADMIN_TOKEN"
     And the authorization bearer token for "GET" requests to path "/services/orb" is set to "READ_TOKEN"
@@ -47,19 +49,19 @@ Feature:
     And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain2IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
     When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
+    # domain1 invites domain4 to be a witness
+    Given variable "inviteWitnessID" is assigned a unique ID
+    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain1IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain1IRI}","to":"${domain4IRI}","object":"${domain4IRI}"}'
+    When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+
     # set witness policy for domain1
-    When an HTTP POST is sent to "https://orb.domain1.com/policy" with content "MinPercent(50,batch) AND MinPercent(50,system)" of type "text/plain"
+    When an HTTP POST is sent to "https://orb.domain1.com/policy" with content "MinPercent(100,batch) AND MinPercent(50,system)" of type "text/plain"
 
     Then we wait 3 seconds
 
     @discover_did
     Scenario: discover did
       When client discover orb endpoints
-
-      # Stop domain3 so that it will miss an anchor credential from domain1. This tests WebCAS resolution
-      # when domain3 is asked for the unknown DID.
-      Then container "orb-domain3" is stopped
-      Then we wait 3 seconds
 
       # orb-domain1 keeps accepting requests
       When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to create DID document
@@ -80,22 +82,16 @@ Feature:
       Then check success response contains "recoveryKey"
       Then check success response contains "#canonicalDID"
 
-      # Wait long enough so that domain1 gives up attempting to deliver the anchor credential to domain3
-      Then we wait 2 seconds
-
-      Then container "orb-domain3" is started
-      Then we wait 10 seconds
-
-      # resolve did in domain3 - it will trigger did discovery in different organisations
-      When client sends request to "https://orb.domain3.com/sidetree/v1/identifiers" to resolve DID document with equivalent did
+      # resolve did in domain4 - it will trigger did discovery in different organisations
+      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with equivalent did
       Then check error response contains "not found"
 
       Then we wait 2 seconds
-      When client sends request to "https://orb.domain3.com/sidetree/v1/identifiers" to resolve DID document with equivalent did
+      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with equivalent did
       Then check success response contains "#canonicalDID"
       Then check success response contains "recoveryKey"
 
-      When client sends request to "https://orb.domain3.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did
       Then check success response contains "#canonicalDID"
       Then check success response contains "recoveryKey"
 

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -293,6 +293,77 @@ services:
     networks:
       - orb_net
 
+
+  orb-domain4:
+    container_name: orb.domain4.com
+    image: ${ORB_FIXTURE_IMAGE}:latest
+    restart: always
+    environment:
+      - ORB_KMS_ENDPOINT=http://orb.kms:7878
+      - LOG_LEVEL=DEBUG
+      - ORB_HOST_URL=0.0.0.0:443
+      # ORB_EXTERNAL_ENDPOINT is the endpoint that external clients use to invoke services. This endpoint is used
+      # to generate IDs of anchor credentials and ActivityPub objects and should be resolvable by external
+      # clients. This endpoint does not (typically) target a single node in the cluster but instead, a load
+      # balancer servicing multiple nodes.
+      - ORB_EXTERNAL_ENDPOINT=https://orb.domain4.com
+      - ORB_TLS_CERTIFICATE=/etc/orb/tls/ec-pubCert.pem
+      - ORB_TLS_KEY=/etc/orb/tls/ec-key.pem
+      - DID_NAMESPACE=did:orb
+      - ALLOWED_ORIGINS=https://orb.domain4.com/services/orb,https://orb.domain1.com/services/orb
+      # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
+      - BATCH_WRITER_TIMEOUT=1000
+      - CAS_TYPE=${CAS_TYPE}
+      - IPFS_URL=ipfs:5001
+      - MQ_URL=amqp://${RABBITMQ_USERNAME}:${RABBITMQ_PASSWORD}@orb.mq.domain4.com:5672/
+      # MQ_OP_POOL specifies the number of subscribers that concurrently process messages in the operation queue.
+      - MQ_OP_POOL=20
+      - CID_VERSION=${CID_VERSION_DOMAIN2}
+      - ANCHOR_CREDENTIAL_ISSUER=http://orb.domain4.com
+      - ANCHOR_CREDENTIAL_URL=http://orb.domain4.com/vc
+      - ANCHOR_CREDENTIAL_SIGNATURE_SUITE=Ed25519Signature2018
+      # used in case that orb server signs anchor credential (there is no local witness log)
+      - ANCHOR_CREDENTIAL_DOMAIN=https://orb.domain4.com
+      - DATABASE_TYPE=couchdb
+      - DATABASE_URL=${COUCHDB_USERNAME}:${COUCHDB_PASSWORD}@couchdb.shared.com:5984
+      - DATABASE_PREFIX=domain4
+      - HTTP_SIGNATURES_ENABLED=true
+
+      # ORB_AUTH_TOKENS_DEF contains the authorization definition for each of the REST endpoints. Format:
+      #
+      # <path-expr>|<read-token1>&<read-token2>&...>|<write-token1>&<write-token2>&...>,<path-expr> ...
+      #
+      # Where:
+      # - path-expr contains a regular expression for a path. Path expressions are processed in the order they are specified.
+      # - read-token defines a token for a read (GET) operation. If not specified then authorization is not performed.
+      # - write-token defines a token for a write (POST) operation. If not specified then authorization is not performed.
+      #
+      # If no definition is included for an endpoint then authorization is NOT performed for that endpoint.
+      #
+      # Example:
+      #
+      # ORB_AUTH_TOKENS_DEF=/services/orb/outbox|admin&read|admin,/services/orb/.*|read&admin
+      # - The client requires a 'read' or 'admin' token in order to view the outbox's contents
+      # - The client requires an 'admin' token in order to post to the outbox
+      # - The client requires a 'read' or 'admin' token in order to perform a GET on any endpoint starting with /services/orb/
+      - ORB_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/.*|read&admin,/transactions|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin
+      # ORB_AUTH_TOKENS specifies the actual values of the tokens defined in ORB_AUTH_TOKENS_DEF.
+      - ORB_AUTH_TOKENS=admin=ADMIN_TOKEN,read=READ_TOKEN
+    ports:
+      - 48726:443
+    command: start
+    volumes:
+      - ./keys/tls:/etc/orb/tls
+      - ./testdata/keys/domain2:/etc/orb/activitypub
+    depends_on:
+      - ipfs
+      - orb.kms
+      - couchdb.kms.com
+      - couchdb.shared.com
+      - orb.mq.domain4.com
+    networks:
+      - orb_net
+
   ipfs:
     container_name: ipfs
     #TODO: this image doesn't work on ARM64 yet (investigate images)
@@ -514,6 +585,21 @@ services:
       - 5692:5672
       # Management port
       - 15692:15672
+    restart: unless-stopped
+    networks:
+      - orb_net
+
+  orb.mq.domain4.com:
+    container_name: orb.mq.domain4.com
+    image: rabbitmq:3-management-alpine
+    environment:
+      - CONFIG_FILE=/etc/rabbitmq/ext-config/rabbitmq.conf
+    volumes:
+      - ./rabbitmq-config/rabbitmq.conf:/etc/rabbitmq/ext-config/rabbitmq.conf
+    ports:
+      - 5694:5672
+      # Management port
+      - 15694:15672
     restart: unless-stopped
     networks:
       - orb_net


### PR DESCRIPTION
Create new domain that will not follow domain1 (domain3 currently follows indirectly domain1 via domain2) and run did discovery test there.

Closes #505

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>