### PR TITLE
fix: Intermittent BDD test failure

### DIFF
--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -122,6 +122,7 @@ services:
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
       - BATCH_WRITER_TIMEOUT=1000
       - CAS_TYPE=${CAS_TYPE}
+      - REPLICATE_LOCAL_CAS_WRITES_IN_IPFS=true
       - IPFS_URL=ipfs:5001
       - IPFS_TIMEOUT=10s
       - MQ_URL=amqp://${RABBITMQ_USERNAME}:${RABBITMQ_PASSWORD}@orb.mq.domain1.com:5672/


### PR DESCRIPTION
The issue was that orb2-domain1 didn't have the REPLICATE_LOCAL_CAS_WRITES_IN_IPFS setting enabled - it was only enabled on orb-domain1. In one of the tests, the create operation would happen on orb2-domain1 (which didn't have IPFS replication on) and then the update would happen on orb-domain1 (which did). Since the create operation wasn't replicated in IPFS, the IPFS DID discovery failed.

There needs to be further investigation into why orb2-domain1 was getting the create request since in the BDD test it appears that it should have been sent to orb.domain1. We also need to figure out why it would sometimes pass.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>

closes #840