### PR TITLE
chore: Use alternate relation instead of working-copy for WebFinger CAS query

### DIFF
--- a/pkg/cas/resolver/resolver_test.go
+++ b/pkg/cas/resolver/resolver_test.go
@@ -694,7 +694,7 @@ func TestResolver_Resolve(t *testing.T) {
 
 			router.HandleFunc("/.well-known/webfinger", func(rw http.ResponseWriter, r *http.Request) {
 				webFingerResponse := restapi.JRD{Links: []restapi.Link{
-					{Rel: "working-copy", Href: "%"},
+					{Rel: "alternate", Href: "%"},
 				}}
 				webFingerResponseBytes, errMarshal := json.Marshal(webFingerResponse)
 				require.NoError(t, errMarshal)

--- a/pkg/discovery/endpoint/restapi/operations.go
+++ b/pkg/discovery/endpoint/restapi/operations.go
@@ -35,11 +35,10 @@ const (
 	webDIDEndpoint       = "/.well-known/did.json"
 	nodeInfoEndpoint     = "/.well-known/nodeinfo"
 
-	selfRelation        = "self"
-	alternateRelation   = "alternate"
-	viaRelation         = "via"
-	serviceRelation     = "service"
-	workingCopyRelation = "working-copy"
+	selfRelation      = "self"
+	alternateRelation = "alternate"
+	viaRelation       = "via"
+	serviceRelation   = "service"
 
 	ldJSONType    = "application/ld+json"
 	jrdJSONType   = "application/jrd+json"
@@ -352,8 +351,7 @@ func (o *Operation) handleWebCASQuery(rw http.ResponseWriter, resource string) {
 		},
 	}
 
-	// Add the local reference.
-	refs := []string{fmt.Sprintf("%s/cas/%s", o.baseURL, cid)}
+	var refs []string
 
 	// Add the references from the configured discovery domains.
 	for _, v := range o.discoveryDomains {
@@ -364,7 +362,7 @@ func (o *Operation) handleWebCASQuery(rw http.ResponseWriter, resource string) {
 	for _, ref := range o.appendAlternateAnchorRefs(refs, cid) {
 		resp.Links = append(resp.Links,
 			Link{
-				Rel: workingCopyRelation, Type: ldJSONType, Href: ref,
+				Rel: alternateRelation, Type: ldJSONType, Href: ref,
 			})
 	}
 

--- a/pkg/discovery/endpoint/restapi/operations_test.go
+++ b/pkg/discovery/endpoint/restapi/operations_test.go
@@ -240,15 +240,13 @@ func TestWebFinger(t *testing.T) {
 			var w restapi.JRD
 
 			require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &w))
-			require.Len(t, w.Links, 4)
+			require.Len(t, w.Links, 3)
 			require.Equal(t, "http://base/cas/bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y",
 				w.Links[0].Href)
-			require.Equal(t, "http://base/cas/bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y",
-				w.Links[1].Href)
 			require.Equal(t, "http://domain1/cas/bafkreiatkubvbkdidscmqynkyls3iqawdqvthi7e6mbky2amuw3inxsi3y",
-				w.Links[2].Href)
+				w.Links[1].Href)
 			require.Equal(t, "ipfs://Qmcq6JWDUkyxehq7RVZkP3NviE4HqRunRjX39vuLvEHaQN",
-				w.Links[3].Href)
+				w.Links[2].Href)
 			require.Empty(t, w.Properties)
 		})
 
@@ -263,15 +261,13 @@ func TestWebFinger(t *testing.T) {
 			var w restapi.JRD
 
 			require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &w))
-			require.Len(t, w.Links, 4)
+			require.Len(t, w.Links, 3)
 			require.Equal(t, "http://base/cas/uEiATVQNQqGgchMhhqsLltEAWHCszo-TzAqxoDKW2ht5I3g",
 				w.Links[0].Href)
-			require.Equal(t, "http://base/cas/uEiATVQNQqGgchMhhqsLltEAWHCszo-TzAqxoDKW2ht5I3g",
-				w.Links[1].Href)
 			require.Equal(t, "http://domain1/cas/uEiATVQNQqGgchMhhqsLltEAWHCszo-TzAqxoDKW2ht5I3g",
-				w.Links[2].Href)
+				w.Links[1].Href)
 			require.Equal(t, "ipfs://Qmcq6JWDUkyxehq7RVZkP3NviE4HqRunRjX39vuLvEHaQN",
-				w.Links[3].Href)
+				w.Links[2].Href)
 			require.Empty(t, w.Properties)
 		})
 
@@ -307,7 +303,7 @@ func TestWebFinger(t *testing.T) {
 			require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &w))
 
 			// The alternate link won't be included due to a storage error, but it should still return results.
