### PR TITLE
fix: REST API for /shares and /likes

### DIFF
--- a/cmd/orb-cli/go.sum
+++ b/cmd/orb-cli/go.sum
@@ -1350,8 +1350,8 @@ github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZ
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9 h1:JCWLY91Vp1qf19IFDSYUmHyPSfnYWZ5/fN6I5s+jq0M=
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9/go.mod h1:BpCeNH2fEH3RX7+C5XfnVIXFQbk7LzBdWdBdgnEb284=
 github.com/trustbloc/sidetree-core-go v0.6.0/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8 h1:LT44qj6qiVXLVUm2/ta3CU1/79eKlIeNP7s3u+hxxro=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798 h1:cgsdeHt7W8o+FLRGYZVsxVg8APfyN0oeNqEf9RMdkWM=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/trustbloc/vct v0.1.2-0.20210701072331-7056b87f3bbb/go.mod h1:JExj0/Up71Ko08nWyaolsyiBL9uhFb68LnF99GCsrHA=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/cmd/orb-driver/go.mod
+++ b/cmd/orb-driver/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9
 	github.com/trustbloc/orb v0.1.2-0.20210630053623-2436c6c2da6a
-	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8
+	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798
 )
 
 replace github.com/trustbloc/orb => ../..

--- a/cmd/orb-driver/go.sum
+++ b/cmd/orb-driver/go.sum
@@ -1328,8 +1328,8 @@ github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZ
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9 h1:JCWLY91Vp1qf19IFDSYUmHyPSfnYWZ5/fN6I5s+jq0M=
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9/go.mod h1:BpCeNH2fEH3RX7+C5XfnVIXFQbk7LzBdWdBdgnEb284=
 github.com/trustbloc/sidetree-core-go v0.6.0/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8 h1:LT44qj6qiVXLVUm2/ta3CU1/79eKlIeNP7s3u+hxxro=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798 h1:cgsdeHt7W8o+FLRGYZVsxVg8APfyN0oeNqEf9RMdkWM=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/trustbloc/vct v0.1.2-0.20210701072331-7056b87f3bbb/go.mod h1:JExj0/Up71Ko08nWyaolsyiBL9uhFb68LnF99GCsrHA=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/cmd/orb-server/go.mod
+++ b/cmd/orb-server/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9
 	github.com/trustbloc/orb v0.0.0
-	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8
+	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798
 	github.com/trustbloc/vct v0.1.2-0.20210701072331-7056b87f3bbb
 )
 

