### PR TITLE
feat: Parameters for unpublished op lifespan and expiry service interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Flags:
   -b, --batch-writer-timeout string                 Maximum time (in millisecond) in-between cutting batches.Alternatively, this can be set with the following environment variable: BATCH_WRITER_TIMEOUT
   -c, --cas-type string                             The type of the Content Addressable Storage (CAS). Supported options: local, ipfs. For local, the storage provider specified by database-type will be used. For ipfs, the node specified by ipfs-url will be used. This is a required parameter. Alternatively, this can be set with the following environment variable: CAS_TYPE
       --cid-version string                          The version of the CID format to use for generating CIDs. Supported options: 0, 1. If not set, defaults to 1.Alternatively, this can be set with the following environment variable: CID_VERSION (default "1")
+      --data-expiry-check-interval string           How frequently to check for (and delete) any expired data. For example, a setting of '1m' will cause the expiry service to run a check every 1 minute. Defaults to 1 minute if not set. Alternatively, this can be set with the following environment variable: DATA_EXPIRY_CHECK_INTERVAL
       --database-prefix string                      An optional prefix to be used when creating and retrieving underlying databases. Alternatively, this can be set with the following environment variable: DATABASE_PREFIX
   -t, --database-type string                        The type of database to use for everything except key storage. Supported options: mem, couchdb, mongodb. Alternatively, this can be set with the following environment variable: DATABASE_TYPE
   -v, --database-url string                         The URL of the database. Not needed if using memstore. For CouchDB, include the username:password@ text if required. Alternatively, this can be set with the following environment variable: DATABASE_URL
@@ -143,6 +144,7 @@ Flags:
       --sync-timeout string                         Total time in seconds to resolve config values. Alternatively, this can be set with the following environment variable: ORB_SYNC_TIMEOUT (default "1")
   -y, --tls-certificate string                      TLS certificate for ORB server. Alternatively, this can be set with the following environment variable: ORB_TLS_CERTIFICATE
   -x, --tls-key string                              TLS key for ORB server. Alternatively, this can be set with the following environment variable: ORB_TLS_KEY
