### PR TITLE
feat: Witness policy for witnesses without VCT log

### DIFF
--- a/pkg/anchor/policy/config/parser.go
+++ b/pkg/anchor/policy/config/parser.go
@@ -21,12 +21,15 @@ type WitnessPolicyConfig struct {
 	MinPercentBatch  int
 
 	Operator operatorFnc
+
+	LogRequired bool
 }
 
 // Gate values.
 const (
-	OutOf      = "OutOf"
-	MinPercent = "MinPercent"
+	OutOf       = "OutOf"
+	MinPercent  = "MinPercent"
+	LogRequired = "LogRequired"
 
 	AND = "AND"
 	OR  = "OR"
@@ -79,6 +82,8 @@ func (wp *WitnessPolicyConfig) processToken(token string) error {
 		if err != nil {
 			return err
 		}
+	case t == LogRequired:
+		wp.LogRequired = true
 	case t == AND:
 		wp.Operator = and
 	case t == OR:
@@ -161,6 +166,11 @@ func (wp *WitnessPolicyConfig) processMinPercent(token string) error {
 	}
 
 	return nil
+}
+
+func (wp *WitnessPolicyConfig) String() string {
+	return fmt.Sprintf("minBatch:%d, minSystem:%d, percentBatch:%d, percentSystem:%d, log:%t",
+		wp.MinNumberBatch, wp.MinNumberSystem, wp.MinPercentBatch, wp.MinPercentSystem, wp.LogRequired)
 }
 
 func and(a, b bool) bool {

--- a/pkg/anchor/policy/config/parser_test.go
+++ b/pkg/anchor/policy/config/parser_test.go
@@ -22,7 +22,10 @@ func TestParse(t *testing.T) {
 		require.Equal(t, 0, wp.MinNumberSystem)
 		require.Equal(t, 100, wp.MinPercentBatch)
 		require.Equal(t, 100, wp.MinPercentSystem)
+		require.Equal(t, false, wp.LogRequired)
 		require.Equal(t, and(true, false), wp.Operator(true, false))
+
+		require.NotEmpty(t, wp.String())
 	})
 
 	t.Run("error - rule not supported ", func(t *testing.T) {
@@ -143,5 +146,20 @@ func TestParse_MinPercent(t *testing.T) {
 		require.Error(t, err)
 		require.Nil(t, wp)
 		require.Contains(t, err.Error(), "expected 2 but got 3 arguments for MinPercent")
+	})
+}
+
+func TestParse_LogRequired(t *testing.T) {
+	t.Run("success - log required", func(t *testing.T) {
+		wp, err := Parse("LogRequired")
+		require.NoError(t, err)
+		require.NotNil(t, wp)
+
+		require.Equal(t, 0, wp.MinNumberBatch)
+		require.Equal(t, 0, wp.MinNumberSystem)
+		require.Equal(t, 100, wp.MinPercentBatch)
+		require.Equal(t, 100, wp.MinPercentSystem)
+		require.Equal(t, true, wp.LogRequired)
+		require.Equal(t, and(true, false), wp.Operator(true, false))
 	})
 }

--- a/pkg/anchor/policy/policy_test.go
+++ b/pkg/anchor/policy/policy_test.go
@@ -85,6 +85,229 @@ func TestEvaluate(t *testing.T) {
 		require.Equal(t, true, ok)
 	})
 
