### PR TITLE
feat: Allow for granular log levels for modules on startup

### DIFF
--- a/cmd/orb-cli/go.mod
+++ b/cmd/orb-cli/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.3.1 // indirect
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.7.0
-	github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716
+	github.com/trustbloc/edge-core v0.1.7-0.20210819195944-a3500e365d5c
 	github.com/trustbloc/orb v0.1.3-0.20210813151342-cd05bd36321d
 )
 

--- a/cmd/orb-cli/go.sum
+++ b/cmd/orb-cli/go.sum
@@ -1201,8 +1201,9 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/trustbloc/edge-core v0.1.7-0.20210812092729-6c61997fa9dd/go.mod h1:lb8Kg33uSTA0912U++p+cpYbMa9I1jvnhcDRyI+vWtw=
-github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716 h1:qBnp316Q4/Bd13oYarCXEI83O9IwOaCbDeEIFfPvW+4=
 github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7jjHQo2gMGNPIRfhvn4aXQ0FYMrG9lRgQcvZKTviCGc=
+github.com/trustbloc/edge-core v0.1.7-0.20210819195944-a3500e365d5c h1:/CzHsVBUM8MUuVR/4t0EeGeCIvwV2HiN0Pj7tNs6VXI=
+github.com/trustbloc/edge-core v0.1.7-0.20210819195944-a3500e365d5c/go.mod h1:7jjHQo2gMGNPIRfhvn4aXQ0FYMrG9lRgQcvZKTviCGc=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b h1:JKQVbQxv0d2C9p4u+GqkJeitB51jvLgzR2YvTeG9AQ0=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3-0.20210812104204-d8ddd5781928 h1:LawxLAbGwgIODvc/VQEnyeNu3h3zq6NLVyAovKoOIAw=

--- a/cmd/orb-driver/go.mod
+++ b/cmd/orb-driver/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/orb v0.0.0-20210817223403-9fb48da0a4b9
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.7.0
-	github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716
+	github.com/trustbloc/edge-core v0.1.7-0.20210819195944-a3500e365d5c
 	github.com/trustbloc/orb v0.1.3-0.20210813151342-cd05bd36321d
 	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b
 )

--- a/cmd/orb-driver/go.sum
+++ b/cmd/orb-driver/go.sum
@@ -1196,8 +1196,9 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/trustbloc/edge-core v0.1.7-0.20210812092729-6c61997fa9dd/go.mod h1:lb8Kg33uSTA0912U++p+cpYbMa9I1jvnhcDRyI+vWtw=
-github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716 h1:qBnp316Q4/Bd13oYarCXEI83O9IwOaCbDeEIFfPvW+4=
 github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7jjHQo2gMGNPIRfhvn4aXQ0FYMrG9lRgQcvZKTviCGc=
+github.com/trustbloc/edge-core v0.1.7-0.20210819195944-a3500e365d5c h1:/CzHsVBUM8MUuVR/4t0EeGeCIvwV2HiN0Pj7tNs6VXI=
+github.com/trustbloc/edge-core v0.1.7-0.20210819195944-a3500e365d5c/go.mod h1:7jjHQo2gMGNPIRfhvn4aXQ0FYMrG9lRgQcvZKTviCGc=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b h1:JKQVbQxv0d2C9p4u+GqkJeitB51jvLgzR2YvTeG9AQ0=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3-0.20210812104204-d8ddd5781928 h1:LawxLAbGwgIODvc/VQEnyeNu3h3zq6NLVyAovKoOIAw=

--- a/cmd/orb-server/go.mod
+++ b/cmd/orb-server/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210812172004-259b50ab3879
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.7.0
-	github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716
+	github.com/trustbloc/edge-core v0.1.7-0.20210819195944-a3500e365d5c
 	github.com/trustbloc/orb v0.0.0
 	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b
 	github.com/trustbloc/vct v0.1.3-0.20210812104204-d8ddd5781928

