### PR TITLE
fix: Post one "Like" activity with multiple URIs in "to" field

### DIFF
--- a/pkg/discovery/endpoint/restapi/operations.go
+++ b/pkg/discovery/endpoint/restapi/operations.go
@@ -280,6 +280,8 @@ func (o *Operation) writeResponseForResourceRequest(rw http.ResponseWriter, reso
 func (o *Operation) handleDIDOrbQuery(rw http.ResponseWriter, resource string) {
 	anchorInfo, err := o.GetAnchorInfo(resource)
 	if err != nil {
+		logger.Warnf("Error getting anchor info for [%s]: %s", resource, err)
+
 		writeErrorResponse(rw, http.StatusInternalServerError,
 			fmt.Sprintf("failed to get info on %s: %s", resource, err.Error()))
 
@@ -327,6 +329,12 @@ func (o *Operation) handleWebCASQuery(rw http.ResponseWriter, resource string) {
 	resourceSplitBySlash := strings.Split(resource, "/")
 
 	cid := resourceSplitBySlash[len(resourceSplitBySlash)-1]
+
+	if cid == "" {
+		writeErrorResponse(rw, http.StatusBadRequest, "resource ID not provided in request")
+
+		return
+	}
 
 	// Ensure that the CID is resolvable.
 	_, err := o.cas.Read(cid)

--- a/pkg/discovery/endpoint/restapi/operations_test.go
+++ b/pkg/discovery/endpoint/restapi/operations_test.go
@@ -280,6 +280,15 @@ func TestWebFinger(t *testing.T) {
 			require.Equal(t, http.StatusNotFound, rr.Code)
 		})
 
+		t.Run("No resource ID in request", func(t *testing.T) {
+			casClient.ReadReturns(nil, orberrors.ErrContentNotFound)
+
+			rr := serveHTTP(t, handler.Handler(), http.MethodGet, restapi.WebFingerEndpoint+
+				"?resource=http://base/cas/", nil, nil, false)
+
+			require.Equal(t, http.StatusBadRequest, rr.Code)
+		})
+
 		t.Run("CAS error", func(t *testing.T) {
 			casClient.ReadReturns(nil, errors.New("injected CAS client error"))
 

--- a/test/bdd/common_steps.go
+++ b/test/bdd/common_steps.go
@@ -417,7 +417,7 @@ func (d *CommonSteps) httpGet(url string) error {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("received status code %d", resp.StatusCode)
+		return fmt.Errorf("received status code %d: %s", resp.StatusCode, resp.ErrorMsg)
 	}
 
 	d.state.setResponse(string(resp.Payload))
@@ -434,7 +434,7 @@ func (d *CommonSteps) httpGetWithSignature(url, pubKeyID string) error {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("received status code %d", resp.StatusCode)
+		return fmt.Errorf("received status code %d: %s", resp.StatusCode, resp.ErrorMsg)
 	}
 
 	d.state.setResponse(string(resp.Payload))
@@ -464,7 +464,7 @@ func (d *CommonSteps) httpPostFile(url, path string) error {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("received status code %d", resp.StatusCode)
+		return fmt.Errorf("received status code %d: %s", resp.StatusCode, resp.ErrorMsg)
 	}
 
 	return nil
@@ -492,7 +492,7 @@ func (d *CommonSteps) httpPostFileWithSignature(url, path, pubKeyID string) erro
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("received status code %d", resp.StatusCode)
+		return fmt.Errorf("received status code %d: %s", resp.StatusCode, resp.ErrorMsg)
 	}
 
 	return nil
@@ -529,7 +529,7 @@ func (d *CommonSteps) httpPost(url, data, contentType string) error {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("received status code %d", resp.StatusCode)
+		return fmt.Errorf("received status code %d: %s", resp.StatusCode, resp.ErrorMsg)
 	}
 
 	d.state.setResponse(string(resp.Payload))
@@ -551,7 +551,7 @@ func (d *CommonSteps) httpPostWithSignature(url, data, contentType, domain strin
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("received status code %d", resp.StatusCode)
+		return fmt.Errorf("received status code %d: %s", resp.StatusCode, resp.ErrorMsg)
 	}
 
 	d.state.setResponse(string(resp.Payload))

--- a/test/bdd/did_orb_steps.go
+++ b/test/bdd/did_orb_steps.go
@@ -170,7 +170,7 @@ func (d *DIDOrbSteps) discoverEndpoints() error {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("received status code %d", resp.StatusCode)
+		return fmt.Errorf("received status code %d: %s", resp.StatusCode, resp.ErrorMsg)
 	}
 
 	var w restapi.WellKnownResponse
@@ -186,7 +186,7 @@ func (d *DIDOrbSteps) discoverEndpoints() error {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("received status code %d", resp.StatusCode)
+		return fmt.Errorf("received status code %d: %s", resp.StatusCode, resp.ErrorMsg)
 	}
 
 	var webFingerResponse restapi.JRD

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -25,13 +25,11 @@ Feature:
     And the authorization bearer token for "POST" requests to path "/policy" is set to "ADMIN_TOKEN"
 
     # domain2 server follows domain1 server
-    Given variable "followID" is assigned a unique ID
-    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain2IRI}/activities/${followID}","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
+    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
     When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
 
     # domain1 server follows domain2 server
-    Given variable "followID" is assigned a unique ID
-    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain1IRI}/activities/${followID}","type":"Follow","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
+    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
     When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
 
     # domain3 server follows domain1 server. Domain3 needs to be a follower of domain1 so that HTTP signature validation succeeds when
@@ -40,13 +38,11 @@ Feature:
     When an HTTP POST is sent to "https://orb.domain3.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
 
     # domain1 invites domain2 to be a witness
-    Given variable "inviteWitnessID" is assigned a unique ID
-    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"id":"${domain1IRI}/activities/${inviteWitnessID}","type":"Invite","actor":"${domain1IRI}","to":"${domain2IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain2IRI}"}'
+    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain1IRI}","to":"${domain2IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain2IRI}"}'
     When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     # domain2 invites domain1 to be a witness
