### PR TITLE
test: Update anchor origins in BDD test

### DIFF
--- a/test/bdd/bddtests_test.go
+++ b/test/bdd/bddtests_test.go
@@ -51,7 +51,7 @@ func TestMain(m *testing.M) {
 					panic(err.Error())
 				}
 
-				if err := os.Setenv("ORB_STRESS_ANCHOR_ORIGIN", "https://orb.domain2.com/services/orb"); err != nil {
+				if err := os.Setenv("ORB_STRESS_ANCHOR_ORIGIN", "https://orb.domain2.com"); err != nil {
 					panic(err.Error())
 				}
 

--- a/test/bdd/cli_steps.go
+++ b/test/bdd/cli_steps.go
@@ -144,7 +144,6 @@ func (e *Steps) resolveDID(did string) (*ariesdid.DocResolution, error) {
 
 	for i := 1; i <= maxRetry; i++ {
 		resp, err := e.httpClient.Get(didURL)
-
 		if err != nil {
 			return nil, err
 		}
@@ -317,7 +316,6 @@ func (e *Steps) createActivity(subCmd, outboxURL, actor, to, action string) erro
 	}
 
 	value, err := execCMD(args...)
-
 	if err != nil {
 		return err
 	}
@@ -340,7 +338,6 @@ func (e *Steps) updateDID() error {
 		"--add-service-file", "fixtures/did-services/update/services.json")
 
 	value, err := execCMD(args...)
-
 	if err != nil {
 		return err
 	}
@@ -357,7 +354,7 @@ func (e *Steps) recoverDID() error {
 		"did", "recover",
 		"--sidetree-url-operation", "https://localhost:48326/sidetree/v1/operations",
 		"--sidetree-url-resolution", "https://localhost:48326/sidetree/v1/identifiers",
-		"--did-anchor-origin", "https://orb.domain2.com/services/orb",
+		"--did-anchor-origin", "https://orb.domain2.com",
 		"--did-uri", e.createdDID.ID, "--signingkey-password", "123",
 		"--tls-cacerts", "fixtures/keys/tls/ec-cacert.pem",
 		"--publickey-file", "fixtures/did-keys/recover/publickeys.json", "--sidetree-write-token", "ADMIN_TOKEN",
@@ -366,7 +363,6 @@ func (e *Steps) recoverDID() error {
 		"./fixtures/keys/update3/public.pem", "--signingkey-file", "./fixtures/keys/recover/key_encrypted.pem")
 
 	value, err := execCMD(args...)
-
 	if err != nil {
 		return err
 	}
@@ -387,7 +383,6 @@ func (e *Steps) deactivateDID() error {
 		"--signingkey-file", "./fixtures/keys/recover2/key_encrypted.pem")
 
 	value, err := execCMD(args...)
-
 	if err != nil {
 		return err
 	}
@@ -400,14 +395,13 @@ func (e *Steps) deactivateDID() error {
 func (e *Steps) createDID() error {
 	var args []string
 
-	args = append(args, "did", "create", "--did-anchor-origin", "https://orb.domain2.com/services/orb",
+	args = append(args, "did", "create", "--did-anchor-origin", "https://orb.domain2.com",
 		"--sidetree-url", "https://localhost:48326/sidetree/v1/operations", "--tls-cacerts", "fixtures/keys/tls/ec-cacert.pem",
 		"--publickey-file", "fixtures/did-keys/create/publickeys.json",
 		"--sidetree-write-token", "ADMIN_TOKEN", "--service-file", "fixtures/did-services/create/services.json",
 		"--recoverykey-file", "./fixtures/keys/recover/public.pem", "--updatekey-file", "./fixtures/keys/update/public.pem")
 
 	value, err := execCMD(args...)
-
 	if err != nil {
 		return err
 	}

--- a/test/bdd/did_orb_steps.go
+++ b/test/bdd/did_orb_steps.go
@@ -68,11 +68,11 @@ var localURLs = map[string]string{
 }
 
 var anchorOriginURLs = map[string]string{
-	"https://localhost:48326/sidetree/v1/operations": "https://orb.domain1.com/services/orb",
+	"https://localhost:48326/sidetree/v1/operations": "https://orb.domain1.com",
 	"https://localhost:48526/sidetree/v1/operations": "ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q",
-	"https://localhost:48426/sidetree/v1/operations": "https://orb.domain1.com/services/orb",
-	"https://localhost:48626/sidetree/v1/operations": "https://orb.domain1.com/services/orb",
-	"https://localhost:48726/sidetree/v1/operations": "https://orb.domain1.com/services/orb",
+	"https://localhost:48426/sidetree/v1/operations": "https://orb.domain1.com",
+	"https://localhost:48626/sidetree/v1/operations": "https://orb.domain1.com",
+	"https://localhost:48726/sidetree/v1/operations": "https://orb.domain1.com",
 }
 
 const addPublicKeysTemplate = `[
@@ -127,8 +127,6 @@ const docTemplate = `{
 	}
   ]
 }`
-
-var emptyJson = []byte("{}")
 
 // DIDOrbSteps
 type DIDOrbSteps struct {
@@ -275,7 +273,7 @@ func (d *DIDOrbSteps) clientRequestsAnchorOrigin(url string) error {
 
 	logger.Infof("got anchor origin: %s", anchorOrigin)
 
-	expectedOrigin := "https://orb.domain1.com/services/orb"
+	expectedOrigin := "https://orb.domain1.com"
 	if anchorOrigin != expectedOrigin {
 		return fmt.Errorf("anchor origin: expected %s, got %s", expectedOrigin, anchorOrigin)
 	}

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - ORB_TLS_KEY=/etc/orb/tls/ec-key.pem
       - ORB_DISCOVERY_DOMAIN=shared.domain.com
       - DID_NAMESPACE=did:orb
-      - ALLOWED_ORIGINS=https://orb.domain1.com/services/orb,https://orb.domain2.com/services/orb,ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q
+      - ALLOWED_ORIGINS=https://orb.domain1.com,https://orb.domain2.com,ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
       - BATCH_WRITER_TIMEOUT=1000
       - CAS_TYPE=${CAS_TYPE}
@@ -112,7 +112,7 @@ services:
       - ORB_TLS_KEY=/etc/orb/tls/ec-key.pem
       - ORB_DISCOVERY_DOMAIN=shared.domain.com
       - DID_NAMESPACE=did:orb
-      - ALLOWED_ORIGINS=https://orb.domain1.com/services/orb,https://orb.domain2.com/services/orb,ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q
+      - ALLOWED_ORIGINS=https://orb.domain1.com,https://orb.domain2.com,ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
       - BATCH_WRITER_TIMEOUT=1000
       - CAS_TYPE=${CAS_TYPE}
@@ -204,7 +204,7 @@ services:
       - ORB_EXTERNAL_ENDPOINT=https://orb.domain2.com
       - ORB_DISCOVERY_DOMAIN=shared.domain.com
       - DID_NAMESPACE=did:orb
-      - ALLOWED_ORIGINS=https://orb.domain1.com/services/orb,https://orb.domain2.com/services/orb,ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q
+      - ALLOWED_ORIGINS=https://orb.domain1.com,https://orb.domain2.com,ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
       - BATCH_WRITER_TIMEOUT=1000
       - CAS_TYPE=${CAS_TYPE}
@@ -279,7 +279,7 @@ services:
       - ORB_EXTERNAL_ENDPOINT=https://orb.domain2.com
       - ORB_DISCOVERY_DOMAIN=shared.domain.com
       - DID_NAMESPACE=did:orb
-      - ALLOWED_ORIGINS=https://orb.domain1.com/services/orb,https://orb.domain2.com/services/orb,ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q
+      - ALLOWED_ORIGINS=https://orb.domain1.com,https://orb.domain2.com,ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
       - BATCH_WRITER_TIMEOUT=1000
       - CAS_TYPE=${CAS_TYPE}
@@ -357,7 +357,7 @@ services:
       - ORB_TLS_KEY=/etc/orb/tls/ec-key.pem
       - ORB_DISCOVERY_DOMAIN=shared.domain.com
       - DID_NAMESPACE=did:orb
-      - ALLOWED_ORIGINS=https://orb.domain1.com/services/orb,https://orb.domain2.com/services/orb,ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q
+      - ALLOWED_ORIGINS=https://orb.domain1.com,https://orb.domain2.com,ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
       - BATCH_WRITER_TIMEOUT=1000
       - CAS_TYPE=${CAS_TYPE}
@@ -435,7 +435,7 @@ services:
       - ORB_TLS_KEY=/etc/orb/tls/ec-key.pem
       - DID_NAMESPACE=did:orb
       - DID_DISCOVERY_ENABLED=true
-      - ALLOWED_ORIGINS=https://orb.domain4.com/services/orb,https://orb.domain1.com/services/orb,ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q
+      - ALLOWED_ORIGINS=https://orb.domain4.com,https://orb.domain1.com,ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
       - BATCH_WRITER_TIMEOUT=1000
       - CAS_TYPE=${CAS_TYPE}


### PR DESCRIPTION
BDD test anchor origins no longer have the /services/orb suffix.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>