### PR TITLE
feat: Add an option for resolution from anchor origin

### DIFF
--- a/cmd/orb-server/startcmd/params.go
+++ b/cmd/orb-server/startcmd/params.go
@@ -282,6 +282,11 @@ const (
 	includePublishedOperationsUsage    = `Set to "true" to include published operations in metadata. ` +
 		commonEnvVarUsageText + includePublishedOperationsEnvKey
 
+	resolveFromAnchorOriginFlagName = "resolve-from-anchor-origin"
+	resolveFromAnchorOriginEnvKey   = "RESOLVE_FROM_ANCHOR_ORIGIN"
+	resolveFromAnchorOriginUsage    = `Set to "true" to resolve from anchor origin. ` +
+		commonEnvVarUsageText + resolveFromAnchorOriginEnvKey
+
 	authTokensDefFlagName      = "auth-tokens-def"
 	authTokensDefFlagShorthand = "D"
 	authTokensDefFlagUsage     = "Authorization token definitions."
@@ -364,6 +369,7 @@ type orbParameters struct {
 	updateDocumentStoreEnabled     bool
 	includeUnpublishedOperations   bool
 	includePublishedOperations     bool
+	resolveFromAnchorOrigin        bool
 	updateDocumentStoreTypes       []operation.Type
 	authTokenDefinitions           []*auth.TokenDef
 	authTokens                     map[string]string
@@ -654,6 +660,21 @@ func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 		includePublishedOperations = enable
 	}
 
+	resolveFromAnchorOriginStr, err := cmdutils.GetUserSetVarFromString(cmd, resolveFromAnchorOriginFlagName, resolveFromAnchorOriginEnvKey, true)
+	if err != nil {
+		return nil, err
+	}
+
+	resolveFromAnchorOrigin := defaultResolveFromAnchorOrigin
+	if resolveFromAnchorOriginStr != "" {
+		enable, parseErr := strconv.ParseBool(resolveFromAnchorOriginStr)
+		if parseErr != nil {
+			return nil, fmt.Errorf("invalid value for %s: %s", resolveFromAnchorOriginFlagName, parseErr)
+		}
+
+		resolveFromAnchorOrigin = enable
+	}
+
 	didNamespace, err := cmdutils.GetUserSetVarFromString(cmd, didNamespaceFlagName, didNamespaceEnvKey, false)
 	if err != nil {
 		return nil, err
@@ -765,6 +786,7 @@ func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 		updateDocumentStoreEnabled:     updateDocumentStoreEnabled,
 		includePublishedOperations:     includePublishedOperations,
 		includeUnpublishedOperations:   includeUnpublishedOperations,
+		resolveFromAnchorOrigin:        resolveFromAnchorOrigin,
 		authTokenDefinitions:           authTokenDefs,
 		authTokens:                     authTokens,
 		activityPubPageSize:            activityPubPageSize,
@@ -1050,6 +1072,7 @@ func createFlags(startCmd *cobra.Command) {
 	startCmd.Flags().String(enableUpdateDocumentStoreFlagName, "", enableUpdateDocumentStoreUsage)
 	startCmd.Flags().String(includeUnpublishedOperationsFlagName, "", includeUnpublishedOperationsUsage)
 	startCmd.Flags().String(includePublishedOperationsFlagName, "", includePublishedOperationsUsage)
+	startCmd.Flags().String(resolveFromAnchorOriginFlagName, "", resolveFromAnchorOriginUsage)
 	startCmd.Flags().StringP(casTypeFlagName, casTypeFlagShorthand, "", casTypeFlagUsage)
 	startCmd.Flags().StringP(ipfsURLFlagName, ipfsURLFlagShorthand, "", ipfsURLFlagUsage)
 	startCmd.Flags().StringP(localCASReplicateInIPFSFlagName, "", "false", localCASReplicateInIPFSFlagUsage)

--- a/cmd/orb-server/startcmd/params_test.go
+++ b/cmd/orb-server/startcmd/params_test.go
@@ -490,6 +490,34 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 		require.Contains(t, err.Error(), "invalid value for enable-update-document-store")
 	})
 
+	t.Run("test invalid resolve-from-anchor-origin", func(t *testing.T) {
+		startCmd := GetStartCmd()
+
+		args := []string{
+			"--" + hostURLFlagName, "localhost:8247",
+			"--" + hostMetricsURLFlagName, "localhost:8248",
+			"--" + vctURLFlagName, "localhost:8081",
+			"--" + externalEndpointFlagName, "orb.example.com",
+			"--" + casTypeFlagName, "ipfs",
+			"--" + ipfsURLFlagName, "localhost:8081",
+			"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
+			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption,
+			"--" + anchorCredentialSignatureSuiteFlagName, "suite",
+			"--" + anchorCredentialDomainFlagName, "domain.com",
+			"--" + anchorCredentialIssuerFlagName, "issuer.com",
+			"--" + anchorCredentialURLFlagName, "peer.com",
+			"--" + LogLevelFlagName, log.ParseString(log.ERROR),
+			"--" + resolveFromAnchorOriginFlagName, "invalid bool",
+		}
+
+		startCmd.SetArgs(args)
+
+		err := startCmd.Execute()
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid value for resolve-from-anchor-origin")
+	})
+
 	t.Run("test invalid include-unpublished-operations-in-metadata", func(t *testing.T) {
 		startCmd := GetStartCmd()
 
@@ -1177,6 +1205,7 @@ func getTestArgs(ipfsURL, casType, localCASReplicateInIPFSEnabled, databaseType,
 		"--" + enableCreateDocumentStoreFlagName, "true",
 		"--" + includePublishedOperationsFlagName, "true",
 		"--" + includeUnpublishedOperationsFlagName, "true",
+		"--" + resolveFromAnchorOriginFlagName, "true",
 	}
 
 	if databaseURL != "" {

--- a/pkg/discovery/endpoint/client/client.go
+++ b/pkg/discovery/endpoint/client/client.go
@@ -311,7 +311,7 @@ func (cs *Client) getEndpointAnchorOrigin(didURI string) (*models.Endpoint, erro
 
 	currentAnchorOrigin := anchorOrigin
 
-	var currentWebFingerRespone *restapi.JRD
+	var currentWebFingerResponse *restapi.JRD
 
 	for {
 		jrdLatestAnchorOrigin, errGet := cs.getLatestAnchorOrigin(currentAnchorOrigin, didURI)
@@ -325,7 +325,7 @@ func (cs *Client) getEndpointAnchorOrigin(didURI string) (*models.Endpoint, erro
 		}
 
 		if latestAnchorOrigin == currentAnchorOrigin {
-			currentWebFingerRespone = jrdLatestAnchorOrigin
+			currentWebFingerResponse = jrdLatestAnchorOrigin
 
 			break
 		}
@@ -333,7 +333,7 @@ func (cs *Client) getEndpointAnchorOrigin(didURI string) (*models.Endpoint, erro
 		currentAnchorOrigin = latestAnchorOrigin
 	}
 
-	return cs.populateAnchorResolutionEndpoint(currentWebFingerRespone)
+	return cs.populateAnchorResolutionEndpoint(currentWebFingerResponse)
 }
 
 func (cs *Client) getCIDAndSuffix(didURI string) (string, string, error) {

--- a/pkg/document/remoteresolver/remoteresolver_test.go
+++ b/pkg/document/remoteresolver/remoteresolver_test.go
@@ -65,7 +65,7 @@ func TestNew(t *testing.T) {
 		require.Error(t, err)
 		require.Nil(t, rr)
 		require.Contains(t, err.Error(),
-			"failed to unmarshal resolution result[invalid-json] for remote request[https://domain.com/identifiers/abc]")
+			"remote request[https://domain.com/identifiers/abc]: failed to unmarshal resolution result[invalid-json]")
 
 		require.NoError(t, result.Body.Close())
 	})

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -261,7 +261,7 @@ Feature:
       When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve interim DID document with hint "https:orb.domain4.com"
       Then check success response does NOT contain "canonicalId"
 
-    @all
+    @local_cas
     @enable_update_document_store
     Scenario: domain4 has update document store enabled
 

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -459,6 +459,7 @@ services:
       - UPDATE_DOCUMENT_STORE_ENABLED=true
       - INCLUDE_UNPUBLISHED_OPERATIONS_IN_METADATA=true
       - INCLUDE_PUBLISHED_OPERATIONS_IN_METADATA=true
+      - RESOLVE_FROM_ANCHOR_ORIGIN=true
 
       # ORB_AUTH_TOKENS_DEF contains the authorization definition for each of the REST endpoints. Format:
       #


### PR DESCRIPTION
Add an option for resolution from anchor origin. If enabled resolver will request document from anchor origin.

Closes #792

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>