### PR TITLE
fix: Don't add empty proof to VC

### DIFF
--- a/cmd/orb-server/startcmd/params.go
+++ b/cmd/orb-server/startcmd/params.go
@@ -215,6 +215,11 @@ const (
 	httpSignaturesEnabledUsage     = `Set to "true" to enable HTTP signatures in ActivityPub. ` +
 		commonEnvVarUsageText + httpSignaturesEnabledEnvKey
 
+	enableDidDiscoveryFlagName = "enable-did-discovery"
+	enableDidDiscoveryEnvKey   = "DID_DISCOVERY_ENABLED"
+	enableDidDiscoveryUsage    = `Set to "true" to enable did discovery. ` +
+		commonEnvVarUsageText + enableDidDiscoveryEnvKey
+
 	authTokensDefFlagName      = "auth-tokens-def"
 	authTokensDefFlagShorthand = "D"
 	authTokensDefFlagUsage     = "Authorization token definitions."
@@ -259,6 +264,7 @@ type orbParameters struct {
 	startupDelay              time.Duration
 	signWithLocalWitness      bool
 	httpSignaturesEnabled     bool
+	didDiscoveryEnabled       bool
 	authTokenDefinitions      []*auth.TokenDef
 	authTokens                map[string]string
 	opQueuePoolSize           uint
@@ -436,6 +442,21 @@ func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 		httpSignaturesEnabled = enable
 	}
 
+	enableDidDiscoveryStr, err := cmdutils.GetUserSetVarFromString(cmd, enableDidDiscoveryFlagName, enableDidDiscoveryEnvKey, true)
+	if err != nil {
+		return nil, err
+	}
+
+	didDiscoveryEnabled := defaultDidDiscoveryEnabled
+	if enableDidDiscoveryStr != "" {
+		enable, parseErr := strconv.ParseBool(enableDidDiscoveryStr)
+		if parseErr != nil {
+			return nil, fmt.Errorf("invalid value for %s: %s", enableDidDiscoveryFlagName, parseErr)
+		}
+
+		didDiscoveryEnabled = enable
+	}
+
 	didNamespace, err := cmdutils.GetUserSetVarFromString(cmd, didNamespaceFlagName, didNamespaceEnvKey, false)
 	if err != nil {
 		return nil, err
@@ -517,6 +538,7 @@ func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 		startupDelay:              startupDelay,
 		signWithLocalWitness:      signWithLocalWitness,
 		httpSignaturesEnabled:     httpSignaturesEnabled,
+		didDiscoveryEnabled:       didDiscoveryEnabled,
 		authTokenDefinitions:      authTokenDefs,
 		authTokens:                authTokens,
 	}, nil
@@ -692,6 +714,7 @@ func createFlags(startCmd *cobra.Command) {
 	startCmd.Flags().StringP(maxWitnessDelayFlagName, maxWitnessDelayFlagShorthand, "", maxWitnessDelayFlagUsage)
 	startCmd.Flags().StringP(signWithLocalWitnessFlagName, signWithLocalWitnessFlagShorthand, "", signWithLocalWitnessFlagUsage)
 	startCmd.Flags().StringP(httpSignaturesEnabledFlagName, httpSignaturesEnabledShorthand, "", httpSignaturesEnabledUsage)
+	startCmd.Flags().String(enableDidDiscoveryFlagName, "", enableDidDiscoveryUsage)
 	startCmd.Flags().StringP(casTypeFlagName, casTypeFlagShorthand, "", casTypeFlagUsage)
 	startCmd.Flags().StringP(ipfsURLFlagName, ipfsURLFlagShorthand, "", ipfsURLFlagUsage)
 	startCmd.Flags().StringP(mqURLFlagName, mqURLFlagShorthand, "", mqURLFlagUsage)

--- a/cmd/orb-server/startcmd/params_test.go
+++ b/cmd/orb-server/startcmd/params_test.go
@@ -378,6 +378,33 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid value for enable-http-signatures")
 	})
