### PR TITLE
chore: Add published/unpublished operations to metadata

### DIFF
--- a/cmd/orb-cli/go.sum
+++ b/cmd/orb-cli/go.sum
@@ -1262,8 +1262,8 @@ github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7j
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
-github.com/trustbloc/sidetree-core-go v0.7.0 h1:qSWq5imzp+cvxpaa4+ft8FtNPg9sxddUhkCtdBB/Yh4=
-github.com/trustbloc/sidetree-core-go v0.7.0/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20210916200150-447dc5dc9dc3 h1:D2h7BgXu2BEGEK7Zsbpv0eWtOWQnLgoqylnOGFBMfX0=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20210916200150-447dc5dc9dc3/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/cmd/orb-driver/go.mod
+++ b/cmd/orb-driver/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7
 	github.com/trustbloc/orb v0.1.3-0.20210914173654-dab098ce4e32
-	github.com/trustbloc/sidetree-core-go v0.7.0
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20210916200150-447dc5dc9dc3
 )
 
 replace github.com/trustbloc/orb => ../..

--- a/cmd/orb-driver/go.sum
+++ b/cmd/orb-driver/go.sum
@@ -1256,8 +1256,8 @@ github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7j
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
-github.com/trustbloc/sidetree-core-go v0.7.0 h1:qSWq5imzp+cvxpaa4+ft8FtNPg9sxddUhkCtdBB/Yh4=
-github.com/trustbloc/sidetree-core-go v0.7.0/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20210916200150-447dc5dc9dc3 h1:D2h7BgXu2BEGEK7Zsbpv0eWtOWQnLgoqylnOGFBMfX0=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20210916200150-447dc5dc9dc3/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/cmd/orb-server/go.mod
+++ b/cmd/orb-server/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7
 	github.com/trustbloc/orb v0.0.0
-	github.com/trustbloc/sidetree-core-go v0.7.0
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20210916200150-447dc5dc9dc3
 	github.com/trustbloc/vct v0.1.3
 	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d // indirect
 )

