### PR TITLE
fix: Add Nack to operation queue

### DIFF
--- a/cmd/orb-cli/go.sum
+++ b/cmd/orb-cli/go.sum
@@ -1310,8 +1310,8 @@ github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZ
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9 h1:JCWLY91Vp1qf19IFDSYUmHyPSfnYWZ5/fN6I5s+jq0M=
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9/go.mod h1:BpCeNH2fEH3RX7+C5XfnVIXFQbk7LzBdWdBdgnEb284=
 github.com/trustbloc/sidetree-core-go v0.6.0/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210618174051-34f0bd013d84 h1:FaGOu/SzEeqJIj6d5yQIr3bWdoKVPFVexlUCd3bWIhI=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210618174051-34f0bd013d84/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8 h1:LT44qj6qiVXLVUm2/ta3CU1/79eKlIeNP7s3u+hxxro=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/trustbloc/vct v0.1.2-0.20210622061858-eca8d26c0efa/go.mod h1:JExj0/Up71Ko08nWyaolsyiBL9uhFb68LnF99GCsrHA=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/cmd/orb-driver/go.mod
+++ b/cmd/orb-driver/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9
 	github.com/trustbloc/orb v0.1.2-0.20210609211752-6b2a1f8d7f21
-	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210618174051-34f0bd013d84
+	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8
 )
 
 replace github.com/trustbloc/orb => ../..

--- a/cmd/orb-driver/go.sum
+++ b/cmd/orb-driver/go.sum
@@ -1328,8 +1328,8 @@ github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZ
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9 h1:JCWLY91Vp1qf19IFDSYUmHyPSfnYWZ5/fN6I5s+jq0M=
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9/go.mod h1:BpCeNH2fEH3RX7+C5XfnVIXFQbk7LzBdWdBdgnEb284=
 github.com/trustbloc/sidetree-core-go v0.6.0/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210618174051-34f0bd013d84 h1:FaGOu/SzEeqJIj6d5yQIr3bWdoKVPFVexlUCd3bWIhI=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210618174051-34f0bd013d84/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8 h1:LT44qj6qiVXLVUm2/ta3CU1/79eKlIeNP7s3u+hxxro=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/trustbloc/vct v0.1.2-0.20210622061858-eca8d26c0efa/go.mod h1:JExj0/Up71Ko08nWyaolsyiBL9uhFb68LnF99GCsrHA=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/cmd/orb-server/go.mod
+++ b/cmd/orb-server/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9
 	github.com/trustbloc/orb v0.0.0
-	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210618174051-34f0bd013d84
+	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8
 	github.com/trustbloc/vct v0.1.2-0.20210622061858-eca8d26c0efa
 )
 

--- a/cmd/orb-server/go.sum
+++ b/cmd/orb-server/go.sum
@@ -1403,8 +1403,8 @@ github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoi
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9 h1:JCWLY91Vp1qf19IFDSYUmHyPSfnYWZ5/fN6I5s+jq0M=
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9/go.mod h1:BpCeNH2fEH3RX7+C5XfnVIXFQbk7LzBdWdBdgnEb284=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210618174051-34f0bd013d84 h1:FaGOu/SzEeqJIj6d5yQIr3bWdoKVPFVexlUCd3bWIhI=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210618174051-34f0bd013d84/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8 h1:LT44qj6qiVXLVUm2/ta3CU1/79eKlIeNP7s3u+hxxro=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/trustbloc/vct v0.1.2-0.20210622061858-eca8d26c0efa h1:E1UH+ul2er/crgNVQekWR/DKQLNbkncXSOA54bO+fZM=
 github.com/trustbloc/vct v0.1.2-0.20210622061858-eca8d26c0efa/go.mod h1:JExj0/Up71Ko08nWyaolsyiBL9uhFb68LnF99GCsrHA=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9
