### PR TITLE
fix: Add signature validation for VC before processing Sidetree batches

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -455,7 +455,6 @@ func startOrbServices(parameters *orbParameters) error {
 	graphProviders := &graph.Providers{
 		CasResolver: casResolver,
 		CasWriter:   coreCASClient,
-		Pkf:         verifiable.NewVDRKeyResolver(vdr).PublicKeyFetcher(),
 		DocLoader:   orbDocumentLoader,
 	}
 
@@ -638,6 +637,7 @@ func startOrbServices(parameters *orbParameters) error {
 		WebFingerResolver:      resourceResolver,
 		CASResolver:            casResolver,
 		DocLoader:              orbDocumentLoader,
+		Pkf:                    verifiable.NewVDRKeyResolver(vdr).PublicKeyFetcher(),
 		AnchorLinkStore:        anchorLinkStore,
 	}
 

--- a/pkg/anchor/graph/graph.go
+++ b/pkg/anchor/graph/graph.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	"github.com/piprate/json-gold/ld"
 	"github.com/trustbloc/edge-core/pkg/log"
 	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
@@ -33,7 +32,6 @@ type Graph struct {
 type Providers struct {
 	CasWriter   casWriter
 	CasResolver casResolver
-	Pkf         verifiable.PublicKeyFetcher
 	DocLoader   ld.DocumentLoader
 }
 

--- a/pkg/anchor/graph/graph_test.go
+++ b/pkg/anchor/graph/graph_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
-	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/util"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	"github.com/stretchr/testify/require"
@@ -51,7 +50,6 @@ func TestGraph_Add(t *testing.T) {
 			casresolver.NewWebCASResolver(
 				&apmocks.HTTPTransport{}, webfingerclient.New(), "https"),
 			&metricsProvider{}),
-		Pkf:       pubKeyFetcherFnc,
 		DocLoader: testutil.GetLoader(t),
 	}
 
@@ -75,7 +73,6 @@ func TestGraph_Read(t *testing.T) {
 			casresolver.NewWebCASResolver(
 				&apmocks.HTTPTransport{}, webfingerclient.New(), "https"),
 			&metricsProvider{}),
-		Pkf:       pubKeyFetcherFnc,
 		DocLoader: testutil.GetLoader(t),
 	}
 
@@ -115,7 +112,6 @@ func TestGraph_GetDidAnchors(t *testing.T) {
 			casresolver.NewWebCASResolver(
 				&apmocks.HTTPTransport{}, webfingerclient.New(), "https"),
 			&metricsProvider{}),
-		Pkf:       pubKeyFetcherFnc,
 		DocLoader: testutil.GetLoader(t),
 	}
 
@@ -298,10 +294,6 @@ func newMockAnchorEvent(t *testing.T, payload *subject.Payload) *vocab.AnchorEve
 	require.NoError(t, err)
 
 	return act
-}
-
-var pubKeyFetcherFnc = func(issuerID, keyID string) (*verifier.PublicKey, error) {
-	return nil, nil
 }
 
 type metricsProvider struct{}

--- a/pkg/anchor/writer/writer_test.go
+++ b/pkg/anchor/writer/writer_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
 	mockstore "github.com/hyperledger/aries-framework-go/component/storageutil/mock"
-	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	"github.com/stretchr/testify/require"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
@@ -120,7 +119,6 @@ func TestWriter_WriteAnchor(t *testing.T) {
 				transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 					transport.DefaultSigner(), transport.DefaultSigner()),
 				wfclient.New(), "https"), &mocks.MetricsProvider{}),
-		Pkf: pubKeyFetcherFnc,
 	}
 
 	apServiceIRI, err := url.Parse(activityPubURL)
@@ -919,7 +917,6 @@ func TestWriter_handle(t *testing.T) {
 				transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 					transport.DefaultSigner(), transport.DefaultSigner()),
 				wfclient.New(), "https"), &mocks.MetricsProvider{}),
-		Pkf: pubKeyFetcherFnc,
 	}
 
 	apServiceIRI, err := url.Parse(activityPubURL)
@@ -1547,7 +1544,6 @@ func TestWriter_Read(t *testing.T) {
 				transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 					transport.DefaultSigner(), transport.DefaultSigner()),
 				wfclient.New(), "https"), &mocks.MetricsProvider{}),
