### PR TITLE
feat: Add handler for the 'Like' activity

### DIFF
--- a/pkg/activitypub/resthandler/activityhandler_test.go
+++ b/pkg/activitypub/resthandler/activityhandler_test.go
@@ -1002,25 +1002,25 @@ func newMockActivity(t vocab.Type, id *url.URL, to ...*url.URL) *vocab.ActivityT
 	}
 
 	if t == vocab.TypeLike {
-		result, err := vocab.NewObjectWithDocument(vocab.MustUnmarshalToDoc([]byte(jsonLikeResult)))
-		if err != nil {
-			panic(err)
-		}
-
 		actor := testutil.MustParseURL("https://example1.com/services/orb")
-		credID := testutil.MustParseURL("http://sally.example.com/transactions/bafkreihwsn")
+		ref := testutil.MustParseURL("hl:uEiCsFp-ft8tI1DFGbXs78tw-HS561mMPa3Z6GsGAHElrNQ:uoQ-CeE1odHRwczovL3NhbGx5LmV4YW1wbGUuY29tL2Nhcy91RWlDc0ZwLWZ0OHRJMURGR2JYczc4dHctSFM1NjFtTVBhM1o2R3NHQUhFbHJOUXhCaXBmczovL2JhZmtyZWlmbWMycHo3bjZsamRrZGNydG5wbTU3ZnhiNmR1eGh2dnRkYjV2eG02cTJ5Z2FieXNsbGd1")           //nolint:lll
+		additionalRef := testutil.MustParseURL("hl:uEiCsFp-ft8tI1DFGbXs78tw-JS571mMPa3Z6GsGAHElrNQ:uoQ-CeE1odHRwczovL3NhbGx5LmV4YW1wbGUuY29tL2Nhcy91RWlDc0ZwLWZ0OHRJMURGR2JYczc4dHctSFM1NjFtTVBhM1o2R3NHQUhFbHJOUXhCaXBmczovL2JhZmtyZWlmbWMycHo3bjZsamRrZGNydG5wbTU3ZnhiNmR1eGh2dnRkYjV2eG02cTJ5Z2FieXNsbGd1") //nolint:lll
 
-		startTime := getStaticTime()
-		endTime := startTime.Add(1 * time.Minute)
+		publishedTime := getStaticTime()
 
 		return vocab.NewLikeActivity(
-			vocab.NewObjectProperty(vocab.WithIRI(credID)),
+			vocab.NewObjectProperty(vocab.WithObject(vocab.NewObject(
+				vocab.WithType(vocab.TypeAnchorRef),
+				vocab.WithURL(ref),
+			))),
 			vocab.WithID(id),
 			vocab.WithActor(actor),
 			vocab.WithTo(to...),
-			vocab.WithStartTime(&startTime),
-			vocab.WithEndTime(&endTime),
-			vocab.WithResult(vocab.NewObjectProperty(vocab.WithObject(result))),
+			vocab.WithPublishedTime(&publishedTime),
+			vocab.WithResult(vocab.NewObjectProperty(vocab.WithObject(vocab.NewObject(
+				vocab.WithType(vocab.TypeAnchorRef),
+				vocab.WithURL(additionalRef),
+			)))),
 		)
 	}
 
