### PR TITLE
fix: Transient error handling

### DIFF
--- a/cmd/orb-server/startcmd/log.go
+++ b/cmd/orb-server/startcmd/log.go
@@ -6,10 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 
 package startcmd
 
-import (
-
-	"github.com/trustbloc/edge-core/pkg/log"
-)
+import "github.com/trustbloc/edge-core/pkg/log"
 
 const (
 	// LogLevelFlagName is the flag name used for setting the default log level.

--- a/pkg/activitypub/service/activityhandler/inboxhandler.go
+++ b/pkg/activitypub/service/activityhandler/inboxhandler.go
@@ -107,7 +107,8 @@ func (h *Inbox) handleCreateActivity(create *vocab.ActivityType) error {
 		}
 
 		if err := h.announceAnchorCredential(create); err != nil {
-			logger.Warnf("[%s] Unable to announce 'Create' to our followers: %s", h.ServiceIRI, err)
+			logger.Warnf("[%s] Unable to announce 'Create' activity [%s] to our followers: %s",
+				h.ServiceIRI, create.ID(), err)
 		}
 
 	case t.Is(vocab.TypeAnchorCredentialRef):
@@ -118,7 +119,8 @@ func (h *Inbox) handleCreateActivity(create *vocab.ActivityType) error {
 		}
 
 		if err := h.announceAnchorCredentialRef(create); err != nil {
-			logger.Warnf("[%s] Unable to announce 'Create' to our followers: %s", h.ServiceIRI, err)
+			logger.Warnf("[%s] Unable to announce 'Create' activity [%s] to our followers: %s",
+				h.ServiceIRI, create.ID(), err)
 		}
 
 	default:

--- a/pkg/activitypub/service/inbox/inbox_test.go
+++ b/pkg/activitypub/service/inbox/inbox_test.go
@@ -467,7 +467,7 @@ func TestInbox_Error(t *testing.T) {
 			}
 		}()
 
-		errExpected := fmt.Errorf("injected store error")
+		errExpected := orberrors.NewTransient(fmt.Errorf("injected transient store error"))
 
 		activityHandler := &mocks.ActivityHandler{}
 		activityStore := &mocks.ActivityStore{}

--- a/pkg/activitypub/store/storeutil/storeutil.go
+++ b/pkg/activitypub/store/storeutil/storeutil.go
@@ -12,6 +12,7 @@ import (
 
 	store "github.com/trustbloc/orb/pkg/activitypub/store/spi"
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+	orberrors "github.com/trustbloc/orb/pkg/errors"
 )
 
 // GetQueryOptions populates and returns the QueryOptions struct with the given options.
@@ -40,7 +41,7 @@ func ReadReferences(it store.ReferenceIterator, maxItems int) ([]*url.URL, error
 				break
 			}
 
-			return nil, err
+			return nil, orberrors.NewTransient(err)
 		}
 
 		refs = append(refs, ref)