+      --unpublished-operation-lifetime              How long unpublished operations remain stored before expiring (and thus, being deleted some time later). For example, '1m' for a 1 minute lifespan. Defaults to 1 minute if not set. Alternatively, this can be set with the following environment variable: UNPUBLISHED_OPERATION_LIFETIME
       --vct-url string                              Verifiable credential transparency URL.
 
 ```

--- a/cmd/orb-server/startcmd/params_test.go
+++ b/cmd/orb-server/startcmd/params_test.go
@@ -654,6 +654,32 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 		require.Contains(t, err.Error(), "missing unit in duration")
 	})
 
+	t.Run("Invalid unpublished operation lifespan", func(t *testing.T) {
+		restoreEnv := setEnv(t, unpublishedOperationLifespanEnvKey, "5")
+		defer restoreEnv()
+
+		startCmd := GetStartCmd()
+
+		startCmd.SetArgs(getTestArgs("localhost:8081", "local", "false", databaseTypeMemOption, ""))
+
+		err := startCmd.Execute()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing unit in duration")
+	})
+
+	t.Run("Invalid expiry check interval", func(t *testing.T) {
+		restoreEnv := setEnv(t, dataExpiryCheckIntervalEnvKey, "5")
+		defer restoreEnv()
+
+		startCmd := GetStartCmd()
+
+		startCmd.SetArgs(getTestArgs("localhost:8081", "local", "false", databaseTypeMemOption, ""))
+
+		err := startCmd.Execute()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing unit in duration")
+	})
+
 	t.Run("Invalid max connection subscriptions", func(t *testing.T) {
 		restoreEnv := setEnv(t, mqMaxConnectionSubscriptionsEnvKey, "xxx")
 		defer restoreEnv()

--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -168,9 +168,6 @@ const (
 
 	webKeyStoreKey = "web-key-store"
 	kidKey         = "kid"
-
-	// Defines how frequently the expiry services checks for (and deletes) expired data.
-	defaultExpiryInterval = time.Minute
 )
 
 type pubSub interface {
@@ -464,10 +461,10 @@ func startOrbServices(parameters *orbParameters) error {
 	if parameters.updateDocumentStoreEnabled {
 		// TODO (#810): Make it possible to run the expiry service from only one instance within a cluster (or as
 		//              a separate server)
-		// TODO (#808): Allow expiry interval to be configurable.
-		expiryService = expiry.NewService(defaultExpiryInterval)
+		expiryService = expiry.NewService(parameters.dataExpiryCheckInterval)
 
-		updateDocumentStore, err = unpublishedopstore.New(storeProviders.provider, expiryService)
+		updateDocumentStore, err = unpublishedopstore.New(storeProviders.provider,
+			parameters.unpublishedOperationLifespan, expiryService)
 		if err != nil {
 			return fmt.Errorf("failed to create unpublished document store: %w", err)
 		}

--- a/pkg/protocolversion/versions/v1_0/factory/factory_test.go
+++ b/pkg/protocolversion/versions/v1_0/factory/factory_test.go
@@ -45,7 +45,8 @@ func TestFactory_Create(t *testing.T) {
 	})
 
 	t.Run("success - with update store config", func(t *testing.T) {
-		updateDocumentStore, err := unpublishedopstore.New(storeProvider, expiry.NewService(time.Millisecond))
+		updateDocumentStore, err := unpublishedopstore.New(storeProvider, time.Minute,
+			expiry.NewService(time.Millisecond))
 		require.NoError(t, err)
 
 		cfg := &config.Sidetree{

--- a/pkg/store/operation/unpublished/store_test.go
+++ b/pkg/store/operation/unpublished/store_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestNew(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		s, err := New(mem.NewProvider(), expiry.NewService(time.Millisecond))
+		s, err := New(mem.NewProvider(), time.Minute, expiry.NewService(time.Millisecond))
 		require.NoError(t, err)
 		require.NotNil(t, s)
 	})
@@ -30,7 +30,7 @@ func TestNew(t *testing.T) {
 	t.Run("error - from open store", func(t *testing.T) {
 		s, err := New(&mockstore.Provider{
 			ErrOpenStore: fmt.Errorf("failed to open store"),
-		}, expiry.NewService(time.Millisecond))
+		}, time.Minute, expiry.NewService(time.Millisecond))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to open store")
 		require.Nil(t, s)
@@ -39,7 +39,7 @@ func TestNew(t *testing.T) {
 
 func TestStore_Put(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		s, err := New(mem.NewProvider(), expiry.NewService(time.Millisecond))
+		s, err := New(mem.NewProvider(), time.Minute, expiry.NewService(time.Millisecond))
 		require.NoError(t, err)
 
 		err = s.Put(&operation.AnchoredOperation{UniqueSuffix: "suffix"})
@@ -52,7 +52,7 @@ func TestStore_Put(t *testing.T) {
 			ErrGet: storage.ErrDataNotFound,
 		}}
 
-		s, err := New(storeProvider, expiry.NewService(time.Millisecond))
+		s, err := New(storeProvider, time.Minute, expiry.NewService(time.Millisecond))
 		require.NoError(t, err)
 
 		err = s.Put(&operation.AnchoredOperation{UniqueSuffix: "suffix"})
@@ -65,7 +65,7 @@ func TestStore_Put(t *testing.T) {
 			ErrGet: fmt.Errorf("random get error"),
 		}}
 
-		s, err := New(storeProvider, expiry.NewService(time.Millisecond))
+		s, err := New(storeProvider, time.Minute, expiry.NewService(time.Millisecond))
 		require.NoError(t, err)
 
 		err = s.Put(&operation.AnchoredOperation{UniqueSuffix: "suffix"})
@@ -75,7 +75,7 @@ func TestStore_Put(t *testing.T) {
 	})
 
 	t.Run("error - consecutive put", func(t *testing.T) {
-		s, err := New(mem.NewProvider(), expiry.NewService(time.Millisecond))
+		s, err := New(mem.NewProvider(), time.Minute, expiry.NewService(time.Millisecond))
 		require.NoError(t, err)
 
 		err = s.Put(&operation.AnchoredOperation{UniqueSuffix: "suffix"})
@@ -90,7 +90,7 @@ func TestStore_Put(t *testing.T) {
 
 func TestStore_Get(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		s, err := New(mem.NewProvider(), expiry.NewService(time.Millisecond))
+		s, err := New(mem.NewProvider(), time.Minute, expiry.NewService(time.Millisecond))
 		require.NoError(t, err)
 
 		err = s.Put(&operation.AnchoredOperation{UniqueSuffix: "suffix"})
@@ -102,7 +102,7 @@ func TestStore_Get(t *testing.T) {
 	})
 
 	t.Run("error - operation without suffix", func(t *testing.T) {
-		s, err := New(mem.NewProvider(), expiry.NewService(time.Millisecond))
+		s, err := New(mem.NewProvider(), time.Minute, expiry.NewService(time.Millisecond))
 		require.NoError(t, err)
 
 		err = s.Put(&operation.AnchoredOperation{})
@@ -115,7 +115,7 @@ func TestStore_Get(t *testing.T) {
 			ErrGet: fmt.Errorf("error get"),
 		}}
 
-		s, err := New(storeProvider, expiry.NewService(time.Millisecond))
+		s, err := New(storeProvider, time.Minute, expiry.NewService(time.Millisecond))
 		require.NoError(t, err)
 
 		op, err := s.Get("suffix")
@@ -133,7 +133,7 @@ func TestStore_Get(t *testing.T) {
 		err = store.Put("suffix", []byte("not-json"))
 		require.NoError(t, err)
 
-		s, err := New(provider, expiry.NewService(time.Millisecond))
+		s, err := New(provider, time.Minute, expiry.NewService(time.Millisecond))
 		require.NoError(t, err)
 
 		op, err := s.Get("suffix")
@@ -145,7 +145,7 @@ func TestStore_Get(t *testing.T) {
 
 func TestStore_Delete(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		s, err := New(mem.NewProvider(), expiry.NewService(time.Millisecond))
+		s, err := New(mem.NewProvider(), time.Minute, expiry.NewService(time.Millisecond))
 		require.NoError(t, err)
 
 		err = s.Put(&operation.AnchoredOperation{UniqueSuffix: "suffix"})
@@ -160,7 +160,7 @@ func TestStore_Delete(t *testing.T) {
 			ErrDelete: fmt.Errorf("delete error"),
 		}}
 
-		s, err := New(storeProvider, expiry.NewService(time.Millisecond))
+		s, err := New(storeProvider, time.Minute, expiry.NewService(time.Millisecond))
 		require.NoError(t, err)
 
 		err = s.Delete("suffix")
@@ -171,7 +171,7 @@ func TestStore_Delete(t *testing.T) {
 
 func TestStore_DeleteAll(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		s, err := New(mem.NewProvider(), expiry.NewService(time.Millisecond))
+		s, err := New(mem.NewProvider(), time.Minute, expiry.NewService(time.Millisecond))
 		require.NoError(t, err)
 
 		err = s.Put(&operation.AnchoredOperation{UniqueSuffix: "suffix"})
@@ -182,7 +182,7 @@ func TestStore_DeleteAll(t *testing.T) {
 	})
 
 	t.Run("success - no suffixes provided", func(t *testing.T) {
-		s, err := New(mem.NewProvider(), expiry.NewService(time.Millisecond))
+		s, err := New(mem.NewProvider(), time.Minute, expiry.NewService(time.Millisecond))
 		require.NoError(t, err)
 
 		err = s.DeleteAll(nil)
@@ -194,7 +194,7 @@ func TestStore_DeleteAll(t *testing.T) {
 			ErrBatch: fmt.Errorf("batch error"),
 		}}
 
-		s, err := New(storeProvider, expiry.NewService(time.Millisecond))
+		s, err := New(storeProvider, time.Minute, expiry.NewService(time.Millisecond))
 		require.NoError(t, err)
 
 		err = s.DeleteAll([]string{"suffix"})


### PR DESCRIPTION
Also added in the registration for the database timeout command line flag, which was missing (which meant that the environment variable would have been the only way to set it before. Now using the --database-timeout flag will work too)

closes #808 

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>