### PR TITLE
chore: Delete anchor event upon witnessing

### DIFF
--- a/pkg/store/anchorevent/store.go
+++ b/pkg/store/anchorevent/store.go
@@ -81,3 +81,14 @@ func (s *Store) Get(id string) (*vocab.AnchorEventType, error) {
 
 	return anchorEvent, nil
 }
+
+// Delete deletes anchor event by id.
+func (s *Store) Delete(id string) error {
+	if err := s.store.Delete(id); err != nil {
+		return orberrors.NewTransient(fmt.Errorf("failed to delete anchor event id[%s]: %w", id, err))
+	}
+
+	logger.Debugf("deleted anchor event id[%s]", id)
+
+	return nil
+}

--- a/pkg/store/anchorevent/store_test.go
+++ b/pkg/store/anchorevent/store_test.go
@@ -143,3 +143,34 @@ func TestStore_Get(t *testing.T) {
 		require.Nil(t, ae)
 	})
 }
+
+func TestStore_Delete(t *testing.T) {
+	t.Run("test success", func(t *testing.T) {
+		s, err := New(mem.NewProvider(), testutil.GetLoader(t))
+		require.NoError(t, err)
+
+		err = s.Put(vocab.NewAnchorEvent(vocab.WithAnchors(anchorsURL)))
+		require.NoError(t, err)
+
+		ae, err := s.Get(anchorsURL.String())
+		require.NoError(t, err)
+		require.Equal(t, ae.Anchors().String(), anchorsURL.String())
+
+		err = s.Delete(anchorsURL.String())
+		require.NoError(t, err)
+		require.Equal(t, ae.Anchors().String(), anchorsURL.String())
+	})
+
+	t.Run("test error from store delete", func(t *testing.T) {
+		storeProvider := &mockstore.Provider{OpenStoreReturn: &mockstore.Store{
+			ErrDelete: fmt.Errorf("error delete"),
+		}}
+
+		s, err := New(storeProvider, testutil.GetLoader(t))
+		require.NoError(t, err)
+
+		err = s.Delete("vc1")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error delete")
+	})
+}


### PR DESCRIPTION
- add delete to anchor event store
- delete anchor event after it has been witnessed (batch writer)

Closes #827

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>