### PR TITLE
test: IPNS witness resolution in BDD test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ test/bdd/fixtures/export
 
 /coverage.txt
 /cmd/orb-cli/ipfskeygencmd/k1.key
+
+test/bdd/website
+test/bdd/OrbBDDTestKey.key

--- a/test/bdd/did_orb_steps.go
+++ b/test/bdd/did_orb_steps.go
@@ -67,7 +67,7 @@ var localURLs = map[string]string{
 
 var anchorOriginURLs = map[string]string{
 	"https://localhost:48326/sidetree/v1/operations": "https://orb.domain1.com/services/orb",
-	"https://localhost:48526/sidetree/v1/operations": "https://orb.domain1.com/services/orb",
+	"https://localhost:48526/sidetree/v1/operations": "ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q",
 	"https://localhost:48426/sidetree/v1/operations": "https://orb.domain1.com/services/orb",
 	"https://localhost:48626/sidetree/v1/operations": "https://orb.domain1.com/services/orb",
 	"https://localhost:48726/sidetree/v1/operations": "https://orb.domain1.com/services/orb",

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - ORB_TLS_KEY=/etc/orb/tls/ec-key.pem
       - ORB_DISCOVERY_DOMAIN=shared.domain.com
       - DID_NAMESPACE=did:orb
-      - ALLOWED_ORIGINS=https://orb.domain1.com/services/orb,https://orb.domain2.com/services/orb
+      - ALLOWED_ORIGINS=https://orb.domain1.com/services/orb,https://orb.domain2.com/services/orb,ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
       - BATCH_WRITER_TIMEOUT=1000
       - CAS_TYPE=${CAS_TYPE}
@@ -103,7 +103,7 @@ services:
       - ORB_TLS_KEY=/etc/orb/tls/ec-key.pem
       - ORB_DISCOVERY_DOMAIN=shared.domain.com
       - DID_NAMESPACE=did:orb
-      - ALLOWED_ORIGINS=https://orb.domain1.com/services/orb,https://orb.domain2.com/services/orb
+      - ALLOWED_ORIGINS=https://orb.domain1.com/services/orb,https://orb.domain2.com/services/orb,ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
       - BATCH_WRITER_TIMEOUT=1000
       - CAS_TYPE=${CAS_TYPE}
@@ -177,7 +177,7 @@ services:
       - ORB_TLS_KEY=/etc/orb/tls/ec-key.pem
       - ORB_DISCOVERY_DOMAIN=shared.domain.com
       - DID_NAMESPACE=did:orb
-      - ALLOWED_ORIGINS=https://orb.domain1.com/services/orb,https://orb.domain2.com/services/orb
+      - ALLOWED_ORIGINS=https://orb.domain1.com/services/orb,https://orb.domain2.com/services/orb,ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
       - BATCH_WRITER_TIMEOUT=1000
       - CAS_TYPE=${CAS_TYPE}
@@ -251,7 +251,7 @@ services:
       - ORB_TLS_KEY=/etc/orb/tls/ec-key.pem
       - ORB_DISCOVERY_DOMAIN=shared.domain.com
       - DID_NAMESPACE=did:orb
-      - ALLOWED_ORIGINS=https://orb.domain1.com/services/orb,https://orb.domain2.com/services/orb
+      - ALLOWED_ORIGINS=https://orb.domain1.com/services/orb,https://orb.domain2.com/services/orb,ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
       - BATCH_WRITER_TIMEOUT=1000
       - CAS_TYPE=${CAS_TYPE}
@@ -325,7 +325,7 @@ services:
       - ORB_TLS_KEY=/etc/orb/tls/ec-key.pem
       - DID_NAMESPACE=did:orb
       - DID_DISCOVERY_ENABLED=true
-      - ALLOWED_ORIGINS=https://orb.domain4.com/services/orb,https://orb.domain1.com/services/orb
+      - ALLOWED_ORIGINS=https://orb.domain4.com/services/orb,https://orb.domain1.com/services/orb,ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
       - BATCH_WRITER_TIMEOUT=1000
       - CAS_TYPE=${CAS_TYPE}

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -5,6 +5,7 @@
 module github.com/trustbloc/orb/test/bdd
 
 require (
+	github.com/cenkalti/backoff/v4 v4.1.0 // indirect
 	github.com/cucumber/godog v0.9.0
 	github.com/cucumber/messages-go/v10 v10.0.3
 	github.com/fsouza/go-dockerclient v1.6.5


### PR DESCRIPTION
One of the anchor origins in the DID tests is now specified via IPNS. The necessary data is uploaded to IPNS at the beginning of the test.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>