### PR TITLE
feat: Separate WebCAS and WebFinger resolving into reusable components

### DIFF
--- a/pkg/activitypub/service/monitoring/monitoring.go
+++ b/pkg/activitypub/service/monitoring/monitoring.go
@@ -235,7 +235,7 @@ func (c *Client) Watch(vc *verifiable.Credential, endTime time.Time, domain stri
 
 	lt, err := c.wfClient.GetLedgerType(domain)
 	if err != nil {
-		if errors.Is(err, model.ErrLedgerTypeNotFound) {
+		if errors.Is(err, model.ErrResourceNotFound) {
 			return nil
 		}
 

--- a/pkg/activitypub/service/monitoring/monitoring_test.go
+++ b/pkg/activitypub/service/monitoring/monitoring_test.go
@@ -405,7 +405,7 @@ func TestClient_Watch(t *testing.T) {
 		},
 			time.Now().Add(time.Minute),
 			"https://vct.com", time.Now(),
-		), "getting ledgerType from cache: fetching cacheable object: failed to retrieve data from webfingerURL[https://vct.com/.well-known/webfinger?resource=https://vct.com/vct] status code: 500 message: internal server error") //nolint:lll
+		), "getting ledgerType from cache: fetching cacheable object: failed to resolve WebFinger resource: received unexpected status code. URL [https://vct.com/.well-known/webfinger?resource=https://vct.com/vct], status code [500], response body [internal server error]") //nolint:lll
 
 		checkQueue(t, db, 0)
 	})