--- a/pkg/anchor/vcpubsub/subscriber.go
+++ b/pkg/anchor/vcpubsub/subscriber.go
@@ -103,13 +103,13 @@ func (h *Subscriber) handleVerifiableCredentialMessage(msg *message.Message) {
 		msg.Ack()
 	case errors.IsTransient(err):
 		// The message should be redelivered to (potentially) another server instance.
-		logger.Warnf("Nacking verifiable credential message since it could not be delivered due"+
+		logger.Warnf("Nacking verifiable credential message since it could not be delivered due "+
 			"to a transient error. MsgID [%s], VC ID [%s]: %s", msg.UUID, vc.ID, err)
 
 		msg.Nack()
 	default:
 		// A persistent message should not be retried.
-		logger.Warnf("Acking verifiable credential message since it could not be delivered due"+
+		logger.Warnf("Acking verifiable credential message since it could not be delivered due "+
 			"to a persistent error. MsgID [%s], VC ID [%s]: %s", msg.UUID, vc.ID, err)
 
 		msg.Ack()

--- a/pkg/cas/ipfs/ipfs.go
+++ b/pkg/cas/ipfs/ipfs.go
@@ -23,7 +23,8 @@ import (
 
 var logger = log.New("cas-ipfs")
 
-const timeout = 5
+// TODO: Should be configurable (issue #594).
+const timeout = 20
 
 // Client will write new documents to IPFS and read existing documents from IPFS based on CID.
 // It implements Sidetree CAS interface.

--- a/pkg/context/opqueue/opqueue.go
+++ b/pkg/context/opqueue/opqueue.go
@@ -155,13 +155,13 @@ func (q *Queue) Remove(num uint) (ops operation.QueuedOperationsAtTime, ack func
 	q.pending = q.pending[n:]
 
 	ack = func() uint {
-		logger.Debugf("Acking %d operation messages...", len(items))
+		logger.Infof("Acking %d operation messages...", len(items))
 
 		// Acknowledge all of the messages that were processed.
 		for _, opMsg := range items {
 			opMsg.msg.Ack()
 
-			logger.Debugf("Acknowledged message [%s] - DID [%s]", opMsg.msg.UUID, opMsg.op.UniqueSuffix)
+			logger.Infof("Acknowledged message [%s] - DID [%s]", opMsg.msg.UUID, opMsg.op.UniqueSuffix)
 		}
 
 		q.mutex.RLock()
@@ -171,13 +171,13 @@ func (q *Queue) Remove(num uint) (ops operation.QueuedOperationsAtTime, ack func
 	}
 
 	nack = func() {
-		logger.Debugf("Nacking %d operation messages...", len(items))
+		logger.Infof("Nacking %d operation messages...", len(items))
 
 		// Send an Nack for all of the messages that were removed so that they may be retried.
 		for _, opMsg := range items {
 			opMsg.msg.Nack()
 
-			logger.Debugf("Nacked message [%s] - DID [%s]", opMsg.msg.UUID, opMsg.op.UniqueSuffix)
+			logger.Infof("Nacked message [%s] - DID [%s]", opMsg.msg.UUID, opMsg.op.UniqueSuffix)
 		}
 	}
 

--- a/pkg/store/operation/store.go
+++ b/pkg/store/operation/store.go
@@ -14,6 +14,8 @@ import (
 	"github.com/hyperledger/aries-framework-go/spi/storage"
 	"github.com/trustbloc/edge-core/pkg/log"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
+
+	orberrors "github.com/trustbloc/orb/pkg/errors"
 )
 
 const (
@@ -74,7 +76,7 @@ func (s *Store) Put(ops []*operation.AnchoredOperation) error {
 
 	err := s.store.Batch(operations)
 	if err != nil {
-		return fmt.Errorf("failed to store operations: %w", err)
+		return orberrors.NewTransient(fmt.Errorf("failed to store operations: %w", err))
 	}
 
 	logger.Debugf("stored %d operations", len(ops))
@@ -90,12 +92,12 @@ func (s *Store) Get(suffix string) ([]*operation.AnchoredOperation, error) {
 
 	iter, err := s.store.Query(query)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get operations for[%s]: %w", query, err)
+		return nil, orberrors.NewTransient(fmt.Errorf("failed to get operations for[%s]: %w", query, err))
 	}
 
 	ok, err := iter.Next()
 	if err != nil {
-		return nil, fmt.Errorf("iterator error for suffix[%s] : %w", suffix, err)
+		return nil, orberrors.NewTransient(fmt.Errorf("iterator error for suffix[%s] : %w", suffix, err))
 	}
 
 	var ops []*operation.AnchoredOperation
@@ -105,7 +107,8 @@ func (s *Store) Get(suffix string) ([]*operation.AnchoredOperation, error) {
 
 		value, err = iter.Value()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get iterator value for suffix[%s]: %w", suffix, err)
+			return nil, orberrors.NewTransient(fmt.Errorf("failed to get iterator value for suffix[%s]: %w",
+				suffix, err))
 		}
 
 		var op operation.AnchoredOperation
@@ -120,7 +123,7 @@ func (s *Store) Get(suffix string) ([]*operation.AnchoredOperation, error) {
 
 		ok, err = iter.Next()
 		if err != nil {
-			return nil, fmt.Errorf("iterator error for suffix[%s] : %w", suffix, err)
+			return nil, orberrors.NewTransient(fmt.Errorf("iterator error for suffix[%s] : %w", suffix, err))
 		}
 	}
 

--- a/pkg/store/vcstatus/store.go
+++ b/pkg/store/vcstatus/store.go
@@ -15,6 +15,7 @@ import (
 	"github.com/trustbloc/edge-core/pkg/log"
 
 	"github.com/trustbloc/orb/pkg/anchor/proof"
+	orberrors "github.com/trustbloc/orb/pkg/errors"
 )
 
 const (
@@ -57,7 +58,8 @@ func (s *Store) AddStatus(vcID string, status proof.VCStatus) error {
 
 	err := s.store.Put(uuid.New().String(), []byte(status), tag)
 	if err != nil {
-		return fmt.Errorf("failed to store vcID[%s] status '%s': %w", vcID, status, err)
+		return orberrors.NewTransient(fmt.Errorf("failed to store vcID[%s] status '%s': %w",
+			vcID, status, err))
 	}
 
 	logger.Debugf("stored vcID[%s] status '%s'", vcID, status)
@@ -75,12 +77,13 @@ func (s *Store) GetStatus(vcID string) (proof.VCStatus, error) {
 
 	iter, err := s.store.Query(query)
 	if err != nil {
-		return "", fmt.Errorf("failed to get statuses for vcID[%s] query[%s]: %w", vcID, query, err)
+		return "", orberrors.NewTransient(fmt.Errorf("failed to get statuses for vcID[%s] query[%s]: %w",
+			vcID, query, err))
 	}
 
 	ok, err := iter.Next()
 	if err != nil {
-		return "", fmt.Errorf("iterator error for vcID[%s] statuses: %w", vcID, err)
+		return "", orberrors.NewTransient(fmt.Errorf("iterator error for vcID[%s] statuses: %w", vcID, err))
 	}
 
 	if !ok {
@@ -92,7 +95,8 @@ func (s *Store) GetStatus(vcID string) (proof.VCStatus, error) {
 	for ok {
 		value, err = iter.Value()
 		if err != nil {
-			return "", fmt.Errorf("failed to get iterator value for vcID[%s]: %w", vcID, err)
+			return "", orberrors.NewTransient(fmt.Errorf("failed to get iterator value for vcID[%s]: %w",
+				vcID, err))
 		}
 
 		if proof.VCStatus(value) == proof.VCStatusCompleted {
@@ -101,7 +105,7 @@ func (s *Store) GetStatus(vcID string) (proof.VCStatus, error) {
 
 		ok, err = iter.Next()
 		if err != nil {
-			return "", fmt.Errorf("iterator error for vcID[%s]: %w", vcID, err)
+			return "", orberrors.NewTransient(fmt.Errorf("iterator error for vcID[%s]: %w", vcID, err))
 		}
 	}
 

--- a/pkg/store/verifiable/store.go
+++ b/pkg/store/verifiable/store.go
@@ -13,6 +13,8 @@ import (
 	"github.com/hyperledger/aries-framework-go/spi/storage"
 	"github.com/piprate/json-gold/ld"
 	"github.com/trustbloc/edge-core/pkg/log"
+
+	orberrors "github.com/trustbloc/orb/pkg/errors"
 )
 
 const nameSpace = "verifiable"
@@ -52,7 +54,7 @@ func (s *Store) Put(vc *verifiable.Credential) error {
 	logger.Debugf("storing credential: %s", string(vcBytes))
 
 	if e := s.store.Put(vc.ID, vcBytes); e != nil {
-		return fmt.Errorf("failed to put vc: %w", e)
+		return orberrors.NewTransient(fmt.Errorf("failed to put vc: %w", e))
 	}
 
 	return nil
@@ -62,7 +64,7 @@ func (s *Store) Put(vc *verifiable.Credential) error {
 func (s *Store) Get(id string) (*verifiable.Credential, error) {
 	vcBytes, err := s.store.Get(id)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get vc: %w", err)
+		return nil, orberrors.NewTransient(fmt.Errorf("failed to get vc: %w", err))
 	}
 
 	vc, err := verifiable.ParseCredential(vcBytes,

--- a/pkg/store/witness/witness.go
+++ b/pkg/store/witness/witness.go
@@ -16,6 +16,7 @@ import (
 	"github.com/trustbloc/edge-core/pkg/log"
 
 	"github.com/trustbloc/orb/pkg/anchor/proof"
+	orberrors "github.com/trustbloc/orb/pkg/errors"
 )
 
 const (
@@ -77,7 +78,7 @@ func (s *Store) Put(vcID string, witnesses []*proof.WitnessProof) error {
 
 	err := s.store.Batch(operations)
 	if err != nil {
-		return fmt.Errorf("failed to store witnesses for vcID[%s]: %w", vcID, err)
+		return orberrors.NewTransient(fmt.Errorf("failed to store witnesses for vcID[%s]: %w", vcID, err))
 	}
 
 	logger.Debugf("stored %d witnesses for vcID[%s]", len(witnesses), vcID)
@@ -94,7 +95,7 @@ func (s *Store) Delete(vcID string) error {
 
 	iter, err := s.store.Query(query)
 	if err != nil {
-		return fmt.Errorf("failed to get witnesses for[%s]: %w", query, err)
+		return orberrors.NewTransient(fmt.Errorf("failed to get witnesses for[%s]: %w", query, err))
 	}
 
 	defer func() {
@@ -141,7 +142,7 @@ func (s *Store) Delete(vcID string) error {
 
 	err = s.store.Batch(operations)
 	if err != nil {
-		return fmt.Errorf("failed to delete witnesses for vcID[%s]: %w", vcID, err)
+		return orberrors.NewTransient(fmt.Errorf("failed to delete witnesses for vcID[%s]: %w", vcID, err))
 	}
 
 	logger.Debugf("deleted %d witnesses for vcID[%s]", len(witnessKeys), vcID)
@@ -159,7 +160,7 @@ func (s *Store) Get(vcID string) ([]*proof.WitnessProof, error) {
 
 	iter, err := s.store.Query(query)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get witnesses for[%s]: %w", query, err)
+		return nil, orberrors.NewTransient(fmt.Errorf("failed to get witnesses for[%s]: %w", query, err))
 	}
 
 	defer func() {
@@ -171,7 +172,7 @@ func (s *Store) Get(vcID string) ([]*proof.WitnessProof, error) {
 
 	ok, err := iter.Next()
 	if err != nil {
-		return nil, fmt.Errorf("iterator error for vcID[%s] : %w", vcID, err)
+		return nil, orberrors.NewTransient(fmt.Errorf("iterator error for vcID[%s] : %w", vcID, err))
 	}
 
 	var witnesses []*proof.WitnessProof
@@ -181,7 +182,8 @@ func (s *Store) Get(vcID string) ([]*proof.WitnessProof, error) {
 
 		value, err = iter.Value()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get iterator value for vcID[%s]: %w", vcID, err)
+			return nil, orberrors.NewTransient(fmt.Errorf("failed to get iterator value for vcID[%s]: %w",
+				vcID, err))
 		}
 
 		var witness proof.WitnessProof
@@ -196,7 +198,7 @@ func (s *Store) Get(vcID string) ([]*proof.WitnessProof, error) {
 
 		ok, err = iter.Next()
 		if err != nil {
-			return nil, fmt.Errorf("iterator error for vcID[%s] : %w", vcID, err)
+			return nil, orberrors.NewTransient(fmt.Errorf("iterator error for vcID[%s] : %w", vcID, err))
 		}
 	}
 
@@ -217,7 +219,7 @@ func (s *Store) AddProof(vcID, witness string, p []byte) error { //nolint:funlen
 
 	iter, err := s.store.Query(query)
 	if err != nil {
-		return fmt.Errorf("failed to get witnesses for[%s]: %w", query, err)
+		return orberrors.NewTransient(fmt.Errorf("failed to get witnesses for[%s]: %w", query, err))
 	}
 
 	defer func() {
@@ -268,8 +270,8 @@ func (s *Store) AddProof(vcID, witness string, p []byte) error { //nolint:funlen
 
 			err = s.store.Put(key, witnessProofBytes, storage.Tag{Name: vcIndex, Value: vcIDEncoded})
 			if err != nil {
-				return fmt.Errorf("failed to add proof for anchor credential vcID[%s] and witness[%s]: %w",
-					vcID, witness, err)
+				return orberrors.NewTransient(fmt.Errorf("failed to add proof for anchor credential vcID[%s] and witness[%s]: %w",
+					vcID, witness, err))
 			}
 
 			updatedNo++

--- a/test/bdd/common_steps.go
+++ b/test/bdd/common_steps.go
@@ -329,7 +329,7 @@ func (d *CommonSteps) responseEquals(value string) error {
 		return nil
 	}
 
-	return fmt.Errorf("Reponse [%s] does not equal expected value [%s]", d.state.getResponse(), value)
+	return fmt.Errorf("Response [%s] does not equal expected value [%s]", d.state.getResponse(), value)
 }
 
 func (d *CommonSteps) httpGetWithExpectedCode(url string, expectingCode int) error {

--- a/test/bdd/did_orb_steps.go
+++ b/test/bdd/did_orb_steps.go
@@ -1053,11 +1053,11 @@ func (d *DIDOrbSteps) createDIDDocuments(strURLs string, num int, concurrency in
 }
 
 func (d *DIDOrbSteps) verifyDIDDocuments(strURLs string) error {
-	logger.Infof("verifying the %d DID document(s) that were created", len(d.dids))
+	logger.Infof("Verifying the %d DID document(s) that were created", len(d.dids))
 
 	urls := strings.Split(strURLs, ",")
 
-	for _, did := range d.dids {
+	for i, did := range d.dids {
 		randomURL := urls[mrand.Intn(len(urls))]
 
 		localURL, err := getLocalURL(randomURL, "/sidetree/v1/")
@@ -1068,6 +1068,8 @@ func (d *DIDOrbSteps) verifyDIDDocuments(strURLs string) error {
 		if err := d.verifyDID(localURL, did); err != nil {
 			return err
 		}
+
+		logger.Infof("... verified %d out of %d DIDs", i+1, len(d.dids))
 	}
 
 	return nil
@@ -1091,12 +1093,12 @@ func (d *DIDOrbSteps) verifyDID(url, did string) error {
 		return err
 	}
 
-	_, ok := rr.DocumentMetadata["canonicalId"]
+	canonicalID, ok := rr.DocumentMetadata["canonicalId"]
 	if !ok {
 		return fmt.Errorf("document metadata is missing field 'canonicalId': %s", resp.Payload)
 	}
 
-	logger.Infof(".. successfully verified DID %s from %s", did, url)
+	logger.Infof(".. successfully verified DID %s from %s", canonicalID, url)
 
 	return nil
 }

--- a/test/bdd/fixtures/.env
+++ b/test/bdd/fixtures/.env
@@ -17,7 +17,7 @@ ORB_FIXTURE_IMAGE=ghcr.io/trustbloc/orb
 
 # couch settings
 COUCHDB_IMAGE=couchdb
-COUCHDB_IMAGE_TAG=3.1.0
+COUCHDB_IMAGE_TAG=3.1.1
 COUCHDB_USERNAME=admin
 COUCHDB_PASSWORD=password
 

--- a/test/bdd/httpclient.go
+++ b/test/bdd/httpclient.go
@@ -139,7 +139,8 @@ func (c *httpClient) GetWithRetry(url string, attempts uint8, retryableCode int,
 			break
 		}
 
-		logger.Infof("not found: %s - remaining attempts: %d", url, remainingAttempts)
+		logger.Infof("Status code %d: %s - %s - remaining attempts: %d",
+			resp.StatusCode, resp.ErrorMsg, url, remainingAttempts)
 
 		remainingAttempts--
 		if remainingAttempts == 0 {


### PR DESCRIPTION
- Return transient error in case of DB errors
- Return a transient error when unable to resolve 'followers' or 'witnesses' when posting to the outbox due to a DB error
- Don't attempt to store an empty anchored operation batch to the DB since it results in an 'empty document' error
- Added more logging to help debug problems

Also:
- Use cached store provider for LD document loader to reduce reads from the DB
- Upgrade to CouchDB 3.1.1 (fixes an issue where an error is logged each time the client disconnects)

closes #596

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>