### PR TITLE
chore: Added Prometheus metrics for CAS write and resolve times

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -322,7 +322,7 @@ func startOrbServices(parameters *orbParameters) error {
 		logger.Infof("Initializing Orb CAS with IPFS.")
 		coreCASClient = ipfscas.New(parameters.ipfsURL, parameters.ipfsTimeout,
 			extendedcasclient.WithCIDVersion(parameters.cidVersion))
-		anchorCasWriter = orbcaswriter.New(coreCASClient, "ipfs")
+		anchorCasWriter = orbcaswriter.New(coreCASClient, "ipfs", metrics.Get())
 	case strings.EqualFold(parameters.casType, "local"):
 		logger.Infof("Initializing Orb CAS with local storage provider.")
 
@@ -351,7 +351,7 @@ func startOrbServices(parameters *orbParameters) error {
 			return fmt.Errorf("failed to parse external endpoint: %s", err.Error())
 		}
 
-		anchorCasWriter = orbcaswriter.New(coreCASClient, "webcas:"+u.Host)
+		anchorCasWriter = orbcaswriter.New(coreCASClient, "webcas:"+u.Host, metrics.Get())
 	default:
 		return fmt.Errorf("%s is not a valid CAS type. It must be either local or ipfs", parameters.casType)
 	}
@@ -417,9 +417,9 @@ func startOrbServices(parameters *orbParameters) error {
 	if parameters.ipfsURL != "" {
 		ipfsReader = ipfscas.New(parameters.ipfsURL, parameters.ipfsTimeout,
 			extendedcasclient.WithCIDVersion(parameters.cidVersion))
-		casResolver = resolver.New(coreCASClient, ipfsReader, webCASResolver)
+		casResolver = resolver.New(coreCASClient, ipfsReader, webCASResolver, metrics.Get())
 	} else {
-		casResolver = resolver.New(coreCASClient, nil, webCASResolver)
+		casResolver = resolver.New(coreCASClient, nil, webCASResolver, metrics.Get())
 	}
 
 	graphProviders := &graph.Providers{

--- a/pkg/anchor/graph/graph_test.go
+++ b/pkg/anchor/graph/graph_test.go
@@ -42,10 +42,11 @@ func TestGraph_Add(t *testing.T) {
 	require.NoError(t, err)
 
 	providers := &Providers{
-		CasWriter: caswriter.New(casClient, "webcas:domain.com"),
+		CasWriter: caswriter.New(casClient, "webcas:domain.com", &metricsProvider{}),
 		CasResolver: casresolver.New(casClient, nil,
 			casresolver.NewWebCASResolver(
-				&apmocks.HTTPTransport{}, webfingerclient.New(), "https")),
+				&apmocks.HTTPTransport{}, webfingerclient.New(), "https"),
+			&metricsProvider{}),
 		Pkf:       pubKeyFetcherFnc,
 		DocLoader: testutil.GetLoader(t),
 	}
@@ -68,10 +69,11 @@ func TestGraph_Read(t *testing.T) {
 	require.NoError(t, err)
 
 	providers := &Providers{
-		CasWriter: caswriter.New(casClient, "ipfs"),
+		CasWriter: caswriter.New(casClient, "ipfs", &metricsProvider{}),
 		CasResolver: casresolver.New(casClient, nil,
 			casresolver.NewWebCASResolver(
-				&apmocks.HTTPTransport{}, webfingerclient.New(), "https")),
+				&apmocks.HTTPTransport{}, webfingerclient.New(), "https"),
+			&metricsProvider{}),
 		Pkf:       pubKeyFetcherFnc,
 		DocLoader: testutil.GetLoader(t),
 	}
@@ -110,10 +112,11 @@ func TestGraph_GetDidAnchors(t *testing.T) {
 	require.NoError(t, err)
 
 	providers := &Providers{
-		CasWriter: caswriter.New(casClient, "webcas:domain.com"),
+		CasWriter: caswriter.New(casClient, "webcas:domain.com", &metricsProvider{}),
 		CasResolver: casresolver.New(casClient, nil,
 			casresolver.NewWebCASResolver(
-				&apmocks.HTTPTransport{}, webfingerclient.New(), "https")),
+				&apmocks.HTTPTransport{}, webfingerclient.New(), "https"),
+			&metricsProvider{}),
 		Pkf:       pubKeyFetcherFnc,
 		DocLoader: testutil.GetLoader(t),
 	}
