### PR TITLE
chore: Reduce INFO and WARNING logs

### DIFF
--- a/cmd/orb-cli/go.sum
+++ b/cmd/orb-cli/go.sum
@@ -1371,8 +1371,8 @@ github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZ
 github.com/trustbloc/edge-core v0.1.7-0.20210527163745-994ae929f957 h1:j3w/Il8Fn74kdiJjAPr0I3RHdD4JqLaBkQzlMnv+Xv4=
 github.com/trustbloc/edge-core v0.1.7-0.20210527163745-994ae929f957/go.mod h1:oAiGOVTKW4XIaMZGthuVUaZru9xaepdiZtxx1D2H4o8=
 github.com/trustbloc/sidetree-core-go v0.6.0/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798 h1:cgsdeHt7W8o+FLRGYZVsxVg8APfyN0oeNqEf9RMdkWM=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210722141654-ccdb0a1c974d h1:6h4OmV4TVwY9M70+uk4qkla/CD6hvD/j1IHO3HGkgEs=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210722141654-ccdb0a1c974d/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/trustbloc/vct v0.1.3-0.20210716152918-7cf3e85adf72 h1:6a6Nt1bmPzOurb3hDvQw1DW2AwkIjSyShyK6TTectsQ=
 github.com/trustbloc/vct v0.1.3-0.20210716152918-7cf3e85adf72/go.mod h1:ZDynP4JWQ/5RRYSS6WuSPRCuUJVsjMMjVjHxgdaZQ2g=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/cmd/orb-driver/go.mod
+++ b/cmd/orb-driver/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7-0.20210527163745-994ae929f957
 	github.com/trustbloc/orb v0.1.2-0.20210630053623-2436c6c2da6a
-	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798
+	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210722141654-ccdb0a1c974d
 )
 
 replace github.com/trustbloc/orb => ../..

--- a/cmd/orb-driver/go.sum
+++ b/cmd/orb-driver/go.sum
@@ -1360,8 +1360,8 @@ github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZ
 github.com/trustbloc/edge-core v0.1.7-0.20210527163745-994ae929f957 h1:j3w/Il8Fn74kdiJjAPr0I3RHdD4JqLaBkQzlMnv+Xv4=
 github.com/trustbloc/edge-core v0.1.7-0.20210527163745-994ae929f957/go.mod h1:oAiGOVTKW4XIaMZGthuVUaZru9xaepdiZtxx1D2H4o8=
 github.com/trustbloc/sidetree-core-go v0.6.0/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798 h1:cgsdeHt7W8o+FLRGYZVsxVg8APfyN0oeNqEf9RMdkWM=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210722141654-ccdb0a1c974d h1:6h4OmV4TVwY9M70+uk4qkla/CD6hvD/j1IHO3HGkgEs=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210722141654-ccdb0a1c974d/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/trustbloc/vct v0.1.3-0.20210716152918-7cf3e85adf72 h1:6a6Nt1bmPzOurb3hDvQw1DW2AwkIjSyShyK6TTectsQ=
 github.com/trustbloc/vct v0.1.3-0.20210716152918-7cf3e85adf72/go.mod h1:ZDynP4JWQ/5RRYSS6WuSPRCuUJVsjMMjVjHxgdaZQ2g=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/cmd/orb-server/go.mod
+++ b/cmd/orb-server/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7-0.20210527163745-994ae929f957
 	github.com/trustbloc/orb v0.0.0
-	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798
+	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210722141654-ccdb0a1c974d
 	github.com/trustbloc/vct v0.1.3-0.20210716152918-7cf3e85adf72
 )
 

--- a/cmd/orb-server/go.sum
+++ b/cmd/orb-server/go.sum
@@ -1417,8 +1417,8 @@ github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoi
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
 github.com/trustbloc/edge-core v0.1.7-0.20210527163745-994ae929f957 h1:j3w/Il8Fn74kdiJjAPr0I3RHdD4JqLaBkQzlMnv+Xv4=
 github.com/trustbloc/edge-core v0.1.7-0.20210527163745-994ae929f957/go.mod h1:oAiGOVTKW4XIaMZGthuVUaZru9xaepdiZtxx1D2H4o8=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798 h1:cgsdeHt7W8o+FLRGYZVsxVg8APfyN0oeNqEf9RMdkWM=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210722141654-ccdb0a1c974d h1:6h4OmV4TVwY9M70+uk4qkla/CD6hvD/j1IHO3HGkgEs=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210722141654-ccdb0a1c974d/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/trustbloc/vct v0.1.3-0.20210716152918-7cf3e85adf72 h1:6a6Nt1bmPzOurb3hDvQw1DW2AwkIjSyShyK6TTectsQ=
 github.com/trustbloc/vct v0.1.3-0.20210716152918-7cf3e85adf72/go.mod h1:ZDynP4JWQ/5RRYSS6WuSPRCuUJVsjMMjVjHxgdaZQ2g=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7-0.20210527163745-994ae929f957