-    Given variable "inviteWitnessID" is assigned a unique ID
-    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"id":"${domain2IRI}/activities/${inviteWitnessID}","type":"Invite","actor":"${domain2IRI}","to":"${domain1IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain1IRI}"}'
+    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain2IRI}","to":"${domain1IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain1IRI}"}'
     When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     # set witness policy for domain1
@@ -317,6 +313,11 @@ Feature:
     And the JSON path "links.#.href" of the response contains expression ".*orb\.domain3\.com.*"
     And the JSON path 'links.#(rel=="via").href' of the response is saved to variable "anchorLink"
     And variable "anchorHash" is assigned the value "$hashlink(|${anchorLink}|).ResourceHash"
+
+    # domain3 is following domain1 so it should also have the DID.
+    When an HTTP GET is sent to "https://orb.domain3.com/.well-known/webfinger?resource=${didID}"
+    And the JSON path "links.#.href" of the response contains expression ".*orb\.domain1\.com.*"
+    And the JSON path "links.#.href" of the response contains expression ".*orb\.domain3\.com.*"
 
     When an HTTP GET is sent to "https://orb.domain1.com/.well-known/webfinger?resource=https://orb.domain1.com/cas/${anchorHash}"
     And the JSON path 'links.#(rel=="self").href' of the response equals "https://orb.domain1.com/cas/${anchorHash}"


### PR DESCRIPTION
Instead of posting two "Like" activities, post one activity with multiple URIs in the "to" field.

Also:
- Fix the WebFinger CAS query to return 400 (bad request) instead of 500 in the CID isn't in the request.
- Added more logging in BDD test to also log the error message.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>