### PR TITLE
chore: Remove references to old anchor credential subject model in tests

### DIFF
--- a/pkg/activitypub/service/activityhandler/activityhandler_test.go
+++ b/pkg/activitypub/service/activityhandler/activityhandler_test.go
@@ -3224,16 +3224,7 @@ const anchorCredential1 = `{
   ],
   "issuer": "https://sally.example.com/services/orb",
   "issuanceDate": "2021-01-27T09:30:10Z",
-  "credentialSubject": {
-	"operationCount": 2,
-	"coreIndex": "bafkreihwsn",
-	"namespace": "did:orb",
-	"version": "1",
-	"previousAnchors": {
-	  "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
-	  "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w"
-	}
-  },
+  "credentialSubject": {},
   "proofChain": [{}]
 }`
 

--- a/pkg/activitypub/service/service_test.go
+++ b/pkg/activitypub/service/service_test.go
@@ -1098,16 +1098,7 @@ const anchorCredential1 = `{
  ],
  "issuer": "https://sally.example.com/services/orb",
  "issuanceDate": "2021-01-27T09:30:10Z",
- "credentialSubject": {
-	"operationCount": 2,
-	"coreIndex": "bafkreihwsn",
-	"namespace": "did:orb",
-	"version": "1",
-	"previousAnchors": {
-	  "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
-	  "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w"
-	}
- },
+ "credentialSubject": {},
  "proofChain": [{}]
 }`
 

--- a/pkg/activitypub/vocab/activitytype_test.go
+++ b/pkg/activitypub/vocab/activitytype_test.go
@@ -1086,16 +1086,7 @@ const (
         "https://www.w3.org/2018/credentials/v1",
         "https://w3id.org/activityanchors/v1"
       ],
-      "credentialSubject": {
-	"operationCount": 2,
-	"coreIndex": "bafkreihwsn",
-        "namespace": "did:orb",
-        "previousAnchors": {
-          "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
-          "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w"
-        },
-        "version": "1"
-      },
+      "credentialSubject": {},
       "id": "http://sally.example.com/transactions/bafkreihwsn",
       "issuanceDate": "2021-01-27T09:30:10Z",
       "issuer": "https://sally.example.com/services/orb",
@@ -1215,16 +1206,7 @@ const (
           ],
           "issuer": "https://sally.example.com/services/orb",
           "issuanceDate": "2021-01-27T09:30:10Z",
-          "credentialSubject": {
-            "operationCount": 2,
-            "coreIndex": "bafkreihwsn",
-            "namespace": "did:orb",
-            "previousAnchors": {
-              "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
-              "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w"
-            },
-            "version": "1"
-          },
+          "credentialSubject": {},
           "proof": {}
         }
       }
@@ -1283,16 +1265,7 @@ const (
   ],
   "issuer": "https://sally.example.com/services/orb",
   "issuanceDate": "2021-01-27T09:30:10Z",
-  "credentialSubject": {
-	"operationCount": 2,
-	"coreIndex": "bafkreihwsn",
-	"namespace": "did:orb",
-	"version": "1",
-	"previousAnchors": {
-	  "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
-	  "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w"
-	}
-  },
+  "credentialSubject": {},
   "proofChain": [{}]
 }`
 
@@ -1333,16 +1306,7 @@ const (
       "https://www.w3.org/2018/credentials/v1",
       "https://w3id.org/activityanchors/v1"
     ],
-    "credentialSubject": {
-      "operationCount": 2,
-      "coreIndex": "bafkreihwsn",
-      "namespace": "did:orb",
-      "previousAnchors": {
-        "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
-        "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w"
-      },
-      "version": "1"
-    },
+    "credentialSubject": {},
     "id": "http://sally.example.com/transactions/bafkreihwsn",
     "issuanceDate": "2021-01-27T09:30:10Z",
     "issuer": "https://sally.example.com/services/orb",
@@ -1459,16 +1423,7 @@ const (
     ],
     "issuer": "https://sally.example.com/services/orb",
     "issuanceDate": "2021-01-27T09:30:10Z",
-    "credentialSubject": {
-      "operationCount": 2,
-      "coreIndex": "bafkreihwsn",
-      "namespace": "did:orb",
-      "previousAnchors": {
-        "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
-        "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w"
-      },
-      "version": "1"
-    },
+    "credentialSubject": {},
     "proof": {}
   }
 }`

