### PR TITLE
test: Re-enable IPNS tests and skip upload if already there

### DIFF
--- a/cmd/orb-cli/ipnshostmetauploadcmd/ipnshostmetauploadcmd.go
+++ b/cmd/orb-cli/ipnshostmetauploadcmd/ipnshostmetauploadcmd.go
@@ -39,7 +39,7 @@ const (
 )
 
 const (
-	timeout = 180
+	timeout = 240
 )
 
 type object struct {

--- a/test/bdd/did_orb_steps.go
+++ b/test/bdd/did_orb_steps.go
@@ -67,9 +67,7 @@ var localURLs = map[string]string{
 
 var anchorOriginURLs = map[string]string{
 	"https://localhost:48326/sidetree/v1/operations": "https://orb.domain1.com/services/orb",
-	// TODO: Change the value below back to ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q once
-	// IPNS is enabled again for the BDD tests.
-	"https://localhost:48526/sidetree/v1/operations": "https://orb.domain1.com/services/orb",
+	"https://localhost:48526/sidetree/v1/operations": "ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q",
 	"https://localhost:48426/sidetree/v1/operations": "https://orb.domain1.com/services/orb",
 	"https://localhost:48626/sidetree/v1/operations": "https://orb.domain1.com/services/orb",
 	"https://localhost:48726/sidetree/v1/operations": "https://orb.domain1.com/services/orb",

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -8,6 +8,7 @@
 @did-orb
 Feature:
   Background: Setup
+    Given host-meta document is uploaded to IPNS
     Given variable "domain1IRI" is assigned the value "https://orb.domain1.com/services/orb"
     And variable "domain2IRI" is assigned the value "https://orb.domain2.com/services/orb"
     And variable "domain3IRI" is assigned the value "https://orb.domain3.com/services/orb"

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210716143947-10d84642fa12
 	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210716143947-10d84642fa12
 	github.com/igor-pavlenko/httpsignatures-go v0.0.21
+	github.com/ipfs/go-ipfs-api v0.2.0 // indirect
 	github.com/mr-tron/base58 v1.2.0
 	github.com/sirupsen/logrus v1.7.0
 	github.com/tidwall/gjson v1.7.4


### PR DESCRIPTION
IPNS upload is now a step at the beginning of the DID tests. This makes it so the IPNS document only gets uploaded for the specific tests that it's needed for. IPNS uploading will also be skipped if the document can already be found at the time of the test.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>