-	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210618174051-34f0bd013d84
+	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8
 	github.com/trustbloc/vct v0.1.2-0.20210622061858-eca8d26c0efa
 	golang.org/x/net v0.0.0-20210525063256-abc453219eb5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1392,8 +1392,8 @@ github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoi
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9 h1:JCWLY91Vp1qf19IFDSYUmHyPSfnYWZ5/fN6I5s+jq0M=
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9/go.mod h1:BpCeNH2fEH3RX7+C5XfnVIXFQbk7LzBdWdBdgnEb284=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210618174051-34f0bd013d84 h1:FaGOu/SzEeqJIj6d5yQIr3bWdoKVPFVexlUCd3bWIhI=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210618174051-34f0bd013d84/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8 h1:LT44qj6qiVXLVUm2/ta3CU1/79eKlIeNP7s3u+hxxro=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/trustbloc/vct v0.1.2-0.20210622061858-eca8d26c0efa h1:E1UH+ul2er/crgNVQekWR/DKQLNbkncXSOA54bO+fZM=
 github.com/trustbloc/vct v0.1.2-0.20210622061858-eca8d26c0efa/go.mod h1:JExj0/Up71Ko08nWyaolsyiBL9uhFb68LnF99GCsrHA=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/pkg/context/opqueue/opqueue_test.go
+++ b/pkg/context/opqueue/opqueue_test.go
@@ -8,70 +8,154 @@ package opqueue
 
 import (
 	"errors"
+	"fmt"
+	"os"
 	"testing"
 	"time"
 
+	dctest "github.com/ory/dockertest/v3"
+	dc "github.com/ory/dockertest/v3/docker"
 	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/edge-core/pkg/log"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 
 	ctxmocks "github.com/trustbloc/orb/pkg/context/mocks"
 	"github.com/trustbloc/orb/pkg/lifecycle"
+	"github.com/trustbloc/orb/pkg/pubsub/amqp"
 	"github.com/trustbloc/orb/pkg/pubsub/mempubsub"
 )
 
 //go:generate counterfeiter -o ../mocks/pubsub.gen.go --fake-name PubSub . pubSub
 