--- a/pkg/activitypub/vocab/anchorcredreftype_test.go
+++ b/pkg/activitypub/vocab/anchorcredreftype_test.go
@@ -217,16 +217,7 @@ const (
   ],
   "issuer": "https://sally.example.com/services/orb",
   "issuanceDate": "2021-01-27T09:30:10Z",
-  "credentialSubject": {
-	"operationCount": 2,
-	"coreIndex": "bafkreihwsn",
-	"namespace": "did:orb",
-	"version": "1",
-	"previousAnchors": {
-	  "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
-	  "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w"
-	}
-  },
+  "credentialSubject": {},
   "proof": {}
 }`
 	anchorReference = `{
@@ -253,16 +244,7 @@ const (
       "https://www.w3.org/2018/credentials/v1",
       "https://w3id.org/activityanchors/v1"
     ],
-    "credentialSubject": {
-      "operationCount": 2,
-      "coreIndex": "bafkreihwsn",
-      "namespace": "did:orb",
-      "previousAnchors": {
-        "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
-        "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w"
-      },
-      "version": "1"
-    },
+    "credentialSubject": {},
     "id": "http://sally.example.com/transactions/bafkreihwsn",
     "issuanceDate": "2021-01-27T09:30:10Z",
     "issuer": "https://sally.example.com/services/orb",

--- a/pkg/activitypub/vocab/objecttype_test.go
+++ b/pkg/activitypub/vocab/objecttype_test.go
@@ -114,19 +114,10 @@ func TestObjectType_WithDocument(t *testing.T) {
 	t.Run("MarshalJSON", func(t *testing.T) {
 		obj, err := NewObjectWithDocument(
 			Document{
-				"credentialSubject": Document{
-					"operationCount": 2,
-					"coreIndex":      "bafkreihwsn",
-					"namespace":      "did:orb",
-					"previousAnchors": Document{
-						"EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
-						"EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w",
-					},
-					"version": "1",
-				},
-				"issuanceDate": "2021-01-27T09:30:10Z",
-				"issuer":       "https://sally.example.com/services/orb",
-				"proofChain":   []interface{}{},
+				"credentialSubject": Document{},
+				"issuanceDate":      "2021-01-27T09:30:10Z",
+				"issuer":            "https://sally.example.com/services/orb",
+				"proofChain":        []interface{}{},
 			},
 			WithID(id),
 			WithContext(ContextCredentials, ContextActivityAnchors),
@@ -213,16 +204,7 @@ const (
     "https://to1",
     "https://to2"
   ],
-  "credentialSubject": {
-    "operationCount": 2,
-    "coreIndex": "bafkreihwsn",
-    "namespace": "did:orb",
-    "previousAnchors": {
-      "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
-      "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w"
-    },
-    "version": "1"
-  },
+  "credentialSubject": {},
   "id": "http://sally.example.com/transactions/bafkreihwsn",
   "issuanceDate": "2021-01-27T09:30:10Z",
   "issuer": "https://sally.example.com/services/orb",

--- a/pkg/anchor/handler/credential/handler_test.go
+++ b/pkg/anchor/handler/credential/handler_test.go
@@ -48,17 +48,7 @@ const sampleAnchorCredential = `{
   ],
   "issuer": "https://sally.example.com/services/orb",
   "issuanceDate": "2021-01-27T09:30:10Z",
-  "credentialSubject": {
-    "operationCount": 1,
-    "coreIndex": "bafkreihwsnuregceqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
-    "namespace": "did:orb",
-    "version": "1",
-    "previousAnchors": {
-      "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrmenuxhgaomod4m26ds5ztdujxzhjobgvpsyl2v2ndcskq2iay",
-      "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3whnisud76knkv7z7ucbf3k2rs6knhvajernrdabdbfaomakli"
-    },
-    "type": "Anchor"
-  },
+  "credentialSubject": {},
   "proof": [{
     "type": "JsonWebSignature2020",
     "proofPurpose": "assertionMethod",
@@ -159,7 +149,7 @@ func TestAnchorCredentialHandler(t *testing.T) {
 		err = anchorCredentialHandler.HandleAnchorCredential(actor, nil, hl, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(),
-			"failed to resolve anchor credential: failed to get data stored at uEiCHEWFkVxHMYKiLFChC_rndCmoY1sMGIvMfpaYOJalZjA from the local CAS: content not found") //nolint:lll
+			"failed to resolve anchor credential: failed to get data stored at uEiCc295Rv9kvQ6eFUSJYBuiESfGPJF0NLkWaEPPmkO6myQ from the local CAS: content not found") //nolint:lll
 	})
 }
 

--- a/pkg/anchor/handler/proof/handler_test.go
+++ b/pkg/anchor/handler/proof/handler_test.go
@@ -694,15 +694,7 @@ const anchorCred = `
   "@context": [
     "https://www.w3.org/2018/credentials/v1"
   ],
-  "credentialSubject": {
-    "coreIndex": "QmZzPwGc3JEMQDiJu21YZcdpEPam7qCoXPLEUQXn34sMhB",
-    "namespace": "did:sidetree",
-    "operationCount": 1,
-    "previousAnchors": {
-      "EiBjG9z921eyj8wI4j-LAqsJBRC_GalIUWPJeXGekxFQ-w": ""
-    },
-    "version": 0
-  },
+  "credentialSubject": {},
   "id": "http://peer1.com/vc/62c153d1-a6be-400e-a6a6-5b700b596d9d",
   "issuanceDate": "2021-03-17T20:01:10.4002903Z",
   "issuer": "http://peer1.com",
@@ -725,15 +717,7 @@ const anchorCredTwoProofs = `
     "https://w3id.org/activityanchors/v1",
     "https://w3id.org/security/jws/v1"
   ],
-  "credentialSubject": {
-    "coreIndex": "QmTTXin1m7Afk3mQJPMZQdCQAafid7eUNsUDYVcLdSRU2s",
-    "namespace": "did:orb",
-    "operationCount": 1,
-    "previousAnchors": {
-      "EiAhqN-B6kLoWMqKkqwxeLB5ppo0gOYWhZYA-BmptZ0Tqw": ""
-    },
-    "version": 0
-  },
+  "credentialSubject": {},
   "id": "http://orb.domain1.com/vc/9ac66b40-bcc6-4ca8-a9c7-d1fd3eaebafd",
   "issuanceDate": "2021-04-20T20:07:19.873389246Z",
   "issuer": "http://orb.domain1.com",

--- a/pkg/anchor/vcpubsub/vcpubsub_test.go
+++ b/pkg/anchor/vcpubsub/vcpubsub_test.go
@@ -230,15 +230,7 @@ var anchorCred = `
   "@context": [
     "https://www.w3.org/2018/credentials/v1"
   ],
-  "credentialSubject": {
-    "coreIndex": "QmZzPwGc3JEMQDiJu21YZcdpEPam7qCoXPLEUQXn34sMhB",
-    "namespace": "did:sidetree",
-    "operationCount": 1,
-    "previousAnchors": {
-      "EiBjG9z921eyj8wI4j-LAqsJBRC_GalIUWPJeXGekxFQ-w": ""
-    },
-    "version": 0
-  },
+  "credentialSubject": {},
   "id": "http://peer1.com/vc/62c153d1-a6be-400e-a6a6-5b700b596d9d",
   "issuanceDate": "2021-03-17T20:01:10.4002903Z",
   "issuer": "http://peer1.com",

--- a/pkg/anchor/writer/writer_test.go
+++ b/pkg/anchor/writer/writer_test.go
@@ -1706,15 +1706,7 @@ var anchorCred = `
   "@context": [
     "https://www.w3.org/2018/credentials/v1"
   ],
-  "credentialSubject": {
-    "coreIndex": "QmZzPwGc3JEMQDiJu21YZcdpEPam7qCoXPLEUQXn34sMhB",
-    "namespace": "did:sidetree",
-    "operationCount": 1,
-    "previousAnchors": {
-      "EiBjG9z921eyj8wI4j-LAqsJBRC_GalIUWPJeXGekxFQ-w": ""
-    },
-    "version": 0
-  },
+  "credentialSubject": {},
   "id": "http://peer1.com/vc/62c153d1-a6be-400e-a6a6-5b700b596d9d",
   "issuanceDate": "2021-03-17T20:01:10.4002903Z",
   "issuer": "http://peer1.com",

--- a/pkg/cas/resolver/resolver_test.go
+++ b/pkg/cas/resolver/resolver_test.go
@@ -56,17 +56,7 @@ const (
   ],
   "issuer": "https://sally.example.com/services/orb",
   "issuanceDate": "2021-01-27T09:30:10Z",
-  "credentialSubject": {
-    "operationCount": 1,
-    "coreIndex": "bafkreihwsnuregceqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
-    "namespace": "did:orb",
-    "version": "1",
-    "previousAnchors": {
-      "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrmenuxhgaomod4m26ds5ztdujxzhjobgvpsyl2v2ndcskq2iay",
-      "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3whnisud76knkv7z7ucbf3k2rs6knhvajernrdabdbfaomakli"
-    },
-    "type": "Anchor"
-  },
+  "credentialSubject": {},
   "proof": [{
     "type": "JsonWebSignature2020",
     "proofPurpose": "assertionMethod",
@@ -461,7 +451,7 @@ func TestResolver_Resolve(t *testing.T) {
 		data, localHL, err := resolver.Resolve(nil, cid, []byte(sampleData))
 		require.EqualError(t, err, "failed to store the data in the local CAS: "+
 			"successfully stored data into the local CAS, but the resource hash produced by the local CAS "+
-			"(uEiA1t3VICW2jRlU-m3o7-3f1lI5hbLTrPkefScZMEFwbEQ) does not match the resource hash from the original request "+
+			"(uEiA2pvVebd3E9E8lc9DvOYAjklWMDwHYDJXGZJ-QJTlGzw) does not match the resource hash from the original request "+
 			"(bafkrwihwsnuregfeqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy)")
 		require.Nil(t, data)
 		require.Empty(t, localHL)
@@ -494,7 +484,7 @@ func TestResolver_Resolve(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failure while getting and storing data from the remote WebCAS endpoints")
 		require.Contains(t, err.Error(), "Response status code: 404. Response body: "+
-			"no content at uEiA1t3VICW2jRlU-m3o7-3f1lI5hbLTrPkefScZMEFwbEQ was found: content not found")
+			"no content at uEiA2pvVebd3E9E8lc9DvOYAjklWMDwHYDJXGZJ-QJTlGzw was found: content not found")
 		require.Nil(t, data)
 		require.Empty(t, localHL)
 	})
@@ -589,9 +579,9 @@ func TestResolver_Resolve(t *testing.T) {
 				"failed to determine WebCAS URL via WebFinger: "+
 				"failed to get WebFinger resource: failed to get response "+
 				"(URL: http://NonExistentDomain/.well-known/webfinger?resource=http://Non"+
-				`ExistentDomain/cas/uEiA1t3VICW2jRlU-m3o7-3f1lI5hbLTrPkefScZMEFwbEQ): Get "http://`+
+				`ExistentDomain/cas/uEiA2pvVebd3E9E8lc9DvOYAjklWMDwHYDJXGZJ-QJTlGzw): Get "http://`+
 				"NonExistentDomain/.well-known/webfinger?resource=http://NonExistentDomain/cas/"+
-				`uEiA1t3VICW2jRlU-m3o7-3f1lI5hbLTrPkefScZMEFwbEQ": dial tcp: lookup NonExistentDomain`)
+				`uEiA2pvVebd3E9E8lc9DvOYAjklWMDwHYDJXGZJ-QJTlGzw": dial tcp: lookup NonExistentDomain`)
 			require.Nil(t, data)
 			require.Empty(t, localHL)
 		})