--- a/cmd/orb-server/go.sum
+++ b/cmd/orb-server/go.sum
@@ -1403,8 +1403,8 @@ github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoi
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9 h1:JCWLY91Vp1qf19IFDSYUmHyPSfnYWZ5/fN6I5s+jq0M=
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9/go.mod h1:BpCeNH2fEH3RX7+C5XfnVIXFQbk7LzBdWdBdgnEb284=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8 h1:LT44qj6qiVXLVUm2/ta3CU1/79eKlIeNP7s3u+hxxro=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798 h1:cgsdeHt7W8o+FLRGYZVsxVg8APfyN0oeNqEf9RMdkWM=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/trustbloc/vct v0.1.2-0.20210701072331-7056b87f3bbb h1:X/nk65nuh2D1qS2WcFadIewqcA6dK+/Or4dfe7Gs/5U=
 github.com/trustbloc/vct v0.1.2-0.20210701072331-7056b87f3bbb/go.mod h1:JExj0/Up71Ko08nWyaolsyiBL9uhFb68LnF99GCsrHA=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -134,8 +134,7 @@ const (
 	baseResolvePath = basePath + "/identifiers"
 	baseUpdatePath  = basePath + "/operations"
 
-	activityPubServicesPath     = "/services/orb"
-	activityPubTransactionsPath = "/transactions"
+	activityPubServicesPath = "/services/orb"
 
 	casPath = "/cas"
 	vctPath = "/vct"
@@ -444,8 +443,6 @@ func startOrbServices(parameters *orbParameters) error {
 
 	apServiceIRI := mustParseURL(parameters.externalEndpoint, activityPubServicesPath)
 
-	apTransactionsIRI := mustParseURL(parameters.externalEndpoint, activityPubTransactionsPath)
-
 	apConfig := &apservice.Config{
 		ServiceEndpoint:        activityPubServicesPath,
 		ServiceIRI:             apServiceIRI,
@@ -635,13 +632,6 @@ func startOrbServices(parameters *orbParameters) error {
 		PageSize:               parameters.activityPubPageSize,
 	}
 
-	apTxnEndpointCfg := &aphandler.Config{
-		Config:    authCfg,
-		BasePath:  activityPubTransactionsPath,
-		ObjectIRI: apTransactionsIRI,
-		PageSize:  parameters.activityPubPageSize,
-	}
-
 	var resolveHandlerOpts []resolvehandler.Option
 	resolveHandlerOpts = append(resolveHandlerOpts, resolvehandler.WithAliases(parameters.didAliases))
 	resolveHandlerOpts = append(resolveHandlerOpts, resolvehandler.WithUnpublishedDIDLabel(unpublishedDIDLabel))
@@ -711,8 +701,8 @@ func startOrbServices(parameters *orbParameters) error {
 		aphandler.NewWitnesses(apEndpointCfg, apStore, apSigVerifier),
 		aphandler.NewWitnessing(apEndpointCfg, apStore, apSigVerifier),
 		aphandler.NewLiked(apEndpointCfg, apStore, apSigVerifier),
-		aphandler.NewLikes(apTxnEndpointCfg, apStore, apSigVerifier),
-		aphandler.NewShares(apTxnEndpointCfg, apStore, apSigVerifier),
+		aphandler.NewLikes(apEndpointCfg, apStore, apSigVerifier),
+		aphandler.NewShares(apEndpointCfg, apStore, apSigVerifier),
 		aphandler.NewPostOutbox(apEndpointCfg, activityPubService.Outbox(), apStore, apSigVerifier),
 		aphandler.NewActivity(apEndpointCfg, apStore, apSigVerifier),
 		webcas.New(apEndpointCfg, apStore, apSigVerifier, coreCasClient),

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9
-	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8
+	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798
 	github.com/trustbloc/vct v0.1.2-0.20210701072331-7056b87f3bbb
 	golang.org/x/net v0.0.0-20210525063256-abc453219eb5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1392,8 +1392,8 @@ github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoi
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9 h1:JCWLY91Vp1qf19IFDSYUmHyPSfnYWZ5/fN6I5s+jq0M=
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9/go.mod h1:BpCeNH2fEH3RX7+C5XfnVIXFQbk7LzBdWdBdgnEb284=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8 h1:LT44qj6qiVXLVUm2/ta3CU1/79eKlIeNP7s3u+hxxro=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798 h1:cgsdeHt7W8o+FLRGYZVsxVg8APfyN0oeNqEf9RMdkWM=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/trustbloc/vct v0.1.2-0.20210701072331-7056b87f3bbb h1:X/nk65nuh2D1qS2WcFadIewqcA6dK+/Or4dfe7Gs/5U=
 github.com/trustbloc/vct v0.1.2-0.20210701072331-7056b87f3bbb/go.mod h1:JExj0/Up71Ko08nWyaolsyiBL9uhFb68LnF99GCsrHA=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/pkg/activitypub/resthandler/referencehandler.go
+++ b/pkg/activitypub/resthandler/referencehandler.go
@@ -102,7 +102,7 @@ func (h *Reference) handle(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	id, err := h.getID(objectIRI)
+	id, err := h.getID(objectIRI, req)
 	if err != nil {
 		logger.Errorf("[%s] Error generating ID: %s", h.endpoint, err)
 

--- a/pkg/activitypub/resthandler/referencehandler_test.go
+++ b/pkg/activitypub/resthandler/referencehandler_test.go
@@ -46,7 +46,7 @@ func TestNewFollowers(t *testing.T) {
 	require.NotNil(t, objectIRI)
 	require.Equal(t, "https://example1.com/services/orb", objectIRI.String())
 
-	id, err := h.getID(objectIRI)
+	id, err := h.getID(objectIRI, nil)
 	require.NoError(t, err)
 	require.NotNil(t, id)
 	require.Equal(t, "https://example1.com/services/orb/followers", id.String())
@@ -70,7 +70,7 @@ func TestNewFollowing(t *testing.T) {
 	require.NotNil(t, objectIRI)
 	require.Equal(t, "https://example1.com/services/orb", objectIRI.String())
 
-	id, err := h.getID(objectIRI)
+	id, err := h.getID(objectIRI, nil)
 	require.NoError(t, err)
 	require.NotNil(t, id)
 	require.Equal(t, "https://example1.com/services/orb/following", id.String())
@@ -94,7 +94,7 @@ func TestNewWitnesses(t *testing.T) {
 	require.NotNil(t, objectIRI)
 	require.Equal(t, "https://example1.com/services/orb", objectIRI.String())
 
-	id, err := h.getID(objectIRI)
+	id, err := h.getID(objectIRI, nil)
 	require.NoError(t, err)
 	require.NotNil(t, id)
 	require.Equal(t, "https://example1.com/services/orb/witnesses", id.String())
@@ -118,7 +118,7 @@ func TestNewWitnessing(t *testing.T) {
 	require.NotNil(t, objectIRI)
 	require.Equal(t, "https://example1.com/services/orb", objectIRI.String())
 
-	id, err := h.getID(objectIRI)
+	id, err := h.getID(objectIRI, nil)
 	require.NoError(t, err)
 	require.NotNil(t, id)
 	require.Equal(t, "https://example1.com/services/orb/witnessing", id.String())
@@ -248,7 +248,7 @@ func TestFollowers_Handler(t *testing.T) {
 
 		errExpected := fmt.Errorf("injected error")
 
-		h.getID = func(*url.URL) (*url.URL, error) {
+		h.getID = func(*url.URL, *http.Request) (*url.URL, error) {
 			return nil, errExpected
 		}
 

--- a/pkg/activitypub/resthandler/serviceshandler.go
+++ b/pkg/activitypub/resthandler/serviceshandler.go
@@ -152,6 +152,16 @@ func (h *Services) newService() (*vocab.ActorType, error) {
 		return nil, err
 	}
 
+	likes, err := newID(h.ObjectIRI, LikesPath)
+	if err != nil {
+		return nil, err
+	}
+
+	shares, err := newID(h.ObjectIRI, SharesPath)
+	if err != nil {
+		return nil, err
+	}
+
 	return vocab.NewService(h.ObjectIRI,
 		vocab.WithPublicKey(h.publicKey),
 		vocab.WithInbox(inbox),
@@ -161,6 +171,8 @@ func (h *Services) newService() (*vocab.ActorType, error) {
 		vocab.WithWitnesses(witnesses),
 		vocab.WithWitnessing(witnessing),
 		vocab.WithLiked(liked),
+		vocab.WithLikes(likes),
+		vocab.WithShares(shares),
 	), nil
 }
 

--- a/pkg/activitypub/resthandler/serviceshandler_test.go
+++ b/pkg/activitypub/resthandler/serviceshandler_test.go
@@ -279,18 +279,20 @@ const (
     "https://w3id.org/security/v1",
     "https://trustbloc.github.io/did-method-orb/contexts/anchor/v1"
   ],
+  "followers": "https://example1.com/services/orb/followers",
+  "following": "https://example1.com/services/orb/following",
   "id": "https://example1.com/services/orb",
-  "type": "Service",
+  "inbox": "https://example1.com/services/orb/inbox",
+  "liked": "https://example1.com/services/orb/liked",
+  "likes": "https://example1.com/services/orb/likes",
+  "outbox": "https://example1.com/services/orb/outbox",
   "publicKey": {
     "id": "https://example1.com/services/orb/keys/main-key",
     "owner": "https://example1.com/services/orb",
     "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhki....."
   },
-  "inbox": "https://example1.com/services/orb/inbox",
-  "outbox": "https://example1.com/services/orb/outbox",
-  "followers": "https://example1.com/services/orb/followers",
-  "following": "https://example1.com/services/orb/following",
-  "liked": "https://example1.com/services/orb/liked",
+  "shares": "https://example1.com/services/orb/shares",
+  "type": "Service",
   "witnesses": "https://example1.com/services/orb/witnesses",
   "witnessing": "https://example1.com/services/orb/witnessing"
 }`

--- a/pkg/activitypub/vocab/actortype.go
+++ b/pkg/activitypub/vocab/actortype.go
@@ -44,6 +44,8 @@ type actorType struct {
 	Witnesses  *URLProperty   `json:"witnesses"`
 	Witnessing *URLProperty   `json:"witnessing"`
 	Liked      *URLProperty   `json:"liked"`
+	Likes      *URLProperty   `json:"likes"`
+	Shares     *URLProperty   `json:"shares"`
 }
 
 // PublicKey returns the actor's public key.
@@ -146,6 +148,8 @@ func NewService(id *url.URL, opts ...Opt) *ActorType {
 			Witnesses:  NewURLProperty(options.Witnesses),
 			Witnessing: NewURLProperty(options.Witnessing),
 			Liked:      NewURLProperty(options.Liked),
+			Likes:      NewURLProperty(options.Likes),
+			Shares:     NewURLProperty(options.Shares),
 		},
 	}
 }

--- a/pkg/activitypub/vocab/actortype_test.go
+++ b/pkg/activitypub/vocab/actortype_test.go
@@ -28,6 +28,8 @@ func TestActor(t *testing.T) {
 	witnesses := testutil.MustParseURL("https://alice.example.com/services/orb/witnesses")
 	witnessing := testutil.MustParseURL("https://alice.example.com/services/orb/witnessing")
 	liked := testutil.MustParseURL("https://alice.example.com/services/orb/liked")
+	likes := testutil.MustParseURL("https://alice.example.com/services/orb/likes")
+	shares := testutil.MustParseURL("https://alice.example.com/services/orb/shares")
 
 	publicKey := NewPublicKey(
 		WithID(keyID),
@@ -45,6 +47,8 @@ func TestActor(t *testing.T) {
 			WithWitnesses(witnesses),
 			WithWitnessing(witnessing),
 			WithLiked(liked),
+			WithShares(shares),
+			WithLikes(likes),
 		)
 
 		bytes, err := canonicalizer.MarshalCanonical(service)
@@ -141,6 +145,7 @@ const jsonService = `{
   "following": "https://sally.example.com/services/orb/following",
   "witnesses": "https://alice.example.com/services/orb/witnesses",
   "witnessing": "https://alice.example.com/services/orb/witnessing",
-  "liked": "https://alice.example.com/services/orb/liked"
-}
-`
+  "liked": "https://alice.example.com/services/orb/liked",
+  "likes": "https://alice.example.com/services/orb/likes",
+  "shares": "https://alice.example.com/services/orb/shares"
+}`

--- a/pkg/activitypub/vocab/collection.go
+++ b/pkg/activitypub/vocab/collection.go
@@ -21,7 +21,7 @@ type collectionType struct {
 	Current    *URLProperty      `json:"current,omitempty"`
 	First      *URLProperty      `json:"first,omitempty"`
 	Last       *URLProperty      `json:"last,omitempty"`
-	TotalItems int               `json:"totalItems,omitempty"`
+	TotalItems int               `json:"totalItems"`
 	Items      []*ObjectProperty `json:"items,omitempty"`
 }
 

--- a/pkg/activitypub/vocab/options.go
+++ b/pkg/activitypub/vocab/options.go
@@ -249,6 +249,8 @@ type ActorOptions struct {
 	Witnesses  *url.URL
 	Witnessing *url.URL
 	Liked      *url.URL
+	Likes      *url.URL
+	Shares     *url.URL
 }
 
 // WithPublicKey sets the 'publicKey' property on the actor.
@@ -304,6 +306,20 @@ func WithWitnessing(witnessing *url.URL) Opt {
 func WithLiked(liked *url.URL) Opt {
 	return func(opts *Options) {
 		opts.Liked = liked
+	}
+}
+
+// WithLikes sets the 'likes' property on the actor.
+func WithLikes(likes *url.URL) Opt {
+	return func(opts *Options) {
+		opts.Likes = likes
+	}
+}
+
+// WithShares sets the 'shares' property on the actor.
+func WithShares(shares *url.URL) Opt {
+	return func(opts *Options) {
+		opts.Shares = shares
 	}
 }
 

--- a/pkg/context/opqueue/opqueue.go
+++ b/pkg/context/opqueue/opqueue.go
@@ -193,8 +193,6 @@ func (q *Queue) Len() uint {
 	q.mutex.RLock()
 	defer q.mutex.RUnlock()
 
-	logger.Debugf("Length of operation queue: %d", len(q.pending))
-
 	return uint(len(q.pending))
 }
 

--- a/test/bdd/features/activitypub.feature
+++ b/test/bdd/features/activitypub.feature
@@ -36,9 +36,11 @@ Feature:
     And the JSON path "followers" of the response equals "${domain2IRI}/followers"
     And the JSON path "following" of the response equals "${domain2IRI}/following"
     And the JSON path "liked" of the response equals "${domain2IRI}/liked"
+    And the JSON path "likes" of the response equals "${domain2IRI}/likes"
     And the JSON path "witnesses" of the response equals "${domain2IRI}/witnesses"
     And the JSON path "witnessing" of the response equals "${domain2IRI}/witnessing"
     And the JSON path "publicKey.id" of the response equals "${domain2IRI}/keys/main-key"
+    And the JSON path "shares" of the response equals "${domain2IRI}/shares"
 
   @activitypub_pubkey
   Scenario: Get service public key
@@ -164,6 +166,13 @@ Feature:
     When an HTTP GET is sent to "https://orb.domain2.com/services/orb/followers?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response does not contain "${domain3IRI}"
+
+    When an HTTP GET is sent to "https://orb.domain3.com/services/orb/shares?id=https%3A%2F%2Forb.domain1.com%2Ftransactions%2Fbafkreiduenhjrl7hjgh3lwxr6nvmfv4kzqzzizhzkbydxdabtcjptavzbm"
+    Then the JSON path "type" of the response equals "OrderedCollection"
+    Then the JSON path "first" of the response is saved to variable "sharesFirstPage"
+    When an HTTP GET is sent to "${sharesFirstPage}"
+    Then the JSON path "type" of the response equals "OrderedCollectionPage"
+    And the JSON path "orderedItems.0.object.items.0.id" of the response equals "https://orb.domain1.com/transactions/bafkreiduenhjrl7hjgh3lwxr6nvmfv4kzqzzizhzkbydxdabtcjptavzbm"
 
   @activitypub_invite_witness
   Scenario: invite witness/accept/undo

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/tidwall/gjson v1.7.4
 	github.com/trustbloc/orb v0.0.0
-	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8
+	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798
 )
 
 replace github.com/trustbloc/orb => ../../

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -1411,8 +1411,8 @@ github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoi
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9 h1:JCWLY91Vp1qf19IFDSYUmHyPSfnYWZ5/fN6I5s+jq0M=
 github.com/trustbloc/edge-core v0.1.7-0.20210310142750-7eb11997c4a9/go.mod h1:BpCeNH2fEH3RX7+C5XfnVIXFQbk7LzBdWdBdgnEb284=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8 h1:LT44qj6qiVXLVUm2/ta3CU1/79eKlIeNP7s3u+hxxro=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210629125844-990561a74be8/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798 h1:cgsdeHt7W8o+FLRGYZVsxVg8APfyN0oeNqEf9RMdkWM=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/trustbloc/vct v0.1.2-0.20210701072331-7056b87f3bbb/go.mod h1:JExj0/Up71Ko08nWyaolsyiBL9uhFb68LnF99GCsrHA=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/test/bdd/httpclient.go
+++ b/test/bdd/httpclient.go
@@ -299,10 +299,10 @@ func (c *httpClient) resolveURL(url string) string {
 	defer c.mutex.RUnlock()
 
 	for domain, mapping := range c.mappings {
-		if strings.Contains(url, domain) {
+		if strings.Contains(url, "//"+domain) {
 			logger.Infof("Mapping %s to %s", domain, mapping)
 
-			return strings.ReplaceAll(url, domain, mapping)
+			return strings.ReplaceAll(url, "//"+domain, "//"+mapping)
 		}
 	}
 


### PR DESCRIPTION
Changed the REST API for shares and likes to:
https://{base-url}/services/orb/shares?id={id}
https://{base-url}/services/orb/likes?id={id}

closes #550

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>