### PR TITLE
feat: Add webfinger client; add HasLog flag to witness proof

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -111,6 +111,7 @@ import (
 	proofstore "github.com/trustbloc/orb/pkg/store/witness"
 	"github.com/trustbloc/orb/pkg/vcsigner"
 	"github.com/trustbloc/orb/pkg/webcas"
+	wfclient "github.com/trustbloc/orb/pkg/webfinger/client"
 )
 
 const (
@@ -512,7 +513,9 @@ func startOrbServices(parameters *orbParameters) error {
 
 	apSigVerifier := getActivityPubVerifier(parameters, km, cr, t)
 
-	monitoringSvc, err := monitoring.New(storeProviders.provider, orbDocumentLoader, monitoring.WithHTTPClient(httpClient))
+	wfClient := wfclient.New(wfclient.WithHTTPClient(httpClient))
+
+	monitoringSvc, err := monitoring.New(storeProviders.provider, orbDocumentLoader, wfClient, monitoring.WithHTTPClient(httpClient))
 	if err != nil {
 		return fmt.Errorf("monitoring: %w", err)
 	}
@@ -594,6 +597,7 @@ func startOrbServices(parameters *orbParameters) error {
 		MonitoringSvc: monitoringSvc,
 		ActivityStore: apStore,
 		WitnessStore:  witnessProofStore,
+		WFClient:      wfClient,
 	}
 
 	// If no local IPFS node is configured, then use the public ipfs.io node as a fallback.

--- a/pkg/anchor/proof/proof.go
+++ b/pkg/anchor/proof/proof.go
@@ -11,6 +11,7 @@ type WitnessProof struct {
 	Type    WitnessType
 	Witness string
 	Proof   []byte
+	HasLog  bool
 }
 
 // WitnessType defines valid values for witness type.

--- a/pkg/webfinger/client/client.go
+++ b/pkg/webfinger/client/client.go
@@ -1,0 +1,211 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/bluele/gcache"
+	"github.com/trustbloc/edge-core/pkg/log"
+	"github.com/trustbloc/vct/pkg/controller/command"
+
+	"github.com/trustbloc/orb/pkg/discovery/endpoint/restapi"
+	"github.com/trustbloc/orb/pkg/webfinger/model"
+)
+
+var logger = log.New("webfinger-client")
+
+const defaultCacheLifetime = 300 * time.Second // five minutes
+
+// httpClient represents HTTP client.
+type httpClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type cacheable interface {
+	CacheLifetime() (time.Duration, error)
+}
+
+// Client implements webfinger client.
+type Client struct {
+	httpClient    httpClient
+	cacheLifetime time.Duration
+
+	ledgerTypeCache gcache.Cache
+}
+
+// New creates new webfinger client.
+func New(opts ...Option) *Client {
+	client := &Client{httpClient: &http.Client{}, cacheLifetime: defaultCacheLifetime}
+
+	for _, opt := range opts {
+		opt(client)
+	}
+
+	client.ledgerTypeCache = makeCache(
+		client.getNewCacheable(func(domain string) (cacheable, error) {
+			return client.getLedgerType(domain)
+		}))
+
+	return client
+}
+
+// GetLedgerType returns ledger type for domain.
+func (c *Client) GetLedgerType(domain string) (string, error) {
+	ledgerType, err := getEntryHelper(c.ledgerTypeCache, domain, "ledgerType")
+	if err != nil {
+		return "", err
+	}
+
+	return ledgerType.(*model.LedgerType).Value, nil
+}
+
+// GetLedgerType returns ledger type for domain.
+func (c *Client) getLedgerType(domain string) (*model.LedgerType, error) {
+	webfingerURL := fmt.Sprintf("%s/.well-known/webfinger?resource=%s/vct", domain, domain)
+
+	logger.Debugf("retrieving ledger type from webfingerURL: %s", webfingerURL)
+
+	req, err := http.NewRequest(http.MethodGet, webfingerURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to created new request for webfingerURL[%s]: %w", webfingerURL, err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request to webfingerURL[%s]: %w", webfingerURL, err)
+	}
+
+	defer func() {
+		if e := resp.Body.Close(); e != nil {
+			logger.Warnf("failed to close response body from %s: %s", webfingerURL, e)
+		}
+	}()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, model.ErrLedgerTypeNotFound
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		responseBody, readErr := ioutil.ReadAll(resp.Body)
+		if readErr != nil {
+			logger.Warnf("failed to read response body for webfingerURI[%s]: %w", webfingerURL, readErr)
+		}
+
+		return nil, fmt.Errorf("failed to retrieve data from webfingerURL[%s]"+
+			" status code: %d message: %s", webfingerURL, resp.StatusCode, string(responseBody))
+	}
+
+	var jrd *restapi.JRD
+
+	if err = json.NewDecoder(resp.Body).Decode(&jrd); err != nil {
+		return nil, fmt.Errorf("decode JRD: %w", err)
+	}
+
+	ltRaw, ok := jrd.Properties[command.LedgerType]
+	if !ok {
+		return nil, model.ErrLedgerTypeNotFound
+	}
+
+	lt, ok := ltRaw.(string)
+	if !ok {
+		return nil, fmt.Errorf("ledger type '%T' is not a string", ltRaw)
+	}
+
+	return &model.LedgerType{Value: lt, MaxAge: c.cacheLifetime}, nil
+}
+
+// HasSupportedLedgerType returns true if domain supports configured ledger type.
+func (c *Client) HasSupportedLedgerType(domain string) (bool, error) {
+	// TODO: Do we need to configure supported ledger types.
+	supportedLedgerTypes := []string{"vct-v1"}
+
+	lt, err := c.GetLedgerType(domain)
+	if err != nil {
+		if errors.Is(err, model.ErrLedgerTypeNotFound) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return contains(supportedLedgerTypes, lt), nil
+}
+
+// Option is a webfinger client instance option.
+type Option func(opts *Client)
+
+// WithHTTPClient option is for custom http client.
+func WithHTTPClient(httpClient httpClient) Option {
+	return func(opts *Client) {
+		opts.httpClient = httpClient
+	}
+}
+
+// WithCacheLifetime option defines the lifetime of an object in the cache.
+// If we end-up with multiple caches that require different lifetime
+// we may have to add different cache lifetime options.
+func WithCacheLifetime(lifetime time.Duration) Option {
+	return func(opts *Client) {
+		opts.cacheLifetime = lifetime
+	}
+}
+
+func getEntryHelper(cache gcache.Cache, key interface{}, objectName string) (interface{}, error) {
+	data, err := cache.Get(key)
+	if err != nil {
+		return nil, fmt.Errorf("getting %s from cache: %w", objectName, err)
+	}
+
+	logger.Debugf("got value for key[%v] from cache: %+v", key, data)
+
+	return data, nil
+}
+
+func (c *Client) getNewCacheable(
+	fetcher func(domain string) (cacheable, error),
+) func(domain string) (interface{}, *time.Duration, error) {
+	return func(domain string) (interface{}, *time.Duration, error) {
+		data, err := fetcher(domain)
+		if err != nil {
+			return nil, nil, fmt.Errorf("fetching cacheable object: %w", err)
+		}
+
+		expiryTime, err := data.CacheLifetime()
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to get object expiry time: %w", err)
+		}
+
+		return data, &expiryTime, nil
+	}
+}
+
+func makeCache(fetcher func(key string) (interface{}, *time.Duration, error)) gcache.Cache {
+	return gcache.New(0).LoaderExpireFunc(func(key interface{}) (interface{}, *time.Duration, error) {
+		r, ok := key.(string)
+		if !ok {
+			return nil, nil, fmt.Errorf("key must be string")
+		}
+
+		return fetcher(r)
+	}).Build()
+}
+
+func contains(l []string, e string) bool {
+	for _, s := range l {
+		if s == e {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/webfinger/client/client_test.go
+++ b/pkg/webfinger/client/client_test.go
@@ -1,0 +1,236 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("success - defaults", func(t *testing.T) {
+		c := New()
+
+		require.NotNil(t, c.httpClient)
+		require.Equal(t, 300*time.Second, c.cacheLifetime)
+	})
+
+	t.Run("success - options", func(t *testing.T) {
+		c := New(WithHTTPClient(http.DefaultClient), WithCacheLifetime(5*time.Second))
+
+		require.Equal(t, http.DefaultClient, c.httpClient)
+		require.Equal(t, 5*time.Second, c.cacheLifetime)
+	})
+}
+
+func TestGetLedgerType(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		httpClient := httpMock(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Body: ioutil.NopCloser(
+					bytes.NewBufferString(`{"properties":{"https://trustbloc.dev/ns/ledger-type":"vct"}}`),
+				),
+				StatusCode: http.StatusOK,
+			}, nil
+		})
+
+		c := New(WithHTTPClient(httpClient))
+
+		lt, err := c.GetLedgerType("https://orb.domain.com")
+		require.NoError(t, err)
+		require.Equal(t, "vct", lt)
+	})
+
+	t.Run("success - cache entry expired", func(t *testing.T) {
+		httpClient := httpMock(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Body: ioutil.NopCloser(
+					bytes.NewBufferString(`{"properties":{"https://trustbloc.dev/ns/ledger-type":"vct"}}`),
+				),
+				StatusCode: http.StatusOK,
+			}, nil
+		})
+
+		c := New(WithHTTPClient(httpClient), WithCacheLifetime(2*time.Second))
+
+		lt, err := c.GetLedgerType("https://orb.domain.com")
+		require.NoError(t, err)
+		require.Equal(t, "vct", lt)
+
+		lt, err = c.GetLedgerType("https://orb.domain.com")
+		require.NoError(t, err)
+		require.Equal(t, "vct", lt)
+
+		// sleep for 3 seconds so that cache entry expires
+		time.Sleep(3 * time.Second)
+
+		lt, err = c.GetLedgerType("https://orb.domain.com")
+		require.NoError(t, err)
+		require.Equal(t, "vct", lt)
+	})
+
+	t.Run("error - http.Do() error", func(t *testing.T) {
+		httpClient := httpMock(func(req *http.Request) (*http.Response, error) {
+			return nil, fmt.Errorf("http.Do() error")
+		})
+
+		c := New(WithHTTPClient(httpClient))
+
+		lt, err := c.GetLedgerType("https://orb.domain.com")
+		require.Error(t, err)
+		require.Empty(t, lt)
+		require.Contains(t, err.Error(), "http.Do() error")
+	})
+
+	t.Run("error - ledger type not a string", func(t *testing.T) {
+		httpClient := httpMock(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Body: ioutil.NopCloser(
+					bytes.NewBufferString(`{"properties":{"https://trustbloc.dev/ns/ledger-type": 100}}`),
+				),
+				StatusCode: http.StatusOK,
+			}, nil
+		})
+
+		c := New(WithHTTPClient(httpClient))
+
+		lt, err := c.GetLedgerType("https://orb.domain.com")
+		require.Error(t, err)
+		require.Empty(t, lt)
+		require.Contains(t, err.Error(), "ledger type 'float64' is not a string")
+	})
+
+	t.Run("error - no ledger type property", func(t *testing.T) {
+		httpClient := httpMock(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Body:       ioutil.NopCloser(bytes.NewBufferString(`{}`)),
+				StatusCode: http.StatusOK,
+			}, nil
+		})
+
+		c := New(WithHTTPClient(httpClient))
+
+		lt, err := c.GetLedgerType("https://orb.domain.com")
+		require.Error(t, err)
+		require.Empty(t, lt)
+		require.Contains(t, err.Error(), "ledger type not found")
+	})
+
+	t.Run("error - resource not found", func(t *testing.T) {
+		httpClient := httpMock(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Body:       ioutil.NopCloser(bytes.NewBufferString("not found")),
+				StatusCode: http.StatusNotFound,
+			}, nil
+		})
+
+		c := New(WithHTTPClient(httpClient))
+
+		lt, err := c.GetLedgerType("https://orb.domain.com")
+		require.Error(t, err)
+		require.Empty(t, lt)
+		require.Contains(t, err.Error(), "ledger type not found")
+	})
+
+	t.Run("error - internal server error", func(t *testing.T) {
+		httpClient := httpMock(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Body: ioutil.NopCloser(
+					bytes.NewBufferString("internal server error"),
+				),
+				StatusCode: http.StatusInternalServerError,
+			}, nil
+		})
+
+		c := New(WithHTTPClient(httpClient))
+		lt, err := c.GetLedgerType("https://orb.domain.com")
+		require.Error(t, err)
+		require.Empty(t, lt)
+		require.Contains(t, err.Error(), "status code: 500 message: internal server error")
+	})
+}
+
+func TestHasSupportedLedgerType(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		httpClient := httpMock(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Body: ioutil.NopCloser(
+					bytes.NewBufferString(`{"properties":{"https://trustbloc.dev/ns/ledger-type":"vct-v1"}}`),
+				),
+				StatusCode: http.StatusOK,
+			}, nil
+		})
+
+		c := New(WithHTTPClient(httpClient))
+
+		supported, err := c.HasSupportedLedgerType("https://orb.domain.com")
+		require.NoError(t, err)
+		require.True(t, supported)
+	})
+
+	t.Run("success - ledger type not supported", func(t *testing.T) {
+		httpClient := httpMock(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Body: ioutil.NopCloser(
+					bytes.NewBufferString(`{"properties":{"https://trustbloc.dev/ns/ledger-type":"vct"}}`),
+				),
+				StatusCode: http.StatusOK,
+			}, nil
+		})
+
+		c := New(WithHTTPClient(httpClient))
+
+		supported, err := c.HasSupportedLedgerType("https://orb.domain.com")
+		require.NoError(t, err)
+		require.False(t, supported)
+	})
+
+	t.Run("success - no ledger type not found", func(t *testing.T) {
+		httpClient := httpMock(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Body:       ioutil.NopCloser(bytes.NewBufferString(`{}`)),
+				StatusCode: http.StatusOK,
+			}, nil
+		})
+
+		c := New(WithHTTPClient(httpClient))
+
+		supported, err := c.HasSupportedLedgerType("https://orb.domain.com")
+		require.NoError(t, err)
+		require.False(t, supported)
+	})
+
+	t.Run("error - internal server error", func(t *testing.T) {
+		httpClient := httpMock(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Body: ioutil.NopCloser(
+					bytes.NewBufferString("internal server error"),
+				),
+				StatusCode: http.StatusInternalServerError,
+			}, nil
+		})
+
+		c := New(WithHTTPClient(httpClient))
+
+		supported, err := c.HasSupportedLedgerType("https://orb.domain.com")
+		require.Error(t, err)
+		require.False(t, supported)
+		require.Contains(t, err.Error(), "status code: 500 message: internal server error")
+	})
+}
+
+type httpMock func(req *http.Request) (*http.Response, error)
+
+func (m httpMock) Do(req *http.Request) (*http.Response, error) {
+	return m(req)
+}

--- a/pkg/webfinger/model/model.go
+++ b/pkg/webfinger/model/model.go
@@ -1,0 +1,26 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package model
+
+import (
+	"fmt"
+	"time"
+)
+
+// LedgerType includes info about ledger type.
+type LedgerType struct {
+	Value  string
+	MaxAge time.Duration
+}
+
+// CacheLifetime returns the cache lifetime of the endpoint config file before it needs to be checked for an update.
+func (lt *LedgerType) CacheLifetime() (time.Duration, error) {
+	return lt.MaxAge, nil
+}
+
+// ErrLedgerTypeNotFound is ledger type not found.
+var ErrLedgerTypeNotFound = fmt.Errorf("ledger type not found")

--- a/pkg/webfinger/model/model_test.go
+++ b/pkg/webfinger/model/model_test.go
@@ -1,0 +1,23 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetLedgerType(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		lt := &LedgerType{}
+
+		dur, err := lt.CacheLifetime()
+		require.NoError(t, err)
+		require.NotNil(t, dur)
+	})
+}


### PR DESCRIPTION
Add webfinger client (with caching) with GetLedgerType and HasSupportedLedgerType functions.

Refactor monitoring service to use webfinger client.
Add hasLog flag to witness proof.

Closes #574

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>