-			require.Len(t, w.Links, 3)
+			require.Len(t, w.Links, 2)
 		})
 
 		t.Run("Invalid alternate hashlink", func(t *testing.T) {
@@ -324,7 +320,7 @@ func TestWebFinger(t *testing.T) {
 			require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &w))
 
 			// The alternate link won't be included due to a storage error, but it should still return results.
-			require.Len(t, w.Links, 3)
+			require.Len(t, w.Links, 2)
 		})
 	})
 

--- a/pkg/webfinger/client/client.go
+++ b/pkg/webfinger/client/client.go
@@ -167,11 +167,23 @@ func (c *Client) GetWebCASURL(domainWithScheme, cid string) (*url.URL, error) {
 
 	var webCASURLFromWebFinger string
 
+	// First try to resolve from self.
 	for _, link := range webFingerResponse.Links {
-		if link.Rel == "working-copy" {
+		if link.Rel == "self" {
 			webCASURLFromWebFinger = link.Href
 
 			break
+		}
+	}
+
+	if webCASURLFromWebFinger == "" {
+		// Try the alternates.
+		for _, link := range webFingerResponse.Links {
+			if link.Rel == "alternate" {
+				webCASURLFromWebFinger = link.Href
+
+				break
+			}
 		}
 	}
 

--- a/pkg/webfinger/client/client_test.go
+++ b/pkg/webfinger/client/client_test.go
@@ -260,10 +260,9 @@ func TestResolveWebFingerResource(t *testing.T) {
 			fmt.Sprintf("%s/cas/%s", testServer.URL, "SomeCID"))
 		require.NoError(t, err)
 
-		require.Len(t, webFingerResponse.Links, 2)
-		require.Equal(t,
-			fmt.Sprintf("%s/cas/SomeCID", testServer.URL), webFingerResponse.Links[0].Href)
-		require.Equal(t, fmt.Sprintf("%s/cas/SomeCID", testServer.URL), webFingerResponse.Links[1].Href)
+		require.Len(t, webFingerResponse.Links, 1)
+		require.Equal(t, "self", webFingerResponse.Links[0].Rel)
+		require.Equal(t, fmt.Sprintf("%s/cas/SomeCID", testServer.URL), webFingerResponse.Links[0].Href)
 		require.Empty(t, webFingerResponse.Properties)
 	})
 	t.Run("Fail to do GET call", func(t *testing.T) {
@@ -357,7 +356,7 @@ func TestGetWebCASURL(t *testing.T) {
 
 		router.HandleFunc("/.well-known/webfinger", func(rw http.ResponseWriter, r *http.Request) {
 			webFingerResponse := discoveryrest.JRD{Links: []discoveryrest.Link{
-				{Rel: "working-copy", Href: "%"},
+				{Rel: "self", Href: "%"},
 			}}
 			webFingerResponseBytes, errMarshal := json.Marshal(webFingerResponse)
 			require.NoError(t, errMarshal)

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -320,6 +320,8 @@ Feature:
 
     When an HTTP GET is sent to "https://orb.domain1.com/.well-known/webfinger?resource=https://orb.domain1.com/cas/${anchorHash}"
     And the JSON path 'links.#(rel=="self").href' of the response equals "https://orb.domain1.com/cas/${anchorHash}"
+    And the JSON path "links.#.href" of the response contains expression ".*orb\.domain2\.com.*"
+    And the JSON path "links.#.href" of the response contains expression ".*orb\.domain3\.com.*"
 
     When an HTTP GET is sent to "https://orb.domain1.com/services/orb/likes?id=${anchorLink}&page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
@@ -340,9 +342,14 @@ Feature:
 
     Then we wait 2 seconds
 
+    # domain2 and domain 3 should no longer appear in the response of the WebFinger DID query.
     When an HTTP GET is sent to "https://orb.domain1.com/.well-known/webfinger?resource=${didID}"
     And the JSON path "links.#.href" of the response contains expression ".*orb\.domain1\.com.*"
+    And the JSON path "links.#.href" of the response does not contain expression ".*orb\.domain2\.com.*"
+    And the JSON path "links.#.href" of the response does not contain expression ".*orb\.domain3\.com.*"
 
-    # domain2 and domain 3 should no longer appear in the response of the WebFinger query.
+    # domain2 and domain 3 should no longer appear in the response of the WebFinger CAS query.
+    When an HTTP GET is sent to "https://orb.domain1.com/.well-known/webfinger?resource=https://orb.domain1.com/cas/${anchorHash}"
+    And the JSON path 'links.#(rel=="self").href' of the response equals "https://orb.domain1.com/cas/${anchorHash}"
     And the JSON path "links.#.href" of the response does not contain expression ".*orb\.domain2\.com.*"
     And the JSON path "links.#.href" of the response does not contain expression ".*orb\.domain3\.com.*"


### PR DESCRIPTION

closes #784

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>