### PR TITLE
fix: Batch cut time metric

### DIFF
--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -27,6 +27,8 @@ func TestMetrics(t *testing.T) {
 		require.NotPanics(t, func() { m.AddOperationTime(time.Second) })
 		require.NotPanics(t, func() { m.BatchCutTime(time.Second) })
 		require.NotPanics(t, func() { m.BatchRollbackTime(time.Second) })
+		require.NotPanics(t, func() { m.BatchAckTime(time.Second) })
+		require.NotPanics(t, func() { m.BatchNackTime(time.Second) })
 		require.NotPanics(t, func() { m.ProcessAnchorTime(time.Second) })
 		require.NotPanics(t, func() { m.ProcessDIDTime(time.Second) })
 		require.NotPanics(t, func() { m.CASWriteTime(time.Second) })

--- a/pkg/mocks/metricsprovider.go
+++ b/pkg/mocks/metricsprovider.go
@@ -59,3 +59,11 @@ func (m *MetricsProvider) CASWriteTime(value time.Duration) {
 // CASResolveTime records the time it takes to resolve a document from CAS.
 func (m *MetricsProvider) CASResolveTime(value time.Duration) {
 }
+
+// BatchAckTime records the time to acknowledge all of the operations that are removed from the queue.
+func (m *MetricsProvider) BatchAckTime(value time.Duration) {
+}
+
+// BatchNackTime records the time to nack all of the operations that are to be placed back on the queue.
+func (m *MetricsProvider) BatchNackTime(value time.Duration) {
+}

--- a/test/bdd/fixtures/nginx-config/nginx.conf
+++ b/test/bdd/fixtures/nginx-config/nginx.conf
@@ -5,7 +5,7 @@
 
 events {}
 
-error_log /dev/stdout info;
+error_log /dev/stdout error;
 
 http {
     access_log /dev/null;


### PR DESCRIPTION
Changed the batch cut time metric to measure the time from when the first operation was added to the operation queue to the time that the batch was cut. Also added new metrics to measure the time to ack/nack messages in the operation queue.

closes #644

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>