### PR TITLE
feat: Resolve witness via HTTP/HTTPS in addition to IPNS

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -99,6 +99,7 @@ import (
 	"github.com/trustbloc/orb/pkg/pubsub/mempubsub"
 	"github.com/trustbloc/orb/pkg/pubsub/spi"
 	"github.com/trustbloc/orb/pkg/resolver/document"
+	"github.com/trustbloc/orb/pkg/resolver/resource"
 	casstore "github.com/trustbloc/orb/pkg/store/cas"
 	didanchorstore "github.com/trustbloc/orb/pkg/store/didanchor"
 	"github.com/trustbloc/orb/pkg/store/operation"
@@ -592,7 +593,7 @@ func startOrbServices(parameters *orbParameters) error {
 		parameters.maxWitnessDelay,
 		parameters.signWithLocalWitness,
 		orbDocumentLoader,
-		ipfsReader)
+		resource.New(httpClient, ipfsReader))
 	if err != nil {
 		return fmt.Errorf("failed to create writer: %s", err.Error())
 	}

--- a/pkg/anchor/writer/writer.go
+++ b/pkg/anchor/writer/writer.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/ThreeDotsLabs/watermill/message"
@@ -32,9 +31,9 @@ import (
 	"github.com/trustbloc/orb/pkg/anchor/subject"
 	"github.com/trustbloc/orb/pkg/anchor/util"
 	"github.com/trustbloc/orb/pkg/anchor/vcpubsub"
-	"github.com/trustbloc/orb/pkg/cas/ipfs"
 	discoveryrest "github.com/trustbloc/orb/pkg/discovery/endpoint/restapi"
 	"github.com/trustbloc/orb/pkg/errors"
+	resourceresolver "github.com/trustbloc/orb/pkg/resolver/resource"
 	"github.com/trustbloc/orb/pkg/vcsigner"
 )
 
@@ -49,7 +48,7 @@ type Writer struct {
 	casIRI               *url.URL
 	maxWitnessDelay      time.Duration
 	signWithLocalWitness bool
-	ipfsReader           *ipfs.Client
+	resourceResolver     *resourceresolver.Resolver
 }
 
 // Providers contains all of the providers required by the client.