--- a/cmd/orb-server/go.sum
+++ b/cmd/orb-server/go.sum
@@ -1297,8 +1297,8 @@ github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoi
 github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7jjHQo2gMGNPIRfhvn4aXQ0FYMrG9lRgQcvZKTviCGc=
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
-github.com/trustbloc/sidetree-core-go v0.7.0 h1:qSWq5imzp+cvxpaa4+ft8FtNPg9sxddUhkCtdBB/Yh4=
-github.com/trustbloc/sidetree-core-go v0.7.0/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20210916200150-447dc5dc9dc3 h1:D2h7BgXu2BEGEK7Zsbpv0eWtOWQnLgoqylnOGFBMfX0=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20210916200150-447dc5dc9dc3/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/cmd/orb-server/startcmd/params.go
+++ b/cmd/orb-server/startcmd/params.go
@@ -272,6 +272,16 @@ const (
 		`Used for resolving unpublished updates for documents.` +
 		commonEnvVarUsageText + enableUpdateDocumentStoreEnvKey
 
+	includeUnpublishedOperationsFlagName = "include-unpublished-operations-in-metadata"
+	includeUnpublishedOperationsEnvKey   = "INCLUDE_UNPUBLISHED_OPERATIONS_IN_METADATA"
+	includeUnpublishedOperationsUsage    = `Set to "true" to include unpublished operations in metadata. ` +
+		commonEnvVarUsageText + includeUnpublishedOperationsEnvKey
+
+	includePublishedOperationsFlagName = "include-published-operations-in-metadata"
+	includePublishedOperationsEnvKey   = "INCLUDE_PUBLISHED_OPERATIONS_IN_METADATA"
+	includePublishedOperationsUsage    = `Set to "true" to include published operations in metadata. ` +
+		commonEnvVarUsageText + includePublishedOperationsEnvKey
+
 	authTokensDefFlagName      = "auth-tokens-def"
 	authTokensDefFlagShorthand = "D"
 	authTokensDefFlagUsage     = "Authorization token definitions."
@@ -347,6 +357,8 @@ type orbParameters struct {
 	didDiscoveryEnabled            bool
 	createDocumentStoreEnabled     bool
 	updateDocumentStoreEnabled     bool
+	includeUnpublishedOperations   bool
+	includePublishedOperations     bool
 	updateDocumentStoreTypes       []operation.Type
 	authTokenDefinitions           []*auth.TokenDef
 	authTokens                     map[string]string
@@ -606,6 +618,36 @@ func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 		updateDocumentStoreEnabled = enable
 	}
 
+	includeUnpublishedOperationsStr, err := cmdutils.GetUserSetVarFromString(cmd, includeUnpublishedOperationsFlagName, includeUnpublishedOperationsEnvKey, true)
+	if err != nil {
+		return nil, err
+	}
+
+	includeUnpublishedOperations := defaultIncludeUnpublishedOperations
+	if includeUnpublishedOperationsStr != "" {
+		enable, parseErr := strconv.ParseBool(includeUnpublishedOperationsStr)
+		if parseErr != nil {
+			return nil, fmt.Errorf("invalid value for %s: %s", includeUnpublishedOperationsFlagName, parseErr)
+		}
+
+		includeUnpublishedOperations = enable
+	}
+
+	includePublishedOperationsStr, err := cmdutils.GetUserSetVarFromString(cmd, includePublishedOperationsFlagName, includePublishedOperationsEnvKey, true)
+	if err != nil {
+		return nil, err
+	}
+
+	includePublishedOperations := defaultIncludePublishedOperations
+	if includePublishedOperationsStr != "" {
+		enable, parseErr := strconv.ParseBool(includePublishedOperationsStr)
+		if parseErr != nil {
+			return nil, fmt.Errorf("invalid value for %s: %s", includePublishedOperationsFlagName, parseErr)
+		}
+
+		includePublishedOperations = enable
+	}
+
 	didNamespace, err := cmdutils.GetUserSetVarFromString(cmd, didNamespaceFlagName, didNamespaceEnvKey, false)
 	if err != nil {
 		return nil, err
@@ -710,6 +752,8 @@ func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 		didDiscoveryEnabled:            didDiscoveryEnabled,
 		createDocumentStoreEnabled:     createDocumentStoreEnabled,
 		updateDocumentStoreEnabled:     updateDocumentStoreEnabled,
+		includePublishedOperations:     includePublishedOperations,
+		includeUnpublishedOperations:   includeUnpublishedOperations,
 		authTokenDefinitions:           authTokenDefs,
 		authTokens:                     authTokens,
 		activityPubPageSize:            activityPubPageSize,
@@ -992,6 +1036,8 @@ func createFlags(startCmd *cobra.Command) {
 	startCmd.Flags().String(enableDidDiscoveryFlagName, "", enableDidDiscoveryUsage)
 	startCmd.Flags().String(enableCreateDocumentStoreFlagName, "", enableCreateDocumentStoreUsage)
 	startCmd.Flags().String(enableUpdateDocumentStoreFlagName, "", enableUpdateDocumentStoreUsage)
+	startCmd.Flags().String(includeUnpublishedOperationsFlagName, "", includeUnpublishedOperationsUsage)
+	startCmd.Flags().String(includePublishedOperationsFlagName, "", includePublishedOperationsUsage)
 	startCmd.Flags().StringP(casTypeFlagName, casTypeFlagShorthand, "", casTypeFlagUsage)
 	startCmd.Flags().StringP(ipfsURLFlagName, ipfsURLFlagShorthand, "", ipfsURLFlagUsage)
 	startCmd.Flags().StringP(localCASReplicateInIPFSFlagName, "", "false", localCASReplicateInIPFSFlagUsage)

--- a/cmd/orb-server/startcmd/params_test.go
+++ b/cmd/orb-server/startcmd/params_test.go
@@ -490,6 +490,62 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 		require.Contains(t, err.Error(), "invalid value for enable-update-document-store")
 	})
 
+	t.Run("test invalid include-unpublished-operations-in-metadata", func(t *testing.T) {
+		startCmd := GetStartCmd()
+
+		args := []string{
+			"--" + hostURLFlagName, "localhost:8247",
+			"--" + hostMetricsURLFlagName, "localhost:8248",
+			"--" + vctURLFlagName, "localhost:8081",
+			"--" + externalEndpointFlagName, "orb.example.com",
+			"--" + casTypeFlagName, "ipfs",
+			"--" + ipfsURLFlagName, "localhost:8081",
+			"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
+			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption,
+			"--" + anchorCredentialSignatureSuiteFlagName, "suite",
+			"--" + anchorCredentialDomainFlagName, "domain.com",
+			"--" + anchorCredentialIssuerFlagName, "issuer.com",
+			"--" + anchorCredentialURLFlagName, "peer.com",
+			"--" + LogLevelFlagName, log.ParseString(log.ERROR),
+			"--" + includeUnpublishedOperationsFlagName, "invalid bool",
+		}
+
+		startCmd.SetArgs(args)
+
+		err := startCmd.Execute()
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid value for include-unpublished-operations-in-metadata")
+	})
+
+	t.Run("test invalid include-published-operations-in-metadata", func(t *testing.T) {
+		startCmd := GetStartCmd()
+
+		args := []string{
+			"--" + hostURLFlagName, "localhost:8247",
+			"--" + hostMetricsURLFlagName, "localhost:8248",
+			"--" + vctURLFlagName, "localhost:8081",
+			"--" + externalEndpointFlagName, "orb.example.com",
+			"--" + casTypeFlagName, "ipfs",
+			"--" + ipfsURLFlagName, "localhost:8081",
+			"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
+			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption,
+			"--" + anchorCredentialSignatureSuiteFlagName, "suite",
+			"--" + anchorCredentialDomainFlagName, "domain.com",
+			"--" + anchorCredentialIssuerFlagName, "issuer.com",
+			"--" + anchorCredentialURLFlagName, "peer.com",
+			"--" + LogLevelFlagName, log.ParseString(log.ERROR),
+			"--" + includePublishedOperationsFlagName, "invalid bool",
+		}
+
+		startCmd.SetArgs(args)
+
+		err := startCmd.Execute()
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid value for include-published-operations-in-metadata")
+	})
+
 	t.Run("Invalid ActivityPub page size", func(t *testing.T) {
 		restoreEnv := setEnv(t, activityPubPageSizeEnvKey, "-125")
 		defer restoreEnv()
@@ -1119,6 +1175,8 @@ func getTestArgs(ipfsURL, casType, localCASReplicateInIPFSEnabled, databaseType,
 		"--" + localCASReplicateInIPFSFlagName, localCASReplicateInIPFSEnabled,
 		"--" + enableUpdateDocumentStoreFlagName, "true",
 		"--" + enableCreateDocumentStoreFlagName, "true",
+		"--" + includePublishedOperationsFlagName, "true",
+		"--" + includeUnpublishedOperationsFlagName, "true",
 	}
 
 	if databaseURL != "" {

--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -129,6 +129,8 @@ const (
 	defaultDidDiscoveryEnabled            = false
 	defaultCreateDocumentStoreEnabled     = false
 	defaultUpdateDocumentStoreEnabled     = false
+	defaultIncludeUnpublishedOperations   = false
+	defaultIncludePublishedOperations     = false
 	defaultLocalCASReplicateInIPFSEnabled = false
 	defaultDevModeEnabled                 = false
 	defaultPolicyCacheExpiry              = 30 * time.Second
@@ -318,7 +320,7 @@ func startOrbServices(parameters *orbParameters) error {
 	}
 
 	// TODO: If we decide to offer deactivate and recover we should configure this
-	parameters.updateDocumentStoreTypes =  []operation.Type{operation.TypeUpdate}
+	parameters.updateDocumentStoreTypes = []operation.Type{operation.TypeUpdate}
 
 	casIRI := mustParseURL(parameters.externalEndpoint, casPath)
 
@@ -858,11 +860,13 @@ func getProtocolClientProvider(parameters *orbParameters, casClient casapi.Clien
 	versions := []string{"1.0"}
 
 	sidetreeCfg := config.Sidetree{
-		MethodContext:              parameters.methodContext,
-		EnableBase:                 parameters.baseEnabled,
-		AnchorOrigins:              parameters.allowedOrigins,
-		UpdateDocumentStoreEnabled: parameters.updateDocumentStoreEnabled,
-		UpdateDocumentStoreTypes:   parameters.updateDocumentStoreTypes,
+		MethodContext:                parameters.methodContext,
+		EnableBase:                   parameters.baseEnabled,
+		AnchorOrigins:                parameters.allowedOrigins,
+		UpdateDocumentStoreEnabled:   parameters.updateDocumentStoreEnabled,
+		UpdateDocumentStoreTypes:     parameters.updateDocumentStoreTypes,
+		IncludeUnpublishedOperations: parameters.includeUnpublishedOperations,
+		IncludePublishedOperations:   parameters.includePublishedOperations,
 	}
 
 	registry := factoryregistry.New()

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7
-	github.com/trustbloc/sidetree-core-go v0.7.0
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20210916200150-447dc5dc9dc3
 	github.com/trustbloc/vct v0.1.3
 	golang.org/x/net v0.0.0-20210525063256-abc453219eb5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1292,8 +1292,8 @@ github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoi
 github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7jjHQo2gMGNPIRfhvn4aXQ0FYMrG9lRgQcvZKTviCGc=
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
-github.com/trustbloc/sidetree-core-go v0.7.0 h1:qSWq5imzp+cvxpaa4+ft8FtNPg9sxddUhkCtdBB/Yh4=
-github.com/trustbloc/sidetree-core-go v0.7.0/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20210916200150-447dc5dc9dc3 h1:D2h7BgXu2BEGEK7Zsbpv0eWtOWQnLgoqylnOGFBMfX0=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20210916200150-447dc5dc9dc3/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,4 +16,7 @@ type Sidetree struct {
 
 	UpdateDocumentStoreEnabled bool
 	UpdateDocumentStoreTypes   []operation.Type
+
+	IncludeUnpublishedOperations bool
+	IncludePublishedOperations   bool
 }

--- a/pkg/protocolversion/versions/v1_0/factory/factory.go
+++ b/pkg/protocolversion/versions/v1_0/factory/factory.go
@@ -60,7 +60,9 @@ func (v *Factory) Create(version string, casClient cas.Client, casResolver ctxco
 	dv := didvalidator.New()
 	dt := didtransformer.New(
 		didtransformer.WithMethodContext(sidetreeCfg.MethodContext),
-		didtransformer.WithBase(sidetreeCfg.EnableBase))
+		didtransformer.WithBase(sidetreeCfg.EnableBase),
+		didtransformer.WithIncludePublishedOperations(sidetreeCfg.IncludePublishedOperations),
+		didtransformer.WithIncludeUnpublishedOperations(sidetreeCfg.IncludeUnpublishedOperations))
 
 	var orbTxnProcessorOpts []txnprocessor.Option
 

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -457,6 +457,8 @@ services:
       - HTTP_SIGNATURES_ENABLED=true
       - CREATE_DOCUMENT_STORE_ENABLED=true
       - UPDATE_DOCUMENT_STORE_ENABLED=true
+      - INCLUDE_UNPUBLISHED_OPERATIONS_IN_METADATA=true
+      - INCLUDE_PUBLISHED_OPERATIONS_IN_METADATA=true
 
       # ORB_AUTH_TOKENS_DEF contains the authorization definition for each of the REST endpoints. Format:
       #

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/tidwall/gjson v1.7.4
 	github.com/trustbloc/orb v0.1.3-0.20210826224204-8f7cf7841ff2
-	github.com/trustbloc/sidetree-core-go v0.7.0
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20210916200150-447dc5dc9dc3
 )
 
 replace github.com/trustbloc/orb => ../../

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -1551,8 +1551,8 @@ github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7j
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
-github.com/trustbloc/sidetree-core-go v0.7.0 h1:qSWq5imzp+cvxpaa4+ft8FtNPg9sxddUhkCtdBB/Yh4=
-github.com/trustbloc/sidetree-core-go v0.7.0/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20210916200150-447dc5dc9dc3 h1:D2h7BgXu2BEGEK7Zsbpv0eWtOWQnLgoqylnOGFBMfX0=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20210916200150-447dc5dc9dc3/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=


### PR DESCRIPTION
Update sidetree-core and add start-up options to add published/unpublished operations to metadata.

Closes #775

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>