### PR TITLE
chore: Move endpoint client code to orb

### DIFF
--- a/pkg/discovery/endpoint/client/client.go
+++ b/pkg/discovery/endpoint/client/client.go
@@ -1,0 +1,509 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package client implements endpoint client
+//
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/bluele/gcache"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+	vdrapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdr"
+	"github.com/hyperledger/aries-framework-go/pkg/vdr"
+	"github.com/hyperledger/aries-framework-go/pkg/vdr/web"
+	"github.com/piprate/json-gold/ld"
+	"github.com/trustbloc/edge-core/pkg/log"
+
+	"github.com/trustbloc/orb/pkg/discovery/endpoint/client/models"
+	"github.com/trustbloc/orb/pkg/discovery/endpoint/restapi"
+	"github.com/trustbloc/orb/pkg/orbclient"
+)
+
+var logger = log.New("endpoint-client")
+
+const (
+	minResolvers         = "https://trustbloc.dev/ns/min-resolvers"
+	anchorOriginProperty = "https://trustbloc.dev/ns/anchor-origin"
+
+	didMethod  = "orb"
+	ipfsGlobal = "https://ipfs.io"
+	didParts   = 5
+)
+
+type httpClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type orbClient interface {
+	GetAnchorOrigin(cid, suffix string) (interface{}, error)
+}
+
+// Client fetches configs, caching results in-memory.
+type Client struct {
+	endpointsCache             gcache.Cache
+	endpointsAnchorOriginCache gcache.Cache
+	httpClient                 httpClient
+	authToken                  string
+	disableProofCheck          bool
+	docLoader                  ld.DocumentLoader
+	orbClient                  orbClient
+}
+
+type req struct {
+	did, domain string
+}
+
+// New create new endpoint client.
+func New(docLoader ld.DocumentLoader, opts ...Option) (*Client, error) {
+	configService := &Client{docLoader: docLoader, httpClient: &http.Client{}}
+
+	for _, opt := range opts {
+		opt(configService)
+	}
+
+	var orbClientOpts []orbclient.Option
+
+	orbClientOpts = append(orbClientOpts, orbclient.WithJSONLDDocumentLoader(docLoader))
+
+	if configService.disableProofCheck {
+		orbClientOpts = append(orbClientOpts, orbclient.WithDisableProofCheck(configService.disableProofCheck))
+	} else {
+		orbClientOpts = append(orbClientOpts, orbclient.WithPublicKeyFetcher(
+			verifiable.NewVDRKeyResolver(vdr.New(vdr.WithVDR(&webVDR{
+				http: configService.httpClient,
+				VDR:  web.New(),
+			}),
+			)).PublicKeyFetcher()))
+	}
+
+	orbClient, err := orbclient.New(fmt.Sprintf("did:%s", didMethod), &casReader{s: configService}, orbClientOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	configService.orbClient = orbClient
+
+	configService.endpointsCache = makeCache(
+		configService.getNewCacheable(func(did, domain string) (cacheable, error) {
+			return configService.getEndpoint(domain)
+		}))
+
+	configService.endpointsAnchorOriginCache = makeCache(
+		configService.getNewCacheable(func(did, domain string) (cacheable, error) {
+			return configService.getEndpointAnchorOrigin(did)
+		}))
+
+	return configService, nil
+}
+
+func makeCache(fetcher func(did, domain string) (interface{}, *time.Duration, error)) gcache.Cache {
+	return gcache.New(0).LoaderExpireFunc(func(key interface{}) (interface{}, *time.Duration, error) {
+		r, ok := key.(req)
+		if !ok {
+			return nil, nil, fmt.Errorf("key must be stringPair")
+		}
+
+		return fetcher(r.did, r.domain)
+	}).Build()
+}
+
+type cacheable interface {
+	CacheLifetime() (time.Duration, error)
+}
+
+func (cs *Client) getNewCacheable(
+	fetcher func(did, domain string) (cacheable, error),
+) func(did, domain string) (interface{}, *time.Duration, error) {
+	return func(did, domain string) (interface{}, *time.Duration, error) {
+		data, err := fetcher(did, domain)
+		if err != nil {
+			return nil, nil, fmt.Errorf("fetching cacheable object: %w", err)
+		}
+
+		expiryTime, err := data.CacheLifetime()
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to get object expiry time: %w", err)
+		}
+
+		return data, &expiryTime, nil
+	}
+}
+
+func getEntryHelper(cache gcache.Cache, key interface{}, objectName string) (interface{}, error) {
+	data, err := cache.Get(key)
+	if err != nil {
+		return nil, fmt.Errorf("getting %s from cache: %w", objectName, err)
+	}
+
+	return data, nil
+}
+
+// GetEndpoint fetches endpoints from domain, caching the value.
+func (cs *Client) GetEndpoint(domain string) (*models.Endpoint, error) {
+	endpoint, err := getEntryHelper(cs.endpointsCache, req{
+		domain: domain,
+	}, "endpoint")
+	if err != nil {
+		return nil, err
+	}
+
+	return endpoint.(*models.Endpoint), nil
+}
+
+// GetEndpointFromAnchorOrigin fetches endpoints from anchor origin, caching the value.
+func (cs *Client) GetEndpointFromAnchorOrigin(didURI string) (*models.Endpoint, error) {
+	endpoint, err := getEntryHelper(cs.endpointsAnchorOriginCache, req{
+		did: didURI,
+	}, "endpointAnchorOrigin")
+	if err != nil {
+		return nil, err
+	}
+
+	return endpoint.(*models.Endpoint), nil
+}
+
+func (cs *Client) getEndpoint(domain string) (*models.Endpoint, error) {
+	var wellKnownResponse restapi.WellKnownResponse
+
+	if !strings.HasPrefix(domain, "http://") && !strings.HasPrefix(domain, "https://") {
+		domain = "https://" + domain
+	}
+
+	err := cs.sendRequest(nil, http.MethodGet, fmt.Sprintf("%s/.well-known/did-orb", domain), &wellKnownResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	var jrd restapi.JRD
+
+	parsedURL, err := url.Parse(wellKnownResponse.ResolutionEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint, err := cs.populateResolutionEndpoint(fmt.Sprintf("%s://%s/.well-known/webfinger?resource=%s",
+		parsedURL.Scheme, parsedURL.Host, url.PathEscape(wellKnownResponse.ResolutionEndpoint)))
+	if err != nil {
+		return nil, err
+	}
+
+	err = cs.sendRequest(nil, http.MethodGet, fmt.Sprintf("%s://%s/.well-known/webfinger?resource=%s",
+		parsedURL.Scheme, parsedURL.Host, url.PathEscape(wellKnownResponse.OperationEndpoint)), &jrd)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, v := range jrd.Links {
+		endpoint.OperationEndpoints = append(endpoint.OperationEndpoints, v.Href)
+	}
+
+	return endpoint, nil
+}
+
+func (cs *Client) populateAnchorResolutionEndpoint(
+	jrd *restapi.JRD) (*models.Endpoint, error) {
+	endpoint := &models.Endpoint{}
+
+	min, ok := jrd.Properties[minResolvers].(float64)
+	if !ok {
+		return nil, fmt.Errorf("%s property is not float64", minResolvers)
+	}
+
+	endpoint.MinResolvers = int(min)
+
+	for _, v := range jrd.Links {
+		if v.Type == "application/did+ld+json" {
+			endpoint.ResolutionEndpoints = append(endpoint.ResolutionEndpoints,
+				v.Href[:strings.Index(v.Href, fmt.Sprintf("did:%s", didMethod))-1])
+		}
+	}
+
+	return endpoint, nil
+}
+
+//nolint: funlen,gocyclo,cyclop
+func (cs *Client) populateResolutionEndpoint(webFingerURL string) (*models.Endpoint, error) {
+	var jrd restapi.JRD
+
+	err := cs.sendRequest(nil, http.MethodGet, webFingerURL, &jrd)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint := &models.Endpoint{}
+
+	min, ok := jrd.Properties[minResolvers].(float64)
+	if !ok {
+		return nil, fmt.Errorf("%s property is not float64", minResolvers)
+	}
+
+	endpoint.MinResolvers = int(min)
+
+	m := make(map[string]struct{})
+
+	for _, v := range jrd.Links {
+		m[v.Href] = struct{}{}
+	}
+
+	// Fetches the configurations at each chosen link using WebFinger.
+	// Validates that each well-known configuration has the same policy for n and that all of the
+	// chosen links are listed in the n fetched configurations.
+
+	for _, v := range jrd.Links {
+		if v.Rel != "self" { //nolint: nestif
+			var webFingerResp restapi.JRD
+
+			parsedURL, err := url.Parse(v.Href)
+			if err != nil {
+				return nil, err
+			}
+
+			err = cs.sendRequest(nil, http.MethodGet, fmt.Sprintf("%s://%s/.well-known/webfinger?resource=%s",
+				parsedURL.Scheme, parsedURL.Host, url.PathEscape(v.Href)), &webFingerResp)
+			if err != nil {
+				return nil, err
+			}
+
+			min, ok = webFingerResp.Properties[minResolvers].(float64)
+			if !ok {
+				return nil, fmt.Errorf("%s property is not float64", minResolvers)
+			}
+
+			if int(min) != endpoint.MinResolvers {
+				logger.Warnf("%s has different policy for n %s", v.Href, minResolvers)
+
+				continue
+			}
+
+			if len(webFingerResp.Links) != len(jrd.Links) {
+				logger.Warnf("%s has different link", v.Href, minResolvers)
+
+				continue
+			}
+
+			for _, link := range webFingerResp.Links {
+				if _, ok = m[link.Href]; !ok {
+					logger.Warnf("%s has different link", v.Href, minResolvers)
+
+					continue
+				}
+			}
+		}
+
+		endpoint.ResolutionEndpoints = append(endpoint.ResolutionEndpoints, v.Href)
+	}
+
+	return endpoint, nil
+}
+
+func (cs *Client) getEndpointAnchorOrigin(didURI string) (*models.Endpoint, error) {
+	didSplit := strings.Split(didURI, ":")
+
+	if len(didSplit) < didParts {
+		return nil, fmt.Errorf("did format is wrong")
+	}
+
+	result, err := cs.orbClient.GetAnchorOrigin(didSplit[3], didSplit[4])
+	if err != nil {
+		return nil, err
+	}
+
+	anchorOrigin, ok := result.(string)
+	if !ok {
+		return nil, fmt.Errorf("get anchor origin didn't return string")
+	}
+
+	currentAnchorOrigin := anchorOrigin
+
+	var currentWebFingerRespone *restapi.JRD
+
+	for {
+		jrdLatestAnchorOrigin, errGet := cs.getLatestAnchorOrigin(currentAnchorOrigin, didURI)
+		if errGet != nil {
+			return nil, errGet
+		}
+
+		latestAnchorOrigin, ok := jrdLatestAnchorOrigin.Properties[anchorOriginProperty].(string)
+		if !ok {
+			return nil, fmt.Errorf("%s property is not string", anchorOriginProperty)
+		}
+
+		if latestAnchorOrigin == currentAnchorOrigin {
+			currentWebFingerRespone = jrdLatestAnchorOrigin
+
+			break
+		}
+
+		currentAnchorOrigin = latestAnchorOrigin
+	}
+
+	return cs.populateAnchorResolutionEndpoint(currentWebFingerRespone)
+}
+
+func (cs *Client) getWebFingerURL(anchorOrigin string) (string, error) {
+	if strings.HasPrefix(anchorOrigin, "ipns://") {
+		anchorOriginSplit := strings.Split(anchorOrigin, "ipns://")
+
+		return fmt.Sprintf("%s/%s/%s/.well-known/host-meta.json", ipfsGlobal, "ipns",
+			anchorOriginSplit[1]), nil
+	} else if strings.HasPrefix(anchorOrigin, "http://") || strings.HasPrefix(anchorOrigin, "https://") {
+		parsedURL, err := url.Parse(anchorOrigin)
+		if err != nil {
+			return "", err
+		}
+
+		urlValue := fmt.Sprintf("%s://%s", parsedURL.Scheme, parsedURL.Host)
+
+		return fmt.Sprintf("%s/.well-known/host-meta.json", urlValue), nil
+	}
+
+	return "", fmt.Errorf("anchorOrigin %s not supported", anchorOrigin)
+}
+
+func (cs *Client) getLatestAnchorOrigin(anchorOrigin, didURI string) (*restapi.JRD, error) {
+	var jrd restapi.JRD
+
+	webFingerURL, err := cs.getWebFingerURL(anchorOrigin)
+	if err != nil {
+		return nil, err
+	}
+
+	err = cs.sendRequest(nil, http.MethodGet, webFingerURL, &jrd)
+	if err != nil {
+		return nil, err
+	}
+
+	templateURL := ""
+
+	for _, v := range jrd.Links {
+		if v.Rel == "self" && v.Type == "application/jrd+json" {
+			templateURL = strings.ReplaceAll(v.Template, "{uri}", didURI)
+
+			break
+		}
+	}
+
+	if templateURL == "" {
+		return nil, fmt.Errorf("failed to find template url in webfinger doc")
+	}
+
+	err = cs.sendRequest(nil, http.MethodGet, templateURL, &jrd)
+	if err != nil {
+		return nil, err
+	}
+
+	return &jrd, nil
+}
+
+func (cs *Client) send(req []byte, method, endpointURL string) ([]byte, error) {
+	var httpReq *http.Request
+
+	var err error
+
+	if len(req) == 0 {
+		httpReq, err = http.NewRequestWithContext(context.Background(),
+			method, endpointURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create http request: %w", err)
+		}
+	} else {
+		httpReq, err = http.NewRequestWithContext(context.Background(),
+			method, endpointURL, bytes.NewBuffer(req))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create http request: %w", err)
+		}
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := cs.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+
+	defer closeResponseBody(resp.Body)
+
+	responseBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response : %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("got unexpected response from %s status '%d' body %s",
+			endpointURL, resp.StatusCode, responseBytes)
+	}
+
+	return responseBytes, nil
+}
+
+func (cs *Client) sendRequest(req []byte, method, endpointURL string, respObj interface{}) error { //nolint: unparam
+	responseBytes, err := cs.send(req, method, endpointURL)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(responseBytes, &respObj)
+}
+
+func closeResponseBody(respBody io.Closer) {
+	e := respBody.Close() // nolint: ifshort
+	if e != nil {
+		logger.Warnf("Failed to close response body: %v", e)
+	}
+}
+
+// Option is a config service instance option.
+type Option func(opts *Client)
+
+// WithHTTPClient option is for custom http client.
+func WithHTTPClient(httpClient httpClient) Option {
+	return func(opts *Client) {
+		opts.httpClient = httpClient
+	}
+}
+
+// WithAuthToken add auth token.
+func WithAuthToken(authToken string) Option {
+	return func(opts *Client) {
+		opts.authToken = "Bearer " + authToken
+	}
+}
+
+// WithDisableProofCheck disable proof check.
+func WithDisableProofCheck(disable bool) Option {
+	return func(opts *Client) {
+		opts.disableProofCheck = disable
+	}
+}
+
+type webVDR struct {
+	http httpClient
+	*web.VDR
+}
+
+func (w *webVDR) Read(didID string, opts ...vdrapi.DIDMethodOption) (*did.DocResolution, error) {
+	return w.VDR.Read(didID, append(opts, vdrapi.WithOption(web.HTTPClientOpt, w.http))...)
+}
+
+type casReader struct {
+	s *Client
+}
+
+func (c *casReader) Read(key string) ([]byte, error) {
+	return c.s.send(nil, http.MethodGet, fmt.Sprintf("%s/%s/%s", ipfsGlobal, "ipfs", key))
+}

--- a/pkg/discovery/endpoint/client/client_test.go
+++ b/pkg/discovery/endpoint/client/client_test.go
@@ -1,0 +1,575 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/pkg/discovery/endpoint/restapi"
+)
+
+const (
+	ipnsURL = "ipns://wwrrww"
+)
+
+func TestConfigService_GetEndpointAnchorOrigin(t *testing.T) {
+	t.Run("test wrong did", func(t *testing.T) {
+		cs, err := New(nil, WithAuthToken("t1"))
+		require.NoError(t, err)
+
+		_, err = cs.GetEndpointFromAnchorOrigin("did")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "did format is wrong")
+	})
+
+	t.Run("test error from orb client", func(t *testing.T) {
+		cs, err := New(nil, WithAuthToken("t1"))
+		require.NoError(t, err)
+
+		cs.orbClient = &mockOrbClient{getAnchorOriginFunc: func(cid, suffix string) (interface{}, error) {
+			return nil, fmt.Errorf("failed to get anchor origin")
+		}}
+
+		_, err = cs.GetEndpointFromAnchorOrigin("did:orb:ipfs:a:123")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to get anchor origin")
+	})
+
+	t.Run("test get anchor origin return not string", func(t *testing.T) {
+		cs, err := New(nil, WithAuthToken("t1"))
+		require.NoError(t, err)
+
+		cs.orbClient = &mockOrbClient{getAnchorOriginFunc: func(cid, suffix string) (interface{}, error) {
+			return []byte(""), nil
+		}}
+
+		_, err = cs.GetEndpointFromAnchorOrigin("did:orb:ipfs:a:123")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "get anchor origin didn't return string")
+	})
+
+	t.Run("test get anchor origin return not ipns", func(t *testing.T) {
+		cs, err := New(nil, WithAuthToken("t1"))
+		require.NoError(t, err)
+
+		cs.orbClient = &mockOrbClient{getAnchorOriginFunc: func(cid, suffix string) (interface{}, error) {
+			return "wrong", nil
+		}}
+
+		_, err = cs.GetEndpointFromAnchorOrigin("did:orb:ipfs:a:123")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "anchorOrigin wrong not supported")
+	})
+
+	t.Run("test get anchor origin return https", func(t *testing.T) {
+		cs, err := New(nil, WithAuthToken("t1"))
+		require.NoError(t, err)
+
+		cs.orbClient = &mockOrbClient{getAnchorOriginFunc: func(cid, suffix string) (interface{}, error) {
+			return "https://localhost", nil
+		}}
+
+		_, err = cs.GetEndpointFromAnchorOrigin("did:orb:ipfs:a:123")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "https://localhost/.well-known")
+	})
+
+	t.Run("test error fetch ipns webfinger", func(t *testing.T) {
+		cs, err := New(nil, WithAuthToken("t1"))
+		require.NoError(t, err)
+
+		cs.orbClient = &mockOrbClient{getAnchorOriginFunc: func(cid, suffix string) (interface{}, error) {
+			return ipnsURL, nil
+		}}
+
+		_, err = cs.GetEndpointFromAnchorOrigin("did:orb:ipfs:a:123")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "got unexpected response from")
+	})
+
+	t.Run("test error origin property not string", func(t *testing.T) {
+		cs, err := New(nil, WithAuthToken("t1"))
+		require.NoError(t, err)
+
+		cs.httpClient = &mockHTTPClient{doFunc: func(req *http.Request) (*http.Response, error) {
+			if strings.Contains(req.URL.Path, "ipns/wwrrww/.well-known/host-meta.json") {
+				b, errMarshal := json.Marshal(restapi.JRD{})
+				require.NoError(t, errMarshal)
+				r := ioutil.NopCloser(bytes.NewReader(b))
+
+				return &http.Response{StatusCode: http.StatusOK, Body: r}, nil
+			}
+
+			return nil, nil
+		}}
+
+		cs.orbClient = &mockOrbClient{getAnchorOriginFunc: func(cid, suffix string) (interface{}, error) {
+			return ipnsURL, nil
+		}}
+
+		_, err = cs.GetEndpointFromAnchorOrigin("did:orb:ipfs:a:123")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to find template url in webfinger doc")
+	})
+
+	t.Run("test error get template webfinger", func(t *testing.T) {
+		cs, err := New(nil, WithAuthToken("t1"))
+		require.NoError(t, err)
+
+		cs.httpClient = &mockHTTPClient{doFunc: func(req *http.Request) (*http.Response, error) {
+			if strings.Contains(req.URL.Path, "ipns/wwrrww/.well-known/host-meta.json") {
+				b, errMarshal := json.Marshal(restapi.JRD{Links: []restapi.Link{{
+					Rel:      "self",
+					Template: "https://localhost/.well-known/webfinger?resource={uri}",
+					Type:     "application/jrd+json",
+				}}})
+				require.NoError(t, errMarshal)
+				r := ioutil.NopCloser(bytes.NewReader(b))
+
+				return &http.Response{StatusCode: http.StatusOK, Body: r}, nil
+			} else if strings.Contains(req.URL.Path, ".well-known/webfinger") {
+				return nil, fmt.Errorf("failed to get template webfinger")
+			}
+
+			return nil, nil
+		}}
+
+		cs.orbClient = &mockOrbClient{getAnchorOriginFunc: func(cid, suffix string) (interface{}, error) {
+			return ipnsURL, nil
+		}}
+
+		_, err = cs.GetEndpointFromAnchorOrigin("did:orb:ipfs:a:123")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to get template webfinger")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		cs, err := New(nil, WithAuthToken("t1"))
+		require.NoError(t, err)
+
+		cs.httpClient = &mockHTTPClient{doFunc: func(req *http.Request) (*http.Response, error) {
+			if strings.Contains(req.URL.Path, "ipns/wwrrww/.well-known/host-meta.json") {
+				b, errMarshal := json.Marshal(restapi.JRD{Links: []restapi.Link{{
+					Rel:      "self",
+					Template: "https://localhost/.well-known/webfinger?resource={uri}",
+					Type:     "application/jrd+json",
+				}}})
+				require.NoError(t, errMarshal)
+				r := ioutil.NopCloser(bytes.NewReader(b))
+
+				return &http.Response{StatusCode: http.StatusOK, Body: r}, nil
+			}
+			if strings.Contains(req.URL.Path, ".well-known/webfinger") {
+				fmt.Println(req.URL.Path)
+				b, errMarshal := json.Marshal(restapi.JRD{
+					Properties: map[string]interface{}{
+						minResolvers:         float64(2),
+						anchorOriginProperty: ipnsURL,
+					},
+					Links: []restapi.Link{
+						{Href: "https://localhost/resolve1/did:orb:ipfs:a:123", Rel: "self", Type: "application/did+ld+json"},
+						{Href: "https://localhost/resolve2/did:orb:ipfs:a:123", Rel: "alternate", Type: "application/did+ld+json"},
+					},
+				})
+
+				require.NoError(t, errMarshal)
+				r := ioutil.NopCloser(bytes.NewReader(b))
+
+				return &http.Response{StatusCode: http.StatusOK, Body: r}, nil
+			}
+
+			return nil, nil
+		}}
+
+		cs.orbClient = &mockOrbClient{getAnchorOriginFunc: func(cid, suffix string) (interface{}, error) {
+			return ipnsURL, nil
+		}}
+
+		endpoint, err := cs.GetEndpointFromAnchorOrigin("did:orb:ipfs:a:123")
+		require.NoError(t, err)
+		require.Equal(t, "https://localhost/resolve1", endpoint.ResolutionEndpoints[0])
+		require.Equal(t, "https://localhost/resolve2", endpoint.ResolutionEndpoints[1])
+	})
+}
+
+func TestConfigService_GetEndpoint(t *testing.T) { //nolint: gocyclo,gocognit,cyclop
+	t.Run("success", func(t *testing.T) {
+		cs, err := New(nil, WithAuthToken("t1"), WithHTTPClient(
+			&mockHTTPClient{doFunc: func(req *http.Request) (*http.Response, error) {
+				if strings.Contains(req.URL.Path, ".well-known/did-orb") {
+					b, err := json.Marshal(restapi.WellKnownResponse{
+						OperationEndpoint:  "https://localhost/op",
+						ResolutionEndpoint: "https://localhost/resolve1",
+					})
+					require.NoError(t, err)
+					r := ioutil.NopCloser(bytes.NewReader(b))
+
+					return &http.Response{StatusCode: http.StatusOK, Body: r}, nil
+				}
+
+				if strings.Contains(req.URL.Path, ".well-known/webfinger") &&
+					strings.Contains(req.URL.RawQuery, "op") {
+					b, err := json.Marshal(restapi.JRD{
+						Links: []restapi.Link{{Href: "https://localhost/op1"}, {Href: "https://localhost/op2"}},
+					})
+					require.NoError(t, err)
+					r := ioutil.NopCloser(bytes.NewReader(b))
+
+					return &http.Response{StatusCode: http.StatusOK, Body: r}, nil
+				}
+
+				if strings.Contains(req.URL.Path, ".well-known/webfinger") &&
+					strings.Contains(req.URL.RawQuery, "resolve1") {
+					b, err := json.Marshal(restapi.JRD{
+						Properties: map[string]interface{}{minResolvers: float64(2)},
+						Links: []restapi.Link{
+							{Href: "https://localhost/resolve1", Rel: "self"},
+							{Href: "https://localhost/resolve2", Rel: "alternate"},
+						},
+					})
+					require.NoError(t, err)
+					r := ioutil.NopCloser(bytes.NewReader(b))
+
+					return &http.Response{StatusCode: http.StatusOK, Body: r}, nil
+				}
+
+				if strings.Contains(req.URL.Path, ".well-known/webfinger") &&
+					strings.Contains(req.URL.RawQuery, "resolve2") {
+					b, err := json.Marshal(restapi.JRD{
+						Properties: map[string]interface{}{minResolvers: float64(2)},
+						Links: []restapi.Link{
+							{Href: "https://localhost/resolve2", Rel: "self"},
+							{Href: "https://localhost/resolve1", Rel: "alternate"},
+						},
+					})
+					require.NoError(t, err)
+					r := ioutil.NopCloser(bytes.NewReader(b))
+
+					return &http.Response{StatusCode: http.StatusOK, Body: r}, nil
+				}
+
+				return nil, nil
+			}}))
+		require.NoError(t, err)
+
+		endpoint, err := cs.GetEndpoint("d1")
+		require.NoError(t, err)
+
+		require.Equal(t, endpoint.ResolutionEndpoints, []string{"https://localhost/resolve1", "https://localhost/resolve2"})
+		require.Equal(t, endpoint.OperationEndpoints, []string{"https://localhost/op1", "https://localhost/op2"})
+		require.Equal(t, endpoint.MinResolvers, 2)
+	})
+
+	t.Run("failed to fetch webfinger links", func(t *testing.T) {
+		cs, err := New(nil, WithAuthToken("t1"), WithHTTPClient(
+			&mockHTTPClient{doFunc: func(req *http.Request) (*http.Response, error) {
+				if strings.Contains(req.URL.Path, ".well-known/did-orb") {
+					b, err := json.Marshal(restapi.WellKnownResponse{
+						OperationEndpoint:  "https://localhost/op",
+						ResolutionEndpoint: "https://localhost/resolve1",
+					})
+					require.NoError(t, err)
+					r := ioutil.NopCloser(bytes.NewReader(b))
+
+					return &http.Response{StatusCode: http.StatusOK, Body: r}, nil
+				}
+
+				if strings.Contains(req.URL.Path, ".well-known/webfinger") &&
+					strings.Contains(req.URL.RawQuery, "resolve1") {
+					b, err := json.Marshal(restapi.JRD{
+						Properties: map[string]interface{}{minResolvers: float64(2)},
+						Links: []restapi.Link{
+							{Href: "https://localhost/resolve1", Rel: "self"},
+							{Href: "https://localhost/resolve2", Rel: "alternate"},
+						},
+					})
+					require.NoError(t, err)
+					r := ioutil.NopCloser(bytes.NewReader(b))
+
+					return &http.Response{StatusCode: http.StatusOK, Body: r}, nil
+				}
+
+				if strings.Contains(req.URL.Path, ".well-known/webfinger") &&
+					strings.Contains(req.URL.RawQuery, "resolve2") {
+					return &http.Response{
+						StatusCode: http.StatusInternalServerError,
+						Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+					}, nil
+				}
+
+				return nil, nil
+			}}))
+		require.NoError(t, err)
+
+		_, err = cs.GetEndpoint("d1")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "got unexpected response from "+
+			"https://localhost/.well-known/webfinger?resource=https:%2F%2Flocalhost%2Fresolve2 status")
+	})
+
+	t.Run("webfinger link return different min resolver", func(t *testing.T) {
+		cs, err := New(nil, WithAuthToken("t1"), WithHTTPClient(
+			&mockHTTPClient{doFunc: func(req *http.Request) (*http.Response, error) {
+				if strings.Contains(req.URL.Path, ".well-known/did-orb") {
+					b, err := json.Marshal(restapi.WellKnownResponse{
+						OperationEndpoint:  "https://localhost/op",
+						ResolutionEndpoint: "https://localhost/resolve1",
+					})
+					require.NoError(t, err)
+					r := ioutil.NopCloser(bytes.NewReader(b))
+
+					return &http.Response{StatusCode: http.StatusOK, Body: r}, nil
+				}
+
+				if strings.Contains(req.URL.Path, ".well-known/webfinger") &&
+					strings.Contains(req.URL.RawQuery, "op") {
+					b, err := json.Marshal(restapi.JRD{
+						Links: []restapi.Link{{Href: "https://localhost/op1"}, {Href: "https://localhost/op2"}},
+					})
+					require.NoError(t, err)
+					r := ioutil.NopCloser(bytes.NewReader(b))
+
+					return &http.Response{StatusCode: http.StatusOK, Body: r}, nil
+				}
+
+				if strings.Contains(req.URL.Path, ".well-known/webfinger") &&
+					strings.Contains(req.URL.RawQuery, "resolve1") {
+					b, err := json.Marshal(restapi.JRD{
+						Properties: map[string]interface{}{minResolvers: float64(2)},
+						Links: []restapi.Link{
+							{Href: "https://localhost/resolve1", Rel: "self"},
+							{Href: "https://localhost/resolve2", Rel: "alternate"},
+						},
+					})
+					require.NoError(t, err)
+					r := ioutil.NopCloser(bytes.NewReader(b))
+
+					return &http.Response{StatusCode: http.StatusOK, Body: r}, nil
+				}
+
+				if strings.Contains(req.URL.Path, ".well-known/webfinger") &&
+					strings.Contains(req.URL.RawQuery, "resolve2") {
+					b, err := json.Marshal(restapi.JRD{
+						Properties: map[string]interface{}{minResolvers: float64(3)},
+						Links: []restapi.Link{
+							{Href: "https://localhost/resolve2", Rel: "self"},
+							{Href: "https://localhost/resolve1", Rel: "alternate"},
+						},
+					})
+					require.NoError(t, err)
+					r := ioutil.NopCloser(bytes.NewReader(b))
+
+					return &http.Response{StatusCode: http.StatusOK, Body: r}, nil
+				}
+
+				return nil, nil
+			}}))
+		require.NoError(t, err)
+
+		endpoint, err := cs.GetEndpoint("d1")
+		require.NoError(t, err)
+
+		require.Equal(t, endpoint.ResolutionEndpoints, []string{"https://localhost/resolve1"})
+		require.Equal(t, endpoint.OperationEndpoints, []string{"https://localhost/op1", "https://localhost/op2"})
+		require.Equal(t, endpoint.MinResolvers, 2)
+	})
+
+	t.Run("webfinger link return different list of endpoints", func(t *testing.T) {
+		cs, err := New(nil, WithAuthToken("t1"), WithHTTPClient(
+			&mockHTTPClient{doFunc: func(req *http.Request) (*http.Response, error) {
+				if strings.Contains(req.URL.Path, ".well-known/did-orb") {
+					b, err := json.Marshal(restapi.WellKnownResponse{
+						OperationEndpoint:  "https://localhost/op",
+						ResolutionEndpoint: "https://localhost/resolve1",
+					})
+					require.NoError(t, err)
+					r := ioutil.NopCloser(bytes.NewReader(b))
+
+					return &http.Response{StatusCode: http.StatusOK, Body: r}, nil
+				}
+
+				if strings.Contains(req.URL.Path, ".well-known/webfinger") &&
+					strings.Contains(req.URL.RawQuery, "op") {
+					b, err := json.Marshal(restapi.JRD{
+						Links: []restapi.Link{{Href: "https://localhost/op1"}, {Href: "https://localhost/op2"}},
+					})
+					require.NoError(t, err)
+					r := ioutil.NopCloser(bytes.NewReader(b))
+
+					return &http.Response{StatusCode: http.StatusOK, Body: r}, nil
+				}
+
+				if strings.Contains(req.URL.Path, ".well-known/webfinger") &&
+					strings.Contains(req.URL.RawQuery, "resolve1") {
+					b, err := json.Marshal(restapi.JRD{
+						Properties: map[string]interface{}{minResolvers: float64(2)},
+						Links: []restapi.Link{
+							{Href: "https://localhost/resolve1", Rel: "self"},
+							{Href: "https://localhost/resolve2", Rel: "alternate"},
+						},
+					})
+					require.NoError(t, err)
+					r := ioutil.NopCloser(bytes.NewReader(b))
+
+					return &http.Response{StatusCode: http.StatusOK, Body: r}, nil
+				}
+
+				if strings.Contains(req.URL.Path, ".well-known/webfinger") &&
+					strings.Contains(req.URL.RawQuery, "resolve2") {
+					b, err := json.Marshal(restapi.JRD{
+						Properties: map[string]interface{}{minResolvers: float64(2)},
+						Links: []restapi.Link{
+							{Href: "https://localhost/resolve2", Rel: "self"},
+						},
+					})
+					require.NoError(t, err)
+					r := ioutil.NopCloser(bytes.NewReader(b))
+
+					return &http.Response{StatusCode: http.StatusOK, Body: r}, nil
+				}
+
+				return nil, nil
+			}}))
+		require.NoError(t, err)
+
+		endpoint, err := cs.GetEndpoint("d1")
+		require.NoError(t, err)
+
+		require.Equal(t, []string{"https://localhost/resolve1"}, endpoint.ResolutionEndpoints)
+		require.Equal(t, []string{"https://localhost/op1", "https://localhost/op2"}, endpoint.OperationEndpoints)
+		require.Equal(t, endpoint.MinResolvers, 2)
+	})
+
+	t.Run("fail to send request for well-known", func(t *testing.T) {
+		cs, err := New(nil, WithHTTPClient(
+			&mockHTTPClient{doFunc: func(req *http.Request) (*http.Response, error) {
+				return nil, fmt.Errorf("failed to send")
+			}}))
+		require.NoError(t, err)
+
+		_, err = cs.GetEndpoint("d1")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to send")
+	})
+
+	t.Run("well-known return 500 status", func(t *testing.T) {
+		cs, err := New(nil, WithHTTPClient(
+			&mockHTTPClient{doFunc: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusInternalServerError,
+					Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+				}, nil
+			}}))
+		require.NoError(t, err)
+
+		_, err = cs.GetEndpoint("d1")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "got unexpected response from https://d1/.well-known/did-orb status")
+	})
+
+	t.Run("web finger resolution return 500 status", func(t *testing.T) {
+		cs, err := New(nil, WithHTTPClient(
+			&mockHTTPClient{doFunc: func(req *http.Request) (*http.Response, error) {
+				if strings.Contains(req.URL.Path, ".well-known/did-orb") {
+					b, err := json.Marshal(restapi.WellKnownResponse{
+						OperationEndpoint:  "https://localhost/op",
+						ResolutionEndpoint: "https://localhost/resolve",
+					})
+					require.NoError(t, err)
+					r := ioutil.NopCloser(bytes.NewReader(b))
+
+					return &http.Response{StatusCode: http.StatusOK, Body: r}, nil
+				}
+
+				return &http.Response{
+					StatusCode: http.StatusInternalServerError,
+					Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+				}, nil
+			}}))
+		require.NoError(t, err)
+
+		_, err = cs.GetEndpoint("d1")
+		require.Error(t, err)
+		require.Contains(t, err.Error(),
+			"got unexpected response from https://localhost/.well-known"+
+				"/webfinger?resource=https:%2F%2Flocalhost%2Fresolve status")
+	})
+
+	t.Run("web finger operation return 500 status", func(t *testing.T) {
+		cs, err := New(nil, WithHTTPClient(
+			&mockHTTPClient{doFunc: func(req *http.Request) (*http.Response, error) {
+				if strings.Contains(req.URL.Path, ".well-known/did-orb") {
+					b, err := json.Marshal(restapi.WellKnownResponse{
+						OperationEndpoint:  "https://localhost/op",
+						ResolutionEndpoint: "https://localhost/resolve",
+					})
+					require.NoError(t, err)
+					r := ioutil.NopCloser(bytes.NewReader(b))
+
+					return &http.Response{StatusCode: http.StatusOK, Body: r}, nil
+				}
+
+				if strings.Contains(req.URL.Path, ".well-known/webfinger") &&
+					strings.Contains(req.URL.RawQuery, "resolve") {
+					b, err := json.Marshal(restapi.JRD{
+						Properties: map[string]interface{}{minResolvers: float64(2)},
+						Links: []restapi.Link{
+							{Href: "https://localhost/resolve1"},
+							{Href: "https://localhost/resolve2"},
+						},
+					})
+					require.NoError(t, err)
+					r := ioutil.NopCloser(bytes.NewReader(b))
+
+					return &http.Response{StatusCode: http.StatusOK, Body: r}, nil
+				}
+
+				return &http.Response{
+					StatusCode: http.StatusInternalServerError,
+					Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+				}, nil
+			}}))
+		require.NoError(t, err)
+
+		_, err = cs.GetEndpoint("d1")
+		require.Error(t, err)
+		require.Contains(t, err.Error(),
+			"got unexpected response from https://localhost/.well-known/"+
+				"webfinger?resource=https:%2F%2Flocalhost%2Fop status")
+	})
+}
+
+type mockHTTPClient struct {
+	doFunc func(req *http.Request) (*http.Response, error)
+}
+
+func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	if m.doFunc != nil {
+		return m.doFunc(req)
+	}
+
+	return nil, nil
+}
+
+type mockOrbClient struct {
+	getAnchorOriginFunc func(cid, suffix string) (interface{}, error)
+}
+
+func (m *mockOrbClient) GetAnchorOrigin(cid, suffix string) (interface{}, error) {
+	if m.getAnchorOriginFunc != nil {
+		return m.getAnchorOriginFunc(cid, suffix)
+	}
+
+	return nil, nil
+}

