### PR TITLE
feat: Use AMQP subscriber pool for Observer

### DIFF
--- a/cmd/orb-server/startcmd/params_test.go
+++ b/cmd/orb-server/startcmd/params_test.go
@@ -996,20 +996,23 @@ func TestGetMQParameters(t *testing.T) {
 	t.Run("Valid env values -> error", func(t *testing.T) {
 		restoreURLEnv := setEnv(t, mqURLEnvKey, u)
 		restoreOpPoolEnv := setEnv(t, mqOpPoolEnvKey, "221")
+		restoreObserverPoolEnv := setEnv(t, mqObserverPoolEnvKey, "3")
 		restoreConnectionSubscriptionsEnv := setEnv(t, mqMaxConnectionSubscriptionsEnvKey, "456")
 
 		defer func() {
 			restoreURLEnv()
 			restoreOpPoolEnv()
+			restoreObserverPoolEnv()
 			restoreConnectionSubscriptionsEnv()
 		}()
 
 		cmd := getTestCmd(t)
 
-		mqURL, poolSize, maxConnectionSubscriptions, err := getMQParameters(cmd)
+		mqURL, mqOpPoolSize, mqObserverPoolSize, maxConnectionSubscriptions, err := getMQParameters(cmd)
 		require.NoError(t, err)
 		require.Equal(t, u, mqURL)
-		require.Equal(t, 221, poolSize)
+		require.Equal(t, 221, mqOpPoolSize)
+		require.Equal(t, 3, mqObserverPoolSize)
 		require.Equal(t, 456, maxConnectionSubscriptions)
 	})
 
@@ -1022,10 +1025,11 @@ func TestGetMQParameters(t *testing.T) {
 
 		cmd := getTestCmd(t)
 
-		mqURL, poolSize, maxConnectionSubscriptions, err := getMQParameters(cmd)
+		mqURL, mqOpPoolSize, mqObserverPoolSize, maxConnectionSubscriptions, err := getMQParameters(cmd)
 		require.NoError(t, err)
 		require.Equal(t, u, mqURL)
-		require.Equal(t, 0, poolSize)
+		require.Equal(t, 0, mqOpPoolSize)
+		require.Equal(t, 0, mqObserverPoolSize)
 		require.Equal(t, mqDefaultMaxConnectionSubscriptions, maxConnectionSubscriptions)
 	})
 
@@ -1038,7 +1042,7 @@ func TestGetMQParameters(t *testing.T) {
 
 		cmd := getTestCmd(t)
 
-		_, _, _, err := getMQParameters(cmd)
+		_, _, _, _, err := getMQParameters(cmd)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid value")
 	})
@@ -1052,7 +1056,7 @@ func TestGetMQParameters(t *testing.T) {
 
 		cmd := getTestCmd(t)
 
-		_, _, _, err := getMQParameters(cmd)
+		_, _, _, _, err := getMQParameters(cmd)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid value")
 	})

--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -624,7 +624,10 @@ func startOrbServices(parameters *orbParameters) error {
 		AnchorLinkStore:        anchorLinkStore,
 	}
 
-	o, err := observer.New(apConfig.ServiceIRI, providers, observer.WithDiscoveryDomain(parameters.discoveryDomain))
+	o, err := observer.New(apConfig.ServiceIRI, providers,
+		observer.WithDiscoveryDomain(parameters.discoveryDomain),
+		observer.WithSubscriberPoolSize(parameters.observerQueuePoolSize),
+	)
 	if err != nil {
 		return fmt.Errorf("failed to create observer: %s", err.Error())
 	}

--- a/pkg/activitypub/service/mocks/mockpubsub.go
+++ b/pkg/activitypub/service/mocks/mockpubsub.go
@@ -79,6 +79,12 @@ func (m *MockPubSub) Subscribe(_ context.Context, topic string) (<-chan *message
 	return msgChan, nil
 }
 
+// SubscribeWithOpts subscribes to the given topic.
+func (m *MockPubSub) SubscribeWithOpts(ctx context.Context,
+	topic string, _ ...spi.Option) (<-chan *message.Message, error) {
+	return m.Subscribe(ctx, topic)
+}
+
 // Publish publishes the messages to the subscribers.
 func (m *MockPubSub) Publish(topic string, messages ...*message.Message) error {
 	if m.Err != nil {

--- a/pkg/mocks/pubsub.gen.go
+++ b/pkg/mocks/pubsub.gen.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/trustbloc/orb/pkg/pubsub/spi"
 )
 
 type PubSub struct {
@@ -20,6 +21,21 @@ type PubSub struct {
 		result2 error
 	}
 	subscribeReturnsOnCall map[int]struct {
+		result1 <-chan *message.Message
+		result2 error
+	}
+	SubscribeWithOptsStub        func(ctx context.Context, topic string, opts ...spi.Option) (<-chan *message.Message, error)
+	subscribeWithOptsMutex       sync.RWMutex
+	subscribeWithOptsArgsForCall []struct {
+		ctx   context.Context
+		topic string
+		opts  []spi.Option
+	}
+	subscribeWithOptsReturns struct {
+		result1 <-chan *message.Message
+		result2 error
+	}
+	subscribeWithOptsReturnsOnCall map[int]struct {
 		result1 <-chan *message.Message
 		result2 error
 	}
@@ -95,6 +111,59 @@ func (fake *PubSub) SubscribeReturnsOnCall(i int, result1 <-chan *message.Messag
 		})
 	}
 	fake.subscribeReturnsOnCall[i] = struct {
+		result1 <-chan *message.Message
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *PubSub) SubscribeWithOpts(ctx context.Context, topic string, opts ...spi.Option) (<-chan *message.Message, error) {
+	fake.subscribeWithOptsMutex.Lock()
+	ret, specificReturn := fake.subscribeWithOptsReturnsOnCall[len(fake.subscribeWithOptsArgsForCall)]
+	fake.subscribeWithOptsArgsForCall = append(fake.subscribeWithOptsArgsForCall, struct {
+		ctx   context.Context
+		topic string
+		opts  []spi.Option
+	}{ctx, topic, opts})
+	fake.recordInvocation("SubscribeWithOpts", []interface{}{ctx, topic, opts})
+	fake.subscribeWithOptsMutex.Unlock()
+	if fake.SubscribeWithOptsStub != nil {
+		return fake.SubscribeWithOptsStub(ctx, topic, opts...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.subscribeWithOptsReturns.result1, fake.subscribeWithOptsReturns.result2
+}
+
+func (fake *PubSub) SubscribeWithOptsCallCount() int {
+	fake.subscribeWithOptsMutex.RLock()
+	defer fake.subscribeWithOptsMutex.RUnlock()
+	return len(fake.subscribeWithOptsArgsForCall)
+}
+
+func (fake *PubSub) SubscribeWithOptsArgsForCall(i int) (context.Context, string, []spi.Option) {
+	fake.subscribeWithOptsMutex.RLock()
+	defer fake.subscribeWithOptsMutex.RUnlock()
+	return fake.subscribeWithOptsArgsForCall[i].ctx, fake.subscribeWithOptsArgsForCall[i].topic, fake.subscribeWithOptsArgsForCall[i].opts
+}
+
+func (fake *PubSub) SubscribeWithOptsReturns(result1 <-chan *message.Message, result2 error) {
+	fake.SubscribeWithOptsStub = nil
+	fake.subscribeWithOptsReturns = struct {
+		result1 <-chan *message.Message
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *PubSub) SubscribeWithOptsReturnsOnCall(i int, result1 <-chan *message.Message, result2 error) {
+	fake.SubscribeWithOptsStub = nil
+	if fake.subscribeWithOptsReturnsOnCall == nil {
+		fake.subscribeWithOptsReturnsOnCall = make(map[int]struct {
+			result1 <-chan *message.Message
+			result2 error
+		})
+	}
+	fake.subscribeWithOptsReturnsOnCall[i] = struct {
 		result1 <-chan *message.Message
 		result2 error
 	}{result1, result2}
@@ -194,6 +263,8 @@ func (fake *PubSub) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.subscribeMutex.RLock()
 	defer fake.subscribeMutex.RUnlock()
+	fake.subscribeWithOptsMutex.RLock()
+	defer fake.subscribeWithOptsMutex.RUnlock()
 	fake.publishMutex.RLock()
 	defer fake.publishMutex.RUnlock()
 	fake.closeMutex.RLock()

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -59,7 +59,7 @@ func TestNew(t *testing.T) {
 	errExpected := errors.New("injected pub-sub error")
 
 	ps := &orbmocks.PubSub{}
-	ps.SubscribeReturns(nil, errExpected)
+	ps.SubscribeWithOptsReturns(nil, errExpected)
 
 	providers := &Providers{
 		DidAnchors: memdidanchor.New(),

--- a/pkg/observer/pubsub.go
+++ b/pkg/observer/pubsub.go
@@ -17,6 +17,7 @@ import (
 	anchorinfo "github.com/trustbloc/orb/pkg/anchor/info"
 	"github.com/trustbloc/orb/pkg/errors"
 	"github.com/trustbloc/orb/pkg/lifecycle"
+	"github.com/trustbloc/orb/pkg/pubsub/spi"
 )
 
 const (
@@ -49,7 +50,8 @@ type PubSub struct {
 }
 
 // NewPubSub returns a new publisher/subscriber.
-func NewPubSub(pubSub pubSub, anchorProcessor anchorProcessor, didProcessor didProcessor) (*PubSub, error) {
+func NewPubSub(pubSub pubSub, anchorProcessor anchorProcessor, didProcessor didProcessor,
+	poolSize uint) (*PubSub, error) {
 	h := &PubSub{
 		publisher:      pubSub,
 		processAnchors: anchorProcessor,
@@ -64,7 +66,7 @@ func NewPubSub(pubSub pubSub, anchorProcessor anchorProcessor, didProcessor didP
 
 	logger.Infof("Subscribing to topic [%s]", anchorTopic)
 
-	anchorCredChan, err := pubSub.Subscribe(context.Background(), anchorTopic)
+	anchorCredChan, err := pubSub.SubscribeWithOpts(context.Background(), anchorTopic, spi.WithPool(poolSize))
 	if err != nil {
 		return nil, fmt.Errorf("subscribe to topic [%s]: %w", anchorTopic, err)
 	}
@@ -73,7 +75,7 @@ func NewPubSub(pubSub pubSub, anchorProcessor anchorProcessor, didProcessor didP
 
 	logger.Infof("Subscribing to topic [%s]", didTopic)
 
-	didChan, err := pubSub.Subscribe(context.Background(), didTopic)
+	didChan, err := pubSub.SubscribeWithOpts(context.Background(), didTopic, spi.WithPool(poolSize))
 	if err != nil {
 		return nil, fmt.Errorf("subscribe to topic [%s]: %w", didTopic, err)
 	}

--- a/pkg/observer/pubsub_test.go
+++ b/pkg/observer/pubsub_test.go
@@ -48,6 +48,7 @@ func TestPubSub(t *testing.T) {
 
 			return nil
 		},
+		5,
 	)
 	require.NoError(t, err)
 	require.NotNil(t, ps)
@@ -79,11 +80,12 @@ func TestPubSub_Error(t *testing.T) {
 		errExpected := errors.New("injected pub/sub error")
 
 		p := &mocks.PubSub{}
-		p.SubscribeReturns(nil, errExpected)
+		p.SubscribeWithOptsReturns(nil, errExpected)
 
 		ps, err := NewPubSub(p,
 			func(anchor *anchorinfo.AnchorInfo) error { return nil },
 			func(did string) error { return nil },
+			5,
 		)
 		require.Error(t, err)
 		require.Nil(t, ps)
@@ -93,11 +95,12 @@ func TestPubSub_Error(t *testing.T) {
 		errExpected := errors.New("injected pub/sub error")
 
 		p := &mocks.PubSub{}
-		p.SubscribeReturnsOnCall(1, nil, errExpected)
+		p.SubscribeWithOptsReturnsOnCall(1, nil, errExpected)
 
 		ps, err := NewPubSub(p,
 			func(anchor *anchorinfo.AnchorInfo) error { return nil },
 			func(did string) error { return nil },
+			5,
 		)
 		require.Error(t, err)
 		require.Nil(t, ps)
@@ -110,6 +113,7 @@ func TestPubSub_Error(t *testing.T) {
 		ps, err := NewPubSub(p,
 			func(anchor *anchorinfo.AnchorInfo) error { return nil },
 			func(did string) error { return nil },
+			5,
 		)
 		require.NoError(t, err)
 		require.NotNil(t, ps)
@@ -155,6 +159,7 @@ func TestPubSub_Error(t *testing.T) {
 
 				return nil
 			},
+			5,
 		)
 		require.NoError(t, err)
 		require.NotNil(t, ps)
@@ -186,6 +191,7 @@ func TestPubSub_Error(t *testing.T) {
 		ps, err := NewPubSub(p,
 			func(anchor *anchorinfo.AnchorInfo) error { return orberrors.NewTransient(errExpected) },
 			func(did string) error { return orberrors.NewTransient(errExpected) },
+			5,
 		)
 		require.NoError(t, err)
 		require.NotNil(t, ps)
@@ -204,6 +210,7 @@ func TestPubSub_Error(t *testing.T) {
 		ps, err := NewPubSub(p,
 			func(anchor *anchorinfo.AnchorInfo) error { return nil },
 			func(did string) error { return nil },
+			5,
 		)
 		require.NoError(t, err)
 		require.NotNil(t, ps)

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -39,6 +39,8 @@ services:
       - MQ_URL=amqp://${RABBITMQ_USERNAME}:${RABBITMQ_PASSWORD}@orb.mq.domain1.com:5672/
       # MQ_OP_POOL specifies the number of subscribers that concurrently process messages in the operation queue.
       - MQ_OP_POOL=20
+      # MQ_OBSERVER_POOL specifies the number of subscribers that concurrently process messages from the observer queue (default 5).
+      - MQ_OBSERVER_POOL=5
       - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN1}
       - ANCHOR_CREDENTIAL_ISSUER=http://orb.domain1.com
@@ -121,6 +123,8 @@ services:
       - MQ_URL=amqp://${RABBITMQ_USERNAME}:${RABBITMQ_PASSWORD}@orb.mq.domain1.com:5672/
       # MQ_OP_POOL specifies the number of subscribers that concurrently process messages in the operation queue.
       - MQ_OP_POOL=20
+      # MQ_OBSERVER_POOL specifies the number of subscribers that concurrently process messages from the observer queue (default 5).
+      - MQ_OBSERVER_POOL=5
       - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN1}
       - ANCHOR_CREDENTIAL_ISSUER=http://orb2.domain1.com
@@ -213,6 +217,8 @@ services:
       - MQ_URL=amqp://${RABBITMQ_USERNAME}:${RABBITMQ_PASSWORD}@orb.mq.domain2.com:5672/
       # MQ_OP_POOL specifies the number of subscribers that concurrently process messages in the operation queue.
       - MQ_OP_POOL=20
+      # MQ_OBSERVER_POOL specifies the number of subscribers that concurrently process messages from the observer queue (default 5).
+      - MQ_OBSERVER_POOL=5
       - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN2}
       - ANCHOR_CREDENTIAL_ISSUER=http://orb.domain2.com
@@ -288,6 +294,8 @@ services:
       - MQ_URL=amqp://${RABBITMQ_USERNAME}:${RABBITMQ_PASSWORD}@orb.mq.domain2.com:5672/
       # MQ_OP_POOL specifies the number of subscribers that concurrently process messages in the operation queue.
       - MQ_OP_POOL=20
+      # MQ_OBSERVER_POOL specifies the number of subscribers that concurrently process messages from the observer queue (default 5).
+      - MQ_OBSERVER_POOL=5
       - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN2}
       - ANCHOR_CREDENTIAL_ISSUER=http://orb.domain2.com
@@ -366,6 +374,8 @@ services:
       - MQ_URL=amqp://${RABBITMQ_USERNAME}:${RABBITMQ_PASSWORD}@orb.mq.domain3.com:5672/
       # MQ_OP_POOL specifies the number of subscribers that concurrently process messages in the operation queue.
       - MQ_OP_POOL=20
+      # MQ_OBSERVER_POOL specifies the number of subscribers that concurrently process messages from the observer queue (default 5).
+      - MQ_OBSERVER_POOL=5
       - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN3}
       - ANCHOR_CREDENTIAL_ISSUER=http://orb.domain3.com
@@ -450,6 +460,8 @@ services:
       - MQ_URL=amqp://${RABBITMQ_USERNAME}:${RABBITMQ_PASSWORD}@orb.mq.domain4.com:5672/
       # MQ_OP_POOL specifies the number of subscribers that concurrently process messages in the operation queue.
       - MQ_OP_POOL=20
+      # MQ_OBSERVER_POOL specifies the number of subscribers that concurrently process messages from the observer queue (default 5).
+      - MQ_OBSERVER_POOL=3
       - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN4}
       - ANCHOR_CREDENTIAL_ISSUER=http://orb.domain4.com


### PR DESCRIPTION
Changed the Observer message queue subscribers (DID and Anchor) to use a pool so that anchor events may be processed concurrently.

closes #802

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>