### PR TITLE
fix: Fix issues related to restart resulting in lost messages/DIDs

### DIFF
--- a/cmd/orb-server/startcmd/params_test.go
+++ b/cmd/orb-server/startcmd/params_test.go
@@ -271,7 +271,6 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 		require.Contains(t, err.Error(), "invalid batch writer timeout format")
 	})
 
-
 	t.Run("test invalid max witness delay", func(t *testing.T) {
 		startCmd := GetStartCmd()
 
@@ -559,7 +558,7 @@ func TestStartCmdValidArgsEnvVar(t *testing.T) {
 		_, err := net.DialTimeout("tcp", os.Getenv(hostURLEnvKey), time.Second)
 
 		return err
-	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second), 3)))
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second), 5)))
 	require.NoError(t, syscall.Kill(syscall.Getpid(), syscall.SIGINT))
 }
 

--- a/pkg/activitypub/httpsig/algorithm.go
+++ b/pkg/activitypub/httpsig/algorithm.go
@@ -91,7 +91,7 @@ func (a *SignatureHashAlgorithm) Verify(secret httpsig.Secret, data, signature [
 	logger.Debugf("Got key %+v from keyID [%s]", pubKey, secret.KeyID)
 
 	if !ed25519.Verify(pubKey.Value, data, signature) {
-		logger.Infof("Signature verification failed using keyID [%s]: %s", secret.KeyID, err)
+		logger.Infof("Signature verification failed using keyID [%s]", secret.KeyID)
 
 		return ErrInvalidSignature
 	}

--- a/pkg/activitypub/service/inbox/inbox.go
+++ b/pkg/activitypub/service/inbox/inbox.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/ThreeDotsLabs/watermill/message/router/middleware"
-	"github.com/ThreeDotsLabs/watermill/message/router/plugin"
 	"github.com/trustbloc/edge-core/pkg/log"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/common"
 
@@ -95,8 +94,6 @@ func New(cfg *Config, s store.Store, pubSub pubSub, activityHandler service.Acti
 	}
 
 	router.AddMiddleware(middleware.Recoverer, middleware.CorrelationID)
-
-	router.AddPlugin(plugin.SignalsHandler)
 
 	router.AddHandler(
 		cfg.ServiceEndpoint, cfg.ServiceEndpoint,

--- a/pkg/activitypub/service/outbox/outbox.go
+++ b/pkg/activitypub/service/outbox/outbox.go
@@ -20,7 +20,6 @@ import (
 	"github.com/ThreeDotsLabs/watermill"
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/ThreeDotsLabs/watermill/message/router/middleware"
-	"github.com/ThreeDotsLabs/watermill/message/router/plugin"
 	"github.com/google/uuid"
 	"github.com/trustbloc/edge-core/pkg/log"
 
@@ -149,8 +148,6 @@ func New(cfg *Config, s store.Store, pubSub pubSub, t httpTransport, activityHan
 			return message.Messages{msg}, nil
 		},
 	)
-
-	router.AddPlugin(plugin.SignalsHandler)
 
 	h.router = router
 	h.httpPublisher = httpPublisher

--- a/pkg/activitypub/service/service.go
+++ b/pkg/activitypub/service/service.go
@@ -135,13 +135,13 @@ func New(cfg *Config, activityStore store.Store, t httpTransport, sigVerifier si
 
 func (s *Service) start() {
 	s.activityHandler.Start()
-	s.inbox.Start()
 	s.outbox.Start()
+	s.inbox.Start()
 }
 
 func (s *Service) stop() {
-	s.outbox.Stop()
 	s.inbox.Stop()
+	s.outbox.Stop()
 	s.activityHandler.Stop()
 }
 

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -11,13 +11,15 @@ import (
 	"sync/atomic"
 
 	"github.com/trustbloc/edge-core/pkg/log"
+
+	orberrors "github.com/trustbloc/orb/pkg/errors"
 )
 
 var logger = log.New("lifecycle")
 
 // ErrNotStarted indicates that an attempt was made to invoke a service that has not been started
 // or is still in the process of starting.
-var ErrNotStarted = errors.New("service has not started")
+var ErrNotStarted = orberrors.NewTransient(errors.New("service has not started"))
 
 // State is the state of the service.
 type State = uint32

--- a/pkg/observer/pubsub.go
+++ b/pkg/observer/pubsub.go
@@ -58,7 +58,7 @@ func NewPubSub(pubSub pubSub, anchorProcessor anchorProcessor, didProcessor didP
 		jsonMarshal:    json.Marshal,
 	}
 
-	h.Lifecycle = lifecycle.New("observer",
+	h.Lifecycle = lifecycle.New("observer-pubsub",
 		lifecycle.WithStart(h.start),
 	)
 
@@ -85,6 +85,10 @@ func NewPubSub(pubSub pubSub, anchorProcessor anchorProcessor, didProcessor didP
 
 // PublishAnchor publishes the anchor to the queue for processing.
 func (h *PubSub) PublishAnchor(anchorInfo *anchorinfo.AnchorInfo) error {
+	if h.State() != lifecycle.StateStarted {
+		return lifecycle.ErrNotStarted
+	}
+
 	payload, err := h.jsonMarshal(anchorInfo)
 	if err != nil {
 		return fmt.Errorf("publish anchorInfo: %w", err)
@@ -104,6 +108,10 @@ func (h *PubSub) PublishAnchor(anchorInfo *anchorinfo.AnchorInfo) error {
 
 // PublishDID publishes the DID to the queue for processing.
 func (h *PubSub) PublishDID(did string) error {
+	if h.State() != lifecycle.StateStarted {
+		return lifecycle.ErrNotStarted
+	}
+
 	payload, err := h.jsonMarshal(did)
 	if err != nil {
 		return fmt.Errorf("publish DID: %w", err)

--- a/pkg/observer/pubsub_test.go
+++ b/pkg/observer/pubsub_test.go
@@ -16,6 +16,7 @@ import (
 
 	anchorinfo "github.com/trustbloc/orb/pkg/anchor/info"
 	orberrors "github.com/trustbloc/orb/pkg/errors"
+	"github.com/trustbloc/orb/pkg/lifecycle"
 	"github.com/trustbloc/orb/pkg/mocks"
 	"github.com/trustbloc/orb/pkg/pubsub/mempubsub"
 )
@@ -194,5 +195,20 @@ func TestPubSub_Error(t *testing.T) {
 
 		require.NoError(t, ps.PublishAnchor(&anchorinfo.AnchorInfo{CID: "abcdefg"}))
 		require.NoError(t, ps.PublishDID("123456"))
+	})
+
+	t.Run("Not started error", func(t *testing.T) {
+		p := mempubsub.New(mempubsub.DefaultConfig())
+		require.NotNil(t, p)
+
+		ps, err := NewPubSub(p,
+			func(anchor *anchorinfo.AnchorInfo) error { return nil },
+			func(did string) error { return nil },
+		)
+		require.NoError(t, err)
+		require.NotNil(t, ps)
+
+		require.EqualError(t, ps.PublishAnchor(&anchorinfo.AnchorInfo{CID: "abcdefg"}), lifecycle.ErrNotStarted.Error())
+		require.EqualError(t, ps.PublishDID("123456"), lifecycle.ErrNotStarted.Error())
 	})
 }

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -131,21 +131,17 @@ Feature:
 
      # write batch of DIDs to multiple servers and check them
      When client sends request to "https://orb2.domain1.com/sidetree/v1/operations,https://orb.domain2.com/sidetree/v1/operations" to create 50 DID documents using 10 concurrent requests
-     # Remove the following sleep after issue #532 is resolved since messages are sometimes lost during shutdown.
-     And we wait 10 seconds
 
      # Stop orb2.domain1. The other instance in the domain should process any pending operations since
      # we're using a durable operation queue.
      Then container "orb2-domain1" is stopped
-     And we wait 10 seconds
+     And we wait 3 seconds
 
      Then client sends request to "https://orb.domain1.com/sidetree/v1/identifiers,https://orb.domain2.com/sidetree/v1/identifiers" to verify the DID documents that were created
 
      Then container "orb-domain1" is stopped
      Then container "orb-domain2" is stopped
      Then container "ipfs" is stopped
-
-     Then we wait 3 seconds
 
      Then container "orb-domain1" is started
      Then container "orb2-domain1" is started


### PR DESCRIPTION
- Ensure that all services are shut down in proper order:
  1. Batch writer
  2. Observer
  3. ActivityPub service
  4. Publisher/subscriber

-  In witness proof handler, publish the VC before setting the status to completed since, if the publisher returns a transient error, this handler would be invoked on another server instance. So, we want the status to remain in-process, otherwise the handler on the other instance would not publish the VC because it would think that is has already been processed.
- Also:
  - When storing KMS keys during startup, a delay was added between the time that the key was stored and retrieved in an attempt to handle the race condition where two Orb instances are both storing keys at the same time.
  - Fixed a data race in MockPubSub.

closes #532
closes #534

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>