-		Pkf: pubKeyFetcherFnc,
 	}
 
 	providers := &Providers{
@@ -1582,10 +1578,6 @@ func (m *mockTxnBuilder) Build(anchorHashlink string) (*verifiable.Credential, e
 	}
 
 	return &verifiable.Credential{Subject: &builder.CredentialSubject{ID: anchorHashlink}}, nil
-}
-
-var pubKeyFetcherFnc = func(issuerID, keyID string) (*verifier.PublicKey, error) {
-	return nil, nil
 }
 
 type mockAnchorGraph struct {

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -132,6 +132,7 @@ type Providers struct {
 	WebFingerResolver resourceResolver
 	CASResolver       casResolver
 	DocLoader         documentLoader
+	Pkf               verifiable.PublicKeyFetcher
 	AnchorLinkStore   anchorLinkStore
 }
 
@@ -307,7 +308,7 @@ func (o *Observer) processAnchor(anchor *anchorinfo.AnchorInfo,
 	}
 
 	vc, err := util.VerifiableCredentialFromAnchorEvent(anchorEvent,
-		verifiable.WithDisabledProofCheck(),
+		verifiable.WithPublicKeyFetcher(o.Pkf),
 		verifiable.WithJSONLDDocumentLoader(o.DocLoader),
 	)
 	if err != nil {

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -84,6 +84,7 @@ func TestStartObserver(t *testing.T) {
 			DidAnchors: memdidanchor.New(),
 			PubSub:     mempubsub.New(mempubsub.DefaultConfig()),
 			Metrics:    &orbmocks.MetricsProvider{},
+			Pkf:        pubKeyFetcherFnc,
 		}
 
 		o, err := New(serviceIRI, providers)
@@ -115,7 +116,6 @@ func TestStartObserver(t *testing.T) {
 					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 						transport.DefaultSigner(), transport.DefaultSigner()),
 					webfingerclient.New(), "https"), &orbmocks.MetricsProvider{}),
-			Pkf:       pubKeyFetcherFnc,
 			DocLoader: testutil.GetLoader(t),
 		}
 
@@ -169,6 +169,7 @@ func TestStartObserver(t *testing.T) {
 			WebFingerResolver:      &apmocks.WebFingerResolver{},
 			CASResolver:            casResolver,
 			DocLoader:              testutil.GetLoader(t),
+			Pkf:                    pubKeyFetcherFnc,
 			AnchorLinkStore:        &orbmocks.AnchorLinkStore{},
 		}
 
@@ -206,7 +207,6 @@ func TestStartObserver(t *testing.T) {
 					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 						transport.DefaultSigner(), transport.DefaultSigner()),
 					webfingerclient.New(), "https"), &orbmocks.MetricsProvider{}),
-			Pkf:       pubKeyFetcherFnc,
 			DocLoader: testutil.GetLoader(t),
 		}
 
@@ -231,6 +231,7 @@ func TestStartObserver(t *testing.T) {
 			DidAnchors:             memdidanchor.New(),
 			PubSub:                 mempubsub.New(mempubsub.DefaultConfig()),
 			Metrics:                &orbmocks.MetricsProvider{},
+			Pkf:                    pubKeyFetcherFnc,
 			DocLoader:              testutil.GetLoader(t),
 		}
 
@@ -267,7 +268,6 @@ func TestStartObserver(t *testing.T) {
 					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 						transport.DefaultSigner(), transport.DefaultSigner()),
 					webfingerclient.New(), "https"), &orbmocks.MetricsProvider{}),
-			Pkf:       pubKeyFetcherFnc,
 			DocLoader: testutil.GetLoader(t),
 		}
 
@@ -298,6 +298,7 @@ func TestStartObserver(t *testing.T) {
 			PubSub:                 mempubsub.New(mempubsub.DefaultConfig()),
 			Metrics:                &orbmocks.MetricsProvider{},
 			DocLoader:              testutil.GetLoader(t),
+			Pkf:                    pubKeyFetcherFnc,
 		}
 
 		o, err := New(serviceIRI, providers)
@@ -331,7 +332,6 @@ func TestStartObserver(t *testing.T) {
 					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 						transport.DefaultSigner(), transport.DefaultSigner()),
 					webfingerclient.New(), "https"), &orbmocks.MetricsProvider{}),
-			Pkf:       pubKeyFetcherFnc,
 			DocLoader: testutil.GetLoader(t),
 		}
 		anchorGraph := graph.New(graphProviders)