--- a/pkg/discovery/endpoint/client/models/endpoint.go
+++ b/pkg/discovery/endpoint/client/models/endpoint.go
@@ -1,0 +1,21 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package models
+
+import "time"
+
+// Endpoint include info about endpoint.
+type Endpoint struct {
+	ResolutionEndpoints []string
+	OperationEndpoints  []string
+	MinResolvers        int
+	MaxAge              uint `json:"-"`
+}
+
+// CacheLifetime returns the cache lifetime of the endpoint config file before it needs to be checked for an update.
+func (c Endpoint) CacheLifetime() (time.Duration, error) {
+	return time.Duration(c.MaxAge) * time.Second, nil
+}

--- a/pkg/versions/1_0/txnprocessor/txnprocessor.go
+++ b/pkg/versions/1_0/txnprocessor/txnprocessor.go
@@ -51,7 +51,7 @@ func (p *TxnProcessor) Process(sidetreeTxn txn.SidetreeTxn, suffixes ...string) 
 		txnOps = filterOps(txnOps, suffixes)
 	}
 
-	return p.processTxnOperations(txnOps, sidetreeTxn)
+	return p.processTxnOperations(txnOps, &sidetreeTxn)
 }
 
 func filterOps(txnOps []*operation.AnchoredOperation, suffixes []string) []*operation.AnchoredOperation {
@@ -76,7 +76,7 @@ func contains(arr []string, v string) bool {
 	return false
 }
 
-func (p *TxnProcessor) processTxnOperations(txnOps []*operation.AnchoredOperation, sidetreeTxn txn.SidetreeTxn) error { //nolint:gocritic,lll
+func (p *TxnProcessor) processTxnOperations(txnOps []*operation.AnchoredOperation, sidetreeTxn *txn.SidetreeTxn) error {
 	logger.Debugf("processing %d transaction operations", len(txnOps))
 
 	batchSuffixes := make(map[string]bool)
@@ -102,10 +102,7 @@ func (p *TxnProcessor) processTxnOperations(txnOps []*operation.AnchoredOperatio
 		}
 
 		op.TransactionTime = sidetreeTxn.TransactionTime
-
-		// The genesis time of the protocol that was used for this operation
 		op.ProtocolGenesisTime = sidetreeTxn.ProtocolGenesisTime
-
 		op.CanonicalReference = sidetreeTxn.CanonicalReference
 		op.EquivalentReferences = sidetreeTxn.EquivalentReferences
 

--- a/pkg/versions/1_0/txnprocessor/txnprocessor_test.go
+++ b/pkg/versions/1_0/txnprocessor/txnprocessor_test.go
@@ -84,7 +84,7 @@ func TestProcessTxnOperations(t *testing.T) {
 
 		p := New(providers)
 		err := p.processTxnOperations([]*operation.AnchoredOperation{{UniqueSuffix: "abc"}},
-			txn.SidetreeTxn{AnchorString: anchorString})
+			&txn.SidetreeTxn{AnchorString: anchorString})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to store operation from anchor string")
 	})
@@ -99,7 +99,7 @@ func TestProcessTxnOperations(t *testing.T) {
 
 		p := New(providers)
 		err := p.processTxnOperations([]*operation.AnchoredOperation{{UniqueSuffix: suffix}},
-			txn.SidetreeTxn{AnchorString: anchorString})
+			&txn.SidetreeTxn{AnchorString: anchorString})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "get error")
 	})
