### PR TITLE
feat: Add caching to resource resolver

### DIFF
--- a/pkg/anchor/writer/writer_test.go
+++ b/pkg/anchor/writer/writer_test.go
@@ -794,8 +794,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 
 		err = c.WriteAnchor("1.anchor", opRefs, 1)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to create witness list: failed to resolve witness: "+
-			`failed to get host-meta document via IPNS: failed to read from IPNS: `+
+		require.Contains(t, err.Error(), `failed to get host-meta document via IPNS: failed to read from IPNS: `+
 			`Post "http://SomeIPFSNodeURL/api/v0/cat?arg=%2Fipns%2Fk51qzi5uqu5dgjceyz40t6xfnae8jqn5z17ojojggzwz2mh`+
 			`l7uyhdre8ateqek%2F.well-known%2Fhost-meta.json":`)
 	})
@@ -1251,7 +1250,7 @@ func TestWriter_getWitnesses(t *testing.T) {
 
 		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
 			testMaxWitnessDelay, signWithLocalWitness, testutil.GetLoader(t),
-			resourceresolver.New(http.DefaultClient, nil))
+			resourceresolver.New(http.DefaultClient, nil, resourceresolver.WithCacheLifetime(0)))
 		require.NoError(t, err)
 
 		opRefs := []*operation.Reference{

--- a/pkg/internal/cacheutil/cacheutil.go
+++ b/pkg/internal/cacheutil/cacheutil.go
@@ -1,0 +1,50 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cacheutil
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/bluele/gcache"
+)
+
+// Cacheable interface has to implemented by objects in the cache.
+type Cacheable interface {
+	CacheLifetime() (time.Duration, error)
+}
+
+// GetNewCacheable uses fetcher function to retrieve object.
+func GetNewCacheable(
+	fetcher func(key string) (Cacheable, error),
+) func(key string) (interface{}, *time.Duration, error) {
+	return func(key string) (interface{}, *time.Duration, error) {
+		data, err := fetcher(key)
+		if err != nil {
+			return nil, nil, fmt.Errorf("fetching cacheable object: %w", err)
+		}
+
+		expiryTime, err := data.CacheLifetime()
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to get object expiry time: %w", err)
+		}
+
+		return data, &expiryTime, nil
+	}
+}
+
+// MakeCache is helper function to create cache with string keys.
+func MakeCache(fetcher func(key string) (interface{}, *time.Duration, error)) gcache.Cache {
+	return gcache.New(0).LoaderExpireFunc(func(key interface{}) (interface{}, *time.Duration, error) {
+		r, ok := key.(string)
+		if !ok {
+			return nil, nil, fmt.Errorf("key must be string")
+		}
+
+		return fetcher(r)
+	}).Build()
+}