--- a/pkg/anchor/graph/graph_test.go
+++ b/pkg/anchor/graph/graph_test.go
@@ -24,6 +24,7 @@ import (
 	caswriter "github.com/trustbloc/orb/pkg/cas/writer"
 	"github.com/trustbloc/orb/pkg/internal/testutil"
 	"github.com/trustbloc/orb/pkg/store/cas"
+	webfingerclient "github.com/trustbloc/orb/pkg/webfinger/client"
 )
 
 const (
@@ -41,10 +42,12 @@ func TestGraph_Add(t *testing.T) {
 	require.NoError(t, err)
 
 	providers := &Providers{
-		CasWriter:   caswriter.New(casClient, "webcas:domain.com"),
-		CasResolver: casresolver.New(casClient, nil, &apmocks.HTTPTransport{}, "https"),
-		Pkf:         pubKeyFetcherFnc,
-		DocLoader:   testutil.GetLoader(t),
+		CasWriter: caswriter.New(casClient, "webcas:domain.com"),
+		CasResolver: casresolver.New(casClient, nil,
+			casresolver.NewWebCASResolver(
+				&apmocks.HTTPTransport{}, webfingerclient.New(), "https")),
+		Pkf:       pubKeyFetcherFnc,
+		DocLoader: testutil.GetLoader(t),
 	}
 
 	t.Run("success", func(t *testing.T) {
@@ -65,10 +68,12 @@ func TestGraph_Read(t *testing.T) {
 	require.NoError(t, err)
 
 	providers := &Providers{
-		CasWriter:   caswriter.New(casClient, "ipfs"),
-		CasResolver: casresolver.New(casClient, nil, &apmocks.HTTPTransport{}, "https"),
-		Pkf:         pubKeyFetcherFnc,
-		DocLoader:   testutil.GetLoader(t),
+		CasWriter: caswriter.New(casClient, "ipfs"),
+		CasResolver: casresolver.New(casClient, nil,
+			casresolver.NewWebCASResolver(
+				&apmocks.HTTPTransport{}, webfingerclient.New(), "https")),
+		Pkf:       pubKeyFetcherFnc,
+		DocLoader: testutil.GetLoader(t),
 	}
 
 	t.Run("success", func(t *testing.T) {
@@ -105,10 +110,12 @@ func TestGraph_GetDidAnchors(t *testing.T) {
 	require.NoError(t, err)
 
 	providers := &Providers{
-		CasWriter:   caswriter.New(casClient, "webcas:domain.com"),
-		CasResolver: casresolver.New(casClient, nil, &apmocks.HTTPTransport{}, "https"),
-		Pkf:         pubKeyFetcherFnc,
-		DocLoader:   testutil.GetLoader(t),
+		CasWriter: caswriter.New(casClient, "webcas:domain.com"),
+		CasResolver: casresolver.New(casClient, nil,
+			casresolver.NewWebCASResolver(
+				&apmocks.HTTPTransport{}, webfingerclient.New(), "https")),
+		Pkf:       pubKeyFetcherFnc,
+		DocLoader: testutil.GetLoader(t),
 	}
 
 	t.Run("success - first did anchor (create), no previous did anchors", func(t *testing.T) {

--- a/pkg/anchor/handler/credential/handler_test.go
+++ b/pkg/anchor/handler/credential/handler_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/trustbloc/orb/pkg/internal/testutil"
 	"github.com/trustbloc/orb/pkg/store/cas"
 	"github.com/trustbloc/orb/pkg/webcas"
+	webfingerclient "github.com/trustbloc/orb/pkg/webfinger/client"
 )
 
 //go:generate counterfeiter -o ../../mocks/anchorPublisher.gen.go --fake-name AnchorPublisher . anchorPublisher
@@ -165,7 +166,7 @@ func TestAnchorCredentialHandler(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to resolve anchor credential: "+
 			"failure while getting and storing data from the remote WebCAS endpoint: "+
-			"failed to retrieve data from")
+			"failed to get data via")
 		require.Contains(t, err.Error(), "Response status code: 404. Response body: "+
 			"no content at bafkreiehcfqwivyrzrqkrcyufbbp5oo5bjvbrvwdayrpgh5fuyhclkkzrq was found: content not found")
 	})
@@ -176,8 +177,10 @@ func createNewAnchorCredentialHandler(t *testing.T,
 	t.Helper()
 
 	casResolver := casresolver.New(client, nil,
-		transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
-			transport.DefaultSigner(), transport.DefaultSigner()), "https")
+		casresolver.NewWebCASResolver(
+			transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
+				transport.DefaultSigner(), transport.DefaultSigner()),
+			webfingerclient.New(), "https"))
 
 	anchorCredentialHandler := New(&anchormocks.AnchorPublisher{}, casResolver, testutil.GetLoader(t),
 		&mocks.MonitoringService{}, time.Second)

--- a/pkg/anchor/writer/writer_test.go
+++ b/pkg/anchor/writer/writer_test.go
@@ -113,10 +113,11 @@ func TestWriter_WriteAnchor(t *testing.T) {
 
 	graphProviders := &graph.Providers{
 		CasWriter: caswriter.New(casClient, "webcas:domain.com"),
-		CasResolver: casresolver.New(casClient, nil, transport.New(&http.Client{},
-			testutil.MustParseURL("https://example.com/keys/public-key"),
-			transport.DefaultSigner(), transport.DefaultSigner()), "https",
-		),
+		CasResolver: casresolver.New(casClient, nil,
+			casresolver.NewWebCASResolver(
+				transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
+					transport.DefaultSigner(), transport.DefaultSigner()),
+				wfclient.New(), "https")),
 		Pkf: pubKeyFetcherFnc,
 	}
 
@@ -809,10 +810,11 @@ func TestWriter_handle(t *testing.T) {
 
 	graphProviders := &graph.Providers{
 		CasWriter: caswriter.New(casClient, "webcas:domain.com"),
-		CasResolver: casresolver.New(casClient, nil, transport.New(&http.Client{},
-			testutil.MustParseURL("https://example.com/keys/public-key"),
-			transport.DefaultSigner(), transport.DefaultSigner()), "https",
-		),
+		CasResolver: casresolver.New(casClient, nil,
+			casresolver.NewWebCASResolver(
+				transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
+					transport.DefaultSigner(), transport.DefaultSigner()),
+				wfclient.New(), "https")),
 		Pkf: pubKeyFetcherFnc,
 	}
 
@@ -1143,13 +1145,13 @@ func TestWriter_postOfferActivity(t *testing.T) {
 		err = c.postOfferActivity(anchorVC, []string{"https://abc.com/services/orb"})
 		require.Error(t, err)
 		require.Contains(t, err.Error(),
-			"failed to retrieve data from webfingerURL[https://abc.com/.well-known/webfinger?resource=https://abc.com/vct] status code: 500 message: internal server error") //nolint:lll
+			"failed to resolve WebFinger resource: received unexpected status code. URL [https://abc.com/.well-known/webfinger?resource=https://abc.com/vct], status code [500], response body [internal server error]") //nolint:lll
 
 		// test error for system witness (no batch witnesses)
 		err = c.postOfferActivity(anchorVC, []string{})
 		require.Error(t, err)
 		require.Contains(t, err.Error(),
-			"failed to retrieve data from webfingerURL[http://orb.domain1.com/.well-known/webfinger?resource=http://orb.domain1.com/vct] status code: 500 message: internal server error") //nolint:lll
+			"failed to resolve WebFinger resource: received unexpected status code. URL [http://orb.domain1.com/.well-known/webfinger?resource=http://orb.domain1.com/vct], status code [500], response body [internal server error]") //nolint:lll
 	})
 
 	t.Run("error - activity store error", func(t *testing.T) {
@@ -1401,10 +1403,11 @@ func TestWriter_Read(t *testing.T) {
 
 	graphProviders := &graph.Providers{
 		CasWriter: caswriter.New(casClient, "webcas:domain.com"),
-		CasResolver: casresolver.New(casClient, nil, transport.New(&http.Client{},
-			testutil.MustParseURL("https://example.com/keys/public-key"),
-			transport.DefaultSigner(), transport.DefaultSigner()), "https",
-		),
+		CasResolver: casresolver.New(casClient, nil,
+			casresolver.NewWebCASResolver(
+				transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
+					transport.DefaultSigner(), transport.DefaultSigner()),
+				wfclient.New(), "https")),
 		Pkf: pubKeyFetcherFnc,
 	}
 

--- a/pkg/cas/ipfs/ipfs.go
+++ b/pkg/cas/ipfs/ipfs.go
@@ -81,7 +81,7 @@ func (m *Client) Read(cid string) ([]byte, error) {
 	reader, err := m.ipfs.Cat(cid)
 	if err != nil {
 		if strings.Contains(err.Error(), "context deadline exceeded") {
-			return nil, fmt.Errorf("%s: %w", err.Error(), orberrors.ErrContentNotFound)
+			return nil, orberrors.NewTransient(fmt.Errorf("%s: %w", err.Error(), orberrors.ErrContentNotFound))
 		}
 
 		return nil, orberrors.NewTransient(err)

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/trustbloc/orb/pkg/pubsub/mempubsub"
 	"github.com/trustbloc/orb/pkg/pubsub/spi"
 	"github.com/trustbloc/orb/pkg/store/cas"
+	webfingerclient "github.com/trustbloc/orb/pkg/webfinger/client"
 )
 
 //go:generate counterfeiter -o ../mocks/anchorgraph.gen.go --fake-name AnchorGraph . AnchorGraph
@@ -94,10 +95,11 @@ func TestStartObserver(t *testing.T) {
 
 		graphProviders := &graph.Providers{
 			CasWriter: caswriter.New(casClient, ""),
-			CasResolver: casresolver.New(casClient, nil, transport.New(&http.Client{},
-				testutil.MustParseURL("https://example.com/keys/public-key"),
-				transport.DefaultSigner(), transport.DefaultSigner()), "https",
-			),
+			CasResolver: casresolver.New(casClient, nil,
+				casresolver.NewWebCASResolver(
+					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
+						transport.DefaultSigner(), transport.DefaultSigner()),
+					webfingerclient.New(), "https")),
 			Pkf:       pubKeyFetcherFnc,
 			DocLoader: testutil.GetLoader(t),
 		}
@@ -161,10 +163,11 @@ func TestStartObserver(t *testing.T) {
 
 		graphProviders := &graph.Providers{
 			CasWriter: caswriter.New(casClient, ""),
-			CasResolver: casresolver.New(casClient, nil, transport.New(&http.Client{},
-				testutil.MustParseURL("https://example.com/keys/public-key"),
-				transport.DefaultSigner(), transport.DefaultSigner()), "https",
-			),
+			CasResolver: casresolver.New(casClient, nil,
+				casresolver.NewWebCASResolver(
+					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
+						transport.DefaultSigner(), transport.DefaultSigner()),
+					webfingerclient.New(), "https")),
 			Pkf:       pubKeyFetcherFnc,
 			DocLoader: testutil.GetLoader(t),
 		}
@@ -221,10 +224,11 @@ func TestStartObserver(t *testing.T) {
 
 		graphProviders := &graph.Providers{
 			CasWriter: caswriter.New(casClient, ""),
-			CasResolver: casresolver.New(casClient, nil, transport.New(&http.Client{},
-				testutil.MustParseURL("https://example.com/keys/public-key"),
-				transport.DefaultSigner(), transport.DefaultSigner()), "https",
-			),
+			CasResolver: casresolver.New(casClient, nil,
+				casresolver.NewWebCASResolver(
+					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
+						transport.DefaultSigner(), transport.DefaultSigner()),
+					webfingerclient.New(), "https")),
 			Pkf:       pubKeyFetcherFnc,
 			DocLoader: testutil.GetLoader(t),
 		}
@@ -287,10 +291,11 @@ func TestStartObserver(t *testing.T) {
 
 		graphProviders := &graph.Providers{
 			CasWriter: caswriter.New(casClient, ""),
-			CasResolver: casresolver.New(casClient, nil, transport.New(&http.Client{},
-				testutil.MustParseURL("https://example.com/keys/public-key"),
-				transport.DefaultSigner(), transport.DefaultSigner()), "https",
-			),
+			CasResolver: casresolver.New(casClient, nil,
+				casresolver.NewWebCASResolver(
+					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
+						transport.DefaultSigner(), transport.DefaultSigner()),
+					webfingerclient.New(), "https")),
 			Pkf:       pubKeyFetcherFnc,
 			DocLoader: testutil.GetLoader(t),
 		}
@@ -349,10 +354,11 @@ func TestStartObserver(t *testing.T) {
 
 		graphProviders := &graph.Providers{
 			CasWriter: caswriter.New(casClient, "webcas:domain.com"),
-			CasResolver: casresolver.New(casClient, nil, transport.New(&http.Client{},
-				testutil.MustParseURL("https://example.com/keys/public-key"),
-				transport.DefaultSigner(), transport.DefaultSigner()), "https",
-			),
+			CasResolver: casresolver.New(casClient, nil,
+				casresolver.NewWebCASResolver(
+					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
+						transport.DefaultSigner(), transport.DefaultSigner()),
+					webfingerclient.New(), "https")),
 			Pkf:       pubKeyFetcherFnc,
 			DocLoader: testutil.GetLoader(t),
 		}
@@ -409,10 +415,11 @@ func TestStartObserver(t *testing.T) {
 
 		graphProviders := &graph.Providers{
 			CasWriter: caswriter.New(casClient, ""),
-			CasResolver: casresolver.New(casClient, nil, transport.New(&http.Client{},
-				testutil.MustParseURL("https://example.com/keys/public-key"),
-				transport.DefaultSigner(), transport.DefaultSigner()), "https",
-			),
+			CasResolver: casresolver.New(casClient, nil,
+				casresolver.NewWebCASResolver(
+					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
+						transport.DefaultSigner(), transport.DefaultSigner()),
+					webfingerclient.New(), "https")),
 			Pkf:       pubKeyFetcherFnc,
 			DocLoader: testutil.GetLoader(t),
 		}
@@ -485,10 +492,11 @@ func TestStartObserver(t *testing.T) {
 
 		graphProviders := &graph.Providers{
 			CasWriter: caswriter.New(casClient, ""),
-			CasResolver: casresolver.New(casClient, nil, transport.New(&http.Client{},
-				testutil.MustParseURL("https://example.com/keys/public-key"),
-				transport.DefaultSigner(), transport.DefaultSigner()), "https",
-			),
+			CasResolver: casresolver.New(casClient, nil,
+				casresolver.NewWebCASResolver(
+					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
+						transport.DefaultSigner(), transport.DefaultSigner()),
+					webfingerclient.New(), "https")),
 			Pkf:       pubKeyFetcherFnc,
 			DocLoader: testutil.GetLoader(t),
 		}
@@ -587,10 +595,11 @@ func TestStartObserver(t *testing.T) {
 
 		graphProviders := &graph.Providers{
 			CasWriter: caswriter.New(casClient, ""),
-			CasResolver: casresolver.New(casClient, nil, transport.New(&http.Client{},
-				testutil.MustParseURL("https://example.com/keys/public-key"),
-				transport.DefaultSigner(), transport.DefaultSigner()), "https",
-			),
+			CasResolver: casresolver.New(casClient, nil,
+				casresolver.NewWebCASResolver(
+					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
+						transport.DefaultSigner(), transport.DefaultSigner()),
+					webfingerclient.New(), "https")),
 			Pkf:       pubKeyFetcherFnc,
 			DocLoader: testutil.GetLoader(t),
 		}

--- a/pkg/protocolversion/versions/v1_0/factory/factory_test.go
+++ b/pkg/protocolversion/versions/v1_0/factory/factory_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/trustbloc/orb/pkg/internal/testutil"
 	"github.com/trustbloc/orb/pkg/protocolversion/mocks"
 	"github.com/trustbloc/orb/pkg/store/cas"
+	webfingerclient "github.com/trustbloc/orb/pkg/webfinger/client"
 )
 
 func TestFactory_Create(t *testing.T) {
@@ -95,10 +96,11 @@ func TestCasClientWrapper_Read(t *testing.T) {
 func createNewResolver(t *testing.T, casClient extendedcasclient.Client) *casresolver.Resolver {
 	t.Helper()
 
-	casResolver := casresolver.New(casClient, nil, transport.New(&http.Client{},
-		testutil.MustParseURL("https://example.com/keys/public-key"),
-		transport.DefaultSigner(), transport.DefaultSigner()), "https",
-	)
+	casResolver := casresolver.New(casClient, nil,
+		casresolver.NewWebCASResolver(
+			transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
+				transport.DefaultSigner(), transport.DefaultSigner()),
+			webfingerclient.New(), "https"))
 	require.NotNil(t, casResolver)
 
 	return casResolver

--- a/pkg/webfinger/model/model.go
+++ b/pkg/webfinger/model/model.go
@@ -22,5 +22,5 @@ func (lt *LedgerType) CacheLifetime() (time.Duration, error) {
 	return lt.MaxAge, nil
 }
 
-// ErrLedgerTypeNotFound is ledger type not found.
-var ErrLedgerTypeNotFound = fmt.Errorf("ledger type not found")
+// ErrResourceNotFound is an error type used to indicate that a given resource could not be found.
+var ErrResourceNotFound = fmt.Errorf("resource not found")


### PR DESCRIPTION
- WebCAS and WebFinger resolving are now in separate, reusable components.
- Discovery endpoint client can make use of this in the future.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>