@@ -114,7 +114,7 @@ func TestProcessTxnOperations(t *testing.T) {
 		batchOps, err := p.OperationProtocolProvider.GetTxnOperations(&txn.SidetreeTxn{AnchorString: anchorString})
 		require.NoError(t, err)
 
-		err = p.processTxnOperations(batchOps, txn.SidetreeTxn{AnchorString: anchorString})
+		err = p.processTxnOperations(batchOps, &txn.SidetreeTxn{AnchorString: anchorString})
 		require.NoError(t, err)
 	})
 
@@ -137,7 +137,7 @@ func TestProcessTxnOperations(t *testing.T) {
 		require.NoError(t, err)
 
 		err = p.processTxnOperations(batchOps,
-			txn.SidetreeTxn{AnchorString: anchorString, CanonicalReference: canonicalRef})
+			&txn.SidetreeTxn{AnchorString: anchorString, CanonicalReference: canonicalRef})
 		require.NoError(t, err)
 	})
 
@@ -155,7 +155,7 @@ func TestProcessTxnOperations(t *testing.T) {
 		// only first operation will be processed, subsequent operations will be discarded
 		batchOps = append(batchOps, batchOps...)
 
-		err = p.processTxnOperations(batchOps, txn.SidetreeTxn{AnchorString: anchorString})
+		err = p.processTxnOperations(batchOps, &txn.SidetreeTxn{AnchorString: anchorString})
 		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
Move code for retrieving endpoint and resource information from orb client to orb. Same code will be used for discovering latest CID for DID on the server side.

Also, minor linter fix in txn processor.

Closes #563

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>