### PR TITLE
chore: delete operation provider wrappers for client and factory

### DIFF
--- a/pkg/orbclient/client_test.go
+++ b/pkg/orbclient/client_test.go
@@ -215,8 +215,7 @@ func TestGetAnchorOrigin(t *testing.T) {
 		origin, err := client.GetAnchorOrigin(cid, testDID)
 		require.Error(t, err)
 		require.Empty(t, origin)
-		require.Contains(t, err.Error(),
-			"error reading core index file: retrieve CAS content at uri[coreIndex]: failed to resolve CID[coreIndex]: not found") //nolint:lll
+		require.Contains(t, err.Error(), "not found")
 	})
 
 	t.Run("error - protocol client error", func(t *testing.T) {

--- a/pkg/protocolversion/versions/v1_0/client/client.go
+++ b/pkg/protocolversion/versions/v1_0/client/client.go
@@ -7,12 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package client
 
 import (
-	"fmt"
-	"strings"
-
-	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
-	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
-	"github.com/trustbloc/sidetree-core-go/pkg/api/txn"
 	"github.com/trustbloc/sidetree-core-go/pkg/compression"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/1_0/operationparser"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/1_0/txnprovider"
@@ -39,70 +33,11 @@ func (v *Factory) Create(version string, casClient common.CASReader) (common.Cli
 
 	cp := compression.New(compression.WithDefaultAlgorithms())
 
-	op := newOperationProviderWrapper(&p, opParser, casClient, cp)
+	op := txnprovider.NewOperationProvider(p, opParser, casClient, cp)
 
 	return &vcommon.ClientVersion{
 		VersionStr: version,
 		P:          p,
 		OpProvider: op,
 	}, nil
-}
-
-type decompressionProvider interface {
-	Decompress(alg string, data []byte) ([]byte, error)
-}
-
-// operationProviderWrapper wraps an OperationProvider with a CAS resolver that can fetch data using WebCAS.
-type operationProviderWrapper struct {
-	*txnprovider.OperationProvider
-
-	*protocol.Protocol
-	parser    txnprovider.OperationParser
-	casReader common.CASReader
-	dp        decompressionProvider
-}
-
-// GetTxnOperations returns transaction operation from the underlying operation provider.
-func (h *operationProviderWrapper) GetTxnOperations(transaction *txn.SidetreeTxn) ([]*operation.AnchoredOperation, error) { //nolint:lll
-	casHint := ""
-
-	if len(transaction.EquivalentReferences) > 0 {
-		lastColonIndex := strings.LastIndex(transaction.EquivalentReferences[0], ":")
-
-		casHint = transaction.EquivalentReferences[0][:lastColonIndex+1]
-	}
-
-	casClient := &casClientWrapper{
-		casReader:                h.casReader,
-		casHintWithTrailingColon: casHint,
-	}
-
-	op := txnprovider.NewOperationProvider(*h.Protocol, h.parser, casClient, h.dp)
-
-	return op.GetTxnOperations(transaction)
-}
-
-type casClientWrapper struct {
-	casReader                common.CASReader
-	casHintWithTrailingColon string
-}
-
-func (c *casClientWrapper) Read(cid string) ([]byte, error) {
-	// TODO: no need for wrapper any more (issue-671)
-	data, err := c.casReader.Read(cid)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve CID[%s]: %w", cid, err)
-	}
-
-	return data, nil
-}
-
-func newOperationProviderWrapper(p *protocol.Protocol, parser *operationparser.Parser, casReader common.CASReader,
-	cp *compression.Registry) *operationProviderWrapper {
-	return &operationProviderWrapper{
-		Protocol:  p,
-		parser:    parser,
-		casReader: casReader,
-		dp:        cp,
-	}
 }

--- a/pkg/protocolversion/versions/v1_0/client/client_test.go
+++ b/pkg/protocolversion/versions/v1_0/client/client_test.go
@@ -7,14 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package client
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
-	"github.com/trustbloc/sidetree-core-go/pkg/api/txn"
-	"github.com/trustbloc/sidetree-core-go/pkg/compression"
-	"github.com/trustbloc/sidetree-core-go/pkg/versions/1_0/operationparser"
 
 	"github.com/trustbloc/orb/pkg/protocolversion/mocks"
 )
@@ -29,51 +24,5 @@ func TestFactory_Create(t *testing.T) {
 		pv, err := f.Create("1.0", casClient)
 		require.NoError(t, err)
 		require.NotNil(t, pv)
-	})
-}
-
-func TestOperationProviderWrapper_GetTxnOperations(t *testing.T) {
-	t.Run("parse anchor data failed", func(t *testing.T) {
-		p := protocol.Protocol{}
-		opWrapper := operationProviderWrapper{
-			Protocol: &p, parser: operationparser.New(p),
-			dp: compression.New(compression.WithDefaultAlgorithms()),
-		}
-
-		anchoredOperations, err := opWrapper.GetTxnOperations(&txn.SidetreeTxn{
-			AnchorString:         "1.2.3",
-			EquivalentReferences: []string{"webcas:orb.domain1.com"},
-		})
-		require.EqualError(t, err, "parse anchor data[1.2.3] failed: expecting [2] parts, got [3] parts")
-		require.Nil(t, anchoredOperations)
-	})
-}
-
-func TestCasClientWrapper_Read(t *testing.T) {
-	t.Run("success", func(t *testing.T) {
-		casClient := &mocks.CasClient{}
-		casClient.ReadReturns([]byte("hello world"), nil)
-
-		wrapper := &casClientWrapper{
-			casReader:                casClient,
-			casHintWithTrailingColon: "webcas:orb.domain1.com:",
-		}
-
-		data, err := wrapper.Read("cid")
-		require.NoError(t, err)
-		require.NotNil(t, data)
-	})
-	t.Run("error - cas error", func(t *testing.T) {
-		casClient := &mocks.CasClient{}
-		casClient.ReadReturns(nil, fmt.Errorf("cas error"))
-
-		wrapper := &casClientWrapper{
-			casReader: casClient,
-		}
-
-		data, err := wrapper.Read("cid")
-		require.Error(t, err)
-		require.Nil(t, data)
-		require.Contains(t, err.Error(), "cas error")
 	})
 }


### PR DESCRIPTION
Delete operation provider wrappers for client and factory - no longer used.

Closes #671

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>