@@ -282,4 +285,12 @@ func buildCredential(payload *subject.Payload) (*verifiable.Credential, error) {
 
 var pubKeyFetcherFnc = func(issuerID, keyID string) (*verifier.PublicKey, error) {
 	return nil, nil
+}
+
+type metricsProvider struct{}
+
+func (m *metricsProvider) CASWriteTime(value time.Duration) {
+}
+
+func (m *metricsProvider) CASResolveTime(value time.Duration) {
 }

--- a/pkg/anchor/handler/credential/handler_test.go
+++ b/pkg/anchor/handler/credential/handler_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/trustbloc/orb/pkg/cas/extendedcasclient"
 	casresolver "github.com/trustbloc/orb/pkg/cas/resolver"
 	"github.com/trustbloc/orb/pkg/internal/testutil"
+	orbmocks "github.com/trustbloc/orb/pkg/mocks"
 	"github.com/trustbloc/orb/pkg/store/cas"
 	"github.com/trustbloc/orb/pkg/webcas"
 	webfingerclient "github.com/trustbloc/orb/pkg/webfinger/client"
@@ -180,7 +181,8 @@ func createNewAnchorCredentialHandler(t *testing.T,
 		casresolver.NewWebCASResolver(
 			transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 				transport.DefaultSigner(), transport.DefaultSigner()),
-			webfingerclient.New(), "https"))
+			webfingerclient.New(), "https"),
+		&orbmocks.MetricsProvider{})
 
 	anchorCredentialHandler := New(&anchormocks.AnchorPublisher{}, casResolver, testutil.GetLoader(t),
 		&mocks.MonitoringService{}, time.Second)

--- a/pkg/anchor/writer/writer_test.go
+++ b/pkg/anchor/writer/writer_test.go
@@ -112,12 +112,12 @@ func TestWriter_WriteAnchor(t *testing.T) {
 	require.NoError(t, err)
 
 	graphProviders := &graph.Providers{
-		CasWriter: caswriter.New(casClient, "webcas:domain.com"),
+		CasWriter: caswriter.New(casClient, "webcas:domain.com", &mocks.MetricsProvider{}),
 		CasResolver: casresolver.New(casClient, nil,
 			casresolver.NewWebCASResolver(
 				transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 					transport.DefaultSigner(), transport.DefaultSigner()),
-				wfclient.New(), "https")),
+				wfclient.New(), "https"), &mocks.MetricsProvider{}),
 		Pkf: pubKeyFetcherFnc,
 	}
 
@@ -809,12 +809,12 @@ func TestWriter_handle(t *testing.T) {
 	require.NoError(t, err)
 
 	graphProviders := &graph.Providers{
-		CasWriter: caswriter.New(casClient, "webcas:domain.com"),
+		CasWriter: caswriter.New(casClient, "webcas:domain.com", &mocks.MetricsProvider{}),
 		CasResolver: casresolver.New(casClient, nil,
 			casresolver.NewWebCASResolver(
 				transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 					transport.DefaultSigner(), transport.DefaultSigner()),
-				wfclient.New(), "https")),
+				wfclient.New(), "https"), &mocks.MetricsProvider{}),
 		Pkf: pubKeyFetcherFnc,
 	}
 
@@ -1403,12 +1403,12 @@ func TestWriter_Read(t *testing.T) {
 	require.NoError(t, err)
 
 	graphProviders := &graph.Providers{
-		CasWriter: caswriter.New(casClient, "webcas:domain.com"),
+		CasWriter: caswriter.New(casClient, "webcas:domain.com", &mocks.MetricsProvider{}),
 		CasResolver: casresolver.New(casClient, nil,
 			casresolver.NewWebCASResolver(
 				transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 					transport.DefaultSigner(), transport.DefaultSigner()),
-				wfclient.New(), "https")),
+				wfclient.New(), "https"), &mocks.MetricsProvider{}),
 		Pkf: pubKeyFetcherFnc,
 	}
 