--- a/pkg/store/verifiable/store_test.go
+++ b/pkg/store/verifiable/store_test.go
@@ -79,15 +79,7 @@ var anchorCred = `
   "@context": [
     "https://www.w3.org/2018/credentials/v1"
   ],
-  "credentialSubject": {
-    "coreIndex": "QmZzPwGc3JEMQDiJu21YZcdpEPam7qCoXPLEUQXn34sMhB",
-    "namespace": "did:sidetree",
-    "operationCount": 1,
-    "previousAnchors": {
-      "EiBjG9z921eyj8wI4j-LAqsJBRC_GalIUWPJeXGekxFQ-w": ""
-    },
-    "version": 0
-  },
+  "credentialSubject": {},
   "id": "http://peer1.com/vc/62c153d1-a6be-400e-a6a6-5b700b596d9d",
   "issuanceDate": "2021-03-17T20:01:10.4002903Z",
   "issuer": "http://peer1.com",

--- a/pkg/webcas/webcas_test.go
+++ b/pkg/webcas/webcas_test.go
@@ -43,17 +43,7 @@ const sampleAnchorCredential = `{
   ],
   "issuer": "https://sally.example.com/services/orb",
   "issuanceDate": "2021-01-27T09:30:10Z",
-  "credentialSubject": {
-    "operationCount": 1,
-    "coreIndex": "bafkreihwsnuregceqh263vgdathcprnbvatyat6h6mu7ipjhhodcdbyhoy",
-    "namespace": "did:orb",
-    "version": "1",
-    "previousAnchors": {
-      "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrmenuxhgaomod4m26ds5ztdujxzhjobgvpsyl2v2ndcskq2iay",
-      "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3whnisud76knkv7z7ucbf3k2rs6knhvajernrdabdbfaomakli"
-    },
-    "type": "Anchor"
-  },
+  "credentialSubject": {},
   "proof": [{
     "type": "JsonWebSignature2020",
     "proofPurpose": "assertionMethod",

--- a/test/bdd/fixtures/testdata/offer_activity.json
+++ b/test/bdd/fixtures/testdata/offer_activity.json
@@ -9,16 +9,7 @@
       "https://www.w3.org/2018/credentials/v1",
       "https://w3id.org/activityanchors/v1"
     ],
-    "credentialSubject": {
-      "operationCount": 2,
-      "coreIndex": "bafkreihwsn",
-      "namespace": "did:orb",
-      "previousAnchors": {
-        "EiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA": "bafkreibmrm",
-        "EiABk7KK58BVLHMataxgYZjTNbsHgtD8BtjF0tOWFV29rw": "bafkreibh3w"
-      },
-      "version": "1"
-    },
+    "credentialSubject": {},
     "id": "http://orb.domain2.com/transactions/bafkreihwsn",
     "issuanceDate": "2021-03-31T09:30:10Z",
     "issuer": "https://orb.domain2.com/services/orb",


### PR DESCRIPTION
Remove references to old anchor crednetial subject model in unit-tests and BDD tests.

Closes #609

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>