+
+	t.Run("test invalid enable-did-discovery", func(t *testing.T) {
+		startCmd := GetStartCmd()
+
+		args := []string{
+			"--" + hostURLFlagName, "localhost:8247",
+			"--" + vctURLFlagName, "localhost:8081",
+			"--" + externalEndpointFlagName, "orb.example.com",
+			"--" + casTypeFlagName, "ipfs",
+			"--" + ipfsURLFlagName, "localhost:8081",
+			"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
+			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption,
+			"--" + anchorCredentialSignatureSuiteFlagName, "suite",
+			"--" + anchorCredentialDomainFlagName, "domain.com",
+			"--" + anchorCredentialIssuerFlagName, "issuer.com",
+			"--" + anchorCredentialURLFlagName, "peer.com",
+			"--" + LogLevelFlagName, log.ParseString(log.ERROR),
+			"--" + enableDidDiscoveryFlagName, "invalid bool",
+		}
+
+		startCmd.SetArgs(args)
+
+		err := startCmd.Execute()
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid value for enable-did-discovery")
+	})
 }
 
 func TestStartCmdWithBlankEnvVar(t *testing.T) {

--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -119,6 +119,7 @@ const (
 	noStartupDelay = 0 * time.Second // no delay
 
 	defaulthttpSignaturesEnabled = true
+	defaultDidDiscoveryEnabled   = false
 
 	unpublishedDIDLabel = "interim"
 
@@ -647,10 +648,11 @@ func startOrbServices(parameters *orbParameters) error {
 
 	orbResolver := document.NewResolveHandler(
 		parameters.didNamespace,
-		parameters.didAliases,
-		unpublishedDIDLabel,
 		didDocHandler,
 		localdiscovery.New(o.Publisher()),
+		document.WithAliases(parameters.didAliases),
+		document.WithUnpublishedDIDLabel(unpublishedDIDLabel),
+		document.WithEnableDIDDiscovery(parameters.didDiscoveryEnabled),
 	)
 
 	// create discovery rest api

--- a/pkg/anchor/handler/proof/handler.go
+++ b/pkg/anchor/handler/proof/handler.go
@@ -108,7 +108,7 @@ func (h *WitnessProofHandler) HandleProof(witness *url.URL, anchorCredID string,
 
 	err = json.Unmarshal(proof, &witnessProof)
 	if err != nil {
-		return fmt.Errorf("failed to unmarshal witness proof for anchor credential[%s]: %w", anchorCredID, err)
+		return fmt.Errorf("failed to unmarshal incoming witness proof for anchor credential[%s]: %w", anchorCredID, err)
 	}
 
 	vc, err := h.VCStore.Get(anchorCredID)
@@ -194,14 +194,16 @@ func (h *WitnessProofHandler) handleWitnessPolicy(vc *verifiable.Credential) err
 
 func addProofs(vc *verifiable.Credential, proofs []*proofapi.WitnessProof) (*verifiable.Credential, error) {
 	for _, p := range proofs {
-		var witnessProof vct.Proof
+		if p.Proof != nil {
+			var witnessProof vct.Proof
 
-		err := json.Unmarshal(p.Proof, &witnessProof)
-		if err != nil {
-			return nil, fmt.Errorf("failed to unmarshal witness proof for anchor credential[%s]: %w", vc.ID, err)
+			err := json.Unmarshal(p.Proof, &witnessProof)
+			if err != nil {
+				return nil, fmt.Errorf("failed to unmarshal stored witness proof for anchor credential[%s]: %w", vc.ID, err)
+			}
+
+			vc.Proofs = append(vc.Proofs, witnessProof.Proof)
 		}
-
-		vc.Proofs = append(vc.Proofs, witnessProof.Proof)
 	}
 
 	return vc, nil

--- a/pkg/cas/ipfs/ipfs.go
+++ b/pkg/cas/ipfs/ipfs.go
@@ -22,7 +22,7 @@ import (
 	"github.com/trustbloc/orb/pkg/store/cas"
 )
 
-const timeout = 2
+const timeout = 5
 
 // Client will write new documents to IPFS and read existing documents from IPFS based on CID.
 // It implements Sidetree CAS interface.

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -143,7 +143,7 @@ func (o *Observer) processDID(did string) error {
 		return err
 	}
 
-	logger.Debugf("got %d anchors for out-of-system did[%s]", did)
+	logger.Debugf("got %d anchors for out-of-system did[%s]", len(anchors), did)
 
 	for _, anchor := range anchors {
 		logger.Debugf("processing anchor[%s] for out-of-system did[%s]", anchor.CID, did)

--- a/pkg/resolver/document/resolvehandler_test.go
+++ b/pkg/resolver/document/resolvehandler_test.go
@@ -24,9 +24,10 @@ const (
 	testNS    = "did:orb"
 	testLabel = "interim"
 
-	testDID        = "did:orb:suffix"
-	testDIDWithCID = "did:orb:webcas:domain.com:cid:suffix"
-	testInterimDID = "did:orb:interim:suffix"
+	testDID               = "did:orb:suffix"
+	testDIDWithCIDAndHint = "did:orb:webcas:domain.com:cid:suffix"
+	testInterimDID        = "did:orb:interim:suffix"
+	invalidTestDID        = "did:webcas"
 )
 
 func TestResolveHandler_Resolve(t *testing.T) {
@@ -36,22 +37,37 @@ func TestResolveHandler_Resolve(t *testing.T) {
 
 		discovery := &mocks.Discovery{}
 
-		handler := NewResolveHandler(testNS, nil, testLabel, coreHandler, discovery)
+		handler := NewResolveHandler(testNS, coreHandler, discovery, WithUnpublishedDIDLabel(testLabel))
 
 		response, err := handler.ResolveDocument(testDID)
 		require.NoError(t, err)
 		require.NotNil(t, response)
 	})
 
-	t.Run("error - not found error (did without cid)", func(t *testing.T) {
+	t.Run("error - not found error (did without hint)", func(t *testing.T) {
 		coreHandler := &mocks.Resolver{}
 		coreHandler.ResolveDocumentReturns(nil, errors.New("not found"))
 
 		discovery := &mocks.Discovery{}
 
-		handler := NewResolveHandler(testNS, nil, testLabel, coreHandler, discovery)
+		handler := NewResolveHandler(testNS, coreHandler, discovery,
+			WithUnpublishedDIDLabel(testLabel), WithEnableDIDDiscovery(true))
 
-		response, err := handler.ResolveDocument(testDID)
+		response, err := handler.ResolveDocument(testInterimDID)
+		require.Error(t, err)
+		require.Nil(t, response)
+	})
+
+	t.Run("error - not found error (invalid did)", func(t *testing.T) {
+		coreHandler := &mocks.Resolver{}
+		coreHandler.ResolveDocumentReturns(nil, errors.New("not found"))
+
+		discovery := &mocks.Discovery{}
+
+		handler := NewResolveHandler("did", coreHandler, discovery,
+			WithUnpublishedDIDLabel(testLabel), WithEnableDIDDiscovery(true))
+
+		response, err := handler.ResolveDocument(invalidTestDID)
 		require.Error(t, err)
 		require.Nil(t, response)
 	})
@@ -62,7 +78,8 @@ func TestResolveHandler_Resolve(t *testing.T) {
 
 		discovery := &mocks.Discovery{}
 
-		handler := NewResolveHandler(testNS, nil, testLabel, coreHandler, discovery)
+		handler := NewResolveHandler(testNS, coreHandler, discovery,
+			WithUnpublishedDIDLabel(testLabel), WithEnableDIDDiscovery(true))
 
 		response, err := handler.ResolveDocument(testInterimDID)
 		require.Error(t, err)
@@ -75,9 +92,10 @@ func TestResolveHandler_Resolve(t *testing.T) {
 
 		discovery := &mocks.Discovery{}
 
-		handler := NewResolveHandler(testNS, nil, testLabel, coreHandler, discovery)
+		handler := NewResolveHandler(testNS, coreHandler, discovery,
+			WithUnpublishedDIDLabel(testLabel), WithEnableDIDDiscovery(true))
 
-		response, err := handler.ResolveDocument(testDIDWithCID)
+		response, err := handler.ResolveDocument(testDIDWithCIDAndHint)
 		require.Error(t, err)
 		require.Nil(t, response)
 	})
@@ -88,9 +106,10 @@ func TestResolveHandler_Resolve(t *testing.T) {
 
 		discovery := &mocks.Discovery{}
 
-		handler := NewResolveHandler("did:not-orb", nil, testLabel, coreHandler, discovery)
+		handler := NewResolveHandler("did:not-orb", coreHandler, discovery,
+			WithUnpublishedDIDLabel(testLabel), WithEnableDIDDiscovery(true))
 
-		response, err := handler.ResolveDocument(testDIDWithCID)
+		response, err := handler.ResolveDocument(testDIDWithCIDAndHint)
 		require.Error(t, err)
 		require.Nil(t, response)
 	})
@@ -101,9 +120,10 @@ func TestResolveHandler_Resolve(t *testing.T) {
 
 		discovery := &mocks.Discovery{}
 
-		handler := NewResolveHandler("did:not-orb", []string{testNS}, testLabel, coreHandler, discovery)
+		handler := NewResolveHandler("did:not-orb", coreHandler, discovery,
+			WithUnpublishedDIDLabel(testLabel), WithAliases([]string{testNS}), WithEnableDIDDiscovery(true))
 
-		response, err := handler.ResolveDocument(testDIDWithCID)
+		response, err := handler.ResolveDocument(testDIDWithCIDAndHint)
 		require.Error(t, err)
 		require.Nil(t, response)
 	})
@@ -115,9 +135,10 @@ func TestResolveHandler_Resolve(t *testing.T) {
 		discovery := &mocks.Discovery{}
 		discovery.RequestDiscoveryReturns(errors.New("discovery error"))
 
-		handler := NewResolveHandler(testNS, nil, testLabel, coreHandler, discovery)
+		handler := NewResolveHandler(testNS, coreHandler, discovery,
+			WithUnpublishedDIDLabel(testLabel), WithEnableDIDDiscovery(true))
 
-		response, err := handler.ResolveDocument(testDIDWithCID)
+		response, err := handler.ResolveDocument(testDIDWithCIDAndHint)
 		require.Error(t, err)
 		require.Nil(t, response)
 	})
@@ -128,7 +149,8 @@ func TestResolveHandler_Resolve(t *testing.T) {
 
 		discovery := &mocks.Discovery{}
 
-		handler := NewResolveHandler(testNS, nil, testLabel, coreHandler, discovery)
+		handler := NewResolveHandler(testNS, coreHandler, discovery,
+			WithUnpublishedDIDLabel(testLabel), WithEnableDIDDiscovery(true))
 
 		response, err := handler.ResolveDocument(testDID)
 		require.Error(t, err)

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -310,6 +310,7 @@ services:
       - ORB_TLS_CERTIFICATE=/etc/orb/tls/ec-pubCert.pem
       - ORB_TLS_KEY=/etc/orb/tls/ec-key.pem
       - DID_NAMESPACE=did:orb
+      - DID_DISCOVERY_ENABLED=true
       - ALLOWED_ORIGINS=https://orb.domain4.com/services/orb,https://orb.domain1.com/services/orb
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
       - BATCH_WRITER_TIMEOUT=1000


### PR DESCRIPTION
Even though policy is satisfied some witness proofs may still be empty. Don't add empty witness proof to VC - causes unmarshal error.

Also, adjusted bdd test to have configured did discovery server.

Closes #515

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>