### PR TITLE
feat: Configure discovery(shared) domain, add to equivalent id

### DIFF
--- a/cmd/orb-server/startcmd/params.go
+++ b/cmd/orb-server/startcmd/params.go
@@ -65,6 +65,10 @@ const (
 		" should be resolvable by external clients. Format: HostName[:Port]."
 	externalEndpointEnvKey = "ORB_EXTERNAL_ENDPOINT"
 
+	discoveryDomainFlagName  = "discovery-domain"
+	discoveryDomainFlagUsage = "Discovery domain for this domain." + " Format: HostName"
+	discoveryDomainEnvKey    = "ORB_DISCOVERY_DOMAIN"
+
 	tlsCertificateFlagName      = "tls-certificate"
 	tlsCertificateFlagShorthand = "y"
 	tlsCertificateFlagUsage     = "TLS certificate for ORB server. " + commonEnvVarUsageText + tlsCertificateLEnvKey
@@ -242,6 +246,7 @@ type orbParameters struct {
 	kmsEndpoint               string
 	kmsStoreEndpoint          string
 	externalEndpoint          string
+	discoveryDomain           string
 	didNamespace              string
 	didAliases                []string
 	batchWriterTimeout        time.Duration
@@ -308,6 +313,11 @@ func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 
 	if externalEndpoint == "" {
 		externalEndpoint = hostURL
+	}
+
+	discoveryDomain, err := cmdutils.GetUserSetVarFromString(cmd, discoveryDomainFlagName, discoveryDomainEnvKey, true)
+	if err != nil {
+		return nil, err
 	}
 
 	tlsCertificate, err := cmdutils.GetUserSetVarFromString(cmd, tlsCertificateFlagName, tlsCertificateLEnvKey, true)
@@ -517,6 +527,7 @@ func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 		secretLockKeyPath:         secretLockKeyPath,
 		kmsStoreEndpoint:          kmsStoreEndpoint,
 		externalEndpoint:          externalEndpoint,
+		discoveryDomain:           discoveryDomain,
 		tlsKey:                    tlsKey,
 		tlsCertificate:            tlsCertificate,
 		didNamespace:              didNamespace,
@@ -708,6 +719,7 @@ func createFlags(startCmd *cobra.Command) {
 	startCmd.Flags().String(keyIDFlagName, "", keyIDFlagUsage)
 	startCmd.Flags().String(secretLockKeyPathFlagName, "", secretLockKeyPathFlagUsage)
 	startCmd.Flags().StringP(externalEndpointFlagName, externalEndpointFlagShorthand, "", externalEndpointFlagUsage)
+	startCmd.Flags().String(discoveryDomainFlagName, "", discoveryDomainFlagUsage)
 	startCmd.Flags().StringP(tlsCertificateFlagName, tlsCertificateFlagShorthand, "", tlsCertificateFlagUsage)
 	startCmd.Flags().StringP(tlsKeyFlagName, tlsKeyFlagShorthand, "", tlsKeyFlagUsage)
 	startCmd.Flags().StringP(batchWriterTimeoutFlagName, batchWriterTimeoutFlagShorthand, "", batchWriterTimeoutFlagUsage)

--- a/cmd/orb-server/startcmd/params_test.go
+++ b/cmd/orb-server/startcmd/params_test.go
@@ -271,6 +271,7 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 		require.Contains(t, err.Error(), "invalid batch writer timeout format")
 	})
 
+
 	t.Run("test invalid max witness delay", func(t *testing.T) {
 		startCmd := GetStartCmd()
 
@@ -568,6 +569,7 @@ func TestStartCmdValidArgs(t *testing.T) {
 	args := []string{
 		"--" + hostURLFlagName, "localhost:8247",
 		"--" + externalEndpointFlagName, "orb.example.com",
+		"--" + discoveryDomainFlagName, "shared.example.com",
 		"--" + ipfsURLFlagName, "localhost:8081",
 		"--" + cidVersionFlagName, "0",
 		"--" + batchWriterTimeoutFlagName, "700",

--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -72,7 +72,6 @@ import (
 	"github.com/trustbloc/orb/pkg/anchor/graph"
 	"github.com/trustbloc/orb/pkg/anchor/handler/credential"
 	"github.com/trustbloc/orb/pkg/anchor/handler/proof"
-	anchorinfo "github.com/trustbloc/orb/pkg/anchor/info"
 	"github.com/trustbloc/orb/pkg/anchor/policy"
 	policyhandler "github.com/trustbloc/orb/pkg/anchor/policy/resthandler"
 	"github.com/trustbloc/orb/pkg/anchor/writer"
@@ -540,7 +539,7 @@ func startOrbServices(parameters *orbParameters) error {
 		PubSub:                 pubSub,
 	}
 
-	o, err := observer.New(providers)
+	o, err := observer.New(providers, observer.WithDiscoveryDomain(parameters.discoveryDomain))
 	if err != nil {
 		return fmt.Errorf("failed to create observer: %s", err.Error())
 	}
@@ -881,19 +880,6 @@ func prepareKeyLock(keyPath string) (secretlock.Service, error) {
 	}
 
 	return local.NewService(masterKeyReader, nil)
-}
-
-type mockTxnProvider struct {
-	registerForAnchor chan []anchorinfo.AnchorInfo
-	registerForDID    chan []string
-}
-
-func (m mockTxnProvider) RegisterForAnchor() <-chan []anchorinfo.AnchorInfo {
-	return m.registerForAnchor
-}
-
-func (m mockTxnProvider) RegisterForDID() <-chan []string {
-	return m.registerForDID
 }
 
 func mustParseURL(basePath, relativePath string) *url.URL {

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -122,7 +122,7 @@ func TestStartObserver(t *testing.T) {
 			PubSub:                 mempubsub.New(mempubsub.DefaultConfig()),
 		}
 
-		o, err := New(providers)
+		o, err := New(providers, WithDiscoveryDomain("webcas:shared.domain.com"))
 		require.NotNil(t, o)
 		require.NoError(t, err)
 

--- a/pkg/orbclient/client.go
+++ b/pkg/orbclient/client.go
@@ -63,8 +63,6 @@ func WithDisableProofCheck(disableProofCheck bool) Option {
 }
 
 // New creates new Orb client.
-// TODO: Discuss if we should create cas reader based on ipfs URL or cas reader should be provided here.
-// TODO: It looks like document loader is not optional.
 func New(namespace string, cas common.CASReader, opts ...Option) (*OrbClient, error) {
 	versions := []string{"1.0"}
 

--- a/test/bdd/did_orb_steps.go
+++ b/test/bdd/did_orb_steps.go
@@ -672,7 +672,16 @@ func (d *DIDOrbSteps) resolveDIDDocumentWithCanonicalDID(url string) error {
 }
 
 func (d *DIDOrbSteps) resolveDIDDocumentWithEquivalentDID(url string) error {
+	// interim DID contains one equivalent ID
 	equivalentDID := d.equivalentDID[len(d.equivalentDID)-1]
+
+	// permanent DID has 2 or more equivalent IDs:
+	// first one is canonical ID (Sidetree spec),
+	// second one is with originator hint,
+	// third one is with shared domain hint (if configured)
+	if len(d.equivalentDID) > 1 {
+		equivalentDID = d.equivalentDID[1]
+	}
 
 	logger.Infof("resolving did document with equivalent did: %s", equivalentDID)
 

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - ORB_EXTERNAL_ENDPOINT=https://orb.domain1.com
       - ORB_TLS_CERTIFICATE=/etc/orb/tls/ec-pubCert.pem
       - ORB_TLS_KEY=/etc/orb/tls/ec-key.pem
+      - ORB_DISCOVERY_DOMAIN=shared.domain.com
       - DID_NAMESPACE=did:orb
       - ALLOWED_ORIGINS=https://orb.domain1.com/services/orb,https://orb.domain2.com/services/orb
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
@@ -96,6 +97,7 @@ services:
       - ORB_EXTERNAL_ENDPOINT=https://orb.domain1.com
       - ORB_TLS_CERTIFICATE=/etc/orb/tls/ec-pubCert.pem
       - ORB_TLS_KEY=/etc/orb/tls/ec-key.pem
+      - ORB_DISCOVERY_DOMAIN=shared.domain.com
       - DID_NAMESPACE=did:orb
       - ALLOWED_ORIGINS=https://orb.domain1.com/services/orb,https://orb.domain2.com/services/orb
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
@@ -167,6 +169,7 @@ services:
       - ORB_EXTERNAL_ENDPOINT=https://orb.domain2.com
       - ORB_TLS_CERTIFICATE=/etc/orb/tls/ec-pubCert.pem
       - ORB_TLS_KEY=/etc/orb/tls/ec-key.pem
+      - ORB_DISCOVERY_DOMAIN=shared.domain.com
       - DID_NAMESPACE=did:orb
       - ALLOWED_ORIGINS=https://orb.domain1.com/services/orb,https://orb.domain2.com/services/orb
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
@@ -238,6 +241,7 @@ services:
       - ORB_EXTERNAL_ENDPOINT=https://orb.domain3.com
       - ORB_TLS_CERTIFICATE=/etc/orb/tls/ec-pubCert.pem
       - ORB_TLS_KEY=/etc/orb/tls/ec-key.pem
+      - ORB_DISCOVERY_DOMAIN=shared.domain.com
       - DID_NAMESPACE=did:orb
       - ALLOWED_ORIGINS=https://orb.domain1.com/services/orb,https://orb.domain2.com/services/orb
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)


### PR DESCRIPTION
Configure shared domain and add it to did document equivalent id.

Closes #474

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>