### PR TITLE
fix: Return the canonical DID in a WebFinger query

### DIFF
--- a/pkg/discovery/endpoint/restapi/anchorinfo.go
+++ b/pkg/discovery/endpoint/restapi/anchorinfo.go
@@ -1,0 +1,80 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package restapi
+
+import (
+	"fmt"
+
+	"github.com/trustbloc/orb/pkg/resolver/resource/registry"
+)
+
+// AnchorInfo contains information about an anchor credential.
+type AnchorInfo struct {
+	AnchorOrigin       string
+	AnchorURI          string
+	CanonicalReference string
+}
+
+// AnchorInfoRetriever retrieves anchor information about a DID.
+type AnchorInfoRetriever struct {
+	resourceRegistry *registry.Registry
+}
+
+// NewAnchorInfoRetriever returns a new AnchorInfoRetriever.
+func NewAnchorInfoRetriever(r *registry.Registry) *AnchorInfoRetriever {
+	return &AnchorInfoRetriever{resourceRegistry: r}
+}
+
+// GetAnchorInfo returns anchor information about the given DID.
+func (r *AnchorInfoRetriever) GetAnchorInfo(did string) (*AnchorInfo, error) {
+	// TODO (#537): Show IPFS alternates if configured.
+	metadata, err := r.resourceRegistry.GetResourceInfo(did)
+	if err != nil {
+		return nil, fmt.Errorf("get info for DID [%s]: %w", did, err)
+	}
+
+	info := &AnchorInfo{}
+
+	info.AnchorOrigin, err = r.getProperty(registry.AnchorOriginProperty, metadata, true)
+	if err != nil {
+		return nil, fmt.Errorf("get anchor origin for DID [%s]: %w", did, err)
+	}
+
+	info.AnchorURI, err = r.getProperty(registry.AnchorURIProperty, metadata, true)
+	if err != nil {
+		return nil, fmt.Errorf("get anchor URI for DID [%s]: %w", did, err)
+	}
+
+	info.CanonicalReference, err = r.getProperty(registry.CanonicalReferenceProperty, metadata, false)
+	if err != nil {
+		return nil, fmt.Errorf("get canonical ID for DID [%s]: %w", did, err)
+	}
+
+	return info, nil
+}
+
+func (r *AnchorInfoRetriever) getProperty(property string, metadata registry.Metadata, required bool) (string, error) {
+	rawValue, ok := metadata[property]
+	if !ok {
+		if !required {
+			return "", nil
+		}
+
+		return "", fmt.Errorf("property required [%s]", property)
+	}
+
+	value, ok := rawValue.(string)
+	if !ok {
+		return "", fmt.Errorf("could not assert property as a string [%s]", property)
+	}
+
+	if value == "" && required {
+		return "", fmt.Errorf("property required [%s]", property)
+	}
+
+	return value, nil
+}