--- a/pkg/cas/resolver/resolver_test.go
+++ b/pkg/cas/resolver/resolver_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/trustbloc/orb/pkg/discovery/endpoint/restapi"
 	orberrors "github.com/trustbloc/orb/pkg/errors"
 	"github.com/trustbloc/orb/pkg/internal/testutil"
+	orbmocks "github.com/trustbloc/orb/pkg/mocks"
 	"github.com/trustbloc/orb/pkg/store/cas"
 	"github.com/trustbloc/orb/pkg/webcas"
 	webfingerclient "github.com/trustbloc/orb/pkg/webfinger/client"
@@ -585,7 +586,7 @@ func createNewResolver(t *testing.T, casClient extendedcasclient.Client, ipfsRea
 		webFingerResolver,
 		"http")
 
-	casResolver := New(casClient, ipfsReader, webCASResolver)
+	casResolver := New(casClient, ipfsReader, webCASResolver, &orbmocks.MetricsProvider{})
 	require.NotNil(t, casResolver)
 
 	return casResolver

--- a/pkg/cas/writer/writer.go
+++ b/pkg/cas/writer/writer.go
@@ -8,16 +8,22 @@ package writer
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/trustbloc/edge-core/pkg/log"
 )
 
 var logger = log.New("cas-writer")
 