-var (
-	op1 = &operation.QueuedOperation{UniqueSuffix: "op1"}
-	op2 = &operation.QueuedOperation{UniqueSuffix: "op2"}
-	op3 = &operation.QueuedOperation{UniqueSuffix: "op3"}
+const (
+	dockerImage = "rabbitmq"
+	dockerTag   = "3-management-alpine"
+	mqURI       = "amqp://guest:guest@localhost:5672/"
 )
 
 func TestQueue(t *testing.T) {
-	ps := mempubsub.New(mempubsub.DefaultConfig())
+	log.SetLevel("sidetree_context", log.DEBUG)
+	log.SetLevel("pubsub", log.DEBUG)
 
-	q, err := New(Config{}, ps)
+	operations := newProcessedOperations(10)
+
+	ps1 := amqp.New(amqp.Config{URI: mqURI})
+	require.NotNil(t, ps1)
+
+	defer ps1.Stop()
+
+	ps2 := amqp.New(amqp.Config{URI: mqURI})
+	require.NotNil(t, ps2)
+
+	defer ps2.Stop()
+
+	q1, err := New(Config{PoolSize: 8}, ps1)
 	require.NoError(t, err)
-	require.NotNil(t, q)
+	require.NotNil(t, q1)
 
-	require.Zero(t, q.Len())
+	defer q1.Stop()
 
-	ops, err := q.Peek(2)
+	require.Zero(t, q1.Len())
+
+	ops1, err := q1.Peek(2)
 	require.NoError(t, err)
-	require.Empty(t, ops)
+	require.Empty(t, ops1)
 
-	_, err = q.Add(op1, 100)
+	q2, err := New(Config{PoolSize: 8}, ps2)
 	require.NoError(t, err)
+	require.NotNil(t, q2)
 
-	_, err = q.Add(op2, 101)
-	require.NoError(t, err)
+	defer q2.Stop()
 
-	_, err = q.Add(op3, 101)
+	require.Zero(t, q2.Len())
+
+	ops2, err := q2.Peek(2)
 	require.NoError(t, err)
+	require.Empty(t, ops2)
+
+	removedOps1, ack1, nack1, err := q1.Remove(2)
+	require.NoError(t, err)
+	require.Empty(t, removedOps1)
+	require.Equal(t, uint(0), ack1())
+	require.NotPanics(t, nack1)
+
+	for _, op := range operations {
+		_, err = q1.Add(op.op, 100)
+		require.NoError(t, err)
+	}
 
 	time.Sleep(100 * time.Millisecond)
 
-	ops, err = q.Peek(2)
+	ops1, err = q1.Peek(10)
 	require.NoError(t, err)
-	require.Len(t, ops, 2)
-	require.Equal(t, *op1, ops[0].QueuedOperation)
-	require.Equal(t, uint64(100), ops[0].ProtocolGenesisTime)
-	require.Equal(t, *op2, ops[1].QueuedOperation)
-	require.Equal(t, uint64(101), ops[1].ProtocolGenesisTime)
+	require.NotEmpty(t, ops1)
 
-	removed, n, err := q.Remove(2)
+	ops2, err = q2.Peek(10)
 	require.NoError(t, err)
-	require.Equal(t, uint(1), n)
-	require.Equal(t, uint(2), removed)
-	require.Equal(t, uint(1), q.Len())
+	require.NotEmpty(t, ops2)
 
-	removed, n, err = q.Remove(2)
+	removedOps1, ack1, _, err = q1.Remove(2)
 	require.NoError(t, err)
-	require.Equal(t, uint(0), n)
-	require.Equal(t, uint(1), removed)
+
+	pending := ack1()
+	require.True(t, pending > 0)
+	require.True(t, q1.Len() > 0)
+	require.Len(t, removedOps1, 2)
+
+	operations.setProcessed(t, removedOps1)
+
+	removedOps1, _, nack1, err = q1.Remove(2)
+	require.NoError(t, err)
+	require.Len(t, removedOps1, 2)
+
+	nack1()
+
+	time.Sleep(100 * time.Millisecond)
+
+	removedOps1, ack1, _, err = q1.Remove(1)
+	require.NoError(t, err)
+
+	ack1()
+
+	operations.setProcessed(t, removedOps1)
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Stop the pub/sub for q1. All messages should be diverted to q2.
+	q1.Stop()
+	ps1.Stop()
+
+	time.Sleep(time.Second)
+
+	removedOps2, ack2, _, err := q2.Remove(10)
+	require.NoError(t, err)
+
+	pending = ack2()
+	require.Equal(t, uint(0), pending)
+	require.Equal(t, uint(0), q2.Len())
+
+	operations.setProcessed(t, removedOps2)
+
+	removedOps2, _, _, err = q2.Remove(10)
+	require.NoError(t, err)
+	require.Empty(t, removedOps2)
+
+	var notProcessed []*processedOperation
+
+	for _, op := range operations {
+		if !op.processed {
+			t.Logf("Not processed: %s", op.op.UniqueSuffix)
+
+			notProcessed = append(notProcessed, op)
+		}
+	}
+
+	require.Emptyf(t, notProcessed, "%d operations were not processed", len(notProcessed))
 }
 
 func TestQueue_Error(t *testing.T) {
+	op1 := &operation.QueuedOperation{UniqueSuffix: "op1"}
+
 	ps := mempubsub.New(mempubsub.DefaultConfig())
 	defer ps.Stop()
 
@@ -90,7 +174,7 @@ func TestQueue_Error(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), lifecycle.ErrNotStarted.Error())
 
-		_, _, err = q.Remove(1)
+		_, _, _, err = q.Remove(1)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), lifecycle.ErrNotStarted.Error())
 
@@ -159,4 +243,65 @@ func TestQueue_Error(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, q.pending)
 	})
+}
+
+func TestMain(m *testing.M) {
+	code := 1
+
+	defer func() { os.Exit(code) }()
+
+	pool, err := dctest.NewPool("")
+	if err != nil {
+		panic(fmt.Sprintf("pool: %v", err))
+	}
+
+	resource, err := pool.RunWithOptions(&dctest.RunOptions{
+		Repository: dockerImage,
+		Tag:        dockerTag,
+		PortBindings: map[dc.Port][]dc.PortBinding{
+			"5672/tcp": {{HostIP: "", HostPort: "5672"}},
+		},
+	})
+	if err != nil {
+		logger.Errorf(`Failed to start RabbitMQ Docker image.`)
+
+		panic(fmt.Sprintf("run with options: %v", err))
+	}
+
+	defer func() {
+		if err := pool.Purge(resource); err != nil {
+			panic(fmt.Sprintf("purge: %v", err))
+		}
+	}()
+
+	code = m.Run()
+}
+
+type processedOperation struct {
+	op        *operation.QueuedOperation
+	processed bool
+}
+
+type processedOperations map[string]*processedOperation
+
+func (po processedOperations) setProcessed(t *testing.T, ops operation.QueuedOperationsAtTime) {
+	t.Helper()
+
+	for _, op := range ops {
+		pOp := po[op.UniqueSuffix]
+		require.False(t, pOp.processed)
+		pOp.processed = true
+	}
+}
+
+func newProcessedOperations(n int) processedOperations {
+	ops := make(processedOperations, n)
+
+	for i := 0; i < n; i++ {
+		op := &operation.QueuedOperation{UniqueSuffix: fmt.Sprintf("op%d", i)}
+
+		ops[op.UniqueSuffix] = &processedOperation{op: op}
+	}
+
+	return ops
 }

--- a/pkg/pubsub/amqp/pooledsubscriber.go
+++ b/pkg/pubsub/amqp/pooledsubscriber.go
@@ -95,7 +95,7 @@ func (s *poolSubscriber) listen() {
 			if !ok {
 				logger.Debugf("[%s-%d] Message channel was closed.", s.topic, s.n)
 
-				s.stoppedChan <- struct{}{}
+				close(s.stoppedChan)
 
 				return
 			}
@@ -106,7 +106,7 @@ func (s *poolSubscriber) listen() {
 		case <-s.stopChan:
 			logger.Debugf("[%s-%d] Listener was requested to stop", s.topic, s.n)
 
-			s.stoppedChan <- struct{}{}
+			close(s.stoppedChan)
 
 			return
 		}

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -411,20 +411,6 @@ services:
     networks:
       - orb_net
 
-  orb.mysql:
-    container_name: orb.mysql
-    image: mysql:8.0.24
-    restart: always
-    cap_add:
-      - SYS_NICE
-    environment:
-      - MYSQL_ALLOW_EMPTY_PASSWORD=true
-      - MYSQL_DATABASE=test
-    networks:
-      - orb_net
-    ports:
-      - 3306:3306
-
   orb.postgres:
     container_name: orb.postgres
     image: postgres:13

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/tidwall/gjson v1.7.4
 	github.com/trustbloc/orb v0.0.0
-	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210618174051-34f0bd013d84
+	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8
 )
 
 replace github.com/trustbloc/orb => ../../

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -1411,8 +1411,8 @@ github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoi
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9 h1:JCWLY91Vp1qf19IFDSYUmHyPSfnYWZ5/fN6I5s+jq0M=
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9/go.mod h1:BpCeNH2fEH3RX7+C5XfnVIXFQbk7LzBdWdBdgnEb284=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210618174051-34f0bd013d84 h1:FaGOu/SzEeqJIj6d5yQIr3bWdoKVPFVexlUCd3bWIhI=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210618174051-34f0bd013d84/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8 h1:LT44qj6qiVXLVUm2/ta3CU1/79eKlIeNP7s3u+hxxro=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/trustbloc/vct v0.1.2-0.20210622061858-eca8d26c0efa/go.mod h1:JExj0/Up71Ko08nWyaolsyiBL9uhFb68LnF99GCsrHA=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=


### PR DESCRIPTION
Upgraded to the latest sidetree-core-go which defines an explicit 'Nack' for the operation queue when operations are removed. If an error occurs then Nack will be invoked and the removed AMQP messages will also be nacked and the messages will be retried on another subscriber. The message broker may be configured to limit the number of retries.

closes #524

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>