@@ -131,7 +130,7 @@ type pubSub interface {
 func New(namespace string, apServiceIRI, casURL *url.URL, providers *Providers,
 	anchorPublisher anchorPublisher, pubSub pubSub,
 	maxWitnessDelay time.Duration, signWithLocalWitness bool,
-	documentLoader ld.DocumentLoader, ipfsReader *ipfs.Client) (*Writer, error) {
+	documentLoader ld.DocumentLoader, resourceResolver *resourceresolver.Resolver) (*Writer, error) {
 	w := &Writer{
 		Providers:            providers,
 		anchorPublisher:      anchorPublisher,
@@ -140,7 +139,7 @@ func New(namespace string, apServiceIRI, casURL *url.URL, providers *Providers,
 		casIRI:               casURL,
 		maxWitnessDelay:      maxWitnessDelay,
 		signWithLocalWitness: signWithLocalWitness,
-		ipfsReader:           ipfsReader,
+		resourceResolver:     resourceResolver,
 	}
 
 	s, err := vcpubsub.NewSubscriber(pubSub, w.handle, documentLoader)
@@ -545,59 +544,24 @@ func (c *Writer) getWitnesses(refs []*operation.Reference) ([]string, error) {
 			return nil, fmt.Errorf("unexpected interface '%T' for anchor origin", anchorOriginObj)
 		}
 
-		if strings.HasPrefix(anchorOrigin, "ipns://") {
-			resolvedAnchorOrigin, err := c.resolveAnchorOriginViaIPNS(anchorOrigin)
-			if err != nil {
-				return nil, fmt.Errorf("failed to resolve anchor origin via IPNS: %w", err)
-			}
+		logger.Debugf("Resolving witness for the following anchor origin: %s", anchorOrigin)
 
-			anchorOrigin = resolvedAnchorOrigin
+		resolvedWitness, err := c.resourceResolver.Resolve(anchorOrigin, discoveryrest.WitnessType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve witness: %w", err)
 		}
 
-		_, ok = uniqueWitnesses[anchorOrigin]
+		logger.Debugf("Successfully resolved witness %s from %s", resolvedWitness, anchorOrigin)
+
+		_, ok = uniqueWitnesses[resolvedWitness]
 
 		if !ok {
-			witnesses = append(witnesses, anchorOrigin)
-			uniqueWitnesses[anchorOrigin] = true
+			witnesses = append(witnesses, resolvedWitness)
+			uniqueWitnesses[resolvedWitness] = true
 		}
 	}
 
 	return witnesses, nil
-}
-
-func (c *Writer) resolveAnchorOriginViaIPNS(anchorOrigin string) (string, error) {
-	anchorOriginSplitBySlashes := strings.Split(anchorOrigin, "//")
-
-	logger.Debugf("Resolving anchor origin from %s", anchorOrigin)
-
-	respBytes, err := c.ipfsReader.Read(fmt.Sprintf("/ipns/%s/.well-known/webfinger",
-		anchorOriginSplitBySlashes[len(anchorOriginSplitBySlashes)-1]))
-	if err != nil {
-		return "", fmt.Errorf("failed to resolve WebFinger response via IPNS: %w", err)
-	}
-
-	var webFingerResp discoveryrest.WebFingerResponse
-
-	err = json.Unmarshal(respBytes, &webFingerResp)
-	if err != nil {
-		return "", fmt.Errorf("failed to unmarshal WebFinger response: %w", err)
-	}
-
-	witnessProperty, exists := webFingerResp.Properties[discoveryrest.WitnessType]
-	if !exists {
-		return "", fmt.Errorf("witness property missing from the WebFinger response "+
-			"obtained by resolving %s", anchorOrigin)
-	}
-
-	witnessPropertyString, ok := witnessProperty.(string)
-	if !ok {
-		return "", fmt.Errorf("failed to assert witness property from the WebFinger response "+
-			"obtained by resolving %s as a string", anchorOrigin)
-	}
-
-	logger.Debugf("Successfully resolved anchor origin %s from %s", witnessPropertyString, anchorOrigin)
-
-	return witnessPropertyString, nil
 }
 
 // Read reads transactions since transaction time.

--- a/pkg/resolver/resource/resolver.go
+++ b/pkg/resolver/resource/resolver.go
@@ -1,0 +1,172 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resource
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/trustbloc/edge-core/pkg/log"
+
+	"github.com/trustbloc/orb/pkg/cas/ipfs"
+	discoveryrest "github.com/trustbloc/orb/pkg/discovery/endpoint/restapi"
+)
+
+var logger = log.New("resource-resolver")
+
+// Resolver is used for resolving WebFinger resources.
+type Resolver struct {
+	httpClient *http.Client
+	ipfsReader *ipfs.Client
+}
+
+// New returns a new Resolver.
+func New(httpClient *http.Client, ipfsReader *ipfs.Client) *Resolver {
+	return &Resolver{httpClient: httpClient, ipfsReader: ipfsReader}
+}
+
+// Resolve resolves the WebFinger resource for the given property.
+func (c *Resolver) Resolve(urlToResolve, property string) (string, error) {
+	var err error
+
+	var baseURLWebFingerResponse discoveryrest.WebFingerResponse
+
+	if strings.HasPrefix(urlToResolve, "ipns://") {
+		baseURLWebFingerResponse, err = c.getBaseURLWebFingerResponseViaIPNS(urlToResolve)
+		if err != nil {
+			return "", fmt.Errorf("failed to get WebFinger response from IPNS URL: %w", err)
+		}
+	} else {
+		baseURLWebFingerResponse, err = c.getBaseURLWebFingerResponseViaHTTP(urlToResolve)
+		if err != nil {
+			return "", fmt.Errorf("failed to get WebFinger response from HTTP/HTTPS URL: %w", err)
+		}
+	}
+
+	resolvedResource, err := c.resolveResourceFromBaseURLWebFingerResponse(baseURLWebFingerResponse, property)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve resource from Base URL WebFinger response: %w", err)
+	}
+
+	return resolvedResource, nil
+}
+
+func (c *Resolver) getBaseURLWebFingerResponseViaIPNS(ipnsURL string) (discoveryrest.WebFingerResponse, error) {
+	ipnsURLSplitByDoubleSlashes := strings.Split(ipnsURL, "//")
+
+	webFingerResponseBytes, err := c.ipfsReader.Read(fmt.Sprintf("/ipns/%s/.well-known/webfinger",
+		ipnsURLSplitByDoubleSlashes[len(ipnsURLSplitByDoubleSlashes)-1]))
+	if err != nil {
+		return discoveryrest.WebFingerResponse{}, fmt.Errorf("failed to read from IPNS: %w", err)
+	}
+
+	var webFingerResponse discoveryrest.WebFingerResponse
+
+	err = json.Unmarshal(webFingerResponseBytes, &webFingerResponse)
+	if err != nil {
+		return discoveryrest.WebFingerResponse{}, fmt.Errorf("failed to unmarshal WebFinger response: %w", err)
+	}
+
+	return webFingerResponse, nil
+}
+
+func (c *Resolver) getBaseURLWebFingerResponseViaHTTP(httpURL string) (discoveryrest.WebFingerResponse, error) {
+	parsedURL, err := url.Parse(httpURL)
+	if err != nil {
+		return discoveryrest.WebFingerResponse{}, fmt.Errorf("failed to parse given URL: %w", err)
+	}
+
+	urlSchemeAndHost := fmt.Sprintf("%s://%s", parsedURL.Scheme, parsedURL.Host)
+
+	webFingerURL := fmt.Sprintf("%s/.well-known/webfinger?resource=%s",
+		urlSchemeAndHost, url.PathEscape(urlSchemeAndHost))
+
+	webFingerResponse, err := c.doWebFingerViaREST(webFingerURL)
+	if err != nil {
+		return discoveryrest.WebFingerResponse{}, fmt.Errorf("failed to do WebFinger via REST: %w", err)
+	}
+
+	return webFingerResponse, nil
+}
+
+func (c *Resolver) resolveResourceFromBaseURLWebFingerResponse(baseURLWebFingerResponse discoveryrest.WebFingerResponse,
+	property string) (string, error) {
+	retrievedPropertyRaw, exists := baseURLWebFingerResponse.Properties[property]
+	if !exists {
+		return "", fmt.Errorf("property missing")
+	}
+
+	retrievedProperty, ok := retrievedPropertyRaw.(string)
+	if !ok {
+		return "", fmt.Errorf("failed to assert property as a string")
+	}
+
+	resource, err := c.getResourceFromPropertyWebFinger(retrievedProperty)
+	if err != nil {
+		return "", fmt.Errorf("failed to get resource from property WebFinger: %w", err)
+	}
+
+	return resource, nil
+}
+
+func (c *Resolver) getResourceFromPropertyWebFinger(propertyWebFingerURL string) (string, error) {
+	propertyWebFingerURLParsed, err := url.Parse(propertyWebFingerURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse property WebFinger URL: %w", err)
+	}
+
+	resourceWebFingerURL := fmt.Sprintf("%s://%s/.well-known/webfinger?resource=%s", propertyWebFingerURLParsed.Scheme,
+		propertyWebFingerURLParsed.Host, url.PathEscape(propertyWebFingerURL))
+
+	webFingerResponse, err := c.doWebFingerViaREST(resourceWebFingerURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to do WebFinger via REST: %w", err)
+	}
+
+	if len(webFingerResponse.Links) > 0 {
+		return webFingerResponse.Links[0].Href, nil
+	}
+
+	return "", fmt.Errorf("webfinger response contains no links")
+}
+
+func (c *Resolver) doWebFingerViaREST(webFingerURL string) (discoveryrest.WebFingerResponse, error) {
+	resp, err := c.httpClient.Get(webFingerURL)
+	if err != nil {
+		return discoveryrest.WebFingerResponse{}, fmt.Errorf("failed to get WebFinger response: %w", err)
+	}
+
+	defer func() {
+		err = resp.Body.Close()
+		if err != nil {
+			logger.Warnf("failed to close WebFinger response body: %s", err.Error())
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return discoveryrest.WebFingerResponse{},
+			fmt.Errorf("got status code %d from %s (expected 200)", resp.StatusCode, webFingerURL)
+	}
+
+	webFingerResponseBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return discoveryrest.WebFingerResponse{}, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var webFingerResponse discoveryrest.WebFingerResponse
+
+	err = json.Unmarshal(webFingerResponseBytes, &webFingerResponse)
+	if err != nil {
+		return discoveryrest.WebFingerResponse{}, fmt.Errorf("failed to unmarshal WebFinger response: %w", err)
+	}
+
+	return webFingerResponse, nil
+}

--- a/pkg/resolver/resource/resolver_test.go
+++ b/pkg/resolver/resource/resolver_test.go
@@ -1,0 +1,293 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resource_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/pkg/cas/ipfs"
+	discoveryrest "github.com/trustbloc/orb/pkg/discovery/endpoint/restapi"
+	resourceresolver "github.com/trustbloc/orb/pkg/resolver/resource"
+)
+
+const (
+	sampleBaseURLWebFingerResponseData = `{"subject":"%s` +
+		`","properties":{"https://trustbloc.dev/ns/cas":"https://testnet.orb.local/cas","https://tru` +
+		`stbloc.dev/ns/min-resolvers":1,"https://trustbloc.dev/ns/vct":"https://testnet.orb.local/vct","https://` +
+		`trustbloc.dev/ns/witness":"%s/services/orb"},"links":[{"rel":"self","href":"http` +
+		`s://testnet.orb.local/sidetree/v1/identifiers"}]}`
+
+	sampleWitnessWebFingerResponseData = `{"subject":"%s","links":` +
+		`[{"rel":"self","type":"application/ld+json","href":"%s/services/orb"}]}`
+)
+
+func TestResolver_Resolve(t *testing.T) {
+	t.Run("Success - resolved via HTTP", func(t *testing.T) {
+		var numTimesMockServerHandlerHit int
+
+		var testServerURL string
+
+		var witnessResource string
+
+		testServer := httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch numTimesMockServerHandlerHit {
+				case 0:
+					numTimesMockServerHandlerHit++
+					_, err := w.Write([]byte(fmt.Sprintf(sampleBaseURLWebFingerResponseData,
+						testServerURL, testServerURL)))
+					require.NoError(t, err)
+				case 1:
+					_, err := w.Write([]byte(fmt.Sprintf(sampleWitnessWebFingerResponseData,
+						fmt.Sprintf("%s/services/orb", testServerURL), testServerURL)))
+					require.NoError(t, err)
+				}
+			}))
+		defer testServer.Close()
+
+		testServerURL = testServer.URL
+		witnessResource = fmt.Sprintf("%s/services/orb", testServerURL)
+
+		resolver := resourceresolver.New(http.DefaultClient, nil)
+
+		resource, err := resolver.Resolve(fmt.Sprintf("%s/services/orb", testServerURL),
+			discoveryrest.WitnessType)
+		require.NoError(t, err)
+		require.Equal(t, witnessResource, resource)
+	})
+	t.Run("Success - resolved via IPNS", func(t *testing.T) {
+		var numTimesMockServerHandlerHit int
+
+		var testServerURL string
+
+		var witnessResource string
+
+		testServer := httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch numTimesMockServerHandlerHit {
+				case 0:
+					numTimesMockServerHandlerHit++
+					_, err := w.Write([]byte(fmt.Sprintf(sampleBaseURLWebFingerResponseData,
+						"ipns://k51qzi5uqu5dgjceyz40t6xfnae8jqn5z17ojojggzwz2mhl7uyhdre8ateqek", testServerURL)))
+					require.NoError(t, err)
+				case 1:
+					_, err := w.Write([]byte(fmt.Sprintf(sampleWitnessWebFingerResponseData,
+						witnessResource, testServerURL)))
+					require.NoError(t, err)
+				}
+			}))
+		defer testServer.Close()
+
+		testServerURL = testServer.URL
+		witnessResource = fmt.Sprintf("%s/services/orb", testServerURL)
+
+		resolver := resourceresolver.New(http.DefaultClient, ipfs.New(testServer.URL))
+
+		resource, err := resolver.Resolve("ipns://k51qzi5uqu5dgjceyz40t6xfnae8jqn5z17ojojggzwz2mhl7uyhdre8ateqek",
+			discoveryrest.WitnessType)
+		require.NoError(t, err)
+		require.Equal(t, witnessResource, resource)
+	})
+	t.Run("Fail to resolve via HTTP (missing protocol scheme)", func(t *testing.T) {
+		resolver := resourceresolver.New(http.DefaultClient, nil)
+
+		resource, err := resolver.Resolve("BadURLName", discoveryrest.WitnessType)
+		require.EqualError(t, err, "failed to get WebFinger response from HTTP/HTTPS URL: "+
+			"failed to do WebFinger via REST: failed to get WebFinger response: parse "+
+			`":///.well-known/webfinger?resource=:%2F%2F": missing protocol scheme`)
+		require.Empty(t, resource)
+	})
+	t.Run("Fail to resolve via IPNS (IPFS node not reachable)", func(t *testing.T) {
+		resolver := resourceresolver.New(nil, ipfs.New("SomeIPFSNodeURL"))
+
+		resource, err := resolver.Resolve("ipns://k51qzi5uqu5dgjceyz40t6xfnae8jqn5z17ojojggzwz2mhl7uyhdre8ateqek",
+			discoveryrest.WitnessType)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to get WebFinger response from IPNS URL: "+
+			`failed to read from IPNS: Post "http://SomeIPFSNodeURL/api/v0/cat?arg=%2Fipns%2Fk51qzi5uqu5dgjc`+
+			`eyz40t6xfnae8jqn5z17ojojggzwz2mhl7uyhdre8ateqek%2F.well-known%2Fwebfinger": dial tcp: `+
+			"lookup SomeIPFSNodeURL:")
+		require.Empty(t, resource)
+	})
+	t.Run("Fail to resolve via IPNS (WebFinger response unmarshal failure)", func(t *testing.T) {
+		testServer := httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		defer testServer.Close()
+
+		resolver := resourceresolver.New(nil, ipfs.New(testServer.URL))
+
+		resource, err := resolver.Resolve("ipns://k51qzi5uqu5dgjceyz40t6xfnae8jqn5z17ojojggzwz2mhl7uyhdre8ateqek",
+			discoveryrest.WitnessType)
+		require.EqualError(t, err, "failed to get WebFinger response from IPNS URL: "+
+			"failed to unmarshal WebFinger response: unexpected end of JSON input")
+		require.Empty(t, resource)
+	})
+	t.Run("Fail to resolve via IPNS (property missing)", func(t *testing.T) {
+		testServer := httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var webFingerResp discoveryrest.WebFingerResponse
+
+				err := json.Unmarshal([]byte(sampleBaseURLWebFingerResponseData), &webFingerResp)
+				require.NoError(t, err)
+
+				delete(webFingerResp.Properties, discoveryrest.WitnessType)
+
+				webFingerRespBytes, errMarshal := json.Marshal(webFingerResp)
+				require.NoError(t, errMarshal)
+
+				_, err = w.Write(webFingerRespBytes)
+				require.NoError(t, err)
+			}))
+		defer testServer.Close()
+
+		resolver := resourceresolver.New(nil, ipfs.New(testServer.URL))
+
+		resource, err := resolver.Resolve("ipns://k51qzi5uqu5dgjceyz40t6xfnae8jqn5z17ojojggzwz2mhl7uyhdre8ateqek",
+			discoveryrest.WitnessType)
+		require.EqualError(t, err, "failed to resolve resource from Base URL WebFinger response: "+
+			"property missing")
+		require.Empty(t, resource)
+	})
+	t.Run("Fail to assert property as a string", func(t *testing.T) {
+		testServer := httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var webFingerResp discoveryrest.WebFingerResponse
+
+				err := json.Unmarshal([]byte(sampleBaseURLWebFingerResponseData), &webFingerResp)
+				require.NoError(t, err)
+
+				webFingerResp.Properties[discoveryrest.WitnessType] = 0
+
+				webFingerRespBytes, errMarshal := json.Marshal(webFingerResp)
+				require.NoError(t, errMarshal)
+
+				_, err = w.Write(webFingerRespBytes)
+				require.NoError(t, err)
+			}))
+		defer testServer.Close()
+
+		resolver := resourceresolver.New(nil, ipfs.New(testServer.URL))
+
+		resource, err := resolver.Resolve("ipns://k51qzi5uqu5dgjceyz40t6xfnae8jqn5z17ojojggzwz2mhl7uyhdre8ateqek",
+			discoveryrest.WitnessType)
+		require.EqualError(t, err, "failed to resolve resource from Base URL WebFinger response: "+
+			"failed to assert property as a string")
+		require.Empty(t, resource)
+	})
+	t.Run("Fail to resolve via HTTP (received status code 500 on first WebFinger)", func(t *testing.T) {
+		testServer := httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+		defer testServer.Close()
+
+		escapedTestServerURL := url.PathEscape(testServer.URL)
+
+		resolver := resourceresolver.New(http.DefaultClient, nil)
+
+		resource, err := resolver.Resolve(testServer.URL, discoveryrest.WitnessType)
+		require.EqualError(t, err, "failed to get WebFinger response from HTTP/HTTPS URL: "+
+			"failed to do WebFinger via REST: got status code 500 from "+testServer.URL+"/.well-known/webfinger?"+
+			"resource="+escapedTestServerURL+" (expected 200)")
+		require.Empty(t, resource)
+	})
+	t.Run("Fail to parse WebFinger URL from base URL WebFinger response", func(t *testing.T) {
+		var testServerURL string
+
+		testServer := httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, err := w.Write([]byte(fmt.Sprintf(sampleBaseURLWebFingerResponseData,
+					testServerURL, "%")))
+				require.NoError(t, err)
+			}))
+		defer testServer.Close()
+
+		testServerURL = testServer.URL
+
+		resolver := resourceresolver.New(http.DefaultClient, nil)
+
+		resource, err := resolver.Resolve(fmt.Sprintf("%s/services/orb", testServerURL),
+			discoveryrest.WitnessType)
+		require.EqualError(t, err, "failed to resolve resource from Base URL WebFinger response: "+
+			"failed to get resource from property WebFinger: failed to parse property WebFinger URL: "+
+			`parse "%/services/orb": invalid URL escape "%/s"`)
+		require.Empty(t, resource)
+	})
+	t.Run("Fail to get second WebFinger response (missing protocol scheme)", func(t *testing.T) {
+		var numTimesMockServerHandlerHit int
+
+		var testServerURL string
+
+		testServer := httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch numTimesMockServerHandlerHit {
+				case 0:
+					numTimesMockServerHandlerHit++
+					_, err := w.Write([]byte(fmt.Sprintf(sampleBaseURLWebFingerResponseData,
+						testServerURL, "BadURL")))
+					require.NoError(t, err)
+				case 1:
+					_, err := w.Write([]byte(fmt.Sprintf(sampleWitnessWebFingerResponseData,
+						fmt.Sprintf("%s/services/orb", testServerURL), testServerURL)))
+					require.NoError(t, err)
+				}
+			}))
+		defer testServer.Close()
+
+		testServerURL = testServer.URL
+
+		resolver := resourceresolver.New(http.DefaultClient, nil)
+
+		resource, err := resolver.Resolve(fmt.Sprintf("%s/services/orb", testServerURL),
+			discoveryrest.WitnessType)
+		require.EqualError(t, err, "failed to resolve resource from Base URL WebFinger response: "+
+			"failed to get resource from property WebFinger: failed to do WebFinger via REST: "+
+			`failed to get WebFinger response: parse ":///.well-known/webfinger?resource=BadURL%2Fservices%2Forb": `+
+			"missing protocol scheme")
+		require.Empty(t, resource)
+	})
+	t.Run("Fail to get second WebFinger response (status code 500)", func(t *testing.T) {
+		var numTimesMockServerHandlerHit int
+
+		var testServerURL string
+
+		testServer := httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch numTimesMockServerHandlerHit {
+				case 0:
+					numTimesMockServerHandlerHit++
+					_, err := w.Write([]byte(fmt.Sprintf(sampleBaseURLWebFingerResponseData,
+						testServerURL, testServerURL)))
+					require.NoError(t, err)
+				case 1:
+					w.WriteHeader(http.StatusInternalServerError)
+				}
+			}))
+		defer testServer.Close()
+
+		testServerURL = testServer.URL
+
+		resolver := resourceresolver.New(http.DefaultClient, nil)
+
+		escapedTestServerURL := url.PathEscape(testServer.URL)
+
+		resource, err := resolver.Resolve(fmt.Sprintf("%s/services/orb", testServerURL),
+			discoveryrest.WitnessType)
+		require.EqualError(t, err, "failed to resolve resource from Base URL WebFinger response: "+
+			"failed to get resource from property WebFinger: failed to do WebFinger via REST: "+
+			"got status code 500 from "+testServer.URL+"/.well-known/webfinger?resource="+escapedTestServerURL+
+			"%2Fservices%2Forb (expected 200)")
+		require.Empty(t, resource)
+	})
+}


### PR DESCRIPTION
Also corrected WebFinger retrievals to not use property directly. It now uses that to do a subsequent WebFinger to grab the proper link.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>