+type metricsProvider interface {
+	CASWriteTime(value time.Duration)
+}
+
 // CasWriter is CAS writer.
 type CasWriter struct {
 	coreCasWriter casWriter
 	hint          string
+	metrics       metricsProvider
 }
 
 type casWriter interface {
@@ -25,13 +31,23 @@ type casWriter interface {
 }
 
 // New creates cas writer.
-func New(writer casWriter, hint string) *CasWriter {
-	return &CasWriter{coreCasWriter: writer, hint: hint}
+func New(writer casWriter, hint string, metrics metricsProvider) *CasWriter {
+	return &CasWriter{
+		coreCasWriter: writer,
+		hint:          hint,
+		metrics:       metrics,
+	}
 }
 
 // Write writes the given content to CAS.
 // returns cid (which represents the address of the content within this CAS) plus hint.
 func (cw *CasWriter) Write(content []byte) (string, string, error) {
+	startTime := time.Now()
+
+	defer func() {
+		cw.metrics.CASWriteTime(time.Since(startTime))
+	}()
+
 	cid, err := cw.coreCasWriter.Write(content)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to write to core cas: %w", err)

--- a/pkg/cas/writer/writer_test.go
+++ b/pkg/cas/writer/writer_test.go
@@ -12,13 +12,15 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
+
+	orbmocks "github.com/trustbloc/orb/pkg/mocks"
 )
 
 func TestWrite(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		casClient := mocks.NewMockCasClient(nil)
 
-		cas := New(casClient, "webcas:domain.com")
+		cas := New(casClient, "webcas:domain.com", &orbmocks.MetricsProvider{})
 		require.NotNil(t, cas)
 
 		cid, hint, err := cas.Write([]byte("content"))
@@ -34,7 +36,7 @@ func TestWrite(t *testing.T) {
 	t.Run("success - no hint provided", func(t *testing.T) {
 		casClient := mocks.NewMockCasClient(nil)
 
-		cas := New(casClient, "")
+		cas := New(casClient, "", &orbmocks.MetricsProvider{})
 		require.NotNil(t, cas)
 
 		cid, hint, err := cas.Write([]byte("content"))
@@ -50,7 +52,7 @@ func TestWrite(t *testing.T) {
 	t.Run("error - core cas error", func(t *testing.T) {
 		casClient := mocks.NewMockCasClient(fmt.Errorf("cas write error"))
 
-		cas := New(casClient, "webcas:domain.com")
+		cas := New(casClient, "webcas:domain.com", &orbmocks.MetricsProvider{})
 		require.NotNil(t, cas)
 
 		cid, hint, err := cas.Write([]byte("content"))

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/trustbloc/edge-core/pkg/log"
 )
 
 const (
@@ -37,7 +38,14 @@ const (
 	observer                        = "observer"
 	observerProcessAnchorTimeMetric = "process_anchor_seconds"
 	observerProcessDIDTimeMetric    = "process_did_seconds"
+
+	// CAS.
+	cas                  = "cas"
+	casWriteTimeMetric   = "cas_write_seconds"
+	casResolveTimeMetric = "cas_resolve_seconds"
 )
+
+var logger = log.New("metrics")
 
 var (
 	createOnce sync.Once //nolint:gochecknoglobals
@@ -59,6 +67,9 @@ type Metrics struct {
 
 	observerProcessAnchorTime prometheus.Histogram
 	observerProcessDIDTime    prometheus.Histogram
+
+	casWriteTime   prometheus.Histogram
+	casResolveTime prometheus.Histogram
 }
 
 // Get returns an Orb metrics provider.
@@ -72,60 +83,24 @@ func Get() *Metrics {
 
 func newMetrics() *Metrics {
 	m := &Metrics{
-		apOutboxPostTime: newHistogram(
-			activityPub, apPostTimeMetric,
-			"The time (in seconds) that it takes to post a message to the outbox.",
-		),
-		apOutboxResolveInboxesTime: newHistogram(
-			activityPub, apResolveInboxesTimeMetric,
-			"The time (in seconds) that it takes to resolve the inboxes of the destinations when posting to the outbox.",
-		),
-		apInboxHandlerTime: newHistogram(
-			activityPub, apInboxHandlerTimeMetric,
-			"The time (in seconds) that it takes to handle an activity posted to the inbox.",
-		),
-		anchorWriteTime: newHistogram(
-			anchor, anchorWriteTimeMetric,
-			"The time (in seconds) that it takes to write an anchor credential and post an 'Offer' activity.",
-		),
-		anchorProcessWitnessedTime: newHistogram(
-			anchor, anchorProcessWitnessedMetric,
-			"The time (in seconds) that it takes to process a witnessed anchor credential by publishing it to "+
-				"the Observer and posting a 'Create' activity.",
-		),
-		opqueueAddOperationTime: newHistogram(
-			operationQueue, opQueueAddOperationTimeMetric,
-			"The time (in seconds) that it takes to add an operation to the queue.",
-		),
-		opqueueBatchCutTime: newHistogram(
-			operationQueue, opQueueBatchCutTimeMetric,
-			"The time (in seconds) that it takes to cut an operation batch.",
-		),
-		opqueueBatchRollbackTime: newHistogram(
-			operationQueue, opQueueBatchRollbackTimeMetric,
-			"The time (in seconds) that it takes to roll back an operation batch.",
-		),
-		observerProcessAnchorTime: newHistogram(
-			observer, observerProcessAnchorTimeMetric,
-			"The time (in seconds) that it takes for the Observer to process an anchor credential.",
-		),
-		observerProcessDIDTime: newHistogram(
-			observer, observerProcessDIDTimeMetric,
-			"The time (in seconds) that it takes for the Observer to process a DID.",
-		),
+		apOutboxPostTime:           newOutboxPostTime(),
+		apOutboxResolveInboxesTime: newOutboxResolveInboxesTime(),
+		apInboxHandlerTime:         newInboxHandlerTime(),
+		anchorWriteTime:            newAnchorWriteTime(),
+		anchorProcessWitnessedTime: newAnchorProcessWitnessedTime(),
+		opqueueAddOperationTime:    newOpQueueAddOperationTime(),
+		opqueueBatchCutTime:        newOpQueueBatchCutTime(),
+		opqueueBatchRollbackTime:   newOpQueueBatchRollbackTime(),
+		observerProcessAnchorTime:  newObserverProcessAnchorTime(),
+		observerProcessDIDTime:     newObserverProcessDIDTime(),
+		casWriteTime:               newCASWriteTime(),
+		casResolveTime:             newCASResolveTime(),
 	}
 
 	prometheus.MustRegister(
-		m.apOutboxPostTime,
-		m.apOutboxResolveInboxesTime,
-		m.apInboxHandlerTime,
-		m.anchorWriteTime,
-		m.anchorProcessWitnessedTime,
-		m.opqueueAddOperationTime,
-		m.opqueueBatchCutTime,
-		m.opqueueBatchRollbackTime,
-		m.observerProcessAnchorTime,
-		m.observerProcessDIDTime,
+		m.apOutboxPostTime, m.apOutboxResolveInboxesTime, m.apInboxHandlerTime, m.anchorWriteTime,
+		m.anchorProcessWitnessedTime, m.opqueueAddOperationTime, m.opqueueBatchCutTime, m.opqueueBatchRollbackTime,
+		m.observerProcessAnchorTime, m.observerProcessDIDTime, m.casWriteTime, m.casResolveTime,
 	)
 
 	return m
@@ -134,52 +109,86 @@ func newMetrics() *Metrics {
 // OutboxPostTime records the time it takes to post a message to the outbox.
 func (m *Metrics) OutboxPostTime(value time.Duration) {
 	m.apOutboxPostTime.Observe(value.Seconds())
+
+	logger.Debugf("OutboxPost time: %s", value)
 }
 
 // OutboxResolveInboxesTime records the time it takes to resolve inboxes for an outbox post.
 func (m *Metrics) OutboxResolveInboxesTime(value time.Duration) {
 	m.apOutboxResolveInboxesTime.Observe(value.Seconds())
+
+	logger.Debugf("OutboxResolveInboxes time: %s", value)
 }
 
 // InboxHandlerTime records the time it takes to handle an activity posted to the inbox.
 func (m *Metrics) InboxHandlerTime(value time.Duration) {
 	m.apInboxHandlerTime.Observe(value.Seconds())
+
+	logger.Debugf("InboxHandler time: %s", value)
 }
 
 // WriteAnchorTime records the time it takes to write an anchor credential and post an 'Offer' activity.
 func (m *Metrics) WriteAnchorTime(value time.Duration) {
 	m.anchorWriteTime.Observe(value.Seconds())
+
+	logger.Infof("WriteAnchor time: %s", value)
 }
 
 // ProcessWitnessedAnchoredCredentialTime records the time it takes to process a witnessed anchor credential
 // by publishing it to the Observer and posting a 'Create' activity.
 func (m *Metrics) ProcessWitnessedAnchoredCredentialTime(value time.Duration) {
 	m.anchorProcessWitnessedTime.Observe(value.Seconds())
+
+	logger.Infof("ProcessWitnessedAnchoredCredential time: %s", value)
 }
 
 // AddOperationTime records the time it takes to add an operation to the queue.
 func (m *Metrics) AddOperationTime(value time.Duration) {
 	m.opqueueAddOperationTime.Observe(value.Seconds())
+
+	logger.Debugf("AddOperation time: %s", value)
 }
 
 // BatchCutTime records the time it takes to cut an operation batch.
 func (m *Metrics) BatchCutTime(value time.Duration) {
 	m.opqueueBatchCutTime.Observe(value.Seconds())
+
+	logger.Infof("BatchCut time: %s", value)
 }
 
 // BatchRollbackTime records the time it takes to roll back an operation batch (in case of a transient error).
 func (m *Metrics) BatchRollbackTime(value time.Duration) {
 	m.opqueueBatchRollbackTime.Observe(value.Seconds())
+
+	logger.Debugf("BatchRollback time: %s", value)
 }
 
 // ProcessAnchorTime records the time it takes for the Observer to process an anchor credential.
 func (m *Metrics) ProcessAnchorTime(value time.Duration) {
 	m.observerProcessAnchorTime.Observe(value.Seconds())
+
+	logger.Infof("ProcessAnchor time: %s", value)
 }
 
 // ProcessDIDTime records the time it takes for the Observer to process a DID.
 func (m *Metrics) ProcessDIDTime(value time.Duration) {
 	m.observerProcessDIDTime.Observe(value.Seconds())
+
+	logger.Infof("ProcessDID time: %s", value)
+}
+
+// CASWriteTime records the time it takes to write a document to CAS.
+func (m *Metrics) CASWriteTime(value time.Duration) {
+	m.casWriteTime.Observe(value.Seconds())
+
+	logger.Debugf("CASWrite time: %s", value)
+}
+
+// CASResolveTime records the time it takes to resolve a document from CAS.
+func (m *Metrics) CASResolveTime(value time.Duration) {
+	m.casResolveTime.Observe(value.Seconds())
+
+	logger.Debugf("CASResolve time: %s", value)
 }
 
 func newCounter(subsystem, name, help string) prometheus.Counter {
@@ -207,4 +216,89 @@ func newHistogram(subsystem, name, help string) prometheus.Histogram {
 		Name:      name,
 		Help:      help,
 	})
+}
+
+func newOutboxPostTime() prometheus.Histogram {
+	return newHistogram(
+		activityPub, apPostTimeMetric,
+		"The time (in seconds) that it takes to post a message to the outbox.",
+	)
+}
+
+func newOutboxResolveInboxesTime() prometheus.Histogram {
+	return newHistogram(
+		activityPub, apResolveInboxesTimeMetric,
+		"The time (in seconds) that it takes to resolve the inboxes of the destinations when posting to the outbox.",
+	)
+}
+
+func newInboxHandlerTime() prometheus.Histogram {
+	return newHistogram(
+		activityPub, apInboxHandlerTimeMetric,
+		"The time (in seconds) that it takes to handle an activity posted to the inbox.",
+	)
+}
+
+func newAnchorWriteTime() prometheus.Histogram {
+	return newHistogram(
+		anchor, anchorWriteTimeMetric,
+		"The time (in seconds) that it takes to write an anchor credential and post an 'Offer' activity.",
+	)
+}
+
+func newAnchorProcessWitnessedTime() prometheus.Histogram {
+	return newHistogram(
+		anchor, anchorProcessWitnessedMetric,
+		"The time (in seconds) that it takes to process a witnessed anchor credential by publishing it to "+
+			"the Observer and posting a 'Create' activity.",
+	)
+}
+
+func newOpQueueAddOperationTime() prometheus.Histogram {
+	return newHistogram(
+		operationQueue, opQueueAddOperationTimeMetric,
+		"The time (in seconds) that it takes to add an operation to the queue.",
+	)
+}
+
+func newOpQueueBatchCutTime() prometheus.Histogram {
+	return newHistogram(
+		operationQueue, opQueueBatchCutTimeMetric,
+		"The time (in seconds) that it takes to cut an operation batch.",
+	)
+}
+
+func newOpQueueBatchRollbackTime() prometheus.Histogram {
+	return newHistogram(
+		operationQueue, opQueueBatchRollbackTimeMetric,
+		"The time (in seconds) that it takes to roll back an operation batch.",
+	)
+}
+
+func newObserverProcessAnchorTime() prometheus.Histogram {
+	return newHistogram(
+		observer, observerProcessAnchorTimeMetric,
+		"The time (in seconds) that it takes for the Observer to process an anchor credential.",
+	)
+}
+
+func newObserverProcessDIDTime() prometheus.Histogram {
+	return newHistogram(
+		observer, observerProcessDIDTimeMetric,
+		"The time (in seconds) that it takes for the Observer to process a DID.",
+	)
+}
+
+func newCASWriteTime() prometheus.Histogram {
+	return newHistogram(
+		cas, casWriteTimeMetric,
+		"The time (in seconds) that it takes to write a document to CAS.",
+	)
+}
+
+func newCASResolveTime() prometheus.Histogram {
+	return newHistogram(
+		cas, casResolveTimeMetric,
+		"The time (in seconds) that it takes to resolve a document from CAS.",
+	)
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -27,6 +27,10 @@ func TestMetrics(t *testing.T) {
 		require.NotPanics(t, func() { m.AddOperationTime(time.Second) })
 		require.NotPanics(t, func() { m.BatchCutTime(time.Second) })
 		require.NotPanics(t, func() { m.BatchRollbackTime(time.Second) })
+		require.NotPanics(t, func() { m.ProcessAnchorTime(time.Second) })
+		require.NotPanics(t, func() { m.ProcessDIDTime(time.Second) })
+		require.NotPanics(t, func() { m.CASWriteTime(time.Second) })
+		require.NotPanics(t, func() { m.CASResolveTime(time.Second) })
 	})
 }
 

--- a/pkg/mocks/metricsprovider.go
+++ b/pkg/mocks/metricsprovider.go
@@ -51,3 +51,11 @@ func (m *MetricsProvider) ProcessAnchorTime(value time.Duration) {
 // ProcessDIDTime records the time it takes for the Observer to process a DID.
 func (m *MetricsProvider) ProcessDIDTime(value time.Duration) {
 }
+
+// CASWriteTime records the time it takes to write a document to CAS.
+func (m *MetricsProvider) CASWriteTime(value time.Duration) {
+}
+
+// CASResolveTime records the time it takes to resolve a document from CAS.
+func (m *MetricsProvider) CASResolveTime(value time.Duration) {
+}

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -96,12 +96,12 @@ func TestStartObserver(t *testing.T) {
 		require.NoError(t, err)
 
 		graphProviders := &graph.Providers{
-			CasWriter: caswriter.New(casClient, ""),
+			CasWriter: caswriter.New(casClient, "", &orbmocks.MetricsProvider{}),
 			CasResolver: casresolver.New(casClient, nil,
 				casresolver.NewWebCASResolver(
 					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 						transport.DefaultSigner(), transport.DefaultSigner()),
-					webfingerclient.New(), "https")),
+					webfingerclient.New(), "https"), &orbmocks.MetricsProvider{}),
 			Pkf:       pubKeyFetcherFnc,
 			DocLoader: testutil.GetLoader(t),
 		}
@@ -165,12 +165,12 @@ func TestStartObserver(t *testing.T) {
 		require.NoError(t, err)
 
 		graphProviders := &graph.Providers{
-			CasWriter: caswriter.New(casClient, ""),
+			CasWriter: caswriter.New(casClient, "", &orbmocks.MetricsProvider{}),
 			CasResolver: casresolver.New(casClient, nil,
 				casresolver.NewWebCASResolver(
 					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 						transport.DefaultSigner(), transport.DefaultSigner()),
-					webfingerclient.New(), "https")),
+					webfingerclient.New(), "https"), &orbmocks.MetricsProvider{}),
 			Pkf:       pubKeyFetcherFnc,
 			DocLoader: testutil.GetLoader(t),
 		}
@@ -227,12 +227,12 @@ func TestStartObserver(t *testing.T) {
 		require.NoError(t, err)
 
 		graphProviders := &graph.Providers{
-			CasWriter: caswriter.New(casClient, ""),
+			CasWriter: caswriter.New(casClient, "", &orbmocks.MetricsProvider{}),
 			CasResolver: casresolver.New(casClient, nil,
 				casresolver.NewWebCASResolver(
 					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 						transport.DefaultSigner(), transport.DefaultSigner()),
-					webfingerclient.New(), "https")),
+					webfingerclient.New(), "https"), &orbmocks.MetricsProvider{}),
 			Pkf:       pubKeyFetcherFnc,
 			DocLoader: testutil.GetLoader(t),
 		}
@@ -295,12 +295,12 @@ func TestStartObserver(t *testing.T) {
 		require.NoError(t, err)
 
 		graphProviders := &graph.Providers{
-			CasWriter: caswriter.New(casClient, ""),
+			CasWriter: caswriter.New(casClient, "", &orbmocks.MetricsProvider{}),
 			CasResolver: casresolver.New(casClient, nil,
 				casresolver.NewWebCASResolver(
 					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 						transport.DefaultSigner(), transport.DefaultSigner()),
-					webfingerclient.New(), "https")),
+					webfingerclient.New(), "https"), &orbmocks.MetricsProvider{}),
 			Pkf:       pubKeyFetcherFnc,
 			DocLoader: testutil.GetLoader(t),
 		}
@@ -359,12 +359,12 @@ func TestStartObserver(t *testing.T) {
 		require.NoError(t, err)
 
 		graphProviders := &graph.Providers{
-			CasWriter: caswriter.New(casClient, "webcas:domain.com"),
+			CasWriter: caswriter.New(casClient, "webcas:domain.com", &orbmocks.MetricsProvider{}),
 			CasResolver: casresolver.New(casClient, nil,
 				casresolver.NewWebCASResolver(
 					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 						transport.DefaultSigner(), transport.DefaultSigner()),
-					webfingerclient.New(), "https")),
+					webfingerclient.New(), "https"), &orbmocks.MetricsProvider{}),
 			Pkf:       pubKeyFetcherFnc,
 			DocLoader: testutil.GetLoader(t),
 		}
@@ -421,12 +421,12 @@ func TestStartObserver(t *testing.T) {
 		require.NoError(t, err)
 
 		graphProviders := &graph.Providers{
-			CasWriter: caswriter.New(casClient, ""),
+			CasWriter: caswriter.New(casClient, "", &orbmocks.MetricsProvider{}),
 			CasResolver: casresolver.New(casClient, nil,
 				casresolver.NewWebCASResolver(
 					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 						transport.DefaultSigner(), transport.DefaultSigner()),
-					webfingerclient.New(), "https")),
+					webfingerclient.New(), "https"), &orbmocks.MetricsProvider{}),
 			Pkf:       pubKeyFetcherFnc,
 			DocLoader: testutil.GetLoader(t),
 		}
