### PR TITLE
feat: Also post a 'Like' to the creator of the VC on an 'Announce'

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -603,6 +603,8 @@ func startOrbServices(parameters *orbParameters) error {
 
 	var activityPubService *apservice.Service
 
+	resourceResolver := resource.New(httpClient, ipfsReader)
+
 	// create new observer and start it
 	providers := &observer.Providers{
 		ProtocolClientProvider: pcp,
@@ -611,14 +613,15 @@ func startOrbServices(parameters *orbParameters) error {
 		PubSub:                 pubSub,
 		Metrics:                metrics.Get(),
 		Outbox:                 func() observer.Outbox { return activityPubService.Outbox() },
+		WebFingerResolver:      resourceResolver,
+		CASResolver:            casResolver,
+		DocLoader:              orbDocumentLoader,
 	}
 
 	o, err := observer.New(providers, observer.WithDiscoveryDomain(parameters.discoveryDomain))
 	if err != nil {
 		return fmt.Errorf("failed to create observer: %s", err.Error())
 	}
-
-	resourceResolver := resource.New(httpClient, ipfsReader)
 
 	activityPubService, err = apservice.New(apConfig,
 		apStore, t, apSigVerifier, pubSub, apClient, resourceResolver, metrics.Get(),

--- a/pkg/cas/ipfs/ipfs.go
+++ b/pkg/cas/ipfs/ipfs.go
@@ -8,6 +8,7 @@ package ipfs
 
 import (
 	"bytes"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -25,7 +26,9 @@ import (
 	"github.com/trustbloc/orb/pkg/multihash"
 )
 
-var logger = log.New("cas-ipfs")
+const logModule = "cas-ipfs"
+
+var logger = log.New(logModule)
 
 const (
 	defaultCacheSize = 1000
@@ -76,7 +79,7 @@ func newClient(ipfs ipfsClient, cacheSize int, metrics metricsProvider,
 			return nil, err
 		}
 
-		logger.Debugf("Cached content for key [%s]: [%s]", key, content)
+		logger.Debugf("Content was cached for key [%s]", key)
 
 		return content, nil
 	}).Build()
@@ -185,7 +188,10 @@ func (m *Client) get(cid string) ([]byte, error) {
 		return nil, fmt.Errorf("read all from IPFS mockReader: %w", err)
 	}
 
-	logger.Debugf("Got content from IPFS for CID [%s]: %s", cid, content)
+	if log.IsEnabledFor(logModule, log.DEBUG) {
+		logger.Debugf("Got content from IPFS for CID (base64-encoded) [%s]: %s", cid,
+			base64.RawStdEncoding.EncodeToString(content))
+	}
 
 	if string(content) == "null" {
 		logger.Debugf("Got 'null' from IPFS for CID [%s]", cid)

--- a/pkg/cas/ipfs/ipfs_test.go
+++ b/pkg/cas/ipfs/ipfs_test.go
@@ -20,6 +20,7 @@ import (
 	dctest "github.com/ory/dockertest/v3"
 	dc "github.com/ory/dockertest/v3/docker"
 	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/edge-core/pkg/log"
 
 	"github.com/trustbloc/orb/pkg/cas/extendedcasclient"
 	"github.com/trustbloc/orb/pkg/cas/ipfs/mocks"
@@ -35,6 +36,8 @@ func TestNew(t *testing.T) {
 }
 
 func TestWrite(t *testing.T) {
+	log.SetLevel(logModule, log.DEBUG)
+
 	t.Run("success", func(t *testing.T) {
 		pool, ipfsResource := startIPFSDockerContainer(t)
 

--- a/pkg/cas/resolver/resolver.go
+++ b/pkg/cas/resolver/resolver.go
@@ -8,6 +8,7 @@ package resolver
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -33,7 +34,9 @@ const (
 	cidWithPossibleHintNumPartsWithDomainPort = 4
 )
 
-var logger = log.New("cas-resolver")
+const logModule = "cas-resolver"
+
+var logger = log.New(logModule)
 
 type httpClient interface {
 	Get(ctx context.Context, req *transport.Request) (*http.Response, error)
@@ -290,9 +293,11 @@ func (h *Resolver) storeLocallyAndVerifyHash(data []byte, resourceHash string) (
 			"(and calculate CID in the process of doing so): %w", err)
 	}
 
-	logger.Debugf("Successfully stored data into CAS. Request resource hash[%s], "+
-		"resource hash as determined by local store [%s], Data: %s", resourceHash, newHLFromLocalCAS,
-		string(data))
+	if log.IsEnabledFor(logModule, log.DEBUG) {
+		logger.Debugf("Successfully stored data into CAS. Request resource hash[%s], "+
+			"resource hash as determined by local store [%s], Data (base64-encoded): %s",
+			resourceHash, newHLFromLocalCAS, base64.RawStdEncoding.EncodeToString(data))
+	}
 
 	newResourceHash, err := hashlink.GetResourceHashFromHashLink(newHLFromLocalCAS)
 	if err != nil {

--- a/pkg/cas/resolver/resolver_test.go
+++ b/pkg/cas/resolver/resolver_test.go
@@ -21,6 +21,7 @@ import (
 	ariesmockstorage "github.com/hyperledger/aries-framework-go/component/storageutil/mock"
 	ariesstorage "github.com/hyperledger/aries-framework-go/spi/storage"
 	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/edge-core/pkg/log"
 
 	"github.com/trustbloc/orb/pkg/activitypub/client/transport"
 	"github.com/trustbloc/orb/pkg/activitypub/resthandler"
@@ -101,6 +102,8 @@ func TestNew(t *testing.T) {
 }
 
 func TestResolver_Resolve(t *testing.T) {
+	log.SetLevel(logModule, log.DEBUG)
+
 	t.Run("Success", func(t *testing.T) {
 		t.Run("No need to get data from remote since it was passed in", func(t *testing.T) {
 			resolver := createNewResolver(t, createInMemoryCAS(t), nil)

--- a/pkg/store/cas/cas.go
+++ b/pkg/store/cas/cas.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package cas
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"time"
@@ -21,7 +22,9 @@ import (
 	"github.com/trustbloc/orb/pkg/hashlink"
 )
 
-var logger = log.New("cas-store")
+const logModule = "cas-store"
+
+var logger = log.New(logModule)
 
 const (
 	defaultCacheSize = 1000
@@ -75,7 +78,7 @@ func New(provider ariesstorage.Provider, casLink string, ipfsClient *ipfs.Client
 				return nil, err
 			}
 
-			logger.Debugf("Cached content for CID [%s]", cid)
+			logger.Debugf("Content was cached for key [%s]", key)
 
 			return cid, nil
 		},
@@ -106,7 +109,10 @@ func (p *CAS) WriteWithCIDFormat(content []byte, opts ...extendedcasclient.CIDFo
 		return "", fmt.Errorf("failed to create resource hash from content: %w", err)
 	}
 
-	logger.Debugf("Writing to CAS store [%s]: %s", resourceHash, content)
+	if log.IsEnabledFor(logModule, log.DEBUG) {
+		logger.Debugf("Writing to CAS store [%s]. Content (base64-encoded): %s",
+			resourceHash, base64.RawStdEncoding.EncodeToString(content))
+	}
 
 	err = p.cas.Put(resourceHash, content)
 	if err != nil {

--- a/pkg/store/cas/cas_test.go
+++ b/pkg/store/cas/cas_test.go
@@ -18,6 +18,7 @@ import (
 	dctest "github.com/ory/dockertest/v3"
 	dc "github.com/ory/dockertest/v3/docker"
 	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/edge-core/pkg/log"
 
 	"github.com/trustbloc/orb/pkg/cas/extendedcasclient"
 	"github.com/trustbloc/orb/pkg/cas/ipfs"
@@ -47,6 +48,8 @@ func TestNew(t *testing.T) {
 }
 
 func TestProvider_Write_Read(t *testing.T) {
+	log.SetLevel("cas-store", log.DEBUG)
+
 	pool, ipfsResource := startIPFSDockerContainer(t)
 
 	defer func() {

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -207,8 +207,21 @@ Feature:
 
      When an HTTP GET is sent to "https://orb.domain2.com/services/orb/likes?id=${anchorHash}&page=true"
      Then the JSON path "type" of the response equals "OrderedCollectionPage"
-     And the JSON path "orderedItems" of the array response is not empty
+     # There should be two Like's:
+     # 1 - From domain1 (which received the 'Create');
+     # 2 - From domain3 (which received the 'Announce')
+     And the JSON path "orderedItems.#" of the response has 2 items
+     And the JSON path "orderedItems.#.actor" of the response contains "${domain1IRI}"
+     And the JSON path "orderedItems.#.actor" of the response contains "${domain3IRI}"
      And the JSON path "orderedItems.0.object.url" of the response equals "${anchorHash}"
+
+      When an HTTP GET is sent to "https://orb.domain1.com/services/orb/likes?id=${anchorHash}&page=true"
+      Then the JSON path "type" of the response equals "OrderedCollectionPage"
+     # There should be one Like:
+     # 1 - From domain3 (which received the 'Announce')
+      And the JSON path "orderedItems.#" of the response has 1 items
+      And the JSON path "orderedItems.#.actor" of the response contains "${domain3IRI}"
+      And the JSON path "orderedItems.0.object.url" of the response equals "${anchorHash}"
 
      Given variable "undoLikeActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${likeActor}","to":#{likeTo},"object":#{likeActivity}}'
      When an HTTP POST is sent to "${likeActor}/outbox" with content "${undoLikeActivity}" of type "application/json"
@@ -219,7 +232,8 @@ Feature:
      Then the JSON path "orderedItems.0.object.url" of the response does not contain "${anchorHash}"
 
      When an HTTP GET is sent to "https://orb.domain2.com/services/orb/likes?id=${anchorHash}&page=true"
-     Then the JSON path "orderedItems.#" of the response has 0 items
+     Then the JSON path "orderedItems.#" of the response has 1 items
+     And the JSON path "orderedItems.#.actor" of the response contains "${domain3IRI}"
 
     @enable_create_document_store_interim
     Scenario: domain4 has create document store enabled (interim DID)


### PR DESCRIPTION
When handling an 'Announce' activity, a 'Like' is posted to both the actor of the 'Announce' and the creator of the anchor credential.

Also changed the logging of CAS binary content to first base64-encode the content before logging it (since logging binary data sometimes screws up the terminal).

closes #737

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>