--- a/pkg/discovery/endpoint/restapi/anchorinfo_test.go
+++ b/pkg/discovery/endpoint/restapi/anchorinfo_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package restapi_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/pkg/discovery/endpoint/restapi"
+	"github.com/trustbloc/orb/pkg/resolver/resource/registry"
+)
+
+func TestAnchorInfoRetriever_GetAnchorInfo(t *testing.T) {
+	const (
+		anchorOrigin = "ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q"
+		anchorURI    = "hl:uEiALYp_C4wk2WegpfnCSoSTBdKZ1MVdDadn4rdmZl5GKzQ:uoQ-BeDVpcGZzOi8vUW1jcTZKV0RVa3l4ZWhxN1JWWmtQM052aUU0SHFSdW5SalgzOXZ1THZFSGFRTg" //nolint:lll
+		interimDID   = "interimDID:orb:uAAA:EiAWMpJJMauUlAr58MBpdWrfL9Y274xwElaCsfb0P5kmjQ"
+		canonicalRef = "uEiDaapVGRRwUa8-8e0wJQknOeFDiYjnhysjsoA6vL8U60g"
+	)
+
+	t.Run("Success", func(t *testing.T) {
+		resourceInfoProvider := newMockResourceInfoProvider().
+			withAnchorOrigin(anchorOrigin).
+			withAnchorURI(anchorURI).
+			withCanonicalRef(canonicalRef)
+
+		r := restapi.NewAnchorInfoRetriever(registry.New(registry.WithResourceInfoProvider(resourceInfoProvider)))
+
+		info, err := r.GetAnchorInfo(interimDID)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		require.Equal(t, anchorOrigin, info.AnchorOrigin)
+		require.Equal(t, anchorURI, info.AnchorURI)
+		require.Equal(t, canonicalRef, info.CanonicalReference)
+	})
+
+	t.Run("Resource registry error", func(t *testing.T) {
+		errExpected := errors.New("injected resource registry error")
+
+		resourceInfoProvider := newMockResourceInfoProvider().withError(errExpected)
+
+		r := restapi.NewAnchorInfoRetriever(registry.New(registry.WithResourceInfoProvider(resourceInfoProvider)))
+
+		info, err := r.GetAnchorInfo(interimDID)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+		require.Nil(t, info)
+	})
+
+	t.Run("No anchor origin -> error", func(t *testing.T) {
+		resourceInfoProvider := newMockResourceInfoProvider().
+			withAnchorOrigin(nil).
+			withAnchorURI(anchorURI).
+			withCanonicalRef(canonicalRef)
+
+		r := restapi.NewAnchorInfoRetriever(registry.New(registry.WithResourceInfoProvider(resourceInfoProvider)))
+
+		info, err := r.GetAnchorInfo(interimDID)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "property required [anchorOrigin]")
+		require.Nil(t, info)
+	})
+
+	t.Run("No anchor URI -> error", func(t *testing.T) {
+		resourceInfoProvider := newMockResourceInfoProvider().
+			withAnchorOrigin(anchorOrigin).
+			withAnchorURI("").
+			withCanonicalRef(canonicalRef)
+
+		r := restapi.NewAnchorInfoRetriever(registry.New(registry.WithResourceInfoProvider(resourceInfoProvider)))
+
+		info, err := r.GetAnchorInfo(interimDID)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "property required [anchorURI]")
+		require.Nil(t, info)
+	})
+
+	t.Run("No canonical reference -> success", func(t *testing.T) {
+		resourceInfoProvider := newMockResourceInfoProvider().
+			withAnchorOrigin(anchorOrigin).
+			withAnchorURI(anchorURI).
+			withCanonicalRef(nil)
+
+		r := restapi.NewAnchorInfoRetriever(registry.New(registry.WithResourceInfoProvider(resourceInfoProvider)))
+
+		info, err := r.GetAnchorInfo(interimDID)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		require.Equal(t, anchorOrigin, info.AnchorOrigin)
+		require.Equal(t, anchorURI, info.AnchorURI)
+		require.Equal(t, "", info.CanonicalReference)
+	})
+
+	t.Run("Invalid canonical reference -> error", func(t *testing.T) {
+		resourceInfoProvider := newMockResourceInfoProvider().
+			withAnchorOrigin(anchorOrigin).
+			withAnchorURI(anchorURI).
+			withCanonicalRef(1000)
+
+		r := restapi.NewAnchorInfoRetriever(registry.New(registry.WithResourceInfoProvider(resourceInfoProvider)))
+
+		info, err := r.GetAnchorInfo(interimDID)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "could not assert property as a string [canonicalReference]")
+		require.Nil(t, info)
+	})
+}

--- a/pkg/resolver/resource/registry/didanchorinfo/didanchorinfo.go
+++ b/pkg/resolver/resource/registry/didanchorinfo/didanchorinfo.go
@@ -76,6 +76,7 @@ func (h *DidAnchorInfo) GetResourceInfo(did string) (registry.Metadata, error) {
 	info := make(registry.Metadata)
 	info[registry.AnchorURIProperty] = anchor
 	info[registry.AnchorOriginProperty] = resolutionResult.AnchorOrigin
+	info[registry.CanonicalReferenceProperty] = resolutionResult.CanonicalReference
 
 	logger.Debugf("latest anchor info for suffix[%s]: %+v", suffix, info)
 

--- a/pkg/resolver/resource/registry/registry.go
+++ b/pkg/resolver/resource/registry/registry.go
@@ -77,4 +77,7 @@ const (
 
 	// AnchorURIProperty is anchor URI key.
 	AnchorURIProperty = "anchorURI"
+
+	// CanonicalReferenceProperty is the canonical reference key.
+	CanonicalReferenceProperty = "canonicalReference"
 )


### PR DESCRIPTION
When an interim DID is used as a resource ID for a WebFinger query, the response returns the canonical DID if it has been anchored.

closes #780

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>