-	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798
+	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210722141654-ccdb0a1c974d
 	github.com/trustbloc/vct v0.1.3-0.20210716152918-7cf3e85adf72
 	golang.org/x/net v0.0.0-20210525063256-abc453219eb5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1414,8 +1414,8 @@ github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoi
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
 github.com/trustbloc/edge-core v0.1.7-0.20210527163745-994ae929f957 h1:j3w/Il8Fn74kdiJjAPr0I3RHdD4JqLaBkQzlMnv+Xv4=
 github.com/trustbloc/edge-core v0.1.7-0.20210527163745-994ae929f957/go.mod h1:oAiGOVTKW4XIaMZGthuVUaZru9xaepdiZtxx1D2H4o8=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798 h1:cgsdeHt7W8o+FLRGYZVsxVg8APfyN0oeNqEf9RMdkWM=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210722141654-ccdb0a1c974d h1:6h4OmV4TVwY9M70+uk4qkla/CD6hvD/j1IHO3HGkgEs=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210722141654-ccdb0a1c974d/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/trustbloc/vct v0.1.3-0.20210716152918-7cf3e85adf72 h1:6a6Nt1bmPzOurb3hDvQw1DW2AwkIjSyShyK6TTectsQ=
 github.com/trustbloc/vct v0.1.3-0.20210716152918-7cf3e85adf72/go.mod h1:ZDynP4JWQ/5RRYSS6WuSPRCuUJVsjMMjVjHxgdaZQ2g=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -248,7 +248,8 @@ func (o *Observer) processAnchor(anchor *anchorinfo.AnchorInfo, info *verifiable
 		return fmt.Errorf("failed updating did anchor references for anchor credential[%s]: %w", anchor.CID, err)
 	}
 
-	logger.Debugf("successfully processed anchor[%s], core index[%s]", anchor.CID, anchorPayload.CoreIndex)
+	logger.Infof("Successfully processed %d DIDs in anchor[%s], core index[%s]",
+		len(acSuffixes), anchor.CID, anchorPayload.CoreIndex)
 
 	return nil
 }

--- a/test/bdd/fixtures/nginx-config/nginx.conf
+++ b/test/bdd/fixtures/nginx-config/nginx.conf
@@ -8,7 +8,7 @@ events {}
 error_log /dev/stdout info;
 
 http {
-    access_log /dev/stdout;
+    access_log /dev/null;
 
     upstream orb-domain2 {
         server orb-domain2.backend;

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/tidwall/gjson v1.7.4
 	github.com/trustbloc/orb v0.1.2-0.20210630053623-2436c6c2da6a
-	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798
+	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210722141654-ccdb0a1c974d
 )
 
 replace github.com/trustbloc/orb => ../../

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -1417,8 +1417,8 @@ github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZ
 github.com/trustbloc/edge-core v0.1.7-0.20210527163745-994ae929f957 h1:j3w/Il8Fn74kdiJjAPr0I3RHdD4JqLaBkQzlMnv+Xv4=
 github.com/trustbloc/edge-core v0.1.7-0.20210527163745-994ae929f957/go.mod h1:oAiGOVTKW4XIaMZGthuVUaZru9xaepdiZtxx1D2H4o8=
 github.com/trustbloc/sidetree-core-go v0.6.0/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798 h1:cgsdeHt7W8o+FLRGYZVsxVg8APfyN0oeNqEf9RMdkWM=
-github.com/trustbloc/sidetree-core-go v0.6.1-0.20210705132944-5a1274856798/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210722141654-ccdb0a1c974d h1:6h4OmV4TVwY9M70+uk4qkla/CD6hvD/j1IHO3HGkgEs=
+github.com/trustbloc/sidetree-core-go v0.6.1-0.20210722141654-ccdb0a1c974d/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/trustbloc/vct v0.1.3-0.20210716152918-7cf3e85adf72 h1:6a6Nt1bmPzOurb3hDvQw1DW2AwkIjSyShyK6TTectsQ=
 github.com/trustbloc/vct v0.1.3-0.20210716152918-7cf3e85adf72/go.mod h1:ZDynP4JWQ/5RRYSS6WuSPRCuUJVsjMMjVjHxgdaZQ2g=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=


### PR DESCRIPTION
Updated to latest sidetree-core-go which reduces the number of INFO and WARNING logs. Also, added an INFO log which indicates the number of DIDs that were processed by the Observer from an anchor.

Also, changed the nginx config so as not to log each HTTP request.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>