### PR TITLE
chore: Make previous anchors list instead of map

### DIFF
--- a/pkg/anchor/anchorevent/anchorevent.go
+++ b/pkg/anchor/anchorevent/anchorevent.go
@@ -65,9 +65,9 @@ func resolveParents(payload *subject.Payload) []*url.URL {
 	var previous []string
 
 	for _, value := range payload.PreviousAnchors {
-		if value != "" {
-			if !contains(previous, value) {
-				previous = append(previous, value)
+		if value.Anchor != "" {
+			if !contains(previous, value.Anchor) {
+				previous = append(previous, value.Anchor)
 			}
 		}
 	}

--- a/pkg/anchor/anchorevent/anchorevent_test.go
+++ b/pkg/anchor/anchorevent/anchorevent_test.go
@@ -35,9 +35,10 @@ const (
 )
 
 func TestBuildAnchorEvent(t *testing.T) {
-	previousAnchors := make(map[string]string)
-	previousAnchors[createSuffix] = ""
-	previousAnchors[updateSuffix] = updatePrevAnchor
+	previousAnchors := []*subject.SuffixAnchor{
+		{Suffix: createSuffix},
+		{Suffix: updateSuffix, Anchor: updatePrevAnchor},
+	}
 
 	publishedTime := time.Now()
 
@@ -141,9 +142,10 @@ func TestBuildAnchorEvent(t *testing.T) {
 }
 
 func TestGetPayloadFromActivity(t *testing.T) {
-	previousAnchors := make(map[string]string)
-	previousAnchors[createSuffix] = ""
-	previousAnchors[updateSuffix] = updatePrevAnchor
+	previousAnchors := []*subject.SuffixAnchor{
+		{Suffix: createSuffix},
+		{Suffix: updateSuffix, Anchor: updatePrevAnchor},
+	}
 
 	publishedTime := time.Now()
 

--- a/pkg/anchor/anchorevent/generator/didorbgenerator/didorbgenerator_test.go
+++ b/pkg/anchor/anchorevent/generator/didorbgenerator/didorbgenerator_test.go
@@ -64,9 +64,14 @@ func TestGenerator_CreateContentObject(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		payload := &subject.Payload{
 			CoreIndex: coreIndexHL2,
-			PreviousAnchors: map[string]string{
-				suffix1: "",
-				suffix2: "hl:uEiAuBQKPYXl90i3ho0aJsEGJpXCrvZvbRBtXH6RUF0rZLA:uoQ-BeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQXVCUUtQWVhsOTBpM2hvMGFKc0VHSnBYQ3J2WnZiUkJ0WEg2UlVGMHJaTEE", //nolint:lll
+			PreviousAnchors: []*subject.SuffixAnchor{
+				{
+					Suffix: suffix1,
+				},
+				{
+					Suffix: suffix2,
+					Anchor: "hl:uEiAuBQKPYXl90i3ho0aJsEGJpXCrvZvbRBtXH6RUF0rZLA:uoQ-BeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQXVCUUtQWVhsOTBpM2hvMGFKc0VHSnBYQ3J2WnZiUkJ0WEg2UlVGMHJaTEE", //nolint:lll
+				},
 			},
 		}
 
@@ -105,8 +110,11 @@ func TestGenerator_CreateContentObject(t *testing.T) {
 	t.Run("Invalid hashlink in previous anchor", func(t *testing.T) {
 		payload := &subject.Payload{
 			CoreIndex: coreIndexHL1,
-			PreviousAnchors: map[string]string{
-				suffix2: "uEiAuBQKPYXl90i3ho0aJsEGJpXCrvZvbRBtXH6RUF0rZLA",
+			PreviousAnchors: []*subject.SuffixAnchor{
+				{
+					Suffix: suffix2,
+					Anchor: "uEiAuBQKPYXl90i3ho0aJsEGJpXCrvZvbRBtXH6RUF0rZLA",
+				},
 			},
 		}
 
@@ -164,8 +172,10 @@ func TestGenerator_GetPayloadFromAnchorEvent(t *testing.T) {
 		require.Equal(t, Version, payload.Version)
 		require.Equal(t, service1, payload.AnchorOrigin)
 		require.Equal(t, published, *payload.Published)
-		require.Equal(t, "", payload.PreviousAnchors["EiDJpL-xeSE4kVgoGjaQm_OurMdR6jIeDRUxv7RhGNf5jw"])
-		require.Equal(t, parentHL1, payload.PreviousAnchors["EiAPcYpwgg88zOvQ4-sdwpj4UKqZeYS_Ej6kkZl_bZIJjw"])
+		require.Equal(t, "", payload.PreviousAnchors[0].Anchor)
+		require.Equal(t, "EiDJpL-xeSE4kVgoGjaQm_OurMdR6jIeDRUxv7RhGNf5jw", payload.PreviousAnchors[0].Suffix)
+		require.Equal(t, parentHL1, payload.PreviousAnchors[1].Anchor)
+		require.Equal(t, "EiAPcYpwgg88zOvQ4-sdwpj4UKqZeYS_Ej6kkZl_bZIJjw", payload.PreviousAnchors[1].Suffix)
 	})
 
 	t.Run("Core index anchor not found", func(t *testing.T) {

--- a/pkg/anchor/graph/graph.go
+++ b/pkg/anchor/graph/graph.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
 	"github.com/trustbloc/orb/pkg/anchor/anchorevent"
+	"github.com/trustbloc/orb/pkg/anchor/subject"
 	"github.com/trustbloc/orb/pkg/errors"
 )
 
@@ -121,13 +122,23 @@ func (g *Graph) GetDidAnchors(hl, suffix string) ([]Anchor, error) {
 
 		previousAnchors := payload.PreviousAnchors
 
-		cur, ok = previousAnchors[suffix]
+		cur, ok = contains(suffix, previousAnchors)
 		if ok && cur == "" { // create
 			break
 		}
 	}
 
 	return reverseOrder(refs), nil
+}
+
+func contains(suffix string, previousAnchors []*subject.SuffixAnchor) (string, bool) {
+	for _, val := range previousAnchors {
+		if val.Suffix == suffix {
+			return val.Anchor, true
+		}
+	}
+
+	return "", false
 }
 
 func reverseOrder(original []Anchor) []Anchor {

--- a/pkg/anchor/graph/graph_test.go
+++ b/pkg/anchor/graph/graph_test.go
@@ -134,8 +134,10 @@ func TestGraph_GetDidAnchors(t *testing.T) {
 	t.Run("success - previous anchor for did exists", func(t *testing.T) {
 		graph := New(providers)
 
-		previousDIDTxns := make(map[string]string)
-		previousDIDTxns[testDID] = ""
+		previousDIDTxns := []*subject.SuffixAnchor{
+			{Suffix: testDID},
+		}
+
 		payload := &subject.Payload{
 			OperationCount:  1,
 			CoreIndex:       "coreIndex-1",
@@ -148,8 +150,9 @@ func TestGraph_GetDidAnchors(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, anchor1HL)
 
-		previousDIDTxns = make(map[string]string)
-		previousDIDTxns[testDID] = anchor1HL
+		previousDIDTxns = []*subject.SuffixAnchor{
+			{Suffix: testDID, Anchor: anchor1HL},
+		}
 
 		payload = &subject.Payload{
 			OperationCount:  1,
@@ -172,8 +175,9 @@ func TestGraph_GetDidAnchors(t *testing.T) {
 	t.Run("success - cid referenced in previous anchor empty (create)", func(t *testing.T) {
 		graph := New(providers)
 
-		previousDIDTxns := make(map[string]string)
-		previousDIDTxns[testDID] = ""
+		previousDIDTxns := []*subject.SuffixAnchor{
+			{Suffix: testDID},
+		}
 
 		payload := &subject.Payload{
 			OperationCount:  1,
@@ -195,8 +199,12 @@ func TestGraph_GetDidAnchors(t *testing.T) {
 	t.Run("error - cid referenced in previous anchor not found", func(t *testing.T) {
 		graph := New(providers)
 
-		previousDIDTxns := make(map[string]string)
-		previousDIDTxns[testDID] = "hl:" + nonExistent + ":metadata"
+		previousDIDTxns := []*subject.SuffixAnchor{
+			{
+				Suffix: testDID,
+				Anchor: "hl:" + nonExistent + ":metadata",
+			},
+		}
 
 		payload := &subject.Payload{
 			CoreIndex:       "coreIndex-2",
@@ -218,8 +226,12 @@ func TestGraph_GetDidAnchors(t *testing.T) {
 	t.Run("error - cid referenced in previous anchor is invalid", func(t *testing.T) {
 		graph := New(providers)
 
-		previousDIDTxns := make(map[string]string)
-		previousDIDTxns[testDID] = "hl:nonExistent:metadata"
+		previousDIDTxns := []*subject.SuffixAnchor{
+			{
+				Suffix: testDID,
+				Anchor: "hl:nonExistent:metadata",
+			},
+		}
 
 		payload := &subject.Payload{
 			CoreIndex:       "coreIndex-2",
@@ -251,8 +263,9 @@ func TestGraph_GetDidAnchors(t *testing.T) {
 func newDefaultMockAnchorEvent(t *testing.T) *vocab.AnchorEventType {
 	t.Helper()
 
-	previousAnchors := make(map[string]string)
-	previousAnchors["suffix"] = ""
+	previousAnchors := []*subject.SuffixAnchor{
+		{Suffix: "suffix"},
+	}
 
 	payload := &subject.Payload{
 		OperationCount:  1,

--- a/pkg/anchor/subject/model.go
+++ b/pkg/anchor/subject/model.go
@@ -19,5 +19,11 @@ type Payload struct {
 	Version         uint64
 	AnchorOrigin    string
 	Published       *time.Time
-	PreviousAnchors map[string]string
+	PreviousAnchors []*SuffixAnchor
+}
+
+// SuffixAnchor describes an anchor for suffix.
+type SuffixAnchor struct {
+	Suffix string
+	Anchor string
 }

--- a/pkg/anchor/util/util_test.go
+++ b/pkg/anchor/util/util_test.go
@@ -27,8 +27,9 @@ const defVCContext = "https://www.w3.org/2018/credentials/v1"
 
 func TestVerifiableCredentialFromAnchorEvent(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		previousAnchors := make(map[string]string)
-		previousAnchors["suffix"] = ""
+		previousAnchors := []*subject.SuffixAnchor{
+			{Suffix: "suffix"},
+		}
 
 		payload := &subject.Payload{
 			OperationCount:  1,

--- a/pkg/anchor/writer/writer.go
+++ b/pkg/anchor/writer/writer.go
@@ -266,13 +266,13 @@ func (c *Writer) buildAnchorEvent(payload *subject.Payload, witnesses []string) 
 	return anchorEvent, nil
 }
 
-func (c *Writer) getPreviousAnchors(refs []*operation.Reference) (map[string]string, error) {
+func (c *Writer) getPreviousAnchors(refs []*operation.Reference) ([]*subject.SuffixAnchor, error) {
 	getPreviousAnchorsStartTime := time.Now()
 
 	defer c.metrics.WriteAnchorGetPreviousAnchorsTime(time.Since(getPreviousAnchorsStartTime))
 
 	// assemble map of latest did anchor references
-	previousAnchors := make(map[string]string)
+	var previousAnchors []*subject.SuffixAnchor
 
 	suffixes := getSuffixes(refs)
 
@@ -292,9 +292,9 @@ func (c *Writer) getPreviousAnchors(refs []*operation.Reference) (map[string]str
 			}
 
 			// create doesn't have previous anchor references
-			previousAnchors[ref.UniqueSuffix] = ""
+			previousAnchors = append(previousAnchors, &subject.SuffixAnchor{Suffix: ref.UniqueSuffix})
 		} else {
-			previousAnchors[ref.UniqueSuffix] = anchors[i]
+			previousAnchors = append(previousAnchors, &subject.SuffixAnchor{Suffix: ref.UniqueSuffix, Anchor: anchors[i]})
 		}
 	}
 

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -26,6 +26,7 @@ import (
 	"github.com/trustbloc/orb/pkg/anchor/anchorevent"
 	"github.com/trustbloc/orb/pkg/anchor/graph"
 	anchorinfo "github.com/trustbloc/orb/pkg/anchor/info"
+	"github.com/trustbloc/orb/pkg/anchor/subject"
 	"github.com/trustbloc/orb/pkg/anchor/util"
 	discoveryrest "github.com/trustbloc/orb/pkg/discovery/endpoint/restapi"
 	"github.com/trustbloc/orb/pkg/errors"
@@ -331,7 +332,7 @@ func (o *Observer) processAnchor(anchor *anchorinfo.AnchorInfo,
 	}
 
 	// update global did/anchor references
-	acSuffixes := getKeys(anchorPayload.PreviousAnchors)
+	acSuffixes := getSuffixes(anchorPayload.PreviousAnchors)
 
 	err = o.DidAnchors.PutBulk(acSuffixes, anchor.Hashlink)
 	if err != nil {
@@ -469,13 +470,13 @@ func (o *Observer) saveAnchorHashlink(ref *url.URL) error {
 	return nil
 }
 
-func getKeys(m map[string]string) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
+func getSuffixes(m []*subject.SuffixAnchor) []string {
+	suffixes := make([]string, 0, len(m))
+	for _, k := range m {
+		suffixes = append(suffixes, k.Suffix)
 	}
 
-	return keys
+	return suffixes
 }
 
 func newLikeResult(hashLink string) (*vocab.ObjectProperty, error) {

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -121,8 +121,10 @@ func TestStartObserver(t *testing.T) {
 
 		anchorGraph := graph.New(graphProviders)
 
-		prevAnchors := make(map[string]string)
-		prevAnchors["did1"] = ""
+		prevAnchors := []*subject.SuffixAnchor{
+			{Suffix: "did1"},
+		}
+
 		payload1 := subject.Payload{Namespace: namespace1, Version: 0, CoreIndex: "core1", PreviousAnchors: prevAnchors}
 
 		cid, err := anchorGraph.Add(newMockAnchorEvent(t, &payload1))
@@ -133,8 +135,10 @@ func TestStartObserver(t *testing.T) {
 			AttributedTo:  "https://example.com/services/orb",
 		}
 
-		prevAnchors = make(map[string]string)
-		prevAnchors["did2"] = ""
+		prevAnchors = []*subject.SuffixAnchor{
+			{Suffix: "did2"},
+		}
+
 		payload2 := subject.Payload{Namespace: namespace2, Version: 1, CoreIndex: "core2", PreviousAnchors: prevAnchors}
 
 		cid, err = anchorGraph.Add(newMockAnchorEvent(t, &payload2))
@@ -211,9 +215,10 @@ func TestStartObserver(t *testing.T) {
 		did1 := "xyz"
 		did2 := "abc"
 
-		previousAnchors := make(map[string]string)
-		previousAnchors[did1] = ""
-		previousAnchors[did2] = ""
+		previousAnchors := []*subject.SuffixAnchor{
+			{Suffix: did1},
+			{Suffix: did2},
+		}
 
 		payload1 := subject.Payload{Namespace: namespace1, Version: 0, CoreIndex: "address", PreviousAnchors: previousAnchors}
 
@@ -270,15 +275,16 @@ func TestStartObserver(t *testing.T) {
 
 		did1 := "jkh"
 
-		previousAnchors := make(map[string]string)
-		previousAnchors[did1] = ""
+		previousAnchors := []*subject.SuffixAnchor{
+			{Suffix: did1},
+		}
 
 		payload1 := subject.Payload{Namespace: namespace1, Version: 0, CoreIndex: "address", PreviousAnchors: previousAnchors}
 
 		cid, err := anchorGraph.Add(newMockAnchorEvent(t, &payload1))
 		require.NoError(t, err)
 
-		previousAnchors[did1] = cid
+		previousAnchors[0].Anchor = cid
 
 		payload2 := subject.Payload{Namespace: namespace1, Version: 0, CoreIndex: "address", PreviousAnchors: previousAnchors}
 
@@ -332,8 +338,9 @@ func TestStartObserver(t *testing.T) {
 
 		did := "123"
 
-		previousDIDAnchors := make(map[string]string)
-		previousDIDAnchors[did] = ""
+		previousDIDAnchors := []*subject.SuffixAnchor{
+			{Suffix: did},
+		}
 
 		payload1 := subject.Payload{
 			Namespace: namespace1,
@@ -396,9 +403,10 @@ func TestStartObserver(t *testing.T) {
 		did1 := "123"
 		did2 := "abc"
 
-		previousAnchors := make(map[string]string)
-		previousAnchors[did1] = ""
-		previousAnchors[did2] = ""
+		previousAnchors := []*subject.SuffixAnchor{
+			{Suffix: did1},
+			{Suffix: did2},
+		}
 
 		payload1 := subject.Payload{Namespace: namespace1, Version: 0, CoreIndex: "address", PreviousAnchors: previousAnchors}
 
@@ -453,8 +461,9 @@ func TestStartObserver(t *testing.T) {
 
 		anchorGraph := graph.New(graphProviders)
 
-		prevAnchors := make(map[string]string)
-		prevAnchors["suffix"] = ""
+		prevAnchors := []*subject.SuffixAnchor{
+			{Suffix: "suffix"},
+		}
 
 		payload1 := subject.Payload{
 			Namespace:       namespace1,
@@ -635,8 +644,9 @@ func TestStartObserver(t *testing.T) {
 
 		did1 := "xyz"
 
-		previousAnchors := make(map[string]string)
-		previousAnchors[did1] = ""
+		previousAnchors := []*subject.SuffixAnchor{
+			{Suffix: did1},
+		}
 
 		payload1 := subject.Payload{Namespace: namespace1, Version: 0, CoreIndex: "address", PreviousAnchors: previousAnchors}
 

--- a/pkg/orbclient/client_test.go
+++ b/pkg/orbclient/client_test.go
@@ -31,8 +31,9 @@ const testDID = "did"
 
 func TestGetAnchorOrigin(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		previousDIDTxns := make(map[string]string)
-		previousDIDTxns[testDID] = ""
+		previousDIDTxns := []*subject.SuffixAnchor{
+			{Suffix: "suffix"},
+		}
 
 		payload := subject.Payload{
 			OperationCount:  2,
@@ -83,8 +84,9 @@ func TestGetAnchorOrigin(t *testing.T) {
 	})
 
 	t.Run("error - anchored operation is an 'update' operation", func(t *testing.T) {
-		previousDIDTxns := make(map[string]string)
-		previousDIDTxns[testDID] = ""
+		previousDIDTxns := []*subject.SuffixAnchor{
+			{Suffix: testDID},
+		}
 
 		payload := subject.Payload{
 			OperationCount:  2,
@@ -136,8 +138,9 @@ func TestGetAnchorOrigin(t *testing.T) {
 	})
 
 	t.Run("error - failed to get anchored operation for suffix", func(t *testing.T) {
-		previousDIDTxns := make(map[string]string)
-		previousDIDTxns[testDID] = ""
+		previousDIDTxns := []*subject.SuffixAnchor{
+			{Suffix: testDID},
+		}
 
 		payload := subject.Payload{
 			OperationCount:  2,
@@ -178,8 +181,9 @@ func TestGetAnchorOrigin(t *testing.T) {
 	})
 
 	t.Run("error - failed to read core index file", func(t *testing.T) {
-		previousDIDTxns := make(map[string]string)
-		previousDIDTxns[testDID] = ""
+		previousDIDTxns := []*subject.SuffixAnchor{
+			{Suffix: testDID},
+		}
 
 		payload := subject.Payload{
 			OperationCount:  2,
@@ -209,8 +213,9 @@ func TestGetAnchorOrigin(t *testing.T) {
 	})
 
 	t.Run("error - protocol client error", func(t *testing.T) {
-		previousDIDTxns := make(map[string]string)
-		previousDIDTxns[testDID] = ""
+		previousDIDTxns := []*subject.SuffixAnchor{
+			{Suffix: testDID},
+		}
 
 		payload := subject.Payload{
 			OperationCount:  2,


### PR DESCRIPTION
Make previous anchors list instead of map in order to have consistent running of unit-test. This change will also make it easier if we decide to support shortcut indexing.

Closes #607

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>