--- a/cmd/orb-server/go.sum
+++ b/cmd/orb-server/go.sum
@@ -1294,8 +1294,9 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/trustbloc/edge-core v0.1.7-0.20210812092729-6c61997fa9dd/go.mod h1:lb8Kg33uSTA0912U++p+cpYbMa9I1jvnhcDRyI+vWtw=
-github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716 h1:qBnp316Q4/Bd13oYarCXEI83O9IwOaCbDeEIFfPvW+4=
 github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7jjHQo2gMGNPIRfhvn4aXQ0FYMrG9lRgQcvZKTviCGc=
+github.com/trustbloc/edge-core v0.1.7-0.20210819195944-a3500e365d5c h1:/CzHsVBUM8MUuVR/4t0EeGeCIvwV2HiN0Pj7tNs6VXI=
+github.com/trustbloc/edge-core v0.1.7-0.20210819195944-a3500e365d5c/go.mod h1:7jjHQo2gMGNPIRfhvn4aXQ0FYMrG9lRgQcvZKTviCGc=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b h1:JKQVbQxv0d2C9p4u+GqkJeitB51jvLgzR2YvTeG9AQ0=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3-0.20210812104204-d8ddd5781928 h1:LawxLAbGwgIODvc/VQEnyeNu3h3zq6NLVyAovKoOIAw=

--- a/cmd/orb-server/startcmd/log.go
+++ b/cmd/orb-server/startcmd/log.go
@@ -16,26 +16,24 @@ const (
 	// LogLevelFlagShorthand is the shorthand flag name used for setting the default log level.
 	LogLevelFlagShorthand = "l"
 	// LogLevelPrefixFlagUsage is the usage text for the log level flag.
-	LogLevelPrefixFlagUsage = "Logging level to set. Supported options: CRITICAL, ERROR, WARNING, INFO, DEBUG." +
+	LogLevelPrefixFlagUsage = "Sets logging levels for individual modules as well as the default level. `+" +
+		"`The format of the string is as follows: module1=level1:module2=level2:defaultLevel. `+" +
+		"`Supported levels are: CRITICAL, ERROR, WARNING, INFO, DEBUG." +
+		"`Example: metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:DEBUG. `+" +
 		`Defaults to info if not set. Setting to debug may adversely impact performance. Alternatively, this can be ` +
 		"set with the following environment variable: " + LogLevelEnvKey
 )
 