@@ -499,12 +499,12 @@ func TestStartObserver(t *testing.T) {
 		require.NoError(t, err)
 
 		graphProviders := &graph.Providers{
-			CasWriter: caswriter.New(casClient, ""),
+			CasWriter: caswriter.New(casClient, "", &orbmocks.MetricsProvider{}),
 			CasResolver: casresolver.New(casClient, nil,
 				casresolver.NewWebCASResolver(
 					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 						transport.DefaultSigner(), transport.DefaultSigner()),
-					webfingerclient.New(), "https")),
+					webfingerclient.New(), "https"), &orbmocks.MetricsProvider{}),
 			Pkf:       pubKeyFetcherFnc,
 			DocLoader: testutil.GetLoader(t),
 		}
@@ -605,12 +605,12 @@ func TestStartObserver(t *testing.T) {
 		require.NoError(t, err)
 
 		graphProviders := &graph.Providers{
-			CasWriter: caswriter.New(casClient, ""),
+			CasWriter: caswriter.New(casClient, "", &orbmocks.MetricsProvider{}),
 			CasResolver: casresolver.New(casClient, nil,
 				casresolver.NewWebCASResolver(
 					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 						transport.DefaultSigner(), transport.DefaultSigner()),
-					webfingerclient.New(), "https")),
+					webfingerclient.New(), "https"), &orbmocks.MetricsProvider{}),
 			Pkf:       pubKeyFetcherFnc,
 			DocLoader: testutil.GetLoader(t),
 		}

