### PR TITLE
feat: Handle 'Undo' Like activity

### DIFF
--- a/pkg/activitypub/service/mocks/mockanchoreventackhandler.go
+++ b/pkg/activitypub/service/mocks/mockanchoreventackhandler.go
@@ -41,6 +41,21 @@ func (m *AnchorEventAcknowledgementHandler) AnchorEventAcknowledged(actor, ancho
 	return m.err
 }
 
+// UndoAnchorEventAcknowledgement undoes the acknowledgement of an anchor event processed from an Orb server.
+func (m *AnchorEventAcknowledgementHandler) UndoAnchorEventAcknowledgement(actor, anchorRef *url.URL,
+	additionalAnchorRefs []*url.URL) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	for i, anchor := range m.anchors {
+		if anchor.String() == anchorRef.String() {
+			m.anchors = append(m.anchors[0:i], m.anchors[i+1:]...)
+		}
+	}
+
+	return m.err
+}
+
 // Anchors returns the anchors that were added to this mock.
 func (m *AnchorEventAcknowledgementHandler) Anchors() []*url.URL {
 	m.mutex.Lock()

--- a/pkg/activitypub/service/spi/spi.go
+++ b/pkg/activitypub/service/spi/spi.go
@@ -42,9 +42,11 @@ type AnchorCredentialHandler interface {
 	HandleAnchorCredential(actor, id *url.URL, cid string, anchorCred []byte) error
 }
 
-// AnchorEventAcknowledgementHandler handles notification of a successful anchor event processed from an Orb server.
+// AnchorEventAcknowledgementHandler handles notification of a successful anchor event processed from an Orb server,
+// as well as undoing a previously acknowledged anchor event.
 type AnchorEventAcknowledgementHandler interface {
 	AnchorEventAcknowledged(actor, anchorRef *url.URL, additionalAnchorRefs []*url.URL) error
+	UndoAnchorEventAcknowledgement(actor, anchorRef *url.URL, additionalAnchorRefs []*url.URL) error
 }
 
 // ActorAuth makes the decision of whether or not a request by the given

--- a/pkg/anchor/handler/acknowlegement/acknowledgement.go
+++ b/pkg/anchor/handler/acknowlegement/acknowledgement.go
@@ -19,6 +19,7 @@ var logger = log.New("anchor-acknowledgement-handler")
 
 type anchorLinkStore interface {
 	PutLinks(links []*url.URL) error
+	DeleteLinks(links []*url.URL) error
 }
 
 // Handler handles notifications of successful anchor events processed from an Orb server.
@@ -32,17 +33,48 @@ func New(store anchorLinkStore) *Handler {
 }
 
 // AnchorEventAcknowledged handles a notification of a successful anchor event processed from an Orb server.
-// The given additional references are added to the anchor link store so that they are available for
-// WebFinger requests.
+// The given additional references are added to the anchor link store so that they are included in WebFinger responses.
 func (p *Handler) AnchorEventAcknowledged(actor, anchorRef *url.URL, additionalAnchorRefs []*url.URL) error {
 	logger.Infof("Anchor event was acknowledged by [%s] for anchor %s. Additional anchors: %s",
 		actor, hashlink.ToString(anchorRef), hashlink.ToString(additionalAnchorRefs...))
 
+	links, err := getLinks(anchorRef, additionalAnchorRefs)
+	if err != nil {
+		return fmt.Errorf("get links: %w", err)
+	}
+
+	if err := p.anchorLinkStore.PutLinks(links); err != nil {
+		return fmt.Errorf("put links: %w", err)
+	}
+
+	return nil
+}
+
+// UndoAnchorEventAcknowledgement handles a notification that the previous acknowledgement of an anchor
+// event was undone. The given additional references are removed from the anchor link store so that they
+// are no longer included in WebFinger responses.
+func (p *Handler) UndoAnchorEventAcknowledgement(actor, anchorRef *url.URL, additionalAnchorRefs []*url.URL) error {
+	logger.Infof("Anchor event acknowledgement was undone [%s] for anchor %s. Additional anchors: %s",
+		actor, hashlink.ToString(anchorRef), hashlink.ToString(additionalAnchorRefs...))
+
+	links, err := getLinks(anchorRef, additionalAnchorRefs)
+	if err != nil {
+		return fmt.Errorf("get links: %w", err)
+	}
+
+	if err := p.anchorLinkStore.DeleteLinks(links); err != nil {
+		return fmt.Errorf("delete links: %w", err)
+	}
+
+	return nil
+}
+
+func getLinks(anchorRef *url.URL, additionalAnchorRefs []*url.URL) ([]*url.URL, error) {
 	parser := hashlink.New()
 
 	info, err := parser.ParseHashLink(anchorRef.String())
 	if err != nil {
-		return fmt.Errorf("parse hashlink [%s]: %w", anchorRef, err)
+		return nil, fmt.Errorf("parse hashlink [%s]: %w", anchorRef, err)
 	}
 
 	var links []*url.URL
@@ -50,7 +82,7 @@ func (p *Handler) AnchorEventAcknowledged(actor, anchorRef *url.URL, additionalA
 	for _, hl := range additionalAnchorRefs {
 		hlInfo, err := parser.ParseHashLink(hl.String())
 		if err != nil {
-			logger.Warnf("Error parsing hashlink [%s]: %s", anchorRef, err)
+			logger.Warnf("Error parsing hashlink [%s]: %s", hl, err)
 
 			continue
 		}
@@ -65,9 +97,5 @@ func (p *Handler) AnchorEventAcknowledged(actor, anchorRef *url.URL, additionalA
 		links = append(links, hl)
 	}
 
-	if err := p.anchorLinkStore.PutLinks(links); err != nil {
-		return fmt.Errorf("put links [%s]: %w", info.ResourceHash, err)
-	}
-
-	return nil
+	return links, nil
 }

--- a/pkg/mocks/anchorlinkstore.gen.go
+++ b/pkg/mocks/anchorlinkstore.gen.go
@@ -31,6 +31,17 @@ type AnchorLinkStore struct {
 		result1 []*url.URL
 		result2 error
 	}
+	DeleteLinksStub        func(links []*url.URL) error
+	deleteLinksMutex       sync.RWMutex
+	deleteLinksArgsForCall []struct {
+		links []*url.URL
+	}
+	deleteLinksReturns struct {
+		result1 error
+	}
+	deleteLinksReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -139,6 +150,59 @@ func (fake *AnchorLinkStore) GetLinksReturnsOnCall(i int, result1 []*url.URL, re
 	}{result1, result2}
 }
 
+func (fake *AnchorLinkStore) DeleteLinks(links []*url.URL) error {
+	var linksCopy []*url.URL
+	if links != nil {
+		linksCopy = make([]*url.URL, len(links))
+		copy(linksCopy, links)
+	}
+	fake.deleteLinksMutex.Lock()
+	ret, specificReturn := fake.deleteLinksReturnsOnCall[len(fake.deleteLinksArgsForCall)]
+	fake.deleteLinksArgsForCall = append(fake.deleteLinksArgsForCall, struct {
+		links []*url.URL
+	}{linksCopy})
+	fake.recordInvocation("DeleteLinks", []interface{}{linksCopy})
+	fake.deleteLinksMutex.Unlock()
+	if fake.DeleteLinksStub != nil {
+		return fake.DeleteLinksStub(links)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fake.deleteLinksReturns.result1
+}
+
+func (fake *AnchorLinkStore) DeleteLinksCallCount() int {
+	fake.deleteLinksMutex.RLock()
+	defer fake.deleteLinksMutex.RUnlock()
+	return len(fake.deleteLinksArgsForCall)
+}
+
+func (fake *AnchorLinkStore) DeleteLinksArgsForCall(i int) []*url.URL {
+	fake.deleteLinksMutex.RLock()
+	defer fake.deleteLinksMutex.RUnlock()
+	return fake.deleteLinksArgsForCall[i].links
+}
+
+func (fake *AnchorLinkStore) DeleteLinksReturns(result1 error) {
+	fake.DeleteLinksStub = nil
+	fake.deleteLinksReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *AnchorLinkStore) DeleteLinksReturnsOnCall(i int, result1 error) {
+	fake.DeleteLinksStub = nil
+	if fake.deleteLinksReturnsOnCall == nil {
+		fake.deleteLinksReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.deleteLinksReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *AnchorLinkStore) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -146,6 +210,8 @@ func (fake *AnchorLinkStore) Invocations() map[string][][]interface{} {
 	defer fake.putLinksMutex.RUnlock()
 	fake.getLinksMutex.RLock()
 	defer fake.getLinksMutex.RUnlock()
+	fake.deleteLinksMutex.RLock()
+	defer fake.deleteLinksMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -46,6 +46,7 @@ import (
 type linkStore interface { //nolint:deadcode,unused
 	PutLinks(links []*url.URL) error
 	GetLinks(anchorHash string) ([]*url.URL, error)
+	DeleteLinks(links []*url.URL) error
 }
 
 const casLink = "https://domain.com/cas"

--- a/test/bdd/httpclient.go
+++ b/test/bdd/httpclient.go
@@ -303,7 +303,7 @@ func (c *httpClient) resolveURL(url string) string {
 		if strings.Contains(url, "//"+domain) {
 			logger.Infof("Mapping %s to %s", domain, mapping)
 
-			return strings.ReplaceAll(url, "//"+domain, "//"+mapping)
+			return strings.Replace(url, "//"+domain, "//"+mapping, 1)
 		}
 	}
 


### PR DESCRIPTION
A handler was added to undo a previous Like of an anchor credential. The handler removes all alternate links for the anchor that were previously added by the 'Like' handler.

closes #765

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>