### PR TITLE
fix: Use select case for pooled subscriber

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -588,15 +588,13 @@ func startOrbServices(parameters *orbParameters) error {
 		}
 	}
 
-	metricsProvider := metrics.New()
-
 	// create new observer and start it
 	providers := &observer.Providers{
 		ProtocolClientProvider: pcp,
 		AnchorGraph:            anchorGraph,
 		DidAnchors:             didAnchors,
 		PubSub:                 pubSub,
-		Metrics:                metricsProvider,
+		Metrics:                metrics.Get(),
 	}
 
 	o, err := observer.New(providers, observer.WithDiscoveryDomain(parameters.discoveryDomain))
@@ -609,7 +607,7 @@ func startOrbServices(parameters *orbParameters) error {
 	resourceResolver := resource.New(httpClient, ipfsReader)
 
 	activityPubService, err := apservice.New(apConfig,
-		apStore, t, apSigVerifier, pubSub, apClient, resourceResolver, metricsProvider,
+		apStore, t, apSigVerifier, pubSub, apClient, resourceResolver, metrics.Get(),
 		apspi.WithProofHandler(proofHandler),
 		apspi.WithWitness(witness),
 		apspi.WithAnchorCredentialHandler(credential.New(
@@ -647,12 +645,12 @@ func startOrbServices(parameters *orbParameters) error {
 		parameters.maxWitnessDelay,
 		parameters.signWithLocalWitness,
 		orbDocumentLoader, resourceResolver,
-		metricsProvider)
+		metrics.Get())
 	if err != nil {
 		return fmt.Errorf("failed to create writer: %s", err.Error())
 	}
 
-	opQueue, err := opqueue.New(opqueue.Config{PoolSize: parameters.opQueuePoolSize}, pubSub, metricsProvider)
+	opQueue, err := opqueue.New(opqueue.Config{PoolSize: parameters.opQueuePoolSize}, pubSub, metrics.Get())
 	if err != nil {
 		return fmt.Errorf("failed to create operation queue: %s", err.Error())
 	}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -14,8 +14,9 @@ import (
 )
 
 func TestMetrics(t *testing.T) {
-	m := New()
+	m := Get()
 	require.NotNil(t, m)
+	require.True(t, m == Get())
 
 	t.Run("ActivityPub", func(t *testing.T) {
 		require.NotPanics(t, func() { m.InboxHandlerTime(time.Second) })

--- a/pkg/pubsub/amqp/amqppubsub_test.go
+++ b/pkg/pubsub/amqp/amqppubsub_test.go
@@ -75,7 +75,8 @@ func TestAMQP(t *testing.T) {
 		receivedMessages := &sync.Map{}
 
 		p := New(Config{
-			URI: "amqp://guest:guest@localhost:5672/",
+			URI:                        "amqp://guest:guest@localhost:5672/",
+			MaxConnectionSubscriptions: 5,
 		})
 		require.NotNil(t, p)
 		defer func() {

--- a/pkg/pubsub/amqp/pooledsubscriber.go
+++ b/pkg/pubsub/amqp/pooledsubscriber.go
@@ -9,6 +9,7 @@ package amqp
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"github.com/ThreeDotsLabs/watermill/message"
 )
@@ -17,110 +18,57 @@ import (
 // the message to a Go channel that is consumed by the subscriber.
 type pooledSubscriber struct {
 	topic       string
-	subscribers []*poolSubscriber
 	msgChan     chan *message.Message
+	subscribers []reflect.SelectCase
 }
 
 func newPooledSubscriber(ctx context.Context, size uint, subscriber subscriber,
 	topic string) (*pooledSubscriber, error) {
 	p := &pooledSubscriber{
-		topic:   topic,
-		msgChan: make(chan *message.Message, size),
+		topic:       topic,
+		msgChan:     make(chan *message.Message, size),
+		subscribers: make([]reflect.SelectCase, size),
 	}
 
 	for i := uint(0); i < size; i++ {
-		ps, err := newPoolSubscriber(ctx, i, topic, subscriber, p.msgChan)
+		logger.Debugf("[%s-%d] Subscribing...", topic, i)
+
+		msgChan, err := subscriber.Subscribe(ctx, topic)
 		if err != nil {
-			return nil, fmt.Errorf("create pool subscriber: %w", err)
+			return nil, fmt.Errorf("subscribe to topic [%s]: %w", topic, err)
 		}
 
-		p.subscribers = append(p.subscribers, ps)
+		p.subscribers[i].Dir = reflect.SelectRecv
+		p.subscribers[i].Chan = reflect.ValueOf(msgChan)
 	}
 
 	return p, nil
 }
 
 func (s *pooledSubscriber) start() {
-	logger.Infof("[%s] Starting pooled subscriber with %d listeners", s.topic, len(s.subscribers))
+	go func() {
+		logger.Infof("[%s] Started pooled subscriber with %d listeners", s.topic, len(s.subscribers))
 
-	for _, subscriber := range s.subscribers {
-		go subscriber.listen()
-	}
+		for {
+			i, value, ok := reflect.Select(s.subscribers)
+
+			if !ok {
+				logger.Infof("[%s] Message channel [%d] was closed. Exiting pooled subscriber.", s.topic, i)
+
+				return
+			}
+
+			msg := value.Interface().(*message.Message) //nolint:errcheck,forcetypeassert
+
+			logger.Debugf("[%s-%d] Pool subscriber got message [%s]", s.topic, i, msg.UUID)
+
+			s.msgChan <- msg
+		}
+	}()
 }
 
 func (s *pooledSubscriber) stop() {
 	logger.Infof("[%s] Closing pooled subscriber", s.topic)
 
-	for _, s := range s.subscribers {
-		s.stop()
-	}
-
 	close(s.msgChan)
-}
-
-type poolSubscriber struct {
-	n           uint
-	topic       string
-	msgChan     <-chan *message.Message
-	poolMsgChan chan<- *message.Message
-	stopChan    chan struct{}
-	stoppedChan chan struct{}
-}
-
-func newPoolSubscriber(ctx context.Context, n uint, topic string, s subscriber,
-	poolMsgChan chan<- *message.Message) (*poolSubscriber, error) {
-	logger.Debugf("[%s-%d] Subscribing...", topic, n)
-
-	msgChan, err := s.Subscribe(ctx, topic)
-	if err != nil {
-		return nil, fmt.Errorf("subscribe to topic [%s]: %w", topic, err)
-	}
-
-	return &poolSubscriber{
-		n:           n,
-		topic:       topic,
-		msgChan:     msgChan,
-		poolMsgChan: poolMsgChan,
-		stopChan:    make(chan struct{}),
-		stoppedChan: make(chan struct{}),
-	}, nil
-}
-
-func (s *poolSubscriber) listen() {
-	logger.Debugf("[%s-%d] Pool subscriber listener started", s.topic, s.n)
-
-	for {
-		select {
-		case msg, ok := <-s.msgChan:
-			if !ok {
-				logger.Debugf("[%s-%d] Message channel was closed.", s.topic, s.n)
-
-				close(s.stoppedChan)
-
-				return
-			}
-
-			logger.Debugf("[%s-%d] Pool subscriber got message [%s]", s.topic, s.n, msg.UUID)
-
-			s.poolMsgChan <- msg
-		case <-s.stopChan:
-			logger.Debugf("[%s-%d] Listener was requested to stop", s.topic, s.n)
-
-			close(s.stoppedChan)
-
-			return
-		}
-	}
-}
-
-func (s *poolSubscriber) stop() {
-	logger.Debugf("[%s-%d] Stopping Pool subscriber listener...", s.topic, s.n)
-
-	close(s.stopChan)
-
-	logger.Debugf("[%s-%d] ... waiting for pool subscriber listener to stop...", s.topic, s.n)
-
-	<-s.stoppedChan
-
-	logger.Debugf("[%s-%d] ... pool subscriber stopped", s.topic, s.n)
 }

--- a/pkg/pubsub/wmlogger/wmlogger.go
+++ b/pkg/pubsub/wmlogger/wmlogger.go
@@ -38,7 +38,8 @@ func (l *Logger) Error(msg string, err error, fields watermill.LogFields) {
 
 // Info logs an informational message.
 func (l *Logger) Info(msg string, fields watermill.LogFields) {
-	if level := log.GetLevel(Module); level < log.INFO {
+	// Watermill outputs too many INFO logs, so use the DEBUG log level.
+	if level := log.GetLevel(Module); level < log.DEBUG {
 		return
 	}
 

--- a/pkg/pubsub/wmlogger/wmlogger_test.go
+++ b/pkg/pubsub/wmlogger/wmlogger_test.go
@@ -65,7 +65,7 @@ func TestWMLogger(t *testing.T) {
 		logger.Trace("message", nil)
 
 		require.Equal(t, 1, l.ErrorfCallCount())
-		require.Equal(t, 1, l.InfofCallCount())
+		require.Equal(t, 0, l.InfofCallCount())
 		require.Equal(t, 0, l.DebugfCallCount())
 	})
 


### PR DESCRIPTION
Currently a goroutine is created for every MQ subscriber channel. This leads to a very large number of goroutines. This commit uses reflect.Select to listen to multiple channels in one goroutine.

Also:
- Reduce the number of logs from Watermill
- Ensure that Prometheus metrics are registered only once in order to fix the startcmd unit tests

closes #641

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>