--- a/pkg/protocolversion/versions/v1_0/factory/factory_test.go
+++ b/pkg/protocolversion/versions/v1_0/factory/factory_test.go
@@ -22,6 +22,7 @@ import (
 	casresolver "github.com/trustbloc/orb/pkg/cas/resolver"
 	"github.com/trustbloc/orb/pkg/config"
 	"github.com/trustbloc/orb/pkg/internal/testutil"
+	orbmocks "github.com/trustbloc/orb/pkg/mocks"
 	"github.com/trustbloc/orb/pkg/protocolversion/mocks"
 	"github.com/trustbloc/orb/pkg/store/cas"
 	webfingerclient "github.com/trustbloc/orb/pkg/webfinger/client"
@@ -100,7 +101,7 @@ func createNewResolver(t *testing.T, casClient extendedcasclient.Client) *casres
 		casresolver.NewWebCASResolver(
 			transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 				transport.DefaultSigner(), transport.DefaultSigner()),
-			webfingerclient.New(), "https"))
+			webfingerclient.New(), "https"), &orbmocks.MetricsProvider{})
 	require.NotNil(t, casResolver)
 
 	return casResolver


### PR DESCRIPTION
Also refactored metrics provider since the linter was complaining that the function was too long.
And added logging for metrics.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>