### PR TITLE
fix: Don't check if actor in offer activity is being witnessed

### DIFF
--- a/pkg/activitypub/httpsig/algorithm.go
+++ b/pkg/activitypub/httpsig/algorithm.go
@@ -91,6 +91,8 @@ func (a *SignatureHashAlgorithm) Verify(secret httpsig.Secret, data, signature [
 	logger.Debugf("Got key %+v from keyID [%s]", pubKey, secret.KeyID)
 
 	if !ed25519.Verify(pubKey.Value, data, signature) {
+		logger.Infof("Signature verification failed using keyID [%s]: %s", secret.KeyID, err)
+
 		return ErrInvalidSignature
 	}
 

--- a/pkg/activitypub/service/activityhandler/activityhandler_test.go
+++ b/pkg/activitypub/service/activityhandler/activityhandler_test.go
@@ -1616,32 +1616,6 @@ func TestHandler_HandleOfferActivity(t *testing.T) {
 		require.Contains(t, err.Error(), "object is required")
 	})
 
-	t.Run("Storage error", func(t *testing.T) {
-		errExpected := fmt.Errorf("injected storage error")
-
-		activityStore := &mocks.ActivityStore{}
-		activityStore.QueryReferencesReturns(nil, errExpected)
-
-		handler := NewInbox(cfg, activityStore, ob, &apmocks.HTTPTransport{}, spi.WithWitness(witness))
-		require.NotNil(t, handler)
-
-		obj, err := vocab.NewObjectWithDocument(vocab.MustUnmarshalToDoc([]byte(anchorCredential1)))
-		require.NoError(t, err)
-
-		startTime := time.Now()
-		endTime := startTime.Add(time.Hour)
-
-		offer := vocab.NewOfferActivity(
-			vocab.NewObjectProperty(vocab.WithObject(obj)),
-			vocab.WithActor(service1IRI),
-			vocab.WithTo(service2IRI),
-			vocab.WithStartTime(&startTime),
-			vocab.WithEndTime(&endTime),
-		)
-
-		require.True(t, errors.Is(handler.HandleActivity(offer), errExpected))
-	})
-
 	t.Run("Not witnessing actor", func(t *testing.T) {
 		witness.WithProof([]byte(proof))
 
@@ -1661,8 +1635,7 @@ func TestHandler_HandleOfferActivity(t *testing.T) {
 		)
 
 		err = h.HandleActivity(offer)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "not in the 'witnessing' collection")
+		require.NoError(t, err)
 	})
 }
 

--- a/pkg/activitypub/service/activityhandler/inboxhandler.go
+++ b/pkg/activitypub/service/activityhandler/inboxhandler.go
@@ -408,16 +408,6 @@ func (h *Inbox) handleOfferActivity(offer *vocab.ActivityType) error {
 		return fmt.Errorf("invalid 'Offer' activity [%s]: %w", offer.ID(), err)
 	}
 
-	isWitnessing, err := h.hasReference(h.ServiceIRI, offer.Actor(), store.Witnessing)
-	if err != nil {
-		return fmt.Errorf("retrieve reference: %w", err)
-	}
-
-	if !isWitnessing {
-		return fmt.Errorf("not handling 'Offer' activity [%s] since [%s] is not in the 'witnessing' collection",
-			offer.ID(), offer.Actor())
-	}
-
 	if time.Now().After(*offer.EndTime()) {
 		return fmt.Errorf("offer [%s] has expired", offer.ID())
 	}

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -49,11 +49,6 @@ Feature:
     And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain2IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
     When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
-    # domain1 invites domain4 to be a witness
-    Given variable "inviteWitnessID" is assigned a unique ID
-    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"],"id":"${domain1IRI}/activities/${inviteWitnessID}","type":"InviteWitness","actor":"${domain1IRI}","to":"${domain4IRI}","object":"${domain4IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
-
     # set witness policy for domain1
     When an HTTP POST is sent to "https://orb.domain1.com/policy" with content "MinPercent(100,batch) AND MinPercent(50,system)" of type "text/plain"
 
@@ -136,6 +131,8 @@ Feature:
 
      # write batch of DIDs to multiple servers and check them
      When client sends request to "https://orb2.domain1.com/sidetree/v1/operations,https://orb.domain2.com/sidetree/v1/operations" to create 50 DID documents using 10 concurrent requests
+     # Remove the following sleep after issue #532 is resolved since messages are sometimes lost during shutdown.
+     And we wait 10 seconds
 
      # Stop orb2.domain1. The other instance in the domain should process any pending operations since
      # we're using a durable operation queue.


### PR DESCRIPTION
In the offer activity handler, remove the check that ensures the actor is in the 'witnessing' collection since a witness can be explicitly added to an operation (without being a system witness).

Actor verification for the /cas endpoint is turned off since now the actor is not in the 'witnessing' collection but needs access to the /cas endpoint.

closes #525

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>