### PR TITLE
test: Temporarily disable IPNS in BDD tests

### DIFF
--- a/test/bdd/bddtests_test.go
+++ b/test/bdd/bddtests_test.go
@@ -70,7 +70,8 @@ func TestMain(m *testing.M) {
 				time.Sleep(time.Second * time.Duration(testSleep))
 			}
 
-			uploadHostMetaFileToIPNS()
+			// TODO: Add this back in, but move it to a BDD test step so it doesn't run every time.
+			// uploadHostMetaFileToIPNS()
 
 			for _, service := range services {
 				if err := AddJSONLDContexts(service); err != nil {

--- a/test/bdd/did_orb_steps.go
+++ b/test/bdd/did_orb_steps.go
@@ -67,7 +67,9 @@ var localURLs = map[string]string{
 
 var anchorOriginURLs = map[string]string{
 	"https://localhost:48326/sidetree/v1/operations": "https://orb.domain1.com/services/orb",
-	"https://localhost:48526/sidetree/v1/operations": "ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q",
+	// TODO: Change the value below back to ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q once
+	// IPNS is enabled again for the BDD tests.
+	"https://localhost:48526/sidetree/v1/operations": "https://orb.domain1.com/services/orb",
 	"https://localhost:48426/sidetree/v1/operations": "https://orb.domain1.com/services/orb",
 	"https://localhost:48626/sidetree/v1/operations": "https://orb.domain1.com/services/orb",
 	"https://localhost:48726/sidetree/v1/operations": "https://orb.domain1.com/services/orb",


### PR DESCRIPTION
Will be re-enabled again in another PR, but implemented as a step instead (and with a longer timeout).

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>