### PR TITLE
feat: Added functions for converting between multihashes and CIDs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/ipfs/go-merkledag v0.2.3
 	github.com/ipfs/go-unixfs v0.2.6
 	github.com/mr-tron/base58 v1.2.0
+	github.com/multiformats/go-multibase v0.0.3
 	github.com/multiformats/go-multihash v0.0.14
 	github.com/ory/dockertest/v3 v3.6.3
 	github.com/piprate/json-gold v0.4.0

--- a/pkg/multihash/multihash.go
+++ b/pkg/multihash/multihash.go
@@ -1,0 +1,48 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package multihash contains functions for converting between multihashes and CIDs.
+package multihash
+
+import (
+	"fmt"
+
+	gocid "github.com/ipfs/go-cid"
+	"github.com/multiformats/go-multibase"
+	mh "github.com/multiformats/go-multihash"
+)
+
+// ToV1CID takes a multibase-encoded multihash and converts it to a V1 CID.
+func ToV1CID(multibaseEncodedMultihash string) (string, error) {
+	_, multihashBytes, err := multibase.Decode(multibaseEncodedMultihash)
+	if err != nil {
+		return "", fmt.Errorf("failed to decode multibase-encoded multihash: %w", err)
+	}
+
+	_, multihash, err := mh.MHFromBytes(multihashBytes)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse the decoded multibase value as a multihash: %w", err)
+	}
+
+	return gocid.NewCidV1(gocid.Raw, multihash).String(), nil
+}
+
+// CIDToMultihash takes a V0 or V1 CID and converts it to a multibase-encoded (with base64url as the base) multihash.
+func CIDToMultihash(cid string) (string, error) {
+	parsedCID, err := gocid.Decode(cid)
+	if err != nil {
+		return "", fmt.Errorf("failed to decode CID: %w", err)
+	}
+
+	multihashFromCID := parsedCID.Hash()
+
+	multibaseEncodedMultihash, err := multibase.Encode(multibase.Base64url, multihashFromCID)
+	if err != nil {
+		return "", fmt.Errorf("failed to encoded multihash as a multibase-encoded string: %w", err)
+	}
+
+	return multibaseEncodedMultihash, nil
+}

--- a/pkg/multihash/multihash_test.go
+++ b/pkg/multihash/multihash_test.go
@@ -1,0 +1,69 @@
+package multihash_test
+
+import (
+	"testing"
+
+	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/pkg/multihash"
+	"github.com/trustbloc/orb/pkg/store/cas"
+)
+
+func TestToV1CID(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		v1CID, err := multihash.ToV1CID("uEiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA")
+		require.NoError(t, err)
+		require.Equal(t, "bafkreibx3pob32ai67uyizvhwndjdydzaa45ln6acf2mmtb7g7l3epateq", v1CID)
+	})
+	t.Run("Fail to decode multibase-encoded multihash", func(t *testing.T) {
+		v1CID, err := multihash.ToV1CID("")
+		require.EqualError(t, err, "failed to decode multibase-encoded multihash: "+
+			"cannot decode multibase for zero length string")
+		require.Empty(t, v1CID)
+	})
+	t.Run("Fail to parse the decoded multibase value as a multihash", func(t *testing.T) {
+		v1CID, err := multihash.ToV1CID("u2ouBBsyLDedeYciUmaihjWUmWhA3LVkruPZwSk7EeHWWqUZF")
+		require.EqualError(t, err, "failed to parse the decoded multibase value as a multihash: "+
+			"length greater than remaining number of bytes in buffer")
+		require.Empty(t, v1CID)
+	})
+}
+
+func TestCIDToMultihash(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		t.Run("V0 CID", func(t *testing.T) {
+			multihashFromCID, err := multihash.CIDToMultihash("QmXtH52gwKmNzfe6PmPf9jmiZ7zuhGmx577bHonXpvKSgL")
+			require.NoError(t, err)
+			require.Equal(t, "uEiCN00z3Gj3oGUbIREZud0Puv-OE4N2x9eTJ0vFMTaju7Q", multihashFromCID)
+		})
+		t.Run("V1 CID", func(t *testing.T) {
+			multihashFromCID, err := multihash.CIDToMultihash("bafkreibx3pob32ai67uyizvhwndjdydzaa45ln6acf2mmtb7g7l3epateq")
+			require.NoError(t, err)
+			require.Equal(t, "uEiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA", multihashFromCID)
+		})
+	})
+	t.Run("Fail to decode CID", func(t *testing.T) {
+		multihashFromCID, err := multihash.CIDToMultihash("")
+		require.EqualError(t, err, "failed to decode CID: cid too short")
+		require.Empty(t, multihashFromCID)
+	})
+}
+
+// Here we test to ensure that CIDs produced by the local CAS implementation can be converted
+// back-and-forth between the multihash and CID formats without loss of data.
+func TestLosslessConversion(t *testing.T) {
+	store, err := cas.New(mem.NewProvider(), nil)
+	require.NoError(t, err)
+
+	originalCID, err := store.Write([]byte("content"))
+	require.NoError(t, err)
+
+	multihashFromCID, err := multihash.CIDToMultihash(originalCID)
+	require.NoError(t, err)
+
+	cidConvertedBackFromMultihash, err := multihash.ToV1CID(multihashFromCID)
+	require.NoError(t, err)
+
+	require.Equal(t, originalCID, cidConvertedBackFromMultihash)
+}


### PR DESCRIPTION
These new functions can be used to convert:
- V0 CIDs to multihashes
- V1 CIDs to multihashes
- Multihashes to V1 CIDs

Support for converting multihashes to V0 CIDs to be added in a future commit.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>

closes #646 