@@ -1393,75 +1393,51 @@ const (
   "last": "https://example1.com/services/orb/liked?page=true&page-num=0"
 }`
 
+	//nolint:lll
 	likedFirstPageJSON = `{
   "@context": "https://www.w3.org/ns/activitystreams",
   "id": "https://example1.com/services/orb/liked?page=true&page-num=9",
   "next": "https://example1.com/services/orb/liked?page=true&page-num=8",
   "orderedItems": [
     {
-      "@context": "https://www.w3.org/ns/activitystreams",
+      "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/activityanchors/v1"
+      ],
       "actor": "https://example1.com/services/orb",
-      "endTime": "2021-01-27T09:31:10Z",
       "id": "https://example18.com/activities/like_activity_18",
-      "object": "http://sally.example.com/transactions/bafkreihwsn",
-      "result": {
-        "@context": [
-          "https://w3id.org/security/v1",
-          "https://w3c-ccg.github.io/lds-jws2020/contexts/lds-jws2020-v1.json"
-        ],
-        "proof": {
-          "created": "2021-01-27T09:30:15Z",
-          "domain": "https://witness1.example.com/ledgers/maple2021",
-          "jws": "eyJ...",
-          "proofPurpose": "assertionMethod",
-          "type": "JsonWebSignature2020",
-          "verificationMethod": "did:example:abcd#key"
-        }
+      "object": {
+        "type": "AnchorReference",
+        "url": "hl:uEiCsFp-ft8tI1DFGbXs78tw-HS561mMPa3Z6GsGAHElrNQ:uoQ-CeE1odHRwczovL3NhbGx5LmV4YW1wbGUuY29tL2Nhcy91RWlDc0ZwLWZ0OHRJMURGR2JYczc4dHctSFM1NjFtTVBhM1o2R3NHQUhFbHJOUXhCaXBmczovL2JhZmtyZWlmbWMycHo3bjZsamRrZGNydG5wbTU3ZnhiNmR1eGh2dnRkYjV2eG02cTJ5Z2FieXNsbGd1"
       },
-      "startTime": "2021-01-27T09:30:10Z",
+      "published": "2021-01-27T09:30:10Z",
+      "result": {
+        "type": "AnchorReference",
+        "url": "hl:uEiCsFp-ft8tI1DFGbXs78tw-JS571mMPa3Z6GsGAHElrNQ:uoQ-CeE1odHRwczovL3NhbGx5LmV4YW1wbGUuY29tL2Nhcy91RWlDc0ZwLWZ0OHRJMURGR2JYczc4dHctSFM1NjFtTVBhM1o2R3NHQUhFbHJOUXhCaXBmczovL2JhZmtyZWlmbWMycHo3bjZsamRrZGNydG5wbTU3ZnhiNmR1eGh2dnRkYjV2eG02cTJ5Z2FieXNsbGd1"
+      },
       "type": "Like"
     },
     {
-      "@context": "https://www.w3.org/ns/activitystreams",
+      "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/activityanchors/v1"
+      ],
       "actor": "https://example1.com/services/orb",
-      "endTime": "2021-01-27T09:31:10Z",
       "id": "https://example17.com/activities/like_activity_17",
-      "object": "http://sally.example.com/transactions/bafkreihwsn",
-      "result": {
-        "@context": [
-          "https://w3id.org/security/v1",
-          "https://w3c-ccg.github.io/lds-jws2020/contexts/lds-jws2020-v1.json"
-        ],
-        "proof": {
-          "created": "2021-01-27T09:30:15Z",
-          "domain": "https://witness1.example.com/ledgers/maple2021",
-          "jws": "eyJ...",
-          "proofPurpose": "assertionMethod",
-          "type": "JsonWebSignature2020",
-          "verificationMethod": "did:example:abcd#key"
-        }
+      "object": {
+        "type": "AnchorReference",
+        "url": "hl:uEiCsFp-ft8tI1DFGbXs78tw-HS561mMPa3Z6GsGAHElrNQ:uoQ-CeE1odHRwczovL3NhbGx5LmV4YW1wbGUuY29tL2Nhcy91RWlDc0ZwLWZ0OHRJMURGR2JYczc4dHctSFM1NjFtTVBhM1o2R3NHQUhFbHJOUXhCaXBmczovL2JhZmtyZWlmbWMycHo3bjZsamRrZGNydG5wbTU3ZnhiNmR1eGh2dnRkYjV2eG02cTJ5Z2FieXNsbGd1"
       },
-      "startTime": "2021-01-27T09:30:10Z",
+      "published": "2021-01-27T09:30:10Z",
+      "result": {
+        "type": "AnchorReference",
+        "url": "hl:uEiCsFp-ft8tI1DFGbXs78tw-JS571mMPa3Z6GsGAHElrNQ:uoQ-CeE1odHRwczovL3NhbGx5LmV4YW1wbGUuY29tL2Nhcy91RWlDc0ZwLWZ0OHRJMURGR2JYczc4dHctSFM1NjFtTVBhM1o2R3NHQUhFbHJOUXhCaXBmczovL2JhZmtyZWlmbWMycHo3bjZsamRrZGNydG5wbTU3ZnhiNmR1eGh2dnRkYjV2eG02cTJ5Z2FieXNsbGd1"
+      },
       "type": "Like"
     }
   ],
   "totalItems": 19,
   "type": "OrderedCollectionPage"
-}`
-
-	jsonLikeResult = `{
-  "@context": [
-    "https://w3id.org/security/v1",
-    "https://w3c-ccg.github.io/lds-jws2020/contexts/lds-jws2020-v1.json"
-  ],
-  "proof": {
-    "type": "JsonWebSignature2020",
-    "proofPurpose": "assertionMethod",
-    "created": "2021-01-27T09:30:15Z",
-    "verificationMethod": "did:example:abcd#key",
-    "domain": "https://witness1.example.com/ledgers/maple2021",
-    "jws": "eyJ..."
-  }
 }`
 
 	activityJSON = `{

--- a/pkg/activitypub/service/activityhandler/activityhandler.go
+++ b/pkg/activitypub/service/activityhandler/activityhandler.go
@@ -175,10 +175,11 @@ func (h *handler) notify(activity *vocab.ActivityType) {
 
 func defaultOptions() *service.Handlers {
 	return &service.Handlers{
-		AnchorCredentialHandler: &noOpAnchorCredentialPublisher{},
-		FollowerAuth:            &acceptAllActorsAuth{},
-		WitnessInvitationAuth:   &acceptAllActorsAuth{},
-		ProofHandler:            &noOpProofHandler{},
+		AnchorCredentialHandler:        &noOpAnchorCredentialPublisher{},
+		FollowerAuth:                   &acceptAllActorsAuth{},
+		WitnessInvitationAuth:          &acceptAllActorsAuth{},
+		ProofHandler:                   &noOpProofHandler{},
+		AnchorEventNotificationHandler: &noOpAnchorEventNotificationHandler{},
 	}
 }
 

--- a/pkg/activitypub/service/mocks/mockanchorcredhandler.go
+++ b/pkg/activitypub/service/mocks/mockanchorcredhandler.go
@@ -33,7 +33,7 @@ func (m *AnchorCredentialHandler) WithError(err error) *AnchorCredentialHandler 
 }
 
 // HandleAnchorCredential stores the anchor credential or returns an error if it was set.
-func (m *AnchorCredentialHandler) HandleAnchorCredential(id *url.URL, cid string, anchorCred []byte) error {
+func (m *AnchorCredentialHandler) HandleAnchorCredential(actor, id *url.URL, cid string, anchorCred []byte) error {
 	if m.err != nil {
 		return m.err
 	}

--- a/pkg/activitypub/service/mocks/mockanchoreventnotifhandler.go
+++ b/pkg/activitypub/service/mocks/mockanchoreventnotifhandler.go
@@ -1,0 +1,50 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	"net/url"
+	"sync"
+)
+
+// AnchorEventNotificationHandler implements a mock anchor event notification handler.
+type AnchorEventNotificationHandler struct {
+	mutex   sync.Mutex
+	err     error
+	anchors []*url.URL
+}
+
+// NewAnchorEventNotificationHandler returns a mock witness handler.
+func NewAnchorEventNotificationHandler() *AnchorEventNotificationHandler {
+	return &AnchorEventNotificationHandler{}
+}
+
+// WithError injects an error.
+func (m *AnchorEventNotificationHandler) WithError(err error) *AnchorEventNotificationHandler {
+	m.err = err
+
+	return m
+}
+
+// AnchorEventProcessed handles notification of a successful anchor event processed from an Orb server.
+func (m *AnchorEventNotificationHandler) AnchorEventProcessed(actor, anchorRef *url.URL,
+	additionalAnchorRefs []*url.URL) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	m.anchors = append(m.anchors, anchorRef)
+
+	return m.err
+}
+
+// Anchors returns the anchors that were added to this mock.
+func (m *AnchorEventNotificationHandler) Anchors() []*url.URL {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	return m.anchors
+}

--- a/pkg/activitypub/service/service_test.go
+++ b/pkg/activitypub/service/service_test.go
@@ -136,7 +136,7 @@ func TestService_Create(t *testing.T) {
 	create := vocab.NewCreateActivity(
 		vocab.NewObjectProperty(vocab.WithObject(obj)),
 		vocab.WithTarget(targetProperty),
-		vocab.WithContext(vocab.ContextOrb),
+		vocab.WithContext(vocab.ContextActivityAnchors),
 		vocab.WithTo(service2IRI, unavailableServiceIRI),
 	)
 
@@ -605,7 +605,7 @@ func TestService_Announce(t *testing.T) {
 		create := vocab.NewCreateActivity(
 			vocab.NewObjectProperty(vocab.WithObject(obj)),
 			vocab.WithTarget(targetProperty),
-			vocab.WithContext(vocab.ContextOrb),
+			vocab.WithContext(vocab.ContextActivityAnchors),
 			vocab.WithTo(service2IRI),
 		)
 
@@ -945,13 +945,14 @@ func TestService_InviteWitness(t *testing.T) {
 }
 
 type mockProviders struct {
-	actorRetriever          *mocks.ActorRetriever
-	anchorCredentialHandler *mocks.AnchorCredentialHandler
-	followerAuth            *mocks.ActorAuth
-	witnessInvitationAuth   *mocks.ActorAuth
-	undeliverableHandler    *mocks.UndeliverableHandler
-	proofHandler            *mocks.ProofHandler
-	witnessHandler          *mocks.WitnessHandler
+	actorRetriever                 *mocks.ActorRetriever
+	anchorCredentialHandler        *mocks.AnchorCredentialHandler
+	followerAuth                   *mocks.ActorAuth
+	witnessInvitationAuth          *mocks.ActorAuth
+	undeliverableHandler           *mocks.UndeliverableHandler
+	proofHandler                   *mocks.ProofHandler
+	witnessHandler                 *mocks.WitnessHandler
+	anchorEventNotificationHandler *mocks.AnchorEventNotificationHandler
 }
 
 func newServiceWithMocks(t *testing.T, endpoint string,
@@ -973,13 +974,14 @@ func newServiceWithMocks(t *testing.T, endpoint string,
 	}
 
 	providers := &mockProviders{
-		actorRetriever:          mocks.NewActorRetriever(),
-		anchorCredentialHandler: mocks.NewAnchorCredentialHandler(),
-		followerAuth:            mocks.NewActorAuth(),
-		witnessInvitationAuth:   mocks.NewActorAuth(),
-		undeliverableHandler:    mocks.NewUndeliverableHandler(),
-		proofHandler:            mocks.NewProofHandler(),
-		witnessHandler:          mocks.NewWitnessHandler(),
+		actorRetriever:                 mocks.NewActorRetriever(),
+		anchorCredentialHandler:        mocks.NewAnchorCredentialHandler(),
+		followerAuth:                   mocks.NewActorAuth(),
+		witnessInvitationAuth:          mocks.NewActorAuth(),
+		undeliverableHandler:           mocks.NewUndeliverableHandler(),
+		proofHandler:                   mocks.NewProofHandler(),
+		witnessHandler:                 mocks.NewWitnessHandler(),
+		anchorEventNotificationHandler: mocks.NewAnchorEventNotificationHandler(),
 	}
 
 	pubKeyBytes, privKey, err := ed25519.GenerateKey(rand.Reader)
@@ -1016,6 +1018,7 @@ func newServiceWithMocks(t *testing.T, endpoint string,
 		service.WithWitnessInvitationAuth(providers.witnessInvitationAuth),
 		service.WithWitness(providers.witnessHandler),
 		service.WithProofHandler(providers.proofHandler),
+		service.WithAnchorEventNotificationHandler(providers.anchorEventNotificationHandler),
 	)
 	require.NoError(t, err)
 

--- a/pkg/activitypub/service/spi/spi.go
+++ b/pkg/activitypub/service/spi/spi.go
@@ -39,7 +39,12 @@ type Inbox interface {
 
 // AnchorCredentialHandler handles a new, published anchor credential.
 type AnchorCredentialHandler interface {
-	HandleAnchorCredential(id *url.URL, cid string, anchorCred []byte) error
+	HandleAnchorCredential(actor, id *url.URL, cid string, anchorCred []byte) error
+}
+
+// AnchorEventNotificationHandler handles notification of a successful anchor event processed from an Orb server.
+type AnchorEventNotificationHandler interface {
+	AnchorEventProcessed(actor, anchorRef *url.URL, additionalAnchorRefs []*url.URL) error
 }
 
 // ActorAuth makes the decision of whether or not a request by the given
@@ -76,12 +81,13 @@ type UndeliverableActivityHandler interface {
 
 // Handlers contains handlers for various activity events, including undeliverable activities.
 type Handlers struct {
-	UndeliverableHandler    UndeliverableActivityHandler
-	AnchorCredentialHandler AnchorCredentialHandler
-	FollowerAuth            ActorAuth
-	WitnessInvitationAuth   ActorAuth
-	Witness                 WitnessHandler
-	ProofHandler            ProofHandler
+	UndeliverableHandler           UndeliverableActivityHandler
+	AnchorCredentialHandler        AnchorCredentialHandler
+	FollowerAuth                   ActorAuth
+	WitnessInvitationAuth          ActorAuth
+	Witness                        WitnessHandler
+	ProofHandler                   ProofHandler
+	AnchorEventNotificationHandler AnchorEventNotificationHandler
 }
 
 // HandlerOpt sets a specific handler.
@@ -126,5 +132,13 @@ func WithWitness(handler WitnessHandler) HandlerOpt {
 func WithProofHandler(handler ProofHandler) HandlerOpt {
 	return func(options *Handlers) {
 		options.ProofHandler = handler
+	}
+}
+
+// WithAnchorEventNotificationHandler sets the handler for notifications of successful anchor event processed
+// from an Orb server.
+func WithAnchorEventNotificationHandler(handler AnchorEventNotificationHandler) HandlerOpt {
+	return func(options *Handlers) {
+		options.AnchorEventNotificationHandler = handler
 	}
 }

--- a/pkg/activitypub/vocab/activitytype.go
+++ b/pkg/activitypub/vocab/activitytype.go
@@ -141,7 +141,7 @@ func NewInviteActivity(obj *ObjectProperty, opts ...Opt) *ActivityType {
 
 	return &ActivityType{
 		ObjectType: NewObject(
-			WithContext(getContexts(options, ContextActivityStreams, ContextOrb)...),
+			WithContext(getContexts(options, ContextActivityStreams, ContextActivityAnchors)...),
 			WithID(options.ID),
 			WithType(TypeInvite),
 			WithTo(options.To...),
@@ -197,12 +197,11 @@ func NewLikeActivity(obj *ObjectProperty, opts ...Opt) *ActivityType {
 
 	return &ActivityType{
 		ObjectType: NewObject(
-			WithContext(getContexts(options, ContextActivityStreams)...),
+			WithContext(getContexts(options, ContextActivityStreams, ContextActivityAnchors)...),
 			WithID(options.ID),
 			WithType(TypeLike),
 			WithTo(options.To...),
-			WithStartTime(options.StartTime),
-			WithEndTime(options.EndTime),
+			WithPublishedTime(options.Published),
 		),
 		activity: &activityType{
 			Actor:  NewURLProperty(options.Actor),

--- a/pkg/activitypub/vocab/actortype.go
+++ b/pkg/activitypub/vocab/actortype.go
@@ -135,7 +135,7 @@ func NewService(id *url.URL, opts ...Opt) *ActorType {
 
 	return &ActorType{
 		ObjectType: NewObject(
-			WithContext(getContexts(options, ContextActivityStreams, ContextSecurity, ContextOrb)...),
+			WithContext(getContexts(options, ContextActivityStreams, ContextSecurity, ContextActivityAnchors)...),
 			WithID(id),
 			WithType(TypeService),
 		),

--- a/pkg/activitypub/vocab/actortype_test.go
+++ b/pkg/activitypub/vocab/actortype_test.go
@@ -70,7 +70,7 @@ func TestActor(t *testing.T) {
 
 		context := a.Context()
 		require.NotNil(t, context)
-		context.Contains(ContextActivityStreams, ContextSecurity, ContextOrb)
+		context.Contains(ContextActivityStreams, ContextSecurity, ContextActivityAnchors)
 
 		key := a.PublicKey()
 		require.NotNil(t, key)

--- a/pkg/activitypub/vocab/anchorcredreftype.go
+++ b/pkg/activitypub/vocab/anchorcredreftype.go
@@ -18,8 +18,9 @@ type AnchorReferenceType struct {
 }
 
 type anchorReferenceType struct {
-	Target *ObjectProperty `json:"target,omitempty"`
-	Object *ObjectProperty `json:"object,omitempty"`
+	Target *ObjectProperty        `json:"target,omitempty"`
+	Object *ObjectProperty        `json:"object,omitempty"`
+	URL    *URLCollectionProperty `json:"url,omitempty"`
 }
 
 // NewAnchorReference returns a new "AnchorReference".
@@ -28,7 +29,7 @@ func NewAnchorReference(id, anchorCredID *url.URL, cid string, opts ...Opt) *Anc
 
 	return &AnchorReferenceType{
 		ObjectType: NewObject(
-			WithContext(getContexts(options, ContextActivityStreams, ContextOrb)...),
+			WithContext(getContexts(options, ContextActivityStreams, ContextActivityAnchors)...),
 			WithID(id),
 			WithType(TypeAnchorRef),
 		),
@@ -56,7 +57,7 @@ func NewAnchorReferenceWithDocument(
 
 	return &AnchorReferenceType{
 		ObjectType: NewObject(
-			WithContext(getContexts(options, ContextActivityStreams, ContextOrb)...),
+			WithContext(getContexts(options, ContextActivityStreams, ContextActivityAnchors)...),
 			WithID(id),
 			WithType(TypeAnchorRef),
 		),
@@ -75,13 +76,34 @@ func NewAnchorReferenceWithDocument(
 	}, nil
 }
 
+// NewAnchorReferenceWithOpts returns a new "AnchorReference".
+func NewAnchorReferenceWithOpts(opts ...Opt) *AnchorReferenceType {
+	options := NewOptions(opts...)
+
+	return &AnchorReferenceType{
+		ObjectType: NewObject(
+			WithType(TypeAnchorRef),
+			WithURL(options.URL...),
+			WithAttachment(options.Attachment...),
+		),
+	}
+}
+
 // Target returns the target of the anchor credential reference.
 func (t *AnchorReferenceType) Target() *ObjectProperty {
+	if t == nil || t.ref == nil {
+		return nil
+	}
+
 	return t.ref.Target
 }
 
 // Object returns the embedded object (if any).
 func (t *AnchorReferenceType) Object() *ObjectProperty {
+	if t == nil || t.ref == nil {
+		return nil
+	}
+
 	return t.ref.Object
 }
 

--- a/pkg/activitypub/vocab/anchorcredreftype_test.go
+++ b/pkg/activitypub/vocab/anchorcredreftype_test.go
@@ -40,23 +40,11 @@ func TestNewAnchorReference(t *testing.T) {
 
 		contextProp := ref.Context()
 		require.NotNil(t, contextProp)
-		require.True(t, contextProp.Contains(ContextActivityStreams, ContextOrb))
+		require.True(t, contextProp.Contains(ContextActivityStreams, ContextActivityAnchors))
 
 		typeProp := ref.Type()
 		require.NotNil(t, typeProp)
 		require.True(t, typeProp.Is(TypeAnchorRef))
-
-		targetProp := ref.Target()
-		require.NotNil(t, targetProp)
-
-		targetObjProp := targetProp.Object()
-		require.NotNil(t, targetObjProp)
-		require.Equal(t, anchorCredIRI.String(), targetObjProp.ID().String())
-		require.Equal(t, cid, targetObjProp.CID())
-
-		targetTypeProp := targetObjProp.Type()
-		require.NotNil(t, targetTypeProp)
-		require.True(t, targetTypeProp.Is(TypeContentAddressedStorage))
 	})
 
 	t.Run("With document", func(t *testing.T) {
@@ -75,7 +63,7 @@ func TestNewAnchorReference(t *testing.T) {
 
 		contextProp := ref.Context()
 		require.NotNil(t, contextProp)
-		require.True(t, contextProp.Contains(ContextActivityStreams, ContextOrb))
+		require.True(t, contextProp.Contains(ContextActivityStreams, ContextActivityAnchors))
 
 		typeProp := ref.Type()
 		require.NotNil(t, typeProp)
@@ -105,7 +93,17 @@ func TestNewAnchorReference(t *testing.T) {
 
 		refObjContext := refObj.Context()
 		require.NotNil(t, refObjContext)
-		require.True(t, refObjContext.Contains(ContextCredentials, ContextOrb))
+		require.True(t, refObjContext.Contains(ContextCredentials, ContextActivityAnchors))
+	})
+
+	t.Run("With URL", func(t *testing.T) {
+		ref := NewAnchorReferenceWithOpts(WithURL(anchorCredIRI))
+		require.NotNil(t, ref)
+		require.True(t, ref.URL().Contains(anchorCredIRI))
+
+		typeProp := ref.Type()
+		require.NotNil(t, typeProp)
+		require.True(t, typeProp.Is(TypeAnchorRef))
 	})
 }
 
@@ -136,23 +134,11 @@ func TestAnchorReferenceMarshal(t *testing.T) {
 
 		contextProp := ref.Context()
 		require.NotNil(t, contextProp)
-		require.True(t, contextProp.Contains(ContextActivityStreams, ContextOrb))
+		require.True(t, contextProp.Contains(ContextActivityStreams, ContextActivityAnchors))
 
 		typeProp := ref.Type()
 		require.NotNil(t, typeProp)
 		require.True(t, typeProp.Is(TypeAnchorRef))
-
-		targetProp := ref.Target()
-		require.NotNil(t, targetProp)
-
-		targetObjProp := targetProp.Object()
-		require.NotNil(t, targetObjProp)
-		require.Equal(t, anchorCredIRI.String(), targetObjProp.ID().String())
-		require.Equal(t, cid, targetObjProp.CID())
-
-		targetTypeProp := targetObjProp.Type()
-		require.NotNil(t, targetTypeProp)
-		require.True(t, targetTypeProp.Is(TypeContentAddressedStorage))
 	})
 
 	t.Run("Marshal with document", func(t *testing.T) {
@@ -177,7 +163,7 @@ func TestAnchorReferenceMarshal(t *testing.T) {
 
 		contextProp := ref.Context()
 		require.NotNil(t, contextProp)
-		require.True(t, contextProp.Contains(ContextActivityStreams, ContextOrb))
+		require.True(t, contextProp.Contains(ContextActivityStreams, ContextActivityAnchors))
 
 		typeProp := ref.Type()
 		require.NotNil(t, typeProp)
@@ -207,8 +193,15 @@ func TestAnchorReferenceMarshal(t *testing.T) {
 
 		refObjContext := refObj.Context()
 		require.NotNil(t, refObjContext)
-		require.True(t, refObjContext.Contains(ContextCredentials, ContextOrb))
+		require.True(t, refObjContext.Contains(ContextCredentials, ContextActivityAnchors))
 	})
+}
+
+func TestAccessors(t *testing.T) {
+	var ref *AnchorReferenceType
+
+	require.Nil(t, ref.Target())
+	require.Nil(t, ref.Object())
 }
 
 const (

--- a/pkg/activitypub/vocab/contextproperty_test.go
+++ b/pkg/activitypub/vocab/contextproperty_test.go
@@ -23,8 +23,8 @@ func TestContextProperty(t *testing.T) {
 		p := NewContextProperty()
 		require.Nil(t, p)
 		require.Empty(t, p.Contexts())
-		require.False(t, p.Contains(ContextOrb))
-		require.False(t, p.ContainsAny(ContextOrb))
+		require.False(t, p.Contains(ContextActivityAnchors))
+		require.False(t, p.ContainsAny(ContextActivityAnchors))
 		require.Equal(t, "", p.String())
 	})
 
@@ -63,7 +63,7 @@ func TestContextProperty(t *testing.T) {
 		p2 := &ContextProperty{}
 		require.NoError(t, json.Unmarshal([]byte(jsonMultiContext), p2))
 		require.True(t, p2.Contains(ContextCredentials, ContextSecurity))
-		require.False(t, p2.Contains(ContextCredentials, ContextOrb))
+		require.False(t, p2.Contains(ContextCredentials, ContextActivityAnchors))
 		require.True(t, p2.ContainsAny(ContextSecurity))
 		require.Equal(t, "[https://www.w3.org/2018/credentials/v1 https://w3id.org/security/v1]", p.String())
 	})

--- a/pkg/activitypub/vocab/objectproperty_test.go
+++ b/pkg/activitypub/vocab/objectproperty_test.go
@@ -150,7 +150,7 @@ func TestObjectProperty_MarshalJSON(t *testing.T) {
 			NewObject(
 				WithType(TypeVerifiableCredential),
 				WithID(objectPropertyID),
-				WithContext(ContextOrb),
+				WithContext(ContextActivityAnchors),
 			),
 		))
 		require.NotNil(t, p)
@@ -232,7 +232,7 @@ func TestObjectProperty_UnmarshalJSON(t *testing.T) {
 
 		context := obj.Context()
 		require.NotNil(t, context)
-		require.True(t, context.Contains(ContextOrb))
+		require.True(t, context.Contains(ContextActivityAnchors))
 
 		require.Equal(t, objectPropertyID.String(), obj.ID().String())
 

--- a/pkg/activitypub/vocab/objecttype.go
+++ b/pkg/activitypub/vocab/objecttype.go
@@ -27,6 +27,7 @@ func NewObject(opts ...Opt) *ObjectType {
 		object: &objectType{
 			Context:    NewContextProperty(options.Context...),
 			ID:         NewURLProperty(options.ID),
+			URL:        NewURLCollectionProperty(options.URL...),
 			CID:        options.CID,
 			Type:       NewTypeProperty(options.Types...),
 			To:         NewURLCollectionProperty(options.To...),
@@ -63,6 +64,7 @@ func NewObjectWithDocument(doc Document, opts ...Opt) (*ObjectType, error) {
 type objectType struct {
 	Context    *ContextProperty       `json:"@context,omitempty"`
 	ID         *URLProperty           `json:"id,omitempty"`
+	URL        *URLCollectionProperty `json:"url,omitempty"`
 	Type       *TypeProperty          `json:"type,omitempty"`
 	To         *URLCollectionProperty `json:"to,omitempty"`
 	Published  *time.Time             `json:"published,omitempty"`
@@ -94,6 +96,21 @@ func (t *ObjectType) ID() *URLProperty {
 // SetID sets the object's ID.
 func (t *ObjectType) SetID(id *url.URL) {
 	t.object.ID = NewURLProperty(id)
+}
+
+// URL returns the object's URLs.
+func (t *ObjectType) URL() Urls {
+	if t == nil || t.object == nil || t.object.URL == nil {
+		return nil
+	}
+
+	urls := make([]*url.URL, len(t.object.URL.urls))
+
+	for i, u := range t.object.URL.urls {
+		urls[i] = u.u
+	}
+
+	return urls
 }
 
 // Type returns the type of the object.

--- a/pkg/activitypub/vocab/objecttype_test.go
+++ b/pkg/activitypub/vocab/objecttype_test.go
@@ -18,6 +18,7 @@ import (
 
 func TestObjectType_WithoutDocument(t *testing.T) {
 	id := testutil.MustParseURL("http://sally.example.com/transactions/bafkreihwsn")
+	u := testutil.MustParseURL("http://sally.example.com/transactions/xyz")
 	to1 := testutil.MustParseURL("https://to1")
 	to2 := testutil.MustParseURL("https://to2")
 
@@ -27,7 +28,8 @@ func TestObjectType_WithoutDocument(t *testing.T) {
 
 	t.Run("NewObject", func(t *testing.T) {
 		obj := NewObject(
-			WithContext(ContextCredentials, ContextOrb),
+			WithURL(u),
+			WithContext(ContextCredentials, ContextActivityAnchors),
 			WithType(TypeVerifiableCredential, TypeAnchorCredential),
 			WithTo(to1, to2),
 			WithPublishedTime(&publishedTime),
@@ -39,9 +41,11 @@ func TestObjectType_WithoutDocument(t *testing.T) {
 
 		context := obj.Context()
 		require.NotNil(t, context)
-		require.True(t, context.Contains(ContextCredentials, ContextOrb))
+		require.True(t, context.Contains(ContextCredentials, ContextActivityAnchors))
 
 		require.Equal(t, id.String(), obj.ID().String())
+
+		require.True(t, obj.URL().Contains(u))
 
 		typeProp := obj.Type()
 		require.NotNil(t, typeProp)
@@ -60,7 +64,7 @@ func TestObjectType_WithoutDocument(t *testing.T) {
 	t.Run("MarshalJSON", func(t *testing.T) {
 		obj := NewObject(
 			WithID(id),
-			WithContext(ContextCredentials, ContextOrb),
+			WithContext(ContextCredentials, ContextActivityAnchors),
 			WithType(TypeVerifiableCredential, TypeAnchorCredential),
 			WithPublishedTime(&publishedTime),
 			WithStartTime(&startTime),
@@ -82,7 +86,7 @@ func TestObjectType_WithoutDocument(t *testing.T) {
 
 		context := obj.Context()
 		require.NotNil(t, context)
-		require.True(t, context.Contains(ContextCredentials, ContextOrb))
+		require.True(t, context.Contains(ContextCredentials, ContextActivityAnchors))
 
 		require.Equal(t, id.String(), obj.ID().String())
 
@@ -125,7 +129,7 @@ func TestObjectType_WithDocument(t *testing.T) {
 				"proofChain":   []interface{}{},
 			},
 			WithID(id),
-			WithContext(ContextCredentials, ContextOrb),
+			WithContext(ContextCredentials, ContextActivityAnchors),
 			WithType(TypeVerifiableCredential, TypeAnchorCredential),
 			WithTo(to1, to2),
 			WithPublishedTime(&publishedTime),
@@ -149,7 +153,7 @@ func TestObjectType_WithDocument(t *testing.T) {
 
 		context := obj.Context()
 		require.NotNil(t, context)
-		require.True(t, context.Contains(ContextCredentials, ContextOrb))
+		require.True(t, context.Contains(ContextCredentials, ContextActivityAnchors))
 
 		require.Equal(t, id.String(), obj.ID().String())
 
@@ -178,6 +182,7 @@ func TestObjectType_Accessors(t *testing.T) {
 	require.Nil(t, o.Context())
 	require.Empty(t, o.CID())
 	require.Nil(t, o.Published())
+	require.Empty(t, o.URL())
 }
 
 const (

--- a/pkg/activitypub/vocab/options.go
+++ b/pkg/activitypub/vocab/options.go
@@ -15,6 +15,7 @@ import (
 type Options struct {
 	Context    []Context
 	ID         *url.URL
+	URL        []*url.URL
 	To         []*url.URL
 	Published  *time.Time
 	StartTime  *time.Time
@@ -56,6 +57,13 @@ func WithContext(context ...Context) Opt {
 func WithID(id *url.URL) Opt {
 	return func(opts *Options) {
 		opts.ID = id
+	}
+}
+
+// WithURL sets the 'url' property on the object.
+func WithURL(u ...*url.URL) Opt {
+	return func(opts *Options) {
+		opts.URL = append(opts.URL, u...)
 	}
 }
 

--- a/pkg/activitypub/vocab/options_test.go
+++ b/pkg/activitypub/vocab/options_test.go
@@ -17,6 +17,8 @@ import (
 
 func TestNewOptions(t *testing.T) {
 	id := testutil.MustParseURL("https://example.com/1234")
+	u1 := testutil.MustParseURL("https://example.com/5678")
+	u2 := testutil.MustParseURL("https://example.com/5679")
 
 	to1 := testutil.MustParseURL("https://to1")
 	to2 := testutil.MustParseURL("https://to2")
@@ -67,6 +69,7 @@ func TestNewOptions(t *testing.T) {
 
 	opts := NewOptions(
 		WithID(id),
+		WithURL(u1, u2),
 		WithContext(ContextCredentials, ContextActivityStreams),
 		WithType(TypeCreate),
 		WithTo(to1, to2),
@@ -103,6 +106,10 @@ func TestNewOptions(t *testing.T) {
 	require.NotNil(t, opts)
 
 	require.Equal(t, id, opts.ID)
+
+	require.Len(t, opts.URL, 2)
+	require.Equal(t, u1.String(), opts.URL[0].String())
+	require.Equal(t, u2.String(), opts.URL[1].String())
 
 	require.Len(t, opts.Context, 2)
 	require.Equal(t, ContextCredentials, opts.Context[0])

--- a/pkg/activitypub/vocab/vocab.go
+++ b/pkg/activitypub/vocab/vocab.go
@@ -16,8 +16,8 @@ const (
 	ContextSecurity Context = "https://w3id.org/security/v1"
 	// ContextCredentials is the verifiable credential context.
 	ContextCredentials Context = "https://www.w3.org/2018/credentials/v1"
-	// ContextOrb is the Orb context.
-	ContextOrb Context = "https://w3id.org/activityanchors/v1"
+	// ContextActivityAnchors is the Activity Anchors context.
+	ContextActivityAnchors Context = "https://w3id.org/activityanchors/v1"
 )
 
 //nolint:gochecknoglobals

--- a/pkg/anchor/handler/credential/handler.go
+++ b/pkg/anchor/handler/credential/handler.go
@@ -84,8 +84,9 @@ func getUniqueDomainCreated(proofs []verifiable.Proof) []verifiable.Proof {
 }
 
 // HandleAnchorCredential handles anchor credential.
-func (h *AnchorCredentialHandler) HandleAnchorCredential(id *url.URL, hl string, anchorCred []byte) error {
-	logger.Debugf("Received request: ID [%s], CID [%s], Anchor credential: %s", id, hl, string(anchorCred))
+func (h *AnchorCredentialHandler) HandleAnchorCredential(actor, id *url.URL, hl string, anchorCred []byte) error {
+	logger.Debugf("Received request from [%s]: ID [%s], CID [%s], Anchor credential: %s",
+		actor, id, hl, string(anchorCred))
 
 	newCred, err := h.casResolver.Resolve(id, hl, anchorCred)
 	if err != nil {
@@ -123,5 +124,10 @@ func (h *AnchorCredentialHandler) HandleAnchorCredential(id *url.URL, hl string,
 		}
 	}
 
-	return h.anchorPublisher.PublishAnchor(&anchorinfo.AnchorInfo{Hashlink: hl})
+	return h.anchorPublisher.PublishAnchor(
+		&anchorinfo.AnchorInfo{
+			Hashlink:     hl,
+			AttributedTo: actor.String(),
+		},
+	)
 }

--- a/pkg/anchor/handler/credential/handler_test.go
+++ b/pkg/anchor/handler/credential/handler_test.go
@@ -90,13 +90,15 @@ func TestNew(t *testing.T) {
 }
 
 func TestAnchorCredentialHandler(t *testing.T) {
+	actor := testutil.MustParseURL("https://domain1.com/services/orb")
+
 	t.Run("Success", func(t *testing.T) {
 		anchorCredentialHandler := createNewAnchorCredentialHandler(t, createInMemoryCAS(t))
 
 		hl, err := hashlink.New().CreateHashLink([]byte(sampleAnchorCredential), nil)
 		require.NoError(t, err)
 
-		err = anchorCredentialHandler.HandleAnchorCredential(nil, hl,
+		err = anchorCredentialHandler.HandleAnchorCredential(actor, nil, hl,
 			[]byte(sampleAnchorCredential))
 		require.NoError(t, err)
 	})
@@ -107,7 +109,7 @@ func TestAnchorCredentialHandler(t *testing.T) {
 		hl, err := hashlink.New().CreateHashLink([]byte(cred), nil)
 		require.NoError(t, err)
 
-		err = createNewAnchorCredentialHandler(t, createInMemoryCAS(t)).HandleAnchorCredential(nil, hl,
+		err = createNewAnchorCredentialHandler(t, createInMemoryCAS(t)).HandleAnchorCredential(actor, nil, hl,
 			[]byte(cred))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "parse created: parsing time")
@@ -122,7 +124,7 @@ func TestAnchorCredentialHandler(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NoError(t, createNewAnchorCredentialHandler(t, createInMemoryCAS(t)).HandleAnchorCredential(
-			nil, hl, []byte(cred),
+			actor, nil, hl, []byte(cred),
 		))
 	})
 
@@ -131,7 +133,7 @@ func TestAnchorCredentialHandler(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NoError(t, createNewAnchorCredentialHandler(t, createInMemoryCAS(t)).HandleAnchorCredential(
-			nil, hl, []byte("null"),
+			actor, nil, hl, []byte("null"),
 		))
 	})
 
@@ -154,7 +156,7 @@ func TestAnchorCredentialHandler(t *testing.T) {
 		hl, err := hashlink.New().CreateHashLink([]byte(sampleAnchorCredential), nil)
 		require.NoError(t, err)
 
-		err = anchorCredentialHandler.HandleAnchorCredential(nil, hl, nil)
+		err = anchorCredentialHandler.HandleAnchorCredential(actor, nil, hl, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(),
 			"failed to resolve anchor credential: failed to get data stored at uEiCHEWFkVxHMYKiLFChC_rndCmoY1sMGIvMfpaYOJalZjA from the local CAS: content not found") //nolint:lll

--- a/pkg/anchor/info/info.go
+++ b/pkg/anchor/info/info.go
@@ -8,5 +8,6 @@ package info
 
 // AnchorInfo represents a hashlink that can be used to fetch the anchor.
 type AnchorInfo struct {
-	Hashlink string
+	Hashlink     string `json:"hashLink"`
+	AttributedTo string `json:"attributedTo,omitempty"`
 }

--- a/pkg/anchor/writer/writer.go
+++ b/pkg/anchor/writer/writer.go
@@ -512,7 +512,7 @@ func (c *Writer) postCreateActivity(vc *verifiable.Credential, hl string) error 
 	create := vocab.NewCreateActivity(
 		vocab.NewObjectProperty(vocab.WithObject(obj)),
 		vocab.WithTarget(targetProperty),
-		vocab.WithContext(vocab.ContextOrb),
+		vocab.WithContext(vocab.ContextActivityAnchors),
 		vocab.WithTo(systemFollowers, vocab.PublicIRI),
 	)
 

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -118,7 +118,7 @@ func TestStartObserver(t *testing.T) {
 
 		cid, err := anchorGraph.Add(c)
 		require.NoError(t, err)
-		anchor1 := &anchorinfo.AnchorInfo{Hashlink: cid}
+		anchor1 := &anchorinfo.AnchorInfo{Hashlink: cid, AttributedTo: "https://example.com/services/orb"}
 
 		prevAnchors = make(map[string]string)
 		prevAnchors["did2"] = ""
@@ -137,6 +137,7 @@ func TestStartObserver(t *testing.T) {
 			DidAnchors:             memdidanchor.New(),
 			PubSub:                 mempubsub.New(mempubsub.DefaultConfig()),
 			Metrics:                &orbmocks.MetricsProvider{},
+			Outbox:                 func() Outbox { return apmocks.NewOutbox() },
 		}
 
 		o, err := New(providers, WithDiscoveryDomain("webcas:shared.domain.com"))

--- a/pkg/observer/pubsub.go
+++ b/pkg/observer/pubsub.go
@@ -174,7 +174,7 @@ func (h *PubSub) handleAnchorCredentialMessage(msg *message.Message) {
 		return
 	}
 
-	h.ackNackMessage(msg, newAnchorInfo(anchorInfo.Hashlink), h.processAnchors(anchorInfo))
+	h.ackNackMessage(msg, newAnchorInfo(anchorInfo), h.processAnchors(anchorInfo))
 }
 
 func (h *PubSub) handleDIDMessage(msg *message.Message) {
@@ -217,15 +217,24 @@ func (h *PubSub) ackNackMessage(msg *message.Message, info fmt.Stringer, err err
 }
 
 type anchorInfo struct {
-	cid string
+	hashLink     string
+	attributedTo string
 }
 
-func newAnchorInfo(cid string) *anchorInfo {
-	return &anchorInfo{cid: cid}
+func newAnchorInfo(info *anchorinfo.AnchorInfo) *anchorInfo {
+	return &anchorInfo{
+		hashLink:     info.Hashlink,
+		attributedTo: info.AttributedTo,
+	}
 }
 
 func (info *anchorInfo) String() string {
-	return fmt.Sprintf("anchor [%s]", info.cid)
+	str := fmt.Sprintf("anchor - HL [%s]", info.hashLink)
+	if info.attributedTo == "" {
+		return str
+	}
+
+	return fmt.Sprintf("%s, attributedTo [%s]", str, info.attributedTo)
 }
 
 type didInfo struct {

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -160,6 +160,16 @@ Feature:
      Then we wait 5 seconds
      Then client sends request to "https://orb.domain1.com/sidetree/v1/identifiers,https://orb2.domain1.com/sidetree/v1/identifiers,https://orb.domain2.com/sidetree/v1/identifiers" to verify the DID documents that were created
 
+     When an HTTP GET is sent to "https://orb.domain1.com/services/orb/liked?page=true"
+     Then the JSON path "type" of the response equals "OrderedCollectionPage"
+     And the JSON path "orderedItems" of the array response is not empty
+     And the JSON path "orderedItems.0.object.url" of the response is saved to variable "anchorHash"
+
+     When an HTTP GET is sent to "https://orb.domain2.com/services/orb/likes?id=${anchorHash}&page=true"
+     Then the JSON path "type" of the response equals "OrderedCollectionPage"
+     And the JSON path "orderedItems" of the array response is not empty
+     And the JSON path "orderedItems.0.object.url" of the response equals "${anchorHash}"
+
     @enable_create_document_store
     Scenario: domain4 has create document store enabled
 


### PR DESCRIPTION
Implements the 'Like' activity according to the latest Activity Anchors spec. In the case of an 'Announce', the Like is currently not propagated back to the creator of the anchor credential. This will be handled in a separate PR.

closes #706

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>