-// SetDefaultLogLevel sets the default log level.
-func SetDefaultLogLevel(logger log.Logger, userLogLevel string) {
-	logLevel, err := log.ParseLevel(userLogLevel)
-	if err != nil {
-		logger.Warnf(`%s is not a valid logging level. It must be one of the following: `+
-			log.ParseString(log.CRITICAL)+", "+
-			log.ParseString(log.ERROR)+", "+
-			log.ParseString(log.WARNING)+", "+
-			log.ParseString(log.INFO)+", "+
-			log.ParseString(log.DEBUG)+". Defaulting to info.", userLogLevel)
+const logSpecErrorMsg = `Invalid log spec. It needs to be in the following format: "ModuleName1=Level1` +
+	`:ModuleName2=Level2:ModuleNameN=LevelN:AllOtherModuleDefaultLevel"
+Valid log levels: critical,error,warn,info,debug
+Error: %s`
 
-		logLevel = log.INFO
-	} else if logLevel == log.DEBUG {
-		logger.Infof(`Log level set to "debug". Performance may be adversely impacted.`)
+// setLogLevels sets the log levels for individual modules as well as the default level.
+func setLogLevels(logger log.Logger, logSpec string) {
+	if err := log.SetSpec(logSpec); err != nil {
+		logger.Warnf(logSpecErrorMsg, err.Error())
+
+		log.SetLevel("", log.INFO)
 	}
-
-	log.SetLevel("", logLevel)
 }

--- a/cmd/orb-server/startcmd/log_test.go
+++ b/cmd/orb-server/startcmd/log_test.go
@@ -19,22 +19,37 @@ var testLogger = log.New(testLogModuleName)
 
 func TestSetLogLevel(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		resetLoggingLevels()
+		resetLoggingLevels(t)
 
-		SetDefaultLogLevel(testLogger, "debug")
+		setLogLevels(testLogger, "debug")
 
 		require.Equal(t, log.DEBUG, log.GetLevel(""))
 	})
-	t.Run("Invalid log level", func(t *testing.T) {
-		resetLoggingLevels()
 
-		SetDefaultLogLevel(testLogger, "mango")
+	t.Run("Log spec -> Success", func(t *testing.T) {
+		resetLoggingLevels(t)
+
+		setLogLevels(testLogger, "module1=debug:module2=error:warning")
+
+		require.Equal(t, log.WARNING, log.GetLevel(""))
+		require.Equal(t, log.DEBUG, log.GetLevel("module1"))
+		require.Equal(t, log.ERROR, log.GetLevel("module2"))
+	})
+
+	t.Run("Invalid log level", func(t *testing.T) {
+		resetLoggingLevels(t)
+
+		setLogLevels(testLogger, "mango")
 
 		// Should remain unchanged
 		require.Equal(t, log.INFO, log.GetLevel(""))
 	})
 }
 
-func resetLoggingLevels() {
+func resetLoggingLevels(t *testing.T) {
+	t.Helper()
+
 	log.SetLevel("", log.INFO)
+	log.SetLevel("module1", log.INFO)
+	log.SetLevel("module2", log.INFO)
 }

--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -288,7 +288,7 @@ func importPrivateKey(km kms.KeyManager, parameters *orbParameters, cfg storage.
 // nolint: gocyclo,funlen,gocognit
 func startOrbServices(parameters *orbParameters) error {
 	if parameters.logLevel != "" {
-		SetDefaultLogLevel(logger, parameters.logLevel)
+		setLogLevels(logger, parameters.logLevel)
 	}
 
 	storeProviders, err := createStoreProviders(parameters)

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/rs/cors v1.7.0
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.7.0
-	github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716
+	github.com/trustbloc/edge-core v0.1.7-0.20210819195944-a3500e365d5c
 	github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b
 	github.com/trustbloc/vct v0.1.3-0.20210812104204-d8ddd5781928
 	golang.org/x/net v0.0.0-20210525063256-abc453219eb5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1231,8 +1231,9 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/trustbloc/edge-core v0.1.7-0.20210812092729-6c61997fa9dd/go.mod h1:lb8Kg33uSTA0912U++p+cpYbMa9I1jvnhcDRyI+vWtw=
-github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716 h1:qBnp316Q4/Bd13oYarCXEI83O9IwOaCbDeEIFfPvW+4=
 github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7jjHQo2gMGNPIRfhvn4aXQ0FYMrG9lRgQcvZKTviCGc=
+github.com/trustbloc/edge-core v0.1.7-0.20210819195944-a3500e365d5c h1:/CzHsVBUM8MUuVR/4t0EeGeCIvwV2HiN0Pj7tNs6VXI=
+github.com/trustbloc/edge-core v0.1.7-0.20210819195944-a3500e365d5c/go.mod h1:7jjHQo2gMGNPIRfhvn4aXQ0FYMrG9lRgQcvZKTviCGc=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b h1:JKQVbQxv0d2C9p4u+GqkJeitB51jvLgzR2YvTeG9AQ0=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3-0.20210812104204-d8ddd5781928 h1:LawxLAbGwgIODvc/VQEnyeNu3h3zq6NLVyAovKoOIAw=

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     environment:
       - ORB_SYNC_TIMEOUT=3
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
-      - LOG_LEVEL=DEBUG
+      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:DEBUG
       - ORB_VCT_URL=http://orb.vct:8077/maple2020
       - ORB_HOST_URL=0.0.0.0:443
       - ORB_HOST_METRICS_URL=0.0.0.0:48327
@@ -95,7 +95,7 @@ services:
     environment:
       - ORB_SYNC_TIMEOUT=3
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
-      - LOG_LEVEL=DEBUG
+      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:DEBUG
       - ORB_VCT_URL=http://orb.vct:8077/maple2020
       - ORB_HOST_URL=0.0.0.0:443
       - ORB_HOST_METRICS_URL=0.0.0.0:48527
@@ -192,7 +192,7 @@ services:
     environment:
       - ORB_SYNC_TIMEOUT=3
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
-      - LOG_LEVEL=DEBUG
+      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:DEBUG
       - ORB_HOST_URL=0.0.0.0:80
       - ORB_HOST_METRICS_URL=0.0.0.0:48827
       - ORB_PRIVATE_KEY=9kRTh70Ut0MKPeHY3Gdv/pi8SACx6dFjaEiIHf7JDugPpXBnCHVvRbgdzYbWfCGsXdvh/Zct+AldKG4bExjHXg
@@ -267,7 +267,7 @@ services:
     environment:
       - ORB_SYNC_TIMEOUT=3
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
-      - LOG_LEVEL=DEBUG
+      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:DEBUG
       - ORB_HOST_URL=0.0.0.0:80
       - ORB_HOST_METRICS_URL=0.0.0.0:48927
       - ORB_PRIVATE_KEY=9kRTh70Ut0MKPeHY3Gdv/pi8SACx6dFjaEiIHf7JDugPpXBnCHVvRbgdzYbWfCGsXdvh/Zct+AldKG4bExjHXg
@@ -342,7 +342,7 @@ services:
     environment:
       - ORB_SYNC_TIMEOUT=3
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
-      - LOG_LEVEL=DEBUG
+      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:DEBUG
       - ORB_PRIVATE_KEY=9kRTh70Ut0MKPeHY3Gdv/pi8SACx6dFjaEiIHf7JDugPpXBnCHVvRbgdzYbWfCGsXdvh/Zct+AldKG4bExjHXg
       - ORB_KEY_ID=orb3key
       - ORB_HOST_URL=0.0.0.0:443
@@ -421,7 +421,7 @@ services:
     environment:
       - ORB_SYNC_TIMEOUT=3
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
-      - LOG_LEVEL=DEBUG
+      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:DEBUG
       - ORB_HOST_URL=0.0.0.0:443
       - ORB_HOST_METRICS_URL=0.0.0.0:48727
       - ORB_PRIVATE_KEY=9kRTh70Ut0MKPeHY3Gdv/pi8SACx6dFjaEiIHf7JDugPpXBnCHVvRbgdzYbWfCGsXdvh/Zct+AldKG4bExjHXg

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -1542,8 +1542,9 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/trustbloc/edge-core v0.1.7-0.20210812092729-6c61997fa9dd/go.mod h1:lb8Kg33uSTA0912U++p+cpYbMa9I1jvnhcDRyI+vWtw=
-github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716 h1:qBnp316Q4/Bd13oYarCXEI83O9IwOaCbDeEIFfPvW+4=
 github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7jjHQo2gMGNPIRfhvn4aXQ0FYMrG9lRgQcvZKTviCGc=
+github.com/trustbloc/edge-core v0.1.7-0.20210819195944-a3500e365d5c h1:/CzHsVBUM8MUuVR/4t0EeGeCIvwV2HiN0Pj7tNs6VXI=
+github.com/trustbloc/edge-core v0.1.7-0.20210819195944-a3500e365d5c/go.mod h1:7jjHQo2gMGNPIRfhvn4aXQ0FYMrG9lRgQcvZKTviCGc=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b h1:JKQVbQxv0d2C9p4u+GqkJeitB51jvLgzR2YvTeG9AQ0=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3-0.20210812104204-d8ddd5781928 h1:LawxLAbGwgIODvc/VQEnyeNu3h3zq6NLVyAovKoOIAw=


### PR DESCRIPTION
The LOG_LEVEL startup parameter may now accept either a default log level (as before) or a log spec which contains log levels for individual modules. For example, LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:DEBUG.

closes #719

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>