### PR TITLE
chore: Rename 'AnchorCredentialReference' to 'AnchorReference'

### DIFF
--- a/internal/pkg/ldcontext/payload/activity-anchors-v1.json
+++ b/internal/pkg/ldcontext/payload/activity-anchors-v1.json
@@ -61,8 +61,8 @@
           "type": "@type"
         }
       },
-      "AnchorCredentialReference": {
-        "@id": "https://w3id.org/activityanchors#AnchorCredentialReference",
+      "AnchorReference": {
+        "@id": "https://w3id.org/activityanchors#AnchorReference",
         "@context": {
           "@version": 1.1,
           "@protected": true,

--- a/pkg/activitypub/resthandler/activityhandler_test.go
+++ b/pkg/activitypub/resthandler/activityhandler_test.go
@@ -1087,7 +1087,7 @@ const (
           "cid": "bafkd34G7hD6gbj94fnKm5D",
           "type": "ContentAddressedStorage"
         },
-        "type": "AnchorCredentialReference"
+        "type": "AnchorReference"
       },
       "type": "Create"
     },
@@ -1105,7 +1105,7 @@ const (
           "cid": "bafkd34G7hD6gbj94fnKm5D",
           "type": "ContentAddressedStorage"
         },
-        "type": "AnchorCredentialReference"
+        "type": "AnchorReference"
       },
       "type": "Create"
     },
@@ -1123,7 +1123,7 @@ const (
           "cid": "bafkd34G7hD6gbj94fnKm5D",
           "type": "ContentAddressedStorage"
         },
-        "type": "AnchorCredentialReference"
+        "type": "AnchorReference"
       },
       "type": "Create"
     },
@@ -1141,7 +1141,7 @@ const (
           "cid": "bafkd34G7hD6gbj94fnKm5D",
           "type": "ContentAddressedStorage"
         },
-        "type": "AnchorCredentialReference"
+        "type": "AnchorReference"
       },
       "type": "Create"
     }
@@ -1168,7 +1168,7 @@ const (
           "cid": "bafkd34G7hD6gbj94fnKm5D",
           "type": "ContentAddressedStorage"
         },
-        "type": "AnchorCredentialReference"
+        "type": "AnchorReference"
       },
       "type": "Create"
     },
@@ -1186,7 +1186,7 @@ const (
           "cid": "bafkd34G7hD6gbj94fnKm5D",
           "type": "ContentAddressedStorage"
         },
-        "type": "AnchorCredentialReference"
+        "type": "AnchorReference"
       },
       "type": "Create"
     },
@@ -1204,7 +1204,7 @@ const (
           "cid": "bafkd34G7hD6gbj94fnKm5D",
           "type": "ContentAddressedStorage"
         },
-        "type": "AnchorCredentialReference"
+        "type": "AnchorReference"
       },
       "type": "Create"
     }
@@ -1233,7 +1233,7 @@ const (
           "cid": "bafkd34G7hD6gbj94fnKm5D",
           "type": "ContentAddressedStorage"
         },
-        "type": "AnchorCredentialReference"
+        "type": "AnchorReference"
       },
       "type": "Create"
     },
@@ -1251,7 +1251,7 @@ const (
           "cid": "bafkd34G7hD6gbj94fnKm5D",
           "type": "ContentAddressedStorage"
         },
-        "type": "AnchorCredentialReference"
+        "type": "AnchorReference"
       },
       "type": "Create"
     },
@@ -1269,7 +1269,7 @@ const (
           "cid": "bafkd34G7hD6gbj94fnKm5D",
           "type": "ContentAddressedStorage"
         },
-        "type": "AnchorCredentialReference"
+        "type": "AnchorReference"
       },
       "type": "Create"
     },
@@ -1287,7 +1287,7 @@ const (
           "cid": "bafkd34G7hD6gbj94fnKm5D",
           "type": "ContentAddressedStorage"
         },
-        "type": "AnchorCredentialReference"
+        "type": "AnchorReference"
       },
       "type": "Create"
     }