+	t.Run("success - default policy(100% batch and 100% system) satisfied with log required", func(t *testing.T) {
+		configStore, err := mem.NewProvider().OpenStore(configStoreName)
+		require.NoError(t, err)
+
+		err = configStore.Put(WitnessPolicyKey, []byte("LogRequired"))
+		require.NoError(t, err)
+
+		wp, err := New(configStore, defaultPolicyCacheExpiry)
+		require.NoError(t, err)
+		require.NotNil(t, wp)
+
+		witnessProofs := []*proof.WitnessProof{
+			{
+				Type:    proof.WitnessTypeBatch,
+				Witness: "batch-witness",
+				Proof:   []byte("proof"),
+				HasLog:  true,
+			},
+			{
+				Type:    proof.WitnessTypeSystem,
+				Witness: "system-witness",
+				Proof:   []byte("proof"),
+				HasLog:  true,
+			},
+		}
+
+		ok, err := wp.Evaluate(witnessProofs)
+		require.NoError(t, err)
+		require.Equal(t, true, ok)
+	})
+
+	t.Run("success - default policy fails with log required", func(t *testing.T) {
+		configStore, err := mem.NewProvider().OpenStore(configStoreName)
+		require.NoError(t, err)
+
+		err = configStore.Put(WitnessPolicyKey, []byte("LogRequired"))
+		require.NoError(t, err)
+
+		wp, err := New(configStore, defaultPolicyCacheExpiry)
+		require.NoError(t, err)
+		require.NotNil(t, wp)
+
+		witnessProofs := []*proof.WitnessProof{
+			{
+				Type:    proof.WitnessTypeBatch,
+				Witness: "batch-witness",
+				Proof:   []byte("proof"),
+				HasLog:  false,
+			},
+			{
+				Type:    proof.WitnessTypeSystem,
+				Witness: "system-witness",
+				Proof:   []byte("proof"),
+				HasLog:  true,
+			},
+		}
+
+		ok, err := wp.Evaluate(witnessProofs)
+		require.NoError(t, err)
+		require.Equal(t, false, ok)
+	})
+
+	t.Run("success - policy(50% batch and 50% system) satisfied with log required", func(t *testing.T) {
+		configStore, err := mem.NewProvider().OpenStore(configStoreName)
+		require.NoError(t, err)
+
+		err = configStore.Put(WitnessPolicyKey, []byte("MinPercent(50,batch) AND MinPercent(50,system) LogRequired"))
+		require.NoError(t, err)
+
+		wp, err := New(configStore, defaultPolicyCacheExpiry)
+		require.NoError(t, err)
+		require.NotNil(t, wp)
+
+		witnessProofs := []*proof.WitnessProof{
+			{
+				Type:    proof.WitnessTypeBatch,
+				Witness: "batch-witness",
+				Proof:   []byte("proof"),
+				HasLog:  true,
+			},
+			{
+				Type:    proof.WitnessTypeBatch,
+				Witness: "batch-witness-2",
+				Proof:   []byte("proof"),
+				HasLog:  false,
+			},
+			{
+				Type:    proof.WitnessTypeSystem,
+				Witness: "system-witness",
+				Proof:   []byte("proof"),
+				HasLog:  true,
+			},
+			{
+				Type:    proof.WitnessTypeSystem,
+				Witness: "system-witness-2",
+				Proof:   []byte("proof"),
+				HasLog:  false,
+			},
+		}
+
+		ok, err := wp.Evaluate(witnessProofs)
+		require.NoError(t, err)
+		require.Equal(t, true, ok)
+	})
+
+	t.Run("success - policy policy(50% batch and 50% system) fails with log required", func(t *testing.T) {
+		configStore, err := mem.NewProvider().OpenStore(configStoreName)
+		require.NoError(t, err)
+
+		err = configStore.Put(WitnessPolicyKey, []byte("MinPercent(50,batch) AND MinPercent(50,system) LogRequired"))
+		require.NoError(t, err)
+
+		wp, err := New(configStore, defaultPolicyCacheExpiry)
+		require.NoError(t, err)
+		require.NotNil(t, wp)
+
+		witnessProofs := []*proof.WitnessProof{
+			{
+				Type:    proof.WitnessTypeSystem,
+				Witness: "system-witness",
+				Proof:   []byte("proof"),
+				HasLog:  false,
+			},
+		}
+
+		ok, err := wp.Evaluate(witnessProofs)
+		require.NoError(t, err)
+		require.Equal(t, false, ok)
+	})
+
+	t.Run("success - policy OutOf(OR) satisfied with log required", func(t *testing.T) {
+		configStore, err := mem.NewProvider().OpenStore(configStoreName)
+		require.NoError(t, err)
+
+		err = configStore.Put(WitnessPolicyKey, []byte("OutOf(1,system) OR OutOf(1,batch) LogRequired"))
+		require.NoError(t, err)
+
+		wp, err := New(configStore, defaultPolicyCacheExpiry)
+		require.NoError(t, err)
+		require.NotNil(t, wp)
+
+		witnessProofs := []*proof.WitnessProof{
+			{
+				Type:    proof.WitnessTypeSystem,
+				Witness: "system-witness",
+				Proof:   []byte("proof"),
+				HasLog:  false,
+			},
+			{
+				Type:    proof.WitnessTypeBatch,
+				Witness: "batch-witness",
+				Proof:   []byte("proof"),
+				HasLog:  true,
+			},
+		}
+
+		ok, err := wp.Evaluate(witnessProofs)
+		require.NoError(t, err)
+		require.Equal(t, true, ok)
+	})
+
+	t.Run("success - policy OutOf(AND) satisfied with log required", func(t *testing.T) {
+		configStore, err := mem.NewProvider().OpenStore(configStoreName)
+		require.NoError(t, err)
+
+		err = configStore.Put(WitnessPolicyKey, []byte("OutOf(1,system) AND OutOf(1,batch) LogRequired"))
+		require.NoError(t, err)
+
+		wp, err := New(configStore, defaultPolicyCacheExpiry)
+		require.NoError(t, err)
+		require.NotNil(t, wp)
+
+		witnessProofs := []*proof.WitnessProof{
+			{
+				Type:    proof.WitnessTypeSystem,
+				Witness: "system-witness",
+				Proof:   []byte("proof"),
+				HasLog:  true,
+			},
+			{
+				Type:    proof.WitnessTypeBatch,
+				Witness: "batch-witness",
+				Proof:   []byte("proof"),
+				HasLog:  true,
+			},
+		}
+
+		ok, err := wp.Evaluate(witnessProofs)
+		require.NoError(t, err)
+		require.Equal(t, true, ok)
+	})
+
+	t.Run("success - policy OutOf(AND) fails with log required", func(t *testing.T) {
+		configStore, err := mem.NewProvider().OpenStore(configStoreName)
+		require.NoError(t, err)
+
+		err = configStore.Put(WitnessPolicyKey, []byte("OutOf(1,system) AND OutOf(1,batch) LogRequired"))
+		require.NoError(t, err)
+
+		wp, err := New(configStore, defaultPolicyCacheExpiry)
+		require.NoError(t, err)
+		require.NotNil(t, wp)
+
+		witnessProofs := []*proof.WitnessProof{
+			{
+				Type:    proof.WitnessTypeSystem,
+				Witness: "system-witness",
+				Proof:   []byte("proof"),
+				HasLog:  false,
+			},
+			{
+				Type:    proof.WitnessTypeBatch,
+				Witness: "batch-witness",
+				Proof:   []byte("proof"),
+				HasLog:  true,
+			},
+		}
+
+		ok, err := wp.Evaluate(witnessProofs)
+		require.NoError(t, err)
+		require.Equal(t, false, ok)
+	})
+
 	t.Run("success - policy not satisfied (no proofs)", func(t *testing.T) {
 		configStore, err := mem.NewProvider().OpenStore(configStoreName)
 		require.NoError(t, err)

--- a/pkg/anchor/proof/proof.go
+++ b/pkg/anchor/proof/proof.go
@@ -6,12 +6,18 @@ SPDX-License-Identifier: Apache-2.0
 
 package proof
 
+import "fmt"
+
 // WitnessProof contains anchor credential witness proof.
 type WitnessProof struct {
 	Type    WitnessType
 	Witness string
 	Proof   []byte
 	HasLog  bool
+}
+
+func (wf *WitnessProof) String() string {
+	return fmt.Sprintf("{type:%s, witness:%s, log:%t, proof:%s}", wf.Type, wf.Witness, wf.HasLog, string(wf.Proof))
 }
 
 // WitnessType defines valid values for witness type.


### PR DESCRIPTION
Add parsing of LogRequired flag for witness policy.

If witness log is NOT required then all witnesses (with or without log) are counted when evaluating witness policy.

If witness log is required then witnesses without log are not counted when evaluating witness policy.

Closes #511

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>