@@ -360,6 +360,7 @@ func TestStartObserver(t *testing.T) {
 			PubSub:                 mempubsub.New(mempubsub.DefaultConfig()),
 			Metrics:                &orbmocks.MetricsProvider{},
 			DocLoader:              testutil.GetLoader(t),
+			Pkf:                    pubKeyFetcherFnc,
 		}
 
 		o, err := New(serviceIRI, providers)
@@ -394,7 +395,6 @@ func TestStartObserver(t *testing.T) {
 					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 						transport.DefaultSigner(), transport.DefaultSigner()),
 					webfingerclient.New(), "https"), &orbmocks.MetricsProvider{}),
-			Pkf:       pubKeyFetcherFnc,
 			DocLoader: testutil.GetLoader(t),
 		}
 
@@ -455,7 +455,6 @@ func TestStartObserver(t *testing.T) {
 					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 						transport.DefaultSigner(), transport.DefaultSigner()),
 					webfingerclient.New(), "https"), &orbmocks.MetricsProvider{}),
-			Pkf:       pubKeyFetcherFnc,
 			DocLoader: testutil.GetLoader(t),
 		}
 
@@ -494,6 +493,7 @@ func TestStartObserver(t *testing.T) {
 			PubSub:                 mempubsub.New(mempubsub.DefaultConfig()),
 			Metrics:                &orbmocks.MetricsProvider{},
 			DocLoader:              testutil.GetLoader(t),
+			Pkf:                    pubKeyFetcherFnc,
 		}
 
 		o, err := New(serviceIRI, providers)
@@ -528,7 +528,6 @@ func TestStartObserver(t *testing.T) {
 					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 						transport.DefaultSigner(), transport.DefaultSigner()),
 					webfingerclient.New(), "https"), &orbmocks.MetricsProvider{}),
-			Pkf:       pubKeyFetcherFnc,
 			DocLoader: testutil.GetLoader(t),
 		}
 
@@ -541,6 +540,7 @@ func TestStartObserver(t *testing.T) {
 			PubSub:                 mempubsub.New(mempubsub.DefaultConfig()),
 			Metrics:                &orbmocks.MetricsProvider{},
 			DocLoader:              testutil.GetLoader(t),
+			Pkf:                    pubKeyFetcherFnc,
 		}
 
 		o, err := New(serviceIRI, providers)
@@ -569,6 +569,7 @@ func TestStartObserver(t *testing.T) {
 			PubSub:                 mempubsub.New(mempubsub.DefaultConfig()),
 			Metrics:                &orbmocks.MetricsProvider{},
 			DocLoader:              testutil.GetLoader(t),
+			Pkf:                    pubKeyFetcherFnc,
 		}
 
 		o, err := New(serviceIRI, providers)
@@ -603,6 +604,7 @@ func TestStartObserver(t *testing.T) {
 			PubSub:                 mempubsub.New(mempubsub.DefaultConfig()),
 			Metrics:                &orbmocks.MetricsProvider{},
 			DocLoader:              testutil.GetLoader(t),
+			Pkf:                    pubKeyFetcherFnc,
 		}
 
 		o, err := New(serviceIRI, providers)
@@ -636,7 +638,6 @@ func TestStartObserver(t *testing.T) {
 					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 						transport.DefaultSigner(), transport.DefaultSigner()),
 					webfingerclient.New(), "https"), &orbmocks.MetricsProvider{}),
-			Pkf:       pubKeyFetcherFnc,
 			DocLoader: testutil.GetLoader(t),
 		}
 
@@ -666,6 +667,7 @@ func TestStartObserver(t *testing.T) {
 			PubSub:                 pubSub,
 			Metrics:                &orbmocks.MetricsProvider{},
 			DocLoader:              testutil.GetLoader(t),
+			Pkf:                    pubKeyFetcherFnc,
 		}
 
 		o, err := New(serviceIRI, providers)
@@ -698,6 +700,7 @@ func TestResolveActorFromHashlink(t *testing.T) {
 		WebFingerResolver: wfResolver,
 		CASResolver:       casResolver,
 		DocLoader:         testutil.GetLoader(t),
+		Pkf:               pubKeyFetcherFnc,
 	}
 
 	o, e := New(serviceIRI, providers)


### PR DESCRIPTION
Included:
- remove unused PublicKeyFetcher from anchor/graph
- add PublicKeyFetcher to observer and verify VC signatures

Closes #831

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>