--- a/pkg/activitypub/resthandler/resthandler_test.go
+++ b/pkg/activitypub/resthandler/resthandler_test.go
@@ -355,8 +355,8 @@ func newMockCreateActivities(num int) []*vocab.ActivityType {
 func newMockCreateActivity(id, objID string) *vocab.ActivityType {
 	return vocab.NewCreateActivity(
 		vocab.NewObjectProperty(
-			vocab.WithAnchorCredentialReference(
-				vocab.NewAnchorCredentialReference(
+			vocab.WithAnchorReference(
+				vocab.NewAnchorReference(
 					testutil.MustParseURL(objID),
 					testutil.MustParseURL("https://example.com/cas/bafkd34G7hD6gbj94fnKm5D"),
 					"bafkd34G7hD6gbj94fnKm5D"),

--- a/pkg/activitypub/service/activityhandler/activityhandler_test.go
+++ b/pkg/activitypub/service/activityhandler/activityhandler_test.go
@@ -186,8 +186,8 @@ func TestHandler_InboxHandleCreateActivity(t *testing.T) {
 
 		t.Run("Success", func(t *testing.T) {
 			create := newMockCreateActivity(service1IRI, service2IRI, target3ID, vocab.NewObjectProperty(
-				vocab.WithAnchorCredentialReference(
-					vocab.NewAnchorCredentialReference(refID, target3ID, cid),
+				vocab.WithAnchorReference(
+					vocab.NewAnchorReference(refID, target3ID, cid),
 				),
 			))
 
@@ -223,8 +223,8 @@ func TestHandler_InboxHandleCreateActivity(t *testing.T) {
 			defer func() { anchorCredHandler.WithError(nil) }()
 
 			create := newMockCreateActivity(service1IRI, service2IRI, target4ID, vocab.NewObjectProperty(
-				vocab.WithAnchorCredentialReference(
-					vocab.NewAnchorCredentialReference(refID, target4ID, cid),
+				vocab.WithAnchorReference(
+					vocab.NewAnchorReference(refID, target4ID, cid),
 				),
 			))
 
@@ -290,8 +290,8 @@ func TestHandler_OutboxHandleCreateActivity(t *testing.T) {
 
 		create := newMockCreateActivity(service1IRI, service2IRI, targetID,
 			vocab.NewObjectProperty(
-				vocab.WithAnchorCredentialReference(
-					vocab.NewAnchorCredentialReference(refID, targetID, cid),
+				vocab.WithAnchorReference(
+					vocab.NewAnchorReference(refID, targetID, cid),
 				),
 			))
 
@@ -1268,15 +1268,15 @@ func TestHandler_HandleAnnounceActivity(t *testing.T) {
 	go subscriber.Listen()
 
 	t.Run("Anchor credential ref - collection (no embedded object)", func(t *testing.T) {
-		ref := vocab.NewAnchorCredentialReference(newTransactionID(service1IRI), targetID, cid)
-		duplicateRef := vocab.NewAnchorCredentialReference(newTransactionID(service1IRI), target2ID, cid)
+		ref := vocab.NewAnchorReference(newTransactionID(service1IRI), targetID, cid)
+		duplicateRef := vocab.NewAnchorReference(newTransactionID(service1IRI), target2ID, cid)
 
 		items := []*vocab.ObjectProperty{
 			vocab.NewObjectProperty(
-				vocab.WithAnchorCredentialReference(ref),
+				vocab.WithAnchorReference(ref),
 			),
 			vocab.NewObjectProperty(
-				vocab.WithAnchorCredentialReference(duplicateRef),
+				vocab.WithAnchorReference(duplicateRef),
 			),
 		}
 
@@ -1319,12 +1319,12 @@ func TestHandler_HandleAnnounceActivity(t *testing.T) {
 	t.Run("Anchor credential ref - ordered collection (no embedded object)", func(t *testing.T) {
 		const cid1 = "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoa"
 
-		ref := vocab.NewAnchorCredentialReference(newTransactionID(service1IRI),
+		ref := vocab.NewAnchorReference(newTransactionID(service1IRI),
 			testutil.MustParseURL(fmt.Sprintf("http://localhost:8301/cas/%s", cid1)), cid1)
 
 		items := []*vocab.ObjectProperty{
 			vocab.NewObjectProperty(
-				vocab.WithAnchorCredentialReference(ref),
+				vocab.WithAnchorReference(ref),
 			),
 		}
 
@@ -1359,7 +1359,7 @@ func TestHandler_HandleAnnounceActivity(t *testing.T) {
 	t.Run("Anchor credential ref (with embedded object)", func(t *testing.T) {
 		const cid1 = "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhob"
 
-		ref, err := vocab.NewAnchorCredentialReferenceWithDocument(newTransactionID(service1IRI),
+		ref, err := vocab.NewAnchorReferenceWithDocument(newTransactionID(service1IRI),
 			testutil.MustParseURL(fmt.Sprintf("http://localhost:8301/cas/%s", cid1)), cid1,
 			vocab.MustUnmarshalToDoc([]byte(anchorCredential1)),
 		)
@@ -1367,7 +1367,7 @@ func TestHandler_HandleAnnounceActivity(t *testing.T) {
 
 		items := []*vocab.ObjectProperty{
 			vocab.NewObjectProperty(
-				vocab.WithAnchorCredentialReference(ref),
+				vocab.WithAnchorReference(ref),
 			),
 		}
 
@@ -1422,7 +1422,7 @@ func TestHandler_HandleAnnounceActivity(t *testing.T) {
 
 		err := h.HandleActivity(announce)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "expecting 'AnchorCredentialReference' type")
+		require.Contains(t, err.Error(), "expecting 'AnchorReference' type")
 	})
 
 	t.Run("Anchor credential ref - ordered collection - unsupported object type", func(t *testing.T) {
@@ -1448,7 +1448,7 @@ func TestHandler_HandleAnnounceActivity(t *testing.T) {
 
 		err := h.HandleActivity(announce)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "expecting 'AnchorCredentialReference' type")
+		require.Contains(t, err.Error(), "expecting 'AnchorReference' type")
 	})
 
 	t.Run("Anchor credential ref - unsupported object type", func(t *testing.T) {
@@ -1470,7 +1470,7 @@ func TestHandler_HandleAnnounceActivity(t *testing.T) {
 	})
 
 	t.Run("Add to shares error", func(t *testing.T) {
-		ref := vocab.NewAnchorCredentialReference(newTransactionID(service1IRI), targetID, cid)
+		ref := vocab.NewAnchorReference(newTransactionID(service1IRI), targetID, cid)
 
 		published := time.Now()
 
@@ -1479,7 +1479,7 @@ func TestHandler_HandleAnnounceActivity(t *testing.T) {
 				vocab.WithCollection(
 					vocab.NewCollection([]*vocab.ObjectProperty{
 						vocab.NewObjectProperty(
-							vocab.WithAnchorCredentialReference(ref),
+							vocab.WithAnchorReference(ref),
 						),
 					}),
 				),
@@ -2192,7 +2192,7 @@ func TestHandler_HandleUndoFollowActivity(t *testing.T) {
 		err = inboxHandler.announceAnchorCredential(create)
 		require.True(t, orberrors.IsTransient(err))
 
-		err = inboxHandler.announceAnchorCredentialRef(create)
+		err = inboxHandler.announceAnchorRef(create)
 		require.True(t, orberrors.IsTransient(err))
 	})
 
@@ -2658,8 +2658,8 @@ func TestHandler_AnnounceAnchorCredential(t *testing.T) {
 
 		create := newMockCreateActivity(service1IRI, service2IRI, targetID,
 			vocab.NewObjectProperty(
-				vocab.WithAnchorCredentialReference(
-					vocab.NewAnchorCredentialReference(refID, targetID, cid),
+				vocab.WithAnchorReference(
+					vocab.NewAnchorReference(refID, targetID, cid),
 				),
 			),
 		)
@@ -2678,7 +2678,7 @@ func TestHandler_AnnounceAnchorCredential(t *testing.T) {
 			h.Start()
 			defer h.Stop()
 
-			require.NoError(t, h.announceAnchorCredentialRef(create))
+			require.NoError(t, h.announceAnchorRef(create))
 
 			time.Sleep(50 * time.Millisecond)
 
@@ -2706,7 +2706,7 @@ func TestHandler_AnnounceAnchorCredential(t *testing.T) {
 			h.Start()
 			defer h.Stop()
 
-			require.NoError(t, h.announceAnchorCredentialRef(create))
+			require.NoError(t, h.announceAnchorRef(create))
 		})
 	})
 }

--- a/pkg/activitypub/service/activityhandler/inboxhandler.go
+++ b/pkg/activitypub/service/activityhandler/inboxhandler.go
@@ -113,14 +113,14 @@ func (h *Inbox) handleCreateActivity(create *vocab.ActivityType) error {
 				h.ServiceIRI, create.ID(), err)
 		}
 
-	case t.Is(vocab.TypeAnchorCredentialRef):
-		ref := obj.AnchorCredentialReference()
+	case t.Is(vocab.TypeAnchorRef):
+		ref := obj.AnchorReference()
 
 		if err := h.handleAnchorCredential(ref.Target(), ref.Object().Object()); err != nil {
 			return fmt.Errorf("error handling 'Create' activity [%s]: %w", create.ID(), err)
 		}
 
-		if err := h.announceAnchorCredentialRef(create); err != nil {
+		if err := h.announceAnchorRef(create); err != nil {
 			logger.Warnf("[%s] Unable to announce 'Create' activity [%s] to our followers: %s",
 				h.ServiceIRI, create.ID(), err)
 		}
@@ -573,11 +573,11 @@ func (h *Inbox) handleAnnounceCollection(announce *vocab.ActivityType, items []*
 	var anchorCredIDs []*url.URL
 
 	for _, item := range items {
-		if !item.Type().Is(vocab.TypeAnchorCredentialRef) {
-			return fmt.Errorf("expecting 'AnchorCredentialReference' type")
+		if !item.Type().Is(vocab.TypeAnchorRef) {
+			return fmt.Errorf("expecting 'AnchorReference' type")
 		}
 
-		ref := item.AnchorCredentialReference()
+		ref := item.AnchorReference()
 		if err := h.handleAnchorCredential(ref.Target(), ref.Object().Object()); err != nil {
 			// Continue processing other anchor credentials on duplicate error.
 			if !errors.Is(err, errDuplicateAnchorCredential) {
@@ -607,7 +607,7 @@ func (h *Inbox) handleAnnounceCollection(announce *vocab.ActivityType, items []*
 }
 
 func (h *Inbox) announceAnchorCredential(create *vocab.ActivityType) error {
-	ref, err := newAnchorCredentialReferenceFromCreate(create)
+	ref, err := newAnchorReferenceFromCreate(create)
 	if err != nil {
 		return err
 	}
@@ -620,7 +620,7 @@ func (h *Inbox) announceAnchorCredential(create *vocab.ActivityType) error {
 				vocab.NewCollection(
 					[]*vocab.ObjectProperty{
 						vocab.NewObjectProperty(
-							vocab.WithAnchorCredentialReference(ref),
+							vocab.WithAnchorReference(ref),
 						),
 					},
 				),
@@ -638,8 +638,8 @@ func (h *Inbox) announceAnchorCredential(create *vocab.ActivityType) error {
 	return nil
 }
 
-func (h *Inbox) announceAnchorCredentialRef(create *vocab.ActivityType) error {
-	ref := create.Object().AnchorCredentialReference()
+func (h *Inbox) announceAnchorRef(create *vocab.ActivityType) error {
+	ref := create.Object().AnchorReference()
 
 	published := time.Now()
 
@@ -649,7 +649,7 @@ func (h *Inbox) announceAnchorCredentialRef(create *vocab.ActivityType) error {
 				vocab.NewCollection(
 					[]*vocab.ObjectProperty{
 						vocab.NewObjectProperty(
-							vocab.WithAnchorCredentialReference(ref),
+							vocab.WithAnchorReference(ref),
 						),
 					},
 				),
@@ -838,7 +838,7 @@ func (h *Inbox) getActivityFromOutbox(activityIRI *url.URL) (*vocab.ActivityType
 	return activities[0], nil
 }
 
-func newAnchorCredentialReferenceFromCreate(create *vocab.ActivityType) (*vocab.AnchorCredentialReferenceType, error) {
+func newAnchorReferenceFromCreate(create *vocab.ActivityType) (*vocab.AnchorReferenceType, error) {
 	anchorCredential := create.Object().Object()
 
 	anchorCredentialBytes, err := json.Marshal(anchorCredential)
@@ -853,7 +853,7 @@ func newAnchorCredentialReferenceFromCreate(create *vocab.ActivityType) (*vocab.
 
 	targetObj := create.Target().Object()
 
-	return vocab.NewAnchorCredentialReferenceWithDocument(anchorCredential.ID().URL(),
+	return vocab.NewAnchorReferenceWithDocument(anchorCredential.ID().URL(),
 		targetObj.ID().URL(), targetObj.CID(), anchorCredDoc)
 }
 

--- a/pkg/activitypub/service/activityhandler/outboxhandler.go
+++ b/pkg/activitypub/service/activityhandler/outboxhandler.go
@@ -66,8 +66,8 @@ func (h *handler) handleCreateActivity(create *vocab.ActivityType) error {
 	case obj.Type().Is(vocab.TypeAnchorCredential, vocab.TypeVerifiableCredential):
 		target = create.Target()
 
-	case obj.Type().Is(vocab.TypeAnchorCredentialRef):
-		target = obj.AnchorCredentialReference().Target()
+	case obj.Type().Is(vocab.TypeAnchorRef):
+		target = obj.AnchorReference().Target()
 
 	default:
 		return fmt.Errorf("unsupported object type in 'Create' activity [%s]: %s", obj.Type(), create.ID())

--- a/pkg/activitypub/service/service_test.go
+++ b/pkg/activitypub/service/service_test.go
@@ -440,11 +440,11 @@ func TestService_Announce(t *testing.T) {
 	defer service3.Stop()
 
 	t.Run("Announce - anchor credential ref (no embedded object)", func(t *testing.T) {
-		ref := vocab.NewAnchorCredentialReference(newActivityID(service2IRI), anchorCredID, cid)
+		ref := vocab.NewAnchorReference(newActivityID(service2IRI), anchorCredID, cid)
 
 		items := []*vocab.ObjectProperty{
 			vocab.NewObjectProperty(
-				vocab.WithAnchorCredentialReference(ref),
+				vocab.WithAnchorReference(ref),
 			),
 		}
 
@@ -496,14 +496,14 @@ func TestService_Announce(t *testing.T) {
 	})
 
 	t.Run("Announce - anchor credential ref (with embedded object)", func(t *testing.T) {
-		ref, err := vocab.NewAnchorCredentialReferenceWithDocument(newTransactionID(service2IRI), anchorCredID,
+		ref, err := vocab.NewAnchorReferenceWithDocument(newTransactionID(service2IRI), anchorCredID,
 			cid, vocab.MustUnmarshalToDoc([]byte(anchorCredential1)),
 		)
 		require.NoError(t, err)
 
 		items := []*vocab.ObjectProperty{
 			vocab.NewObjectProperty(
-				vocab.WithAnchorCredentialReference(ref),
+				vocab.WithAnchorReference(ref),
 			),
 		}
 

--- a/pkg/activitypub/vocab/activitytype_test.go
+++ b/pkg/activitypub/vocab/activitytype_test.go
@@ -110,14 +110,14 @@ func TestCreateTypeMarshal(t *testing.T) {
 		require.True(t, obj.Type().Is(TypeVerifiableCredential, TypeAnchorCredential))
 	})
 
-	t.Run("With AnchorCredentialReference", func(t *testing.T) {
+	t.Run("With AnchorReference", func(t *testing.T) {
 		refID := newMockID(host1, "/transactions/bafkreihwsnuregceqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy")
 
 		t.Run("Marshal", func(t *testing.T) {
 			create := NewCreateActivity(
 				NewObjectProperty(
-					WithAnchorCredentialReference(
-						NewAnchorCredentialReference(refID, anchorCredIRI, cid),
+					WithAnchorReference(
+						NewAnchorReference(refID, anchorCredIRI, cid),
 					),
 				),
 				WithID(createActivityID),
@@ -161,9 +161,9 @@ func TestCreateTypeMarshal(t *testing.T) {
 			objProp := a.Object()
 			require.NotNil(t, objProp)
 
-			ref := objProp.AnchorCredentialReference()
+			ref := objProp.AnchorReference()
 			require.NotNil(t, ref)
-			require.True(t, ref.Type().Is(TypeAnchorCredentialRef))
+			require.True(t, ref.Type().Is(TypeAnchorRef))
 
 			refTarget := ref.Target()
 			require.NotNil(t, refTarget)
@@ -311,7 +311,7 @@ func TestAnnounceTypeMarshal(t *testing.T) {
 		})
 	})
 
-	t.Run("With AnchorCredentialReferences", func(t *testing.T) {
+	t.Run("With AnchorReferences", func(t *testing.T) {
 		const (
 			cid1 = "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
 			cid2 = "bafkreiatkubvbkdedscmqwnkyls3iqawdqvthi7e6mbky2amuw3inxsi3y"
@@ -328,13 +328,13 @@ func TestAnnounceTypeMarshal(t *testing.T) {
 		t.Run("Marshal", func(t *testing.T) {
 			items := []*ObjectProperty{
 				NewObjectProperty(
-					WithAnchorCredentialReference(
-						NewAnchorCredentialReference(refID1, anchorCredIRI1, cid1),
+					WithAnchorReference(
+						NewAnchorReference(refID1, anchorCredIRI1, cid1),
 					),
 				),
 				NewObjectProperty(
-					WithAnchorCredentialReference(
-						NewAnchorCredentialReference(refID2, anchorCredIRI2, cid2),
+					WithAnchorReference(
+						NewAnchorReference(refID2, anchorCredIRI2, cid2),
 					),
 				),
 			}
@@ -390,8 +390,8 @@ func TestAnnounceTypeMarshal(t *testing.T) {
 
 			item := items[0]
 
-			require.True(t, item.Type().Is(TypeAnchorCredentialRef))
-			ref := item.AnchorCredentialReference()
+			require.True(t, item.Type().Is(TypeAnchorRef))
+			ref := item.AnchorReference()
 			require.NotNil(t, ref)
 			require.Equal(t, refID1.String(), ref.ID().String())
 
@@ -405,7 +405,7 @@ func TestAnnounceTypeMarshal(t *testing.T) {
 
 			item = items[1]
 
-			ref = item.AnchorCredentialReference()
+			ref = item.AnchorReference()
 			require.NotNil(t, ref)
 			require.Equal(t, refID2.String(), ref.ID().String())
 
@@ -419,20 +419,20 @@ func TestAnnounceTypeMarshal(t *testing.T) {
 		})
 	})
 
-	t.Run("With AnchorCredentialReference and embedded object", func(t *testing.T) {
+	t.Run("With AnchorReference and embedded object", func(t *testing.T) {
 		refID := newMockID(host1, "/transactions/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy")
 
 		published := getStaticTime()
 
 		t.Run("Marshal", func(t *testing.T) {
-			ref, err := NewAnchorCredentialReferenceWithDocument(refID, anchorCredIRI, cid,
+			ref, err := NewAnchorReferenceWithDocument(refID, anchorCredIRI, cid,
 				MustUnmarshalToDoc([]byte(anchorCredential)),
 			)
 			require.NoError(t, err)
 
 			items := []*ObjectProperty{
 				NewObjectProperty(
-					WithAnchorCredentialReference(ref),
+					WithAnchorReference(ref),
 				),
 			}
 
@@ -489,7 +489,7 @@ func TestAnnounceTypeMarshal(t *testing.T) {
 
 			item := items[0]
 
-			ref := item.AnchorCredentialReference()
+			ref := item.AnchorReference()
 			require.NotNil(t, ref)
 			require.NotNil(t, refID, ref.ID())
 
@@ -1156,7 +1156,7 @@ const (
           "https://w3id.org/activityanchors/v1"
         ],
         "id": "https://sally.example.com/transactions/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
-        "type": "AnchorCredentialReference",
+        "type": "AnchorReference",
         "target": {
           "id": "https://sally.example.com/cas/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
           "cid": "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
@@ -1169,7 +1169,7 @@ const (
           "https://w3id.org/activityanchors/v1"
         ],
         "id": "https://sally.example.com/transactions/bafkreiatkubvbkdedscmqwnkyls3iqawdqvthi7e6mbky2amuw3inxsi3y",
-        "type": "AnchorCredentialReference",
+        "type": "AnchorReference",
         "target": {
           "id": "https://sally.example.com/cas/bafkreiatkubvbkdedscmqwnkyls3iqawdqvthi7e6mbky2amuw3inxsi3y",
           "cid": "bafkreiatkubvbkdedscmqwnkyls3iqawdqvthi7e6mbky2amuw3inxsi3y",
@@ -1200,7 +1200,7 @@ const (
           "https://w3id.org/activityanchors/v1"
         ],
         "id": "https://sally.example.com/transactions/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
-        "type": "AnchorCredentialReference",
+        "type": "AnchorReference",
         "target": {
           "id": "https://sally.example.com/cas/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
           "cid": "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
@@ -1439,7 +1439,7 @@ const (
       "https://w3id.org/activityanchors/v1"
     ],
     "id": "https://sally.example.com/transactions/bafkreihwsnuregceqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
-    "type": "AnchorCredentialReference",
+    "type": "AnchorReference",
     "target": {
       "type": "ContentAddressedStorage",
       "id": "https://sally.example.com/cas/bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",

--- a/pkg/activitypub/vocab/anchorcredreftype.go
+++ b/pkg/activitypub/vocab/anchorcredreftype.go
@@ -10,29 +10,29 @@ import (
 	"net/url"
 )
 
-// AnchorCredentialReferenceType defines an "AnchorCredentialReference" type.
-type AnchorCredentialReferenceType struct {
+// AnchorReferenceType defines an "AnchorReference" type.
+type AnchorReferenceType struct {
 	*ObjectType
 
-	ref *anchorCredentialReferenceType
+	ref *anchorReferenceType
 }
 
-type anchorCredentialReferenceType struct {
+type anchorReferenceType struct {
 	Target *ObjectProperty `json:"target,omitempty"`
 	Object *ObjectProperty `json:"object,omitempty"`
 }
 
-// NewAnchorCredentialReference returns a new "AnchorCredentialReference".
-func NewAnchorCredentialReference(id, anchorCredID *url.URL, cid string, opts ...Opt) *AnchorCredentialReferenceType {
+// NewAnchorReference returns a new "AnchorReference".
+func NewAnchorReference(id, anchorCredID *url.URL, cid string, opts ...Opt) *AnchorReferenceType {
 	options := NewOptions(opts...)
 
-	return &AnchorCredentialReferenceType{
+	return &AnchorReferenceType{
 		ObjectType: NewObject(
 			WithContext(getContexts(options, ContextActivityStreams, ContextOrb)...),
 			WithID(id),
-			WithType(TypeAnchorCredentialRef),
+			WithType(TypeAnchorRef),
 		),
-		ref: &anchorCredentialReferenceType{
+		ref: &anchorReferenceType{
 			Target: NewObjectProperty(
 				WithObject(
 					NewObject(
@@ -44,9 +44,9 @@ func NewAnchorCredentialReference(id, anchorCredID *url.URL, cid string, opts ..
 	}
 }
 
-// NewAnchorCredentialReferenceWithDocument returns a new "AnchorCredentialReference" with the given document embedded.
-func NewAnchorCredentialReferenceWithDocument(
-	id, anchorCredID *url.URL, cid string, doc Document, opts ...Opt) (*AnchorCredentialReferenceType, error) {
+// NewAnchorReferenceWithDocument returns a new "AnchorReference" with the given document embedded.
+func NewAnchorReferenceWithDocument(
+	id, anchorCredID *url.URL, cid string, doc Document, opts ...Opt) (*AnchorReferenceType, error) {
 	options := NewOptions(opts...)
 
 	obj, err := NewObjectWithDocument(doc)
@@ -54,13 +54,13 @@ func NewAnchorCredentialReferenceWithDocument(
 		return nil, err
 	}
 
-	return &AnchorCredentialReferenceType{
+	return &AnchorReferenceType{
 		ObjectType: NewObject(
 			WithContext(getContexts(options, ContextActivityStreams, ContextOrb)...),
 			WithID(id),
-			WithType(TypeAnchorCredentialRef),
+			WithType(TypeAnchorRef),
 		),
-		ref: &anchorCredentialReferenceType{
+		ref: &anchorReferenceType{
 			Target: NewObjectProperty(
 				WithObject(
 					NewObject(
@@ -76,24 +76,24 @@ func NewAnchorCredentialReferenceWithDocument(
 }
 
 // Target returns the target of the anchor credential reference.
-func (t *AnchorCredentialReferenceType) Target() *ObjectProperty {
+func (t *AnchorReferenceType) Target() *ObjectProperty {
 	return t.ref.Target
 }
 
 // Object returns the embedded object (if any).
-func (t *AnchorCredentialReferenceType) Object() *ObjectProperty {
+func (t *AnchorReferenceType) Object() *ObjectProperty {
 	return t.ref.Object
 }
 
 // MarshalJSON mmarshals the object to JSON.
-func (t *AnchorCredentialReferenceType) MarshalJSON() ([]byte, error) {
+func (t *AnchorReferenceType) MarshalJSON() ([]byte, error) {
 	return MarshalJSON(t.ObjectType, t.ref)
 }
 
 // UnmarshalJSON ummarshals the object from JSON.
-func (t *AnchorCredentialReferenceType) UnmarshalJSON(bytes []byte) error {
+func (t *AnchorReferenceType) UnmarshalJSON(bytes []byte) error {
 	t.ObjectType = NewObject()
-	t.ref = &anchorCredentialReferenceType{}
+	t.ref = &anchorReferenceType{}
 
 	return UnmarshalJSON(bytes, t.ObjectType, t.ref)
 }

--- a/pkg/activitypub/vocab/anchorcredreftype_test.go
+++ b/pkg/activitypub/vocab/anchorcredreftype_test.go
@@ -23,9 +23,9 @@ var (
 	txID          = testutil.MustParseURL("https://org1.com/transactions/tx1")
 )
 
-func TestNewAnchorCredentialReference(t *testing.T) {
+func TestNewAnchorReference(t *testing.T) {
 	t.Run("No document", func(t *testing.T) {
-		ref := NewAnchorCredentialReference(txID, anchorCredIRI, cid,
+		ref := NewAnchorReference(txID, anchorCredIRI, cid,
 			WithTarget(
 				NewObjectProperty(
 					WithObject(
@@ -44,7 +44,7 @@ func TestNewAnchorCredentialReference(t *testing.T) {
 
 		typeProp := ref.Type()
 		require.NotNil(t, typeProp)
-		require.True(t, typeProp.Is(TypeAnchorCredentialRef))
+		require.True(t, typeProp.Is(TypeAnchorRef))
 
 		targetProp := ref.Target()
 		require.NotNil(t, targetProp)
@@ -60,12 +60,12 @@ func TestNewAnchorCredentialReference(t *testing.T) {
 	})
 
 	t.Run("With document", func(t *testing.T) {
-		ref, err := NewAnchorCredentialReferenceWithDocument(txID, anchorCredIRI, cid, nil)
+		ref, err := NewAnchorReferenceWithDocument(txID, anchorCredIRI, cid, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "nil document")
 		require.Nil(t, ref)
 
-		ref, err = NewAnchorCredentialReferenceWithDocument(txID, anchorCredIRI, cid,
+		ref, err = NewAnchorReferenceWithDocument(txID, anchorCredIRI, cid,
 			MustUnmarshalToDoc([]byte(anchorCredential)),
 		)
 		require.NoError(t, err)
@@ -79,7 +79,7 @@ func TestNewAnchorCredentialReference(t *testing.T) {
 
 		typeProp := ref.Type()
 		require.NotNil(t, typeProp)
-		require.True(t, typeProp.Is(TypeAnchorCredentialRef))
+		require.True(t, typeProp.Is(TypeAnchorRef))
 
 		targetProp := ref.Target()
 		require.NotNil(t, targetProp)
@@ -109,9 +109,9 @@ func TestNewAnchorCredentialReference(t *testing.T) {
 	})
 }
 
-func TestAnchorCredentialReferenceMarshal(t *testing.T) {
+func TestAnchorReferenceMarshal(t *testing.T) {
 	t.Run("Marshal", func(t *testing.T) {
-		ref := NewAnchorCredentialReference(txID, anchorCredIRI, cid,
+		ref := NewAnchorReference(txID, anchorCredIRI, cid,
 			WithTarget(
 				NewObjectProperty(
 					WithObject(
@@ -125,12 +125,12 @@ func TestAnchorCredentialReferenceMarshal(t *testing.T) {
 		require.NoError(t, err)
 		t.Log(string(bytes))
 
-		require.Equal(t, testutil.GetCanonical(t, anchorCredentialReference), string(bytes))
+		require.Equal(t, testutil.GetCanonical(t, anchorReference), string(bytes))
 	})
 
 	t.Run("Unmarshal", func(t *testing.T) {
-		ref := &AnchorCredentialReferenceType{}
-		require.NoError(t, json.Unmarshal([]byte(anchorCredentialReference), ref))
+		ref := &AnchorReferenceType{}
+		require.NoError(t, json.Unmarshal([]byte(anchorReference), ref))
 
 		require.Equal(t, txID.String(), ref.ID().String())
 
@@ -140,7 +140,7 @@ func TestAnchorCredentialReferenceMarshal(t *testing.T) {
 
 		typeProp := ref.Type()
 		require.NotNil(t, typeProp)
-		require.True(t, typeProp.Is(TypeAnchorCredentialRef))
+		require.True(t, typeProp.Is(TypeAnchorRef))
 
 		targetProp := ref.Target()
 		require.NotNil(t, targetProp)
@@ -156,7 +156,7 @@ func TestAnchorCredentialReferenceMarshal(t *testing.T) {
 	})
 
 	t.Run("Marshal with document", func(t *testing.T) {
-		ref, err := NewAnchorCredentialReferenceWithDocument(txID, anchorCredIRI, cid,
+		ref, err := NewAnchorReferenceWithDocument(txID, anchorCredIRI, cid,
 			MustUnmarshalToDoc([]byte(anchorCredential)),
 		)
 		require.NoError(t, err)
@@ -165,12 +165,12 @@ func TestAnchorCredentialReferenceMarshal(t *testing.T) {
 		require.NoError(t, err)
 		t.Log(string(bytes))
 
-		require.Equal(t, testutil.GetCanonical(t, anchorCredentialReferenceWithDoc), string(bytes))
+		require.Equal(t, testutil.GetCanonical(t, anchorReferenceWithDoc), string(bytes))
 	})
 
 	t.Run("Unmarshal with doc", func(t *testing.T) {
-		ref := &AnchorCredentialReferenceType{}
-		require.NoError(t, json.Unmarshal([]byte(anchorCredentialReferenceWithDoc), ref))
+		ref := &AnchorReferenceType{}
+		require.NoError(t, json.Unmarshal([]byte(anchorReferenceWithDoc), ref))
 
 		require.NotNil(t, ref)
 		require.Equal(t, txID.String(), ref.ID().String())
@@ -181,7 +181,7 @@ func TestAnchorCredentialReferenceMarshal(t *testing.T) {
 
 		typeProp := ref.Type()
 		require.NotNil(t, typeProp)
-		require.True(t, typeProp.Is(TypeAnchorCredentialRef))
+		require.True(t, typeProp.Is(TypeAnchorRef))
 
 		targetProp := ref.Target()
 		require.NotNil(t, targetProp)
@@ -236,7 +236,7 @@ const (
   },
   "proof": {}
 }`
-	anchorCredentialReference = `{
+	anchorReference = `{
   "@context": [
     "https://www.w3.org/ns/activitystreams",
     "https://w3id.org/activityanchors/v1"
@@ -247,9 +247,9 @@ const (
     "cid": "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
     "type": "ContentAddressedStorage"
   },
-  "type": "AnchorCredentialReference"
+  "type": "AnchorReference"
 }`
-	anchorCredentialReferenceWithDoc = `{
+	anchorReferenceWithDoc = `{
   "@context": [
     "https://www.w3.org/ns/activitystreams",
     "https://w3id.org/activityanchors/v1"
@@ -284,6 +284,6 @@ const (
     "type": "ContentAddressedStorage",
     "cid":  "bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy"
   },
-  "type": "AnchorCredentialReference"
+  "type": "AnchorReference"
 }`
 )

--- a/pkg/activitypub/vocab/objectproperty.go
+++ b/pkg/activitypub/vocab/objectproperty.go
@@ -20,7 +20,7 @@ type ObjectProperty struct {
 	coll          *CollectionType
 	orderedColl   *OrderedCollectionType
 	activity      *ActivityType
-	anchorCredRef *AnchorCredentialReferenceType
+	anchorCredRef *AnchorReferenceType
 }
 
 // NewObjectProperty returns a new 'object' property with the given options.
@@ -112,9 +112,9 @@ func (p *ObjectProperty) Activity() *ActivityType {
 	return p.activity
 }
 
-// AnchorCredentialReference returns the anchored credential reference or nil if
+// AnchorReference returns the anchored credential reference or nil if
 // the anchored credential reference is not set.
-func (p *ObjectProperty) AnchorCredentialReference() *AnchorCredentialReferenceType {
+func (p *ObjectProperty) AnchorReference() *AnchorReferenceType {
 	if p == nil {
 		return nil
 	}
@@ -185,8 +185,8 @@ func (p *ObjectProperty) UnmarshalJSON(bytes []byte) error {
 	case obj.object.Type.IsAny(TypeFollow, TypeAccept, TypeReject, TypeOffer, TypeLike, TypeInvite):
 		err = p.unmarshalActivity(bytes)
 
-	case obj.object.Type.Is(TypeAnchorCredentialRef):
-		err = p.unmarshalAnchorCredentialReference(bytes)
+	case obj.object.Type.Is(TypeAnchorRef):
+		err = p.unmarshalAnchorReference(bytes)
 
 	default:
 		p.obj = obj
@@ -231,8 +231,8 @@ func (p *ObjectProperty) unmarshalActivity(bytes []byte) error {
 	return nil
 }
 
-func (p *ObjectProperty) unmarshalAnchorCredentialReference(bytes []byte) error {
-	ot := &AnchorCredentialReferenceType{}
+func (p *ObjectProperty) unmarshalAnchorReference(bytes []byte) error {
+	ot := &AnchorReferenceType{}
 
 	if err := json.Unmarshal(bytes, &ot); err != nil {
 		return err

--- a/pkg/activitypub/vocab/objectproperty_test.go
+++ b/pkg/activitypub/vocab/objectproperty_test.go
@@ -34,7 +34,7 @@ func TestNewObjectProperty(t *testing.T) {
 		require.Nil(t, p.Collection())
 		require.Nil(t, p.OrderedCollection())
 		require.Nil(t, p.Activity())
-		require.Nil(t, p.AnchorCredentialReference())
+		require.Nil(t, p.AnchorReference())
 	})
 
 	t.Run("Empty", func(t *testing.T) {
@@ -45,7 +45,7 @@ func TestNewObjectProperty(t *testing.T) {
 		require.Nil(t, p.Collection())
 		require.Nil(t, p.OrderedCollection())
 		require.Nil(t, p.Activity())
-		require.Nil(t, p.AnchorCredentialReference())
+		require.Nil(t, p.AnchorReference())
 	})
 
 	t.Run("WithIRI", func(t *testing.T) {

--- a/pkg/activitypub/vocab/options.go
+++ b/pkg/activitypub/vocab/options.go
@@ -182,7 +182,7 @@ type ObjectPropertyOptions struct {
 	Collection        *CollectionType
 	OrderedCollection *OrderedCollectionType
 	Activity          *ActivityType
-	AnchorCredRef     *AnchorCredentialReferenceType
+	AnchorCredRef     *AnchorReferenceType
 }
 
 // WithIRI sets the 'object' property to an IRI.
@@ -220,8 +220,8 @@ func WithActivity(activity *ActivityType) Opt {
 	}
 }
 
-// WithAnchorCredentialReference sets the 'object' property to an embedded anchored credential reference.
-func WithAnchorCredentialReference(ref *AnchorCredentialReferenceType) Opt {
+// WithAnchorReference sets the 'object' property to an embedded anchored credential reference.
+func WithAnchorReference(ref *AnchorReferenceType) Opt {
 	return func(opts *Options) {
 		opts.AnchorCredRef = ref
 	}

--- a/pkg/activitypub/vocab/options_test.go
+++ b/pkg/activitypub/vocab/options_test.go
@@ -60,7 +60,7 @@ func TestNewOptions(t *testing.T) {
 		iri: NewURLProperty(testutil.MustParseURL("https://property_result")),
 	}
 
-	anchorRef := NewAnchorCredentialReference(
+	anchorRef := NewAnchorReference(
 		testutil.MustParseURL("https://example.com/anchor_cred_ref_id"),
 		testutil.MustParseURL("https://example.com/anchor_cred_iri"),
 		"cid")
@@ -87,7 +87,7 @@ func TestNewOptions(t *testing.T) {
 		WithTarget(target),
 		WithActor(actor),
 		WithResult(result),
-		WithAnchorCredentialReference(anchorRef),
+		WithAnchorReference(anchorRef),
 		WithFollowers(followers),
 		WithFollowing(following),
 		WithInbox(inbox),

--- a/pkg/activitypub/vocab/vocab.go
+++ b/pkg/activitypub/vocab/vocab.go
@@ -66,8 +66,8 @@ const (
 	TypeContentAddressedStorage Type = "ContentAddressedStorage"
 	// TypeAnchorCredential specifies the "AnchorCredential" object type.
 	TypeAnchorCredential Type = "AnchorCredential"
-	// TypeAnchorCredentialRef specifies the "AnchorCredentialReference" object type.
-	TypeAnchorCredentialRef Type = "AnchorCredentialReference"
+	// TypeAnchorRef specifies the "AnchorReference" object type.
+	TypeAnchorRef Type = "AnchorReference"
 	// TypeAnchorReceipt specifies the "AnchorReceipt" object type.
 	TypeAnchorReceipt Type = "AnchorReceipt"
 	// TypeOffer specifies the "Offer" activity type.

--- a/pkg/internal/aptestutil/aptestutil.go
+++ b/pkg/internal/aptestutil/aptestutil.go
@@ -141,8 +141,8 @@ func NewMockCreateActivities(num int) []*vocab.ActivityType {
 func NewMockCreateActivity(id, objID string) *vocab.ActivityType {
 	return vocab.NewCreateActivity(
 		vocab.NewObjectProperty(
-			vocab.WithAnchorCredentialReference(
-				vocab.NewAnchorCredentialReference(
+			vocab.WithAnchorReference(
+				vocab.NewAnchorReference(
 					testutil.MustParseURL(objID),
 					testutil.MustParseURL("https://example.com/cas/bafkd34G7hD6gbj94fnKm5D"),
 					"bafkd34G7hD6gbj94fnKm5D"),
@@ -167,8 +167,8 @@ func NewMockLikeActivities(num int) []*vocab.ActivityType {
 func NewMockLikeActivity(id, objID string) *vocab.ActivityType {
 	return vocab.NewLikeActivity(
 		vocab.NewObjectProperty(
-			vocab.WithAnchorCredentialReference(
-				vocab.NewAnchorCredentialReference(
+			vocab.WithAnchorReference(
+				vocab.NewAnchorReference(
 					testutil.MustParseURL(objID),
 					testutil.MustParseURL("https://example.com/cas/bafkd34G7hD6gbj94fnKm5D"),
 					"bafkd34G7hD6gbj94fnKm5D"),


### PR DESCRIPTION
closes #734

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>