--- a/pkg/internal/cacheutil/cacheutil_test.go
+++ b/pkg/internal/cacheutil/cacheutil_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cacheutil
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/bluele/gcache"
+	"github.com/stretchr/testify/require"
+)
+
+const value = "value"
+
+func TestCacheUtil(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		r := newResolver()
+
+		val, err := r.Resolve("key")
+		require.NoError(t, err)
+		require.Equal(t, value, val)
+	})
+
+	t.Run("success - cache expired", func(t *testing.T) {
+		r := newResolver()
+		r.CacheLifetime = 1 * time.Second
+
+		val, err := r.Resolve("key")
+		require.NoError(t, err)
+		require.Equal(t, value, val)
+
+		// cache expires
+		time.Sleep(2 * time.Second)
+
+		val, err = r.Resolve("key")
+		require.NoError(t, err)
+		require.Equal(t, value, val)
+	})
+
+	t.Run("error - fetcher error", func(t *testing.T) {
+		r := newResolver()
+		r.ResolveErr = fmt.Errorf("resolve error")
+
+		val, err := r.Resolve("key")
+		require.Error(t, err)
+		require.Empty(t, val)
+		require.Contains(t, err.Error(), "fetching cacheable object: resolve error")
+	})
+
+	t.Run("error - cacheable error", func(t *testing.T) {
+		r := newResolver()
+		r.ResolveObj = &cacheObjType{Err: fmt.Errorf("cacheable error")}
+
+		val, err := r.Resolve("key")
+		require.Error(t, err)
+		require.Empty(t, val)
+		require.Contains(t, err.Error(),
+			"failed to get object expiry time: cacheable error")
+	})
+}
+
+func newResolver() *resolver {
+	r := resolver{CacheLifetime: 5 * time.Second}
+
+	r.ResolverCache = MakeCache(
+		GetNewCacheable(func(key string) (Cacheable, error) {
+			return r.resolve(key)
+		}))
+
+	return &r
+}
+
+type resolver struct {
+	CacheLifetime time.Duration
+	ResolverCache gcache.Cache
+
+	ResolveErr error
+	ResolveObj *cacheObjType
+}
+
+func (r *resolver) Resolve(key string) (string, error) {
+	cachedObj, err := r.ResolverCache.Get(key)
+	if err != nil {
+		return "", err
+	}
+
+	obj, ok := cachedObj.(*cacheObjType)
+	if !ok {
+		return "", fmt.Errorf("unexpected interface for cached object")
+	}
+
+	return obj.Value, nil
+}
+
+func (r *resolver) resolve(_ string) (*cacheObjType, error) {
+	if r.ResolveErr != nil {
+		return nil, r.ResolveErr
+	}
+
+	if r.ResolveObj != nil {
+		return r.ResolveObj, nil
+	}
+
+	return &cacheObjType{Value: "value", MaxAge: r.CacheLifetime}, nil
+}
+
+type cacheObjType struct {
+	Value  string
+	MaxAge time.Duration
+	Err    error
+}
+
+// CacheLifetime returns the cache object lifetime before it needs to be checked for an update.
+func (t *cacheObjType) CacheLifetime() (time.Duration, error) {
+	if t.Err != nil {
+		return 0, t.Err
+	}
+
+	return t.MaxAge, nil
+}

--- a/pkg/resolver/resource/resolver.go
+++ b/pkg/resolver/resource/resolver.go
@@ -14,11 +14,18 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
+	"github.com/bluele/gcache"
 	"github.com/trustbloc/edge-core/pkg/log"
 
 	"github.com/trustbloc/orb/pkg/cas/ipfs"
 	discoveryrest "github.com/trustbloc/orb/pkg/discovery/endpoint/restapi"
+)
+
+const (
+	defaultCacheLifetime = 300 * time.Second // five minutes
+	defaultCacheSize     = 100
 )
 
 var logger = log.New("resource-resolver")
@@ -27,12 +34,33 @@ var logger = log.New("resource-resolver")
 type Resolver struct {
 	httpClient *http.Client
 	ipfsReader *ipfs.Client
+
+	cacheLifetime    time.Duration
+	cacheSize        int
+	hostMetaDocCache gcache.Cache
 }
 
 // New returns a new Resolver.
 // ipfsReader is optional. If not provided (is nil), then host-meta links specified with IPNS won't be resolvable.
-func New(httpClient *http.Client, ipfsReader *ipfs.Client) *Resolver {
-	return &Resolver{httpClient: httpClient, ipfsReader: ipfsReader}
+func New(httpClient *http.Client, ipfsReader *ipfs.Client, opts ...Option) *Resolver {
+	resolver := &Resolver{
+		httpClient:    httpClient,
+		ipfsReader:    ipfsReader,
+		cacheLifetime: defaultCacheLifetime,
+		cacheSize:     defaultCacheSize,
+	}
+
+	for _, opt := range opts {
+		opt(resolver)
+	}
+
+	resolver.hostMetaDocCache = gcache.New(resolver.cacheSize).
+		Expiration(resolver.cacheLifetime).
+		LoaderFunc(func(key interface{}) (interface{}, error) {
+			return resolver.resolveHostMetaLink(key.(string))
+		}).Build()
+
+	return resolver
 }
 
 // ResolveHostMetaLink resolves a host-meta link for a given url and linkType. The url may have an HTTP, HTTPS, or
@@ -43,24 +71,16 @@ func New(httpClient *http.Client, ipfsReader *ipfs.Client) *Resolver {
 // address. In both cases, the first link in the host-meta document with a matching type will have its associated
 // href value returned.
 func (c *Resolver) ResolveHostMetaLink(urlToGetHostMetaFrom, linkType string) (string, error) {
-	var err error
+	hostMetaDocumentObj, err := c.hostMetaDocCache.Get(urlToGetHostMetaFrom)
+	if err != nil {
+		return "", fmt.Errorf("failed to get key[%s] from host metadata cache: %w", urlToGetHostMetaFrom, err)
+	}
 
-	var hostMetaDocument discoveryrest.JRD
+	logger.Debugf("got value for key[%v] from metadata cache: %+v", urlToGetHostMetaFrom, hostMetaDocumentObj)
 
-	if strings.HasPrefix(urlToGetHostMetaFrom, "ipns://") {
-		if c.ipfsReader == nil {
-			return "", errors.New("unable to resolve since IPFS is not enabled")
-		}
-
-		hostMetaDocument, err = c.getHostMetaDocumentViaIPNS(urlToGetHostMetaFrom)
-		if err != nil {
-			return "", fmt.Errorf("failed to get host-meta document via IPNS: %w", err)
-		}
-	} else {
-		hostMetaDocument, err = c.getHostMetaDocumentViaHTTP(urlToGetHostMetaFrom)
-		if err != nil {
-			return "", fmt.Errorf("failed to get host-meta document via HTTP/HTTPS: %w", err)
-		}
+	hostMetaDocument, ok := hostMetaDocumentObj.(*discoveryrest.JRD)
+	if !ok {
+		return "", fmt.Errorf("unexpected value type[%T] for key[%s] in host metadata cache", hostMetaDocumentObj, urlToGetHostMetaFrom) //nolint:lll
 	}
 
 	for _, link := range hostMetaDocument.Links {
@@ -70,6 +90,30 @@ func (c *Resolver) ResolveHostMetaLink(urlToGetHostMetaFrom, linkType string) (s
 	}
 
 	return "", fmt.Errorf("no links with type %s were found via %s", linkType, urlToGetHostMetaFrom)
+}
+
+func (c *Resolver) resolveHostMetaLink(urlToGetHostMetaFrom string) (*discoveryrest.JRD, error) {
+	var err error
+
+	var hostMetaDocument discoveryrest.JRD
+
+	if strings.HasPrefix(urlToGetHostMetaFrom, "ipns://") {
+		if c.ipfsReader == nil {
+			return nil, errors.New("unable to resolve since IPFS is not enabled")
+		}
+
+		hostMetaDocument, err = c.getHostMetaDocumentViaIPNS(urlToGetHostMetaFrom)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get host-meta document via IPNS: %w", err)
+		}
+	} else {
+		hostMetaDocument, err = c.getHostMetaDocumentViaHTTP(urlToGetHostMetaFrom)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get host-meta document via HTTP/HTTPS: %w", err)
+		}
+	}
+
+	return &hostMetaDocument, nil
 }
 
 func (c *Resolver) getHostMetaDocumentViaIPNS(ipnsURL string) (discoveryrest.JRD, error) {
@@ -142,4 +186,21 @@ func (c *Resolver) getHostMetaDocumentFromEndpoint(hostMetaEndpoint string) (dis
 	}
 
 	return hostMetaDocument, nil
+}
+
+// Option is a resolver option.
+type Option func(opts *Resolver)
+
+// WithCacheLifetime option defines the lifetime of an object in the cache.
+func WithCacheLifetime(lifetime time.Duration) Option {
+	return func(opts *Resolver) {
+		opts.cacheLifetime = lifetime
+	}
+}
+
+// WithCacheSize option defines the cache size.
+func WithCacheSize(size int) Option {
+	return func(opts *Resolver) {
+		opts.cacheSize = size
+	}
 }


### PR DESCRIPTION
Host metadata document should be cached.

Closes #612

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>