### PR TITLE
fix: Use the anchor credential as the object in the 'likes' collection

### DIFF
--- a/pkg/activitypub/service/activityhandler/activityhandler_test.go
+++ b/pkg/activitypub/service/activityhandler/activityhandler_test.go
@@ -1750,7 +1750,7 @@ func TestHandler_HandleLikeActivity(t *testing.T) {
 
 		require.NotEmpty(t, proofHandler.Proof(anchorCredID.String()))
 
-		it, err := h.store.QueryReferences(store.Like, store.NewCriteria(store.WithObjectIRI(h.ServiceIRI)))
+		it, err := h.store.QueryReferences(store.Like, store.NewCriteria(store.WithObjectIRI(anchorCredID)))
 		require.NoError(t, err)
 
 		likes, err := storeutil.ReadReferences(it, -1)

--- a/pkg/activitypub/service/activityhandler/inboxhandler.go
+++ b/pkg/activitypub/service/activityhandler/inboxhandler.go
@@ -464,7 +464,7 @@ func (h *Inbox) handleLikeActivity(like *vocab.ActivityType) error {
 		return fmt.Errorf("proof handler returned error for 'Like' activity [%s]: %w", like.ID(), err)
 	}
 
-	err = h.store.AddReference(store.Like, h.ServiceIRI, like.ID().URL())
+	err = h.store.AddReference(store.Like, like.Object().IRI(), like.ID().URL())
 	if err != nil {
 		return orberrors.NewTransient(fmt.Errorf("unable to store 'Like' activity [%s]: %w", like.ID(), err))
 	}

--- a/pkg/activitypub/service/service_test.go
+++ b/pkg/activitypub/service/service_test.go
@@ -772,7 +772,7 @@ func TestService_Offer(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, liked)
 
-		rit, err = store1.QueryReferences(spi.Like, spi.NewCriteria(spi.WithObjectIRI(service1IRI)))
+		rit, err = store1.QueryReferences(spi.Like, spi.NewCriteria(spi.WithObjectIRI(obj.ID().URL())))
 		require.NoError(t, err)
 
 		likes, err := storeutil.ReadReferences(rit, -1)


### PR DESCRIPTION
Store the reference using the anchor credential as the object in the reference to the 'Like' activity. Previously the service URI was being used.

closes #549

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>