### PR TITLE
chore: Add support for IPFS hint in did discovery

### DIFF
--- a/pkg/cas/resolver/resolver.go
+++ b/pkg/cas/resolver/resolver.go
@@ -23,6 +23,7 @@ import (
 	"github.com/trustbloc/orb/pkg/cas/extendedcasclient"
 	orberrors "github.com/trustbloc/orb/pkg/errors"
 	"github.com/trustbloc/orb/pkg/hashlink"
+	"github.com/trustbloc/orb/pkg/multihash"
 	webfingerclient "github.com/trustbloc/orb/pkg/webfinger/client"
 )
 
@@ -175,6 +176,16 @@ func (h *Resolver) getResourceHashWithPossibleDomainAndLinks(hashWithPossibleHin
 		}
 
 		links = hlInfo.Links
+
+	case "ipfs":
+		resourceHash = hashWithPossibleHintParts[1]
+
+		cid, err := multihash.ToV1CID(resourceHash)
+		if err != nil {
+			return "", "", nil, fmt.Errorf("resource hash[%s] cannot be converted to V1 CID: %w", resourceHash, err)
+		}
+
+		links = []string{ipfsPrefix + cid}
 
 	default:
 		return "", "", nil, fmt.Errorf("hint '%s' not supported", hashWithPossibleHintParts[0])

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -129,6 +129,43 @@ Feature:
       Then check success response contains "recoveryKey"
 
     @all
+    @discover_did_ipfs
+    Scenario: discover did (ipfs)
+      When client discover orb endpoints
+
+      # orb-domain1 keeps accepting requests
+      When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to create DID document
+      Then check success response contains "#interimDID"
+
+      Then we wait 2 seconds
+      When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with interim did
+      Then check success response contains "canonicalId"
+
+      When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+      Then check success response contains "#canonicalDID"
+
+      When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to add public key with ID "firstKey" to DID document
+      Then check for request success
+      Then we wait 2 seconds
+
+      When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+      Then check success response contains "firstKey"
+      Then check success response contains "#canonicalDID"
+
+      # resolve did in domain4 - it will trigger did discovery in different organisations
+      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with hint "ipfs"
+      Then check error response contains "not found"
+
+      Then we wait 3 seconds
+      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with hint "ipfs"
+      Then check success response contains "#canonicalDID"
+      Then check success response contains "firstKey"
+
+      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+      Then check success response contains "#canonicalDID"
+      Then check success response contains "firstKey"
+
+    @all
     @resolve_from_anchor_origin
     Scenario: discover did followed by resolve from anchor origin
       When client discover orb endpoints


### PR DESCRIPTION
Add support for IPFS hint in CAS resolver and add bdd test for did discovery with 'ipfs' hint.

Closes #813

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>