### PR TITLE
feat: Move witness to separate attachment in AnchorEvent

### DIFF
--- a/pkg/activitypub/service/activityhandler/inboxhandler.go
+++ b/pkg/activitypub/service/activityhandler/inboxhandler.go
@@ -18,6 +18,7 @@ import (
 	store "github.com/trustbloc/orb/pkg/activitypub/store/spi"
 	"github.com/trustbloc/orb/pkg/activitypub/store/storeutil"
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+	"github.com/trustbloc/orb/pkg/anchor/util"
 	orberrors "github.com/trustbloc/orb/pkg/errors"
 	"github.com/trustbloc/orb/pkg/hashlink"
 )
@@ -483,7 +484,12 @@ func (h *Inbox) handleOfferActivity(offer *vocab.ActivityType) error {
 
 	anchorEvent := offer.Object().AnchorEvent()
 
-	result, err := h.witnessAnchorCredential(anchorEvent.Witness())
+	witnessDoc, err := util.GetWitnessDoc(anchorEvent)
+	if err != nil {
+		return fmt.Errorf("get witness document for 'Offer' activity [%s]: %w", offer.ID(), err)
+	}
+
+	result, err := h.witnessAnchorCredential(witnessDoc)
 	if err != nil {
 		return fmt.Errorf("error creating result for 'Offer' activity [%s]: %w", offer.ID(), err)
 	}
@@ -875,7 +881,7 @@ func (h *Inbox) validateLikeActivity(like *vocab.ActivityType) error {
 	return nil
 }
 
-func (h *Inbox) witnessAnchorCredential(vc *vocab.ObjectType) (*vocab.ObjectType, error) {
+func (h *Inbox) witnessAnchorCredential(vc vocab.Document) (*vocab.ObjectType, error) {
 	bytes, err := json.Marshal(vc)
 	if err != nil {
 		return nil, fmt.Errorf("unable to marshal object in 'Offer' activity: %w", err)

--- a/pkg/activitypub/vocab/linktype.go
+++ b/pkg/activitypub/vocab/linktype.go
@@ -1,0 +1,80 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vocab
+
+import (
+	"net/url"
+)
+
+// LinkType defines the ActivityPub 'Link' type.
+type LinkType struct {
+	link *linkType
+}
+
+type linkType struct {
+	HRef *URLProperty `json:"href,omitempty"`
+	Rel  []string     `json:"rel,omitempty"`
+}
+
+// NewLink creates a new Link type.
+func NewLink(hRef *url.URL, rel ...string) *LinkType {
+	return &LinkType{
+		link: &linkType{
+			HRef: NewURLProperty(hRef),
+			Rel:  rel,
+		},
+	}
+}
+
+// Type always returns the "Link" type.
+func (t *LinkType) Type() *TypeProperty {
+	return NewTypeProperty(TypeLink)
+}
+
+// HRef return the reference ('href' field).
+func (t *LinkType) HRef() *url.URL {
+	if t == nil || t.link == nil || t.link.HRef == nil {
+		return nil
+	}
+
+	return t.link.HRef.URL()
+}
+
+// Rel returns the relationship ('rel' field).
+func (t *LinkType) Rel() Relationship {
+	if t == nil || t.link == nil {
+		return nil
+	}
+
+	return t.link.Rel
+}
+
+// MarshalJSON marshals the link type to JSON.
+func (t *LinkType) MarshalJSON() ([]byte, error) {
+	return MarshalJSON(t.link, Document{propertyType: TypeLink})
+}
+
+// UnmarshalJSON umarshals the link type from JSON.
+func (t *LinkType) UnmarshalJSON(bytes []byte) error {
+	t.link = &linkType{}
+
+	return UnmarshalJSON(bytes, &t.link)
+}
+
+// Relationship holds the relationship of the Link.
+type Relationship []string
+
+// Is return true if the given relationship is contained.
+func (r Relationship) Is(relationship string) bool {
+	for _, rel := range r {
+		if rel == relationship {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/activitypub/vocab/linktype_test.go
+++ b/pkg/activitypub/vocab/linktype_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vocab
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
+
+	"github.com/trustbloc/orb/pkg/internal/testutil"
+)
+
+var href = MustParseURL("hl:uEiDaKXK8DrWLEz-mJk9JCvhVpBg6DUiR-84p8cuG_kLKwg")
+
+func TestNewLink(t *testing.T) {
+	t.Run("Nil type", func(t *testing.T) {
+		var link *LinkType
+
+		require.Nil(t, link.HRef())
+		require.True(t, link.Type().Is(TypeLink))
+		require.False(t, link.Rel().Is(RelationshipWitness))
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		link := NewLink(href, RelationshipWitness)
+		require.NotNil(t, link)
+		require.True(t, link.Type().Is(TypeLink))
+		require.NotNil(t, link.HRef())
+		require.Equal(t, href.String(), link.HRef().String())
+		require.True(t, link.Rel().Is(RelationshipWitness))
+	})
+}
+
+func TestLinkType_MarshalJSON(t *testing.T) {
+	link := NewLink(href, RelationshipWitness)
+	require.NotNil(t, link)
+
+	linkBytes, err := canonicalizer.MarshalCanonical(link)
+	require.NoError(t, err)
+
+	t.Logf("Link: %s", linkBytes)
+
+	require.Equal(t, testutil.GetCanonical(t, jsonLink), string(linkBytes))
+}
+
+func TestLinkType_UnmarshalJSON(t *testing.T) {
+	link := &LinkType{}
+
+	require.NoError(t, json.Unmarshal([]byte(jsonLink), &link))
+	require.True(t, link.Type().Is(TypeLink))
+	require.NotNil(t, link.HRef())
+	require.Equal(t, href.String(), link.HRef().String())
+	require.True(t, link.Rel().Is(RelationshipWitness))
+}
+
+const (
+	jsonLink = `{
+  "href": "hl:uEiDaKXK8DrWLEz-mJk9JCvhVpBg6DUiR-84p8cuG_kLKwg",
+  "rel": ["witness"],
+  "type": "Link"
+}`
+)

--- a/pkg/activitypub/vocab/objecttype.go
+++ b/pkg/activitypub/vocab/objecttype.go
@@ -40,6 +40,7 @@ func NewObject(opts ...Opt) *ObjectType {
 			Attachment:   options.Attachment,
 			AttributedTo: NewURLProperty(options.AttributedTo),
 			Generator:    options.Generator,
+			Tag:          options.Tag,
 		},
 	}
 }
@@ -79,6 +80,7 @@ type objectType struct {
 	Attachment   []*ObjectProperty      `json:"attachment,omitempty"`
 	AttributedTo *URLProperty           `json:"attributedTo,omitempty"`
 	Generator    string                 `json:"generator,omitempty"`
+	Tag          []*TagProperty         `json:"tag,omitempty"`
 }
 
 // Context returns the context property.
@@ -189,6 +191,15 @@ func (t *ObjectType) Generator() string {
 	}
 
 	return t.object.Generator
+}
+
+// Tag returns the 'tag' field.
+func (t *ObjectType) Tag() []*TagProperty {
+	if t == nil || t.object == nil {
+		return nil
+	}
+
+	return t.object.Tag
 }
 
 // Urls holds a collection of URLs.

--- a/pkg/activitypub/vocab/objecttype_test.go
+++ b/pkg/activitypub/vocab/objecttype_test.go
@@ -174,6 +174,9 @@ func TestObjectType_Accessors(t *testing.T) {
 	require.Empty(t, o.CID())
 	require.Nil(t, o.Published())
 	require.Empty(t, o.URL())
+	require.Nil(t, o.Tag())
+	require.Empty(t, o.Generator())
+	require.Nil(t, o.AttributedTo())
 }
 
 const (

--- a/pkg/activitypub/vocab/options.go
+++ b/pkg/activitypub/vocab/options.go
@@ -26,6 +26,8 @@ type Options struct {
 	Attachment   []*ObjectProperty
 	AttributedTo *url.URL
 	Generator    string
+	Tag          []*TagProperty
+	Link         *LinkType
 
 	ObjectPropertyOptions
 	CollectionOptions
@@ -137,6 +139,22 @@ func WithAttributedTo(u *url.URL) Opt {
 func WithGenerator(generator string) Opt {
 	return func(opts *Options) {
 		opts.Generator = generator
+	}
+}
+
+// WithTag sets the 'tag' property on the object.
+func WithTag(tag *TagProperty) Opt {
+	return func(opts *Options) {
+		if tag != nil {
+			opts.Tag = append(opts.Tag, tag)
+		}
+	}
+}
+
+// WithLink sets the 'link' property on the object.
+func WithLink(link *LinkType) Opt {
+	return func(opts *Options) {
+		opts.Link = link
 	}
 }
 

--- a/pkg/activitypub/vocab/options_test.go
+++ b/pkg/activitypub/vocab/options_test.go
@@ -35,6 +35,7 @@ func TestNewOptions(t *testing.T) {
 	partOf := testutil.MustParseURL("https://activities")
 	next := testutil.MustParseURL("https://activities?page=3")
 	prev := testutil.MustParseURL("https://activities?page=1")
+	linkURL := testutil.MustParseURL("hl:uEiDzOEQi2wRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw")
 
 	publishedTime := time.Now()
 	startTime := time.Now()
@@ -67,7 +68,6 @@ func TestNewOptions(t *testing.T) {
 	anchorObj, err := NewAnchorObject(
 		sampleGenerator,
 		MustMarshalToDoc(&sampleContentObj{Field1: "value1", Field2: "value2"}),
-		nil,
 	)
 	require.NoError(t, err)
 	require.Len(t, anchorObj.URL(), 1)
@@ -107,6 +107,7 @@ func TestNewOptions(t *testing.T) {
 		WithInReplyTo(id),
 		WithAttachment(NewObjectProperty(WithObject(NewObject()))),
 		WithAnchorObject(anchorObj),
+		WithTag(NewTagProperty(WithLink(NewLink(linkURL)))),
 	)
 
 	require.NotNil(t, opts)

--- a/pkg/activitypub/vocab/tagproperty.go
+++ b/pkg/activitypub/vocab/tagproperty.go
@@ -1,0 +1,103 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vocab
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// TagProperty defines the 'tag' property.
+type TagProperty struct {
+	obj  *ObjectType
+	link *LinkType
+}
+
+// NewTagProperty returns a new Tag property.
+func NewTagProperty(opts ...Opt) *TagProperty {
+	options := NewOptions(opts...)
+
+	return &TagProperty{
+		obj:  options.Object,
+		link: options.Link,
+	}
+}
+
+// Type returns the type of the tag property.
+func (p *TagProperty) Type() *TypeProperty {
+	if p == nil {
+		return nil
+	}
+
+	if p.link != nil {
+		return p.link.Type()
+	}
+
+	if p.obj != nil {
+		return p.obj.Type()
+	}
+
+	return nil
+}
+
+// Link returns the link of the tag property. Nil is returned if the tag is not a Link type.
+func (p *TagProperty) Link() *LinkType {
+	if p == nil {
+		return nil
+	}
+
+	return p.link
+}
+
+// Object returns the object of the tag property. Nil is returned if the tag is not an Object type.
+func (p *TagProperty) Object() *ObjectType {
+	if p == nil {
+		return nil
+	}
+
+	return p.obj
+}
+
+// MarshalJSON marshals the 'tag' property.
+func (p *TagProperty) MarshalJSON() ([]byte, error) {
+	if p.obj != nil {
+		return json.Marshal(p.obj)
+	}
+
+	if p.link != nil {
+		return json.Marshal(p.link)
+	}
+
+	return nil, fmt.Errorf("neither object or link is set on the tag property")
+}
+
+// UnmarshalJSON unmarshals the 'tag' property.
+func (p *TagProperty) UnmarshalJSON(bytes []byte) error {
+	obj := &ObjectType{}
+
+	err := json.Unmarshal(bytes, &obj)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case obj.Type().Is(TypeLink):
+		link := &LinkType{}
+
+		e := json.Unmarshal(bytes, &link)
+		if e != nil {
+			return e
+		}
+
+		p.link = link
+
+	default:
+		p.obj = obj
+	}
+
+	return err
+}

--- a/pkg/activitypub/vocab/tagproperty_test.go
+++ b/pkg/activitypub/vocab/tagproperty_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vocab
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
+
+	"github.com/trustbloc/orb/pkg/internal/testutil"
+)
+
+func TestNewTagProperty(t *testing.T) {
+	t.Run("Nil", func(t *testing.T) {
+		var p *TagProperty
+
+		require.Nil(t, p.Object())
+		require.Nil(t, p.Link())
+		require.Nil(t, p.Type())
+	})
+
+	t.Run("No object or link", func(t *testing.T) {
+		p := NewTagProperty()
+
+		require.Nil(t, p.Object())
+		require.Nil(t, p.Type())
+		require.Nil(t, p.Type())
+	})
+
+	t.Run("Link type", func(t *testing.T) {
+		p := NewTagProperty(WithLink(NewLink(href, RelationshipWitness)))
+		require.NotNil(t, p)
+		require.True(t, p.Type().Is(TypeLink))
+		require.NotNil(t, p.Link())
+		require.Nil(t, p.Object())
+	})
+
+	t.Run("Object type", func(t *testing.T) {
+		p := NewTagProperty(WithObject(NewObject(WithType(TypeService))))
+		require.NotNil(t, p)
+		require.True(t, p.Type().Is(TypeService))
+		require.NotNil(t, p.Object())
+		require.Nil(t, p.Link())
+	})
+}
+
+func TestTagProperty_MarshalJSON(t *testing.T) {
+	t.Run("Link type", func(t *testing.T) {
+		p := NewTagProperty(WithLink(NewLink(href, RelationshipWitness)))
+		require.NotNil(t, p)
+
+		tagBytes, err := canonicalizer.MarshalCanonical(p)
+		require.NoError(t, err)
+
+		t.Logf("Tag: %s", tagBytes)
+
+		require.Equal(t, testutil.GetCanonical(t, jsonLink), string(tagBytes))
+	})
+
+	t.Run("Object type", func(t *testing.T) {
+		p := NewTagProperty(WithObject(NewObject(WithType(TypeService))))
+		require.NotNil(t, p)
+
+		tagBytes, err := canonicalizer.MarshalCanonical(p)
+		require.NoError(t, err)
+
+		t.Logf("Tag: %s", tagBytes)
+
+		require.Equal(t, `{"type":"Service"}`, string(tagBytes))
+	})
+
+	t.Run("No object or link -> error", func(t *testing.T) {
+		p := NewTagProperty()
+		require.NotNil(t, p)
+
+		_, err := canonicalizer.MarshalCanonical(p)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "neither object or link is set on the tag property")
+	})
+}
+
+func TestTagProperty_UnmarshalJSON(t *testing.T) {
+	t.Run("Link type", func(t *testing.T) {
+		p := &TagProperty{}
+
+		require.NoError(t, json.Unmarshal([]byte(jsonLink), &p))
+		require.True(t, p.Type().Is(TypeLink))
+		require.NotNil(t, p.Link())
+		require.Nil(t, p.Object())
+	})
+
+	t.Run("Object type", func(t *testing.T) {
+		p := &TagProperty{}
+
+		require.NoError(t, json.Unmarshal([]byte(`{"type":"Service"}`), &p))
+		require.True(t, p.Type().Is(TypeService))
+		require.Nil(t, p.Link())
+		require.NotNil(t, p.Object())
+	})
+}

--- a/pkg/activitypub/vocab/vocab.go
+++ b/pkg/activitypub/vocab/vocab.go
@@ -59,6 +59,9 @@ const (
 	// TypeInvite specifies the 'Invite' activity type.
 	TypeInvite Type = "Invite"
 
+	// TypeLink specifies the 'Link' object type.
+	TypeLink Type = "Link"
+
 	// TypeVerifiableCredential specifies the "VerifiableCredential" object type.
 	TypeVerifiableCredential Type = "VerifiableCredential"
 
@@ -74,6 +77,9 @@ const (
 	TypeOffer Type = "Offer"
 	// TypeUndo specifies the "Undo" activity type.
 	TypeUndo Type = "Undo"
+
+	// RelationshipWitness defines the 'witness' relationship of a Link.
+	RelationshipWitness = "witness"
 )
 
 const (

--- a/pkg/anchor/anchorevent/anchorevent_test.go
+++ b/pkg/anchor/anchorevent/anchorevent_test.go
@@ -55,7 +55,8 @@ func TestBuildAnchorEvent(t *testing.T) {
 		contentObj, err := BuildContentObject(payload)
 		require.NoError(t, err)
 
-		anchorEvent, err := BuildAnchorEvent(payload, contentObj, &verifiable.Credential{})
+		anchorEvent, err := BuildAnchorEvent(payload, contentObj.GeneratorID, contentObj.Payload,
+			vocab.MustMarshalToDoc(&verifiable.Credential{}))
 		require.NoError(t, err)
 
 		require.Equal(t, anchorOrigin, anchorEvent.AttributedTo().String())
@@ -66,7 +67,7 @@ func TestBuildAnchorEvent(t *testing.T) {
 		require.Equal(t, updatePrevAnchor, anchorEvent.Parent()[0].String())
 
 		// check attachment
-		require.Equal(t, 1, len(anchorEvent.Attachment()))
+		require.Equal(t, 2, len(anchorEvent.Attachment()))
 
 		attachment := anchorEvent.Attachment()[0]
 		require.True(t, attachment.Type().Is(vocab.TypeAnchorObject))
@@ -163,7 +164,8 @@ func TestGetPayloadFromActivity(t *testing.T) {
 		contentObj, err := BuildContentObject(inPayload)
 		require.NoError(t, err)
 
-		anchorEvent, err := BuildAnchorEvent(inPayload, contentObj, &verifiable.Credential{})
+		anchorEvent, err := BuildAnchorEvent(inPayload, contentObj.GeneratorID, contentObj.Payload,
+			vocab.MustMarshalToDoc(&verifiable.Credential{}))
 		require.NoError(t, err)
 
 		activityBytes, err := json.Marshal(anchorEvent)
@@ -218,40 +220,70 @@ func TestGetPayloadFromActivity(t *testing.T) {
 const (
 	//nolint:lll
 	exampleAnchorEvent = `{
-  "@context": "https://w3id.org/activityanchors/v1",
-  "anchors": "hl:uEiBL1RVIr2DdyRE5h6b8bPys-PuVs5mMPPC778OtklPa-w",
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://w3id.org/activityanchors/v1"
+  ],
+  "anchors": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
   "attachment": [
     {
       "contentObject": {
         "properties": {
-          "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v1",
+          "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v0",
           "https://w3id.org/activityanchors#resources": [
             {
-              "id": "did:orb:uAAA:EiD6mH7iCLGjm9mhBr2TP_5_vRz6nyLYZ5E74xbZzrlmLg"
-            },
-            {
-              "id": "did:orb:uAAA:uEiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA",
-              "previousAnchor": "hl:uEiAsiwjaXOYDmOHxmvDl3Mx0TfJ0uCar5YXqumjFJUNIBg"
-            },
-            {
-              "id": "did:orb:uAAA:uEiARIc_M1ZE_CmP-xApv_UTqZPncE1xmY0ugAdELz0MCogo",
-              "previousAnchor": "hl:uEiAn3Y7USoP_lNVX-f0EEu1ajLymnqBJItiMARhKBzAKWg"
+              "id": "did:orb:uAAA:EiAqm7CXVPxriNZv_A6GVCrqlmCmrUSGJ1YaheTzFxa_Fw"
             }
           ]
         },
-        "subject": "hl:uEiB1miJeUsG7PiLvFel8DKoluzDVl3OnpjKgAGZS588PXQ:uoQ-BeEJpcGZzOi8vYmFma3JlaWR2dGlyZjR1d2J4bTdjZjN5djVmNmF6a3JmeG15bmxmM3R1NnRkZmlhYW16am9wdHlwbHU"
+        "subject": "hl:uEiDYMTm9nJ5B0gwpNtflwrcZCT9uT6BFiEs5sYWB45piXg:uoQ-BeEJpcGZzOi8vYmFma3JlaWd5Z2U0MzNoZTZpaGpheWtqdzI3czRmbnl6YmU3dzR0NWFpd2Vld29ucnF3YTZoZ3RjbHk"
       },
+      "generator": "https://w3id.org/orb#v0",
+      "tag": [
+        {
+          "type": "Link",
+          "href": "hl:uEiDzOEQi2wRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
+          "rel": [
+            "witness"
+          ]
+        }
+      ],
       "type": "AnchorObject",
-      "url": "hl:uEiBL1RVIr2DdyRE5h6b8bPys-PuVs5mMPPC778OtklPa-w",
-      "witness": {
-        "@context": "https://www.w3.org/2018/credentials/v1",
-        "credentialSubject": {
-          "id": "hl:uEiBy8pPgN9eS3hpQAwpSwJJvm6Awpsnc8kR_fkbUPotehg"
-        },
-        "issuanceDate": "2021-01-27T09:30:10Z",
-        "issuer": "https://sally.example.com/services/anchor",
+      "url": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw"
+    },
+    {
+      "contentObject": {
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://w3id.org/security/jws/v1"
+        ],
+        "credentialSubject": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
+        "id": "http://orb2.domain1.com/vc/3994cc26-555c-47f1-9890-058148c154f1",
+        "issuanceDate": "2021-10-14T18:32:17.894314751Z",
+        "issuer": "http://orb2.domain1.com",
+        "proof": [
+          {
+            "created": "2021-10-14T18:32:17.91Z",
+            "domain": "http://orb.vct:8077/maple2020",
+            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..h3-0HC3L87TM0j0o3Nd0VLlalcVVphwOPsfdkCLZ4q-uL4z8eO2vQ4sobbtOtFpNNZlpIOQnaWJMX3Ch5Wh-AQ",
+            "proofPurpose": "assertionMethod",
+            "type": "Ed25519Signature2018",
+            "verificationMethod": "did:web:orb.domain1.com#orb1key"
+          },
+          {
+            "created": "2021-10-14T18:32:18.09110265Z",
+            "domain": "https://orb.domain2.com",
+            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..DSL3zsltnh9dbSn3VNPb1C-6pKt6VOy-H1WadO5ZV2QZd3xZq3uRRhaShi9K1SzX-VaGPxs3gfbazJ-fpHVxBg",
+            "proofPurpose": "assertionMethod",
+            "type": "Ed25519Signature2018",
+            "verificationMethod": "did:web:orb.domain2.com#orb2key"
+          }
+        ],
         "type": "VerifiableCredential"
-      }
+      },
+      "generator": "https://w3id.org/orb#v0",
+      "type": "AnchorObject",
+      "url": "hl:uEiDzOEQi2wRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw"
     }
   ],
   "attributedTo": "https://orb.domain1.com/services/orb",
@@ -259,9 +291,9 @@ const (
     "hl:uEiAsiwjaXOYDmOHxmvDl3Mx0TfJ0uCar5YXqumjFJUNIBg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBc2l3amFYT1lEbU9IeG12RGwzTXgwVGZKMHVDYXI1WVhxdW1qRkpVTklCZ3hCaXBmczovL2JhZmtyZWlibXJtZW51eGhnYW9tb2Q0bTI2ZHM1enRkdWp4emhqb2JndnBzeWwydjJuZGNza3EyaWF5",
     "hl:uEiAn3Y7USoP_lNVX-f0EEu1ajLymnqBJItiMARhKBzAKWg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBbjNZN1VTb1BfbE5WWC1mMEVFdTFhakx5bW5xQkpJdGlNQVJoS0J6QUtXZ3hCaXBmczovL2JhZmtyZWliaDN3aG5pc3VkNzZrbmt2N3o3dWNiZjNrMnJzNmtuaHZhamVybnJkYWJkYmZhb21ha2xp"
   ],
-  "published": "2021-01-27T09:30:10Z",
-  "type": "Info",
-  "url": "hl:uEiCJWrCq8ttsWob5UVueRQiQ_QUrocJY6ZA8BDgzgakuhg:uoQ-BeEJpcGZzOi8vYmFma3JlaWVqbGt5a3Y0dzNucm5pbjZrcmxvcGVrY2VxN3Vjc3hpb2NsZHV6YXBhZWhhenlka2pvcXk"
+  "published": "2021-10-14T18:32:17.888176489Z",
+  "type": "AnchorEvent",
+  "url": "hl:uEiDhdDIS_-_SWKoh5Y3KJ_sWpIoXZUPBeTBMCSBUKXpe5w:uoQ-BeEJpcGZzOi8vYmFma3JlaWhib3F6YmY3N3Ayam1rdWlwZnJ4ZmNwNnl3dXNmYm96a2R5ZjR0YXRhamVia2NzNnM2NDQ"
 }`
 
 	//nolint:lll
@@ -353,10 +385,10 @@ const (
     "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v0",
     "https://w3id.org/activityanchors#resources": [
       {
-        "ID": "did:orb:uAAA:uEiDahaOGH-liLLdDtTxEAdc8i-cfCz-WUcQdRJheMVNn3A"
+        "id": "did:orb:uAAA:uEiDahaOGH-liLLdDtTxEAdc8i-cfCz-WUcQdRJheMVNn3A"
       },
       {
-        "ID": "did:orb:uEiAsiwjaXOYDmOHxmvDl3Mx0TfJ0uCar5YXqumjFJUNIBg:uEiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA",
+        "id": "did:orb:uEiAsiwjaXOYDmOHxmvDl3Mx0TfJ0uCar5YXqumjFJUNIBg:uEiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA",
         "previousAnchor": "hl:uEiAsiwjaXOYDmOHxmvDl3Mx0TfJ0uCar5YXqumjFJUNIBg"
       }
     ]
@@ -367,21 +399,13 @@ const (
 	//nolint:lll
 	jsonContentObj2 = `{
   "properties": {
-    "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v1",
+    "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v0",
     "https://w3id.org/activityanchors#resources": [
       {
-        "id": "did:orb:uAAA:EiD6mH7iCLGjm9mhBr2TP_5_vRz6nyLYZ5E74xbZzrlmLg"
-      },
-      {
-        "id": "did:orb:uAAA:uEiA329wd6Aj36YRmp7NGkeB5ADnVt8ARdMZMPzfXsjwTJA",
-        "previousAnchor": "hl:uEiAsiwjaXOYDmOHxmvDl3Mx0TfJ0uCar5YXqumjFJUNIBg"
-      },
-      {
-        "id": "did:orb:uAAA:uEiARIc_M1ZE_CmP-xApv_UTqZPncE1xmY0ugAdELz0MCogo",
-        "previousAnchor": "hl:uEiAn3Y7USoP_lNVX-f0EEu1ajLymnqBJItiMARhKBzAKWg"
+        "id": "did:orb:uAAA:EiAqm7CXVPxriNZv_A6GVCrqlmCmrUSGJ1YaheTzFxa_Fw"
       }
     ]
   },
-  "subject": "hl:uEiB1miJeUsG7PiLvFel8DKoluzDVl3OnpjKgAGZS588PXQ:uoQ-BeEJpcGZzOi8vYmFma3JlaWR2dGlyZjR1d2J4bTdjZjN5djVmNmF6a3JmeG15bmxmM3R1NnRkZmlhYW16am9wdHlwbHU"
+  "subject": "hl:uEiDYMTm9nJ5B0gwpNtflwrcZCT9uT6BFiEs5sYWB45piXg:uoQ-BeEJpcGZzOi8vYmFma3JlaWd5Z2U0MzNoZTZpaGpheWtqdzI3czRmbnl6YmU3dzR0NWFpd2Vld29ucnF3YTZoZ3RjbHk"
 }`
 )

--- a/pkg/anchor/anchorevent/generator/didorbgenerator/didorbgenerator.go
+++ b/pkg/anchor/anchorevent/generator/didorbgenerator/didorbgenerator.go
@@ -227,7 +227,7 @@ type propertiesType struct {
 }
 
 type resource struct {
-	ID             string `json:"ID"`
+	ID             string `json:"id"`
 	PreviousAnchor string `json:"previousAnchor,omitempty"`
 }
 

--- a/pkg/anchor/anchorevent/generator/didorbgenerator/didorbgenerator_test.go
+++ b/pkg/anchor/anchorevent/generator/didorbgenerator/didorbgenerator_test.go
@@ -145,20 +145,23 @@ func TestGenerator_GetPayloadFromAnchorEvent(t *testing.T) {
 		},
 	}
 
-	witness, err := vocab.NewObjectWithDocument(vocab.MustUnmarshalToDoc([]byte(verifiableCred)))
+	witnessAnchorObj, err := vocab.NewAnchorObject(ID, vocab.MustUnmarshalToDoc([]byte(verifiableCred)))
 	require.NoError(t, err)
+	require.Len(t, witnessAnchorObj.URL(), 1)
 
-	anchorObj, err := vocab.NewAnchorObject(ID, vocab.MustMarshalToDoc(contentObj), witness)
+	indexAnchorObj, err := vocab.NewAnchorObject(ID, vocab.MustMarshalToDoc(contentObj),
+		vocab.WithLink(vocab.NewLink(witnessAnchorObj.URL()[0], vocab.RelationshipWitness)))
 	require.NoError(t, err)
-	require.Len(t, anchorObj.URL(), 1)
+	require.Len(t, indexAnchorObj.URL(), 1)
 
 	published := time.Now()
 
 	t.Run("Success", func(t *testing.T) {
 		anchorEvent := vocab.NewAnchorEvent(
-			vocab.WithAnchors(anchorObj.URL()[0]),
+			vocab.WithAnchors(indexAnchorObj.URL()[0]),
 			vocab.WithParent(testutil.MustParseURL(parentHL1)),
-			vocab.WithAttachment(vocab.NewObjectProperty(vocab.WithAnchorObject(anchorObj))),
+			vocab.WithAttachment(vocab.NewObjectProperty(vocab.WithAnchorObject(indexAnchorObj))),
+			vocab.WithAttachment(vocab.NewObjectProperty(vocab.WithAnchorObject(witnessAnchorObj))),
 			vocab.WithAttributedTo(testutil.MustParseURL(service1)),
 			vocab.WithPublishedTime(&published),
 		)
@@ -182,7 +185,7 @@ func TestGenerator_GetPayloadFromAnchorEvent(t *testing.T) {
 		anchorEvent := vocab.NewAnchorEvent(
 			vocab.WithAnchors(testutil.MustParseURL("hl:adsfwsds")),
 			vocab.WithParent(testutil.MustParseURL(parentHL1)),
-			vocab.WithAttachment(vocab.NewObjectProperty(vocab.WithAnchorObject(anchorObj))),
+			vocab.WithAttachment(vocab.NewObjectProperty(vocab.WithAnchorObject(indexAnchorObj))),
 			vocab.WithAttributedTo(testutil.MustParseURL(service1)),
 			vocab.WithPublishedTime(&published),
 		)
@@ -194,7 +197,7 @@ func TestGenerator_GetPayloadFromAnchorEvent(t *testing.T) {
 	})
 
 	t.Run("No subject in content object", func(t *testing.T) {
-		anchorObj, err := vocab.NewAnchorObject(ID, vocab.MustMarshalToDoc(&contentObject{}), witness)
+		anchorObj, err := vocab.NewAnchorObject(ID, vocab.MustMarshalToDoc(&contentObject{}))
 		require.NoError(t, err)
 		require.Len(t, anchorObj.URL(), 1)
 
@@ -220,10 +223,10 @@ const (
     "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v0",
     "https://w3id.org/activityanchors#resources": [
       {
-        "ID": "did:orb:uAAA:EiDJpL-xeSE4kVgoGjaQm_OurMdR6jIeDRUxv7RhGNf5jw"
+        "id": "did:orb:uAAA:EiDJpL-xeSE4kVgoGjaQm_OurMdR6jIeDRUxv7RhGNf5jw"
       },
       {
-        "ID": "did:orb:uEiAuBQKPYXl90i3ho0aJsEGJpXCrvZvbRBtXH6RUF0rZLA:EiAPcYpwgg88zOvQ4-sdwpj4UKqZeYS_Ej6kkZl_bZIJjw",
+        "id": "did:orb:uEiAuBQKPYXl90i3ho0aJsEGJpXCrvZvbRBtXH6RUF0rZLA:EiAPcYpwgg88zOvQ4-sdwpj4UKqZeYS_Ej6kkZl_bZIJjw",
         "previousAnchor": "hl:uEiAuBQKPYXl90i3ho0aJsEGJpXCrvZvbRBtXH6RUF0rZLA"
       }
     ]

--- a/pkg/anchor/graph/graph_test.go
+++ b/pkg/anchor/graph/graph_test.go
@@ -290,7 +290,8 @@ func newMockAnchorEvent(t *testing.T, payload *subject.Payload) *vocab.AnchorEve
 		Issued: &util.TimeWrapper{Time: time.Now()},
 	}
 
-	act, err := anchorevent.BuildAnchorEvent(payload, contentObj, vc)
+	act, err := anchorevent.BuildAnchorEvent(payload, contentObj.GeneratorID, contentObj.Payload,
+		vocab.MustMarshalToDoc(vc))
 	require.NoError(t, err)
 
 	return act

--- a/pkg/anchor/handler/credential/handler_test.go
+++ b/pkg/anchor/handler/credential/handler_test.go
@@ -39,8 +39,11 @@ import (
 
 //nolint:lll
 const sampleAnchorEvent = `{
-  "@context": "https://w3id.org/activityanchors/v1",
-  "anchors": "hl:uEiBL1RVIr2DdyRE5h6b8bPys-PuVs5mMPPC778OtklPa-w",
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://w3id.org/activityanchors/v1"
+  ],
+  "anchors": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
   "attachment": [
     {
       "contentObject": {
@@ -48,42 +51,58 @@ const sampleAnchorEvent = `{
           "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v0",
           "https://w3id.org/activityanchors#resources": [
             {
-              "id": "did:orb:uAAA:EiD6mH7iCLGjm9mhBr2TP_5_vRz6nyLYZ5E74xbZzrlmLg"
+              "ID": "did:orb:uAAA:EiAqm7CXVPxriNZv_A6GVCrqlmCmrUSGJ1YaheTzFxa_Fw"
             }
           ]
         },
-        "subject": "hl:uEiB1miJeUsG7PiLvFel8DKoluzDVl3OnpjKgAGZS588PXQ:uoQ-BeEJpcGZzOi8vYmFma3JlaWR2dGlyZjR1d2J4bTdjZjN5djVmNmF6a3JmeG15bmxmM3R1NnRkZmlhYW16am9wdHlwbHU"
+        "subject": "hl:uEiDYMTm9nJ5B0gwpNtflwrcZCT9uT6BFiEs5sYWB45piXg:uoQ-BeEJpcGZzOi8vYmFma3JlaWd5Z2U0MzNoZTZpaGpheWtqdzI3czRmbnl6YmU3dzR0NWFpd2Vld29ucnF3YTZoZ3RjbHk"
       },
-      "type": "AnchorObject",
       "generator": "https://w3id.org/orb#v0",
-      "url": "hl:uEiBL1RVIr2DdyRE5h6b8bPys-PuVs5mMPPC778OtklPa-w",
-      "witness": {
-        "@context": "https://www.w3.org/2018/credentials/v1",
-        "credentialSubject": {
-          "id": "hl:uEiBy8pPgN9eS3hpQAwpSwJJvm6Awpsnc8kR_fkbUPotehg"
-        },
-        "issuanceDate": "2021-01-27T09:30:10Z",
-        "issuer": "https://sally.example.com/services/anchor",
+      "tag": [
+        {
+          "type": "Link",
+          "href": "hl:uEiDzOEQi2wRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
+          "rel": [
+            "witness"
+          ]
+        }
+      ],
+      "type": "AnchorObject",
+      "url": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw"
+    },
+    {
+      "contentObject": {
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://w3id.org/security/jws/v1"
+        ],
+        "credentialSubject": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
+        "id": "http://orb2.domain1.com/vc/3994cc26-555c-47f1-9890-058148c154f1",
+        "issuanceDate": "2021-10-14T18:32:17.894314751Z",
+        "issuer": "http://orb2.domain1.com",
         "proof": [
           {
-            "created": "2021-01-27T09:30:00Z",
-            "domain": "sally.example.com",
-            "jws": "eyJ...",
+            "created": "2021-10-14T18:32:17.91Z",
+            "domain": "http://orb.vct:8077/maple2020",
+            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..h3-0HC3L87TM0j0o3Nd0VLlalcVVphwOPsfdkCLZ4q-uL4z8eO2vQ4sobbtOtFpNNZlpIOQnaWJMX3Ch5Wh-AQ",
             "proofPurpose": "assertionMethod",
-            "type": "JsonWebSignature2020",
-            "verificationMethod": "did:example:abcd#key"
+            "type": "Ed25519Signature2018",
+            "verificationMethod": "did:web:orb.domain1.com#orb1key"
           },
           {
-            "created": "2021-01-27T09:30:05Z",
-            "domain": "https://witness1.example.com/ledgers/maple2021",
-            "jws": "eyJ...",
+            "created": "2021-10-14T18:32:18.09110265Z",
+            "domain": "https://orb.domain2.com",
+            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..DSL3zsltnh9dbSn3VNPb1C-6pKt6VOy-H1WadO5ZV2QZd3xZq3uRRhaShi9K1SzX-VaGPxs3gfbazJ-fpHVxBg",
             "proofPurpose": "assertionMethod",
-            "type": "JsonWebSignature2020",
-            "verificationMethod": "did:example:abcd#key"
+            "type": "Ed25519Signature2018",
+            "verificationMethod": "did:web:orb.domain2.com#orb2key"
           }
         ],
         "type": "VerifiableCredential"
-      }
+      },
+      "generator": "https://w3id.org/orb#v0",
+      "type": "AnchorObject",
+      "url": "hl:uEiDzOEQi2wRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw"
     }
   ],
   "attributedTo": "https://orb.domain1.com/services/orb",
@@ -91,8 +110,9 @@ const sampleAnchorEvent = `{
     "hl:uEiAsiwjaXOYDmOHxmvDl3Mx0TfJ0uCar5YXqumjFJUNIBg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBc2l3amFYT1lEbU9IeG12RGwzTXgwVGZKMHVDYXI1WVhxdW1qRkpVTklCZ3hCaXBmczovL2JhZmtyZWlibXJtZW51eGhnYW9tb2Q0bTI2ZHM1enRkdWp4emhqb2JndnBzeWwydjJuZGNza3EyaWF5",
     "hl:uEiAn3Y7USoP_lNVX-f0EEu1ajLymnqBJItiMARhKBzAKWg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBbjNZN1VTb1BfbE5WWC1mMEVFdTFhakx5bW5xQkpJdGlNQVJoS0J6QUtXZ3hCaXBmczovL2JhZmtyZWliaDN3aG5pc3VkNzZrbmt2N3o3dWNiZjNrMnJzNmtuaHZhamVybnJkYWJkYmZhb21ha2xp"
   ],
-  "published": "2021-01-27T09:30:10Z",
-  "type": "AnchorEvent"
+  "published": "2021-10-14T18:32:17.888176489Z",
+  "type": "AnchorEvent",
+  "url": "hl:uEiDhdDIS_-_SWKoh5Y3KJ_sWpIoXZUPBeTBMCSBUKXpe5w:uoQ-BeEJpcGZzOi8vYmFma3JlaWhib3F6YmY3N3Ayam1rdWlwZnJ4ZmNwNnl3dXNmYm96a2R5ZjR0YXRhamVia2NzNnM2NDQ"
 }`
 
 func TestNew(t *testing.T) {
@@ -128,7 +148,7 @@ func TestAnchorCredentialHandler(t *testing.T) {
 	})
 
 	t.Run("Parse created time (error)", func(t *testing.T) {
-		cred := strings.Replace(sampleAnchorEvent, "2021-01-27T09:30:00Z", "2021-27T09:30:00Z", 1)
+		cred := strings.Replace(sampleAnchorEvent, "2021-10-14T18:32:17.91Z", "2021-27T09:30:00Z", 1)
 
 		anchorEvent := &vocab.AnchorEventType{}
 		require.NoError(t, json.Unmarshal([]byte(cred), anchorEvent))

--- a/pkg/anchor/handler/proof/handler_test.go
+++ b/pkg/anchor/handler/proof/handler_test.go
@@ -663,8 +663,11 @@ func (wp *mockWitnessPolicy) Evaluate(_ []*proofapi.WitnessProof) (bool, error) 
 
 //nolint:lll
 const anchorEvent = `{
-  "@context": "https://w3id.org/activityanchors/v1",
-  "anchors": "hl:uEiBL1RVIr2DdyRE5h6b8bPys-PuVs5mMPPC778OtklPa-w",
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://w3id.org/activityanchors/v1"
+  ],
+  "anchors": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
   "attachment": [
     {
       "contentObject": {
@@ -672,34 +675,50 @@ const anchorEvent = `{
           "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v0",
           "https://w3id.org/activityanchors#resources": [
             {
-              "id": "did:orb:uAAA:EiD6mH7iCLGjm9mhBr2TP_5_vRz6nyLYZ5E74xbZzrlmLg"
+              "ID": "did:orb:uAAA:EiAqm7CXVPxriNZv_A6GVCrqlmCmrUSGJ1YaheTzFxa_Fw"
             }
           ]
         },
-        "subject": "hl:uEiB1miJeUsG7PiLvFel8DKoluzDVl3OnpjKgAGZS588PXQ:uoQ-BeEJpcGZzOi8vYmFma3JlaWR2dGlyZjR1d2J4bTdjZjN5djVmNmF6a3JmeG15bmxmM3R1NnRkZmlhYW16am9wdHlwbHU"
+        "subject": "hl:uEiDYMTm9nJ5B0gwpNtflwrcZCT9uT6BFiEs5sYWB45piXg:uoQ-BeEJpcGZzOi8vYmFma3JlaWd5Z2U0MzNoZTZpaGpheWtqdzI3czRmbnl6YmU3dzR0NWFpd2Vld29ucnF3YTZoZ3RjbHk"
       },
-      "type": "AnchorObject",
       "generator": "https://w3id.org/orb#v0",
-      "url": "hl:uEiBL1RVIr2DdyRE5h6b8bPys-PuVs5mMPPC778OtklPa-w",
-      "witness": {
-        "@context": "https://www.w3.org/2018/credentials/v1",
-        "credentialSubject": {
-          "id": "hl:uEiBy8pPgN9eS3hpQAwpSwJJvm6Awpsnc8kR_fkbUPotehg"
-        },
-        "issuanceDate": "2021-01-27T09:30:10Z",
-        "issuer": "https://sally.example.com/services/anchor",
+      "tag": [
+        {
+          "type": "Link",
+          "href": "hl:uEiDzOEQi2wRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
+          "rel": [
+            "witness"
+          ]
+        }
+      ],
+      "type": "AnchorObject",
+      "url": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw"
+    },
+    {
+      "contentObject": {
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://w3id.org/security/jws/v1"
+        ],
+        "credentialSubject": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
+        "id": "http://orb2.domain1.com/vc/3994cc26-555c-47f1-9890-058148c154f1",
+        "issuanceDate": "2021-10-14T18:32:17.894314751Z",
+        "issuer": "http://orb2.domain1.com",
         "proof": [
           {
-            "created": "2021-01-27T09:30:05Z",
-            "domain": "https://witness1.example.com/ledgers/maple2021",
-            "jws": "eyJ...",
+            "created": "2021-10-14T18:32:18.09110265Z",
+            "domain": "https://orb.domain2.com",
+            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..DSL3zsltnh9dbSn3VNPb1C-6pKt6VOy-H1WadO5ZV2QZd3xZq3uRRhaShi9K1SzX-VaGPxs3gfbazJ-fpHVxBg",
             "proofPurpose": "assertionMethod",
-            "type": "JsonWebSignature2020",
-            "verificationMethod": "did:example:abcd#key"
+            "type": "Ed25519Signature2018",
+            "verificationMethod": "did:web:orb.domain2.com#orb2key"
           }
         ],
         "type": "VerifiableCredential"
-      }
+      },
+      "generator": "https://w3id.org/orb#v0",
+      "type": "AnchorObject",
+      "url": "hl:uEiDzOEQi2wRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw"
     }
   ],
   "attributedTo": "https://orb.domain1.com/services/orb",
@@ -707,15 +726,18 @@ const anchorEvent = `{
     "hl:uEiAsiwjaXOYDmOHxmvDl3Mx0TfJ0uCar5YXqumjFJUNIBg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBc2l3amFYT1lEbU9IeG12RGwzTXgwVGZKMHVDYXI1WVhxdW1qRkpVTklCZ3hCaXBmczovL2JhZmtyZWlibXJtZW51eGhnYW9tb2Q0bTI2ZHM1enRkdWp4emhqb2JndnBzeWwydjJuZGNza3EyaWF5",
     "hl:uEiAn3Y7USoP_lNVX-f0EEu1ajLymnqBJItiMARhKBzAKWg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBbjNZN1VTb1BfbE5WWC1mMEVFdTFhakx5bW5xQkpJdGlNQVJoS0J6QUtXZ3hCaXBmczovL2JhZmtyZWliaDN3aG5pc3VkNzZrbmt2N3o3dWNiZjNrMnJzNmtuaHZhamVybnJkYWJkYmZhb21ha2xp"
   ],
-  "published": "2021-01-27T09:30:10Z",
+  "published": "2021-10-14T18:32:17.888176489Z",
   "type": "AnchorEvent",
-  "url": "hl:uEiCJWrCq8ttsWob5UVueRQiQ_QUrocJY6ZA8BDgzgakuhg:uoQ-BeEJpcGZzOi8vYmFma3JlaWVqbGt5a3Y0dzNucm5pbjZrcmxvcGVrY2VxN3Vjc3hpb2NsZHV6YXBhZWhhenlka2pvcXk"
+  "url": "hl:uEiDhdDIS_-_SWKoh5Y3KJ_sWpIoXZUPBeTBMCSBUKXpe5w:uoQ-BeEJpcGZzOi8vYmFma3JlaWhib3F6YmY3N3Ayam1rdWlwZnJ4ZmNwNnl3dXNmYm96a2R5ZjR0YXRhamVia2NzNnM2NDQ"
 }`
 
 //nolint:lll
 const anchorEventTwoProofs = `{
-  "@context": "https://w3id.org/activityanchors/v1",
-  "anchors": "hl:uEiBL1RVIr2DdyRE5h6b8bPys-PuVs5mMPPC778OtklPa-w",
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://w3id.org/activityanchors/v1"
+  ],
+  "anchors": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
   "attachment": [
     {
       "contentObject": {
@@ -723,42 +745,58 @@ const anchorEventTwoProofs = `{
           "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v0",
           "https://w3id.org/activityanchors#resources": [
             {
-              "id": "did:orb:uAAA:EiD6mH7iCLGjm9mhBr2TP_5_vRz6nyLYZ5E74xbZzrlmLg"
+              "ID": "did:orb:uAAA:EiAqm7CXVPxriNZv_A6GVCrqlmCmrUSGJ1YaheTzFxa_Fw"
             }
           ]
         },
-        "subject": "hl:uEiB1miJeUsG7PiLvFel8DKoluzDVl3OnpjKgAGZS588PXQ:uoQ-BeEJpcGZzOi8vYmFma3JlaWR2dGlyZjR1d2J4bTdjZjN5djVmNmF6a3JmeG15bmxmM3R1NnRkZmlhYW16am9wdHlwbHU"
+        "subject": "hl:uEiDYMTm9nJ5B0gwpNtflwrcZCT9uT6BFiEs5sYWB45piXg:uoQ-BeEJpcGZzOi8vYmFma3JlaWd5Z2U0MzNoZTZpaGpheWtqdzI3czRmbnl6YmU3dzR0NWFpd2Vld29ucnF3YTZoZ3RjbHk"
       },
-      "type": "AnchorObject",
       "generator": "https://w3id.org/orb#v0",
-      "url": "hl:uEiBL1RVIr2DdyRE5h6b8bPys-PuVs5mMPPC778OtklPa-w",
-      "witness": {
-        "@context": "https://www.w3.org/2018/credentials/v1",
-        "credentialSubject": {
-          "id": "hl:uEiBy8pPgN9eS3hpQAwpSwJJvm6Awpsnc8kR_fkbUPotehg"
-        },
-        "issuanceDate": "2021-01-27T09:30:10Z",
-        "issuer": "https://sally.example.com/services/anchor",
+      "tag": [
+        {
+          "type": "Link",
+          "href": "hl:uEiDzOEQi2wRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
+          "rel": [
+            "witness"
+          ]
+        }
+      ],
+      "type": "AnchorObject",
+      "url": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw"
+    },
+    {
+      "contentObject": {
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://w3id.org/security/jws/v1"
+        ],
+        "credentialSubject": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
+        "id": "http://orb2.domain1.com/vc/3994cc26-555c-47f1-9890-058148c154f1",
+        "issuanceDate": "2021-10-14T18:32:17.894314751Z",
+        "issuer": "http://orb2.domain1.com",
         "proof": [
           {
-            "created": "2021-01-27T09:30:00Z",
-            "domain": "sally.example.com",
-            "jws": "eyJ...",
+            "created": "2021-10-14T18:32:17.91Z",
+            "domain": "http://orb.vct:8077/maple2020",
+            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..h3-0HC3L87TM0j0o3Nd0VLlalcVVphwOPsfdkCLZ4q-uL4z8eO2vQ4sobbtOtFpNNZlpIOQnaWJMX3Ch5Wh-AQ",
             "proofPurpose": "assertionMethod",
-            "type": "JsonWebSignature2020",
-            "verificationMethod": "did:example:abcd#key"
+            "type": "Ed25519Signature2018",
+            "verificationMethod": "did:web:orb.domain1.com#orb1key"
           },
           {
-            "created": "2021-01-27T09:30:05Z",
-            "domain": "https://witness1.example.com/ledgers/maple2021",
-            "jws": "eyJ...",
+            "created": "2021-10-14T18:32:18.09110265Z",
+            "domain": "https://orb.domain2.com",
+            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..DSL3zsltnh9dbSn3VNPb1C-6pKt6VOy-H1WadO5ZV2QZd3xZq3uRRhaShi9K1SzX-VaGPxs3gfbazJ-fpHVxBg",
             "proofPurpose": "assertionMethod",
-            "type": "JsonWebSignature2020",
-            "verificationMethod": "did:example:abcd#key"
+            "type": "Ed25519Signature2018",
+            "verificationMethod": "did:web:orb.domain2.com#orb2key"
           }
         ],
         "type": "VerifiableCredential"
-      }
+      },
+      "generator": "https://w3id.org/orb#v0",
+      "type": "AnchorObject",
+      "url": "hl:uEiDzOEQi2wRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw"
     }
   ],
   "attributedTo": "https://orb.domain1.com/services/orb",
@@ -766,9 +804,9 @@ const anchorEventTwoProofs = `{
     "hl:uEiAsiwjaXOYDmOHxmvDl3Mx0TfJ0uCar5YXqumjFJUNIBg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBc2l3amFYT1lEbU9IeG12RGwzTXgwVGZKMHVDYXI1WVhxdW1qRkpVTklCZ3hCaXBmczovL2JhZmtyZWlibXJtZW51eGhnYW9tb2Q0bTI2ZHM1enRkdWp4emhqb2JndnBzeWwydjJuZGNza3EyaWF5",
     "hl:uEiAn3Y7USoP_lNVX-f0EEu1ajLymnqBJItiMARhKBzAKWg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBbjNZN1VTb1BfbE5WWC1mMEVFdTFhakx5bW5xQkpJdGlNQVJoS0J6QUtXZ3hCaXBmczovL2JhZmtyZWliaDN3aG5pc3VkNzZrbmt2N3o3dWNiZjNrMnJzNmtuaHZhamVybnJkYWJkYmZhb21ha2xp"
   ],
-  "published": "2021-01-27T09:30:10Z",
+  "published": "2021-10-14T18:32:17.888176489Z",
   "type": "AnchorEvent",
-  "url": "hl:uEiCJWrCq8ttsWob5UVueRQiQ_QUrocJY6ZA8BDgzgakuhg:uoQ-BeEJpcGZzOi8vYmFma3JlaWVqbGt5a3Y0dzNucm5pbjZrcmxvcGVrY2VxN3Vjc3hpb2NsZHV6YXBhZWhhenlka2pvcXk"
+  "url": "hl:uEiDhdDIS_-_SWKoh5Y3KJ_sWpIoXZUPBeTBMCSBUKXpe5w:uoQ-BeEJpcGZzOi8vYmFma3JlaWhib3F6YmY3N3Ayam1rdWlwZnJ4ZmNwNnl3dXNmYm96a2R5ZjR0YXRhamVia2NzNnM2NDQ"
 }`
 
 //nolint:lll

--- a/pkg/anchor/util/util.go
+++ b/pkg/anchor/util/util.go
@@ -15,15 +15,19 @@ import (
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
 )
 
-// VerifiableCredentialFromAnchorEvent validates and returns the verifiable credential embedded in the
-// given anchor event.
+// VerifiableCredentialFromAnchorEvent validates the AnchorEvent and returns the embedded verifiable credential.
 func VerifiableCredentialFromAnchorEvent(anchorEvent *vocab.AnchorEventType,
 	opts ...verifiable.CredentialOpt) (*verifiable.Credential, error) {
 	if err := anchorEvent.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid anchor event: %w", err)
 	}
 
-	vcBytes, err := json.Marshal(anchorEvent.Witness())
+	witnessDoc, err := GetWitnessDoc(anchorEvent)
+	if err != nil {
+		return nil, fmt.Errorf("get witness from anchor event: %w", err)
+	}
+
+	vcBytes, err := json.Marshal(witnessDoc)
 	if err != nil {
 		return nil, fmt.Errorf("marshal witness: %w", err)
 	}
@@ -34,4 +38,31 @@ func VerifiableCredentialFromAnchorEvent(anchorEvent *vocab.AnchorEventType,
 	}
 
 	return vc, nil
+}
+
+// GetWitnessDoc returns the 'witness' content object in the given anchor event.
+func GetWitnessDoc(anchorEvent *vocab.AnchorEventType) (vocab.Document, error) {
+	indexAnchorObj, err := anchorEvent.AnchorObject(anchorEvent.Anchors())
+	if err != nil {
+		return nil, fmt.Errorf("get anchor object for index [%s]: %w", anchorEvent.Anchors(), err)
+	}
+
+	tags := indexAnchorObj.Tag()
+
+	if len(tags) == 0 {
+		return nil, fmt.Errorf("anchor object [%s] does not contain a 'tag' field", anchorEvent.Anchors())
+	}
+
+	link := indexAnchorObj.Tag()[0].Link()
+	if link == nil || !link.Rel().Is(vocab.RelationshipWitness) {
+		return nil, fmt.Errorf("anchor object [%s] does not contain a tag of type 'Link' and 'rel' 'witness'",
+			anchorEvent.Anchors())
+	}
+
+	witnessAnchorObj, err := anchorEvent.AnchorObject(link.HRef())
+	if err != nil {
+		return nil, fmt.Errorf("witness [%s] not found in anchor event", link.HRef())
+	}
+
+	return witnessAnchorObj.ContentObject(), nil
 }

--- a/pkg/anchor/util/util_test.go
+++ b/pkg/anchor/util/util_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package util
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -58,7 +59,10 @@ func TestVerifiableCredentialFromAnchorEvent(t *testing.T) {
 			Issued: &util.TimeWrapper{Time: time.Now()},
 		}
 
-		act, err := anchorevent.BuildAnchorEvent(payload, contentObj, vc)
+		vcDoc, err := vocab.MarshalToDoc(vc)
+		require.NoError(t, err)
+
+		act, err := anchorevent.BuildAnchorEvent(payload, contentObj.GeneratorID, contentObj.Payload, vcDoc)
 		require.NoError(t, err)
 
 		vcBytes, err := vc.MarshalJSON()
@@ -80,5 +84,148 @@ func TestVerifiableCredentialFromAnchorEvent(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid anchor event")
 		require.Nil(t, vc)
+	})
+
+	t.Run("GetWitness error", func(t *testing.T) {
+		doc, err := vocab.UnmarshalToDoc([]byte(`{}`))
+		require.NoError(t, err)
+
+		indexAnchorObj, err := vocab.NewAnchorObject("some-generator", doc)
+		require.NoError(t, err)
+
+		act := vocab.NewAnchorEvent(
+			vocab.WithAnchors(indexAnchorObj.URL()[0]),
+			vocab.WithAttachment(vocab.NewObjectProperty(vocab.WithAnchorObject(indexAnchorObj))),
+		)
+
+		_, err = VerifiableCredentialFromAnchorEvent(act, verifiable.WithJSONLDDocumentLoader(testutil.GetLoader(t)))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "does not contain a 'tag' field")
+	})
+}
+
+func TestGetWitnessDoc(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		previousAnchors := []*subject.SuffixAnchor{
+			{Suffix: "suffix"},
+		}
+
+		payload := &subject.Payload{
+			OperationCount:  1,
+			CoreIndex:       "coreIndex",
+			Namespace:       "did:orb",
+			Version:         0,
+			PreviousAnchors: previousAnchors,
+		}
+
+		contentObj, err := anchorevent.BuildContentObject(payload)
+		require.NoError(t, err)
+
+		contentObjBytes, err := canonicalizer.MarshalCanonical(contentObj)
+		require.NoError(t, err)
+
+		hl, err := hashlink.New().CreateHashLink(contentObjBytes, nil)
+		require.NoError(t, err)
+
+		vc := &verifiable.Credential{
+			Types:   []string{"VerifiableCredential"},
+			Context: []string{defVCContext},
+			Subject: &builder.CredentialSubject{ID: hl},
+			Issuer: verifiable.Issuer{
+				ID: "http://peer1.com",
+			},
+			Issued: &util.TimeWrapper{Time: time.Now()},
+		}
+
+		vcDoc, err := vocab.MarshalToDoc(vc)
+		require.NoError(t, err)
+
+		act, err := anchorevent.BuildAnchorEvent(payload, contentObj.GeneratorID, contentObj.Payload, vcDoc)
+		require.NoError(t, err)
+
+		vcDoc, err = GetWitnessDoc(act)
+		require.NoError(t, err)
+
+		vc2Bytes, err := json.Marshal(vcDoc)
+		require.NoError(t, err)
+
+		vcBytes, err := vc.MarshalJSON()
+		require.NoError(t, err)
+
+		require.Equal(t, vcBytes, vc2Bytes)
+	})
+
+	t.Run("No tag in index anchor object", func(t *testing.T) {
+		doc, err := vocab.UnmarshalToDoc([]byte(`{}`))
+		require.NoError(t, err)
+
+		indexAnchorObj, err := vocab.NewAnchorObject("some-generator", doc)
+		require.NoError(t, err)
+
+		ae := vocab.NewAnchorEvent(
+			vocab.WithAnchors(indexAnchorObj.URL()[0]),
+			vocab.WithAttachment(vocab.NewObjectProperty(vocab.WithAnchorObject(indexAnchorObj))),
+		)
+
+		_, err = GetWitnessDoc(ae)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "does not contain a 'tag' field")
+	})
+
+	t.Run("No tag field of type witness", func(t *testing.T) {
+		doc, err := vocab.UnmarshalToDoc([]byte(`{}`))
+		require.NoError(t, err)
+
+		indexAnchorObj, err := vocab.NewAnchorObject("some-generator", doc,
+			vocab.WithLink(vocab.NewLink(testutil.MustParseURL("hl:uEiCYs2XYno8FGuqzbiQ6gBrg_hqpELV9pJaUA75Y0mATRw"),
+				"some-relationship")))
+		require.NoError(t, err)
+
+		ae := vocab.NewAnchorEvent(
+			vocab.WithAnchors(indexAnchorObj.URL()[0]),
+			vocab.WithAttachment(vocab.NewObjectProperty(vocab.WithAnchorObject(indexAnchorObj))),
+		)
+
+		_, err = GetWitnessDoc(ae)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "does not contain a tag of type 'Link' and 'rel' 'witness'")
+	})
+
+	t.Run("Index not found", func(t *testing.T) {
+		doc, err := vocab.UnmarshalToDoc([]byte(`{}`))
+		require.NoError(t, err)
+
+		indexAnchorObj, err := vocab.NewAnchorObject("some-generator", doc,
+			vocab.WithLink(vocab.NewLink(testutil.MustParseURL("hl:uEiCYs2XYno8FGuqzbiQ6gBrg_hqpELV9pJaUA75Y0mATRw"),
+				vocab.RelationshipWitness)))
+		require.NoError(t, err)
+
+		ae := vocab.NewAnchorEvent(
+			vocab.WithAnchors(testutil.MustParseURL("hl:uEiB7dnp4KR_LmSO_IqXMUquZzXuOEov9UzML-YoRWTZrrw")),
+			vocab.WithAttachment(vocab.NewObjectProperty(vocab.WithAnchorObject(indexAnchorObj))),
+		)
+
+		_, err = GetWitnessDoc(ae)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "content not found")
+	})
+
+	t.Run("Witness not found", func(t *testing.T) {
+		doc, err := vocab.UnmarshalToDoc([]byte(`{}`))
+		require.NoError(t, err)
+
+		indexAnchorObj, err := vocab.NewAnchorObject("some-generator", doc,
+			vocab.WithLink(vocab.NewLink(testutil.MustParseURL("hl:uEiCYs2XYno8FGuqzbiQ6gBrg_hqpELV9pJaUA75Y0mATRw"),
+				vocab.RelationshipWitness)))
+		require.NoError(t, err)
+
+		ae := vocab.NewAnchorEvent(
+			vocab.WithAnchors(indexAnchorObj.URL()[0]),
+			vocab.WithAttachment(vocab.NewObjectProperty(vocab.WithAnchorObject(indexAnchorObj))),
+		)
+
+		_, err = GetWitnessDoc(ae)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not found in anchor event")
 	})
 }

--- a/pkg/anchor/writer/writer.go
+++ b/pkg/anchor/writer/writer.go
@@ -248,12 +248,12 @@ func (c *Writer) WriteAnchor(anchor string, attachments []*protocol.AnchorDocume
 }
 
 func (c *Writer) buildAnchorEvent(payload *subject.Payload, witnesses []string) (*vocab.AnchorEventType, error) {
-	contentObj, err := anchorevent.BuildContentObject(payload)
+	indexContentObj, err := anchorevent.BuildContentObject(payload)
 	if err != nil {
 		return nil, fmt.Errorf("build content object: %w", err)
 	}
 
-	vc, err := c.buildCredential(contentObj.Payload)
+	vc, err := c.buildCredential(indexContentObj.Payload)
 	if err != nil {
 		return nil, fmt.Errorf("build credential: %w", err)
 	}
@@ -264,7 +264,13 @@ func (c *Writer) buildAnchorEvent(payload *subject.Payload, witnesses []string) 
 		return nil, fmt.Errorf("sign credential: %w", err)
 	}
 
-	anchorEvent, err := anchorevent.BuildAnchorEvent(payload, contentObj, vc)
+	witnessContentObj, err := vocab.MarshalToDoc(vc)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal verifiable credential to doc: %w", err)
+	}
+
+	anchorEvent, err := anchorevent.BuildAnchorEvent(payload, indexContentObj.GeneratorID,
+		indexContentObj.Payload, witnessContentObj)
 	if err != nil {
 		return nil, fmt.Errorf("build anchor event: %w", err)
 	}

--- a/pkg/anchor/writer/writer_test.go
+++ b/pkg/anchor/writer/writer_test.go
@@ -1762,8 +1762,11 @@ func (m httpMock) Do(req *http.Request) (*http.Response, error) {
 
 //nolint: lll
 const jsonAnchorEvent = `{
-  "@context": "https://w3id.org/activityanchors/v1",
-  "anchors": "hl:uEiBL1RVIr2DdyRE5h6b8bPys-PuVs5mMPPC778OtklPa-w",
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://w3id.org/activityanchors/v1"
+  ],
+  "anchors": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
   "attachment": [
     {
       "contentObject": {
@@ -1771,43 +1774,58 @@ const jsonAnchorEvent = `{
           "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v0",
           "https://w3id.org/activityanchors#resources": [
             {
-              "id": "did:orb:uAAA:EiD6mH7iCLGjm9mhBr2TP_5_vRz6nyLYZ5E74xbZzrlmLg"
+              "ID": "did:orb:uAAA:EiAqm7CXVPxriNZv_A6GVCrqlmCmrUSGJ1YaheTzFxa_Fw"
             }
           ]
         },
-        "subject": "hl:uEiB1miJeUsG7PiLvFel8DKoluzDVl3OnpjKgAGZS588PXQ:uoQ-BeEJpcGZzOi8vYmFma3JlaWR2dGlyZjR1d2J4bTdjZjN5djVmNmF6a3JmeG15bmxmM3R1NnRkZmlhYW16am9wdHlwbHU"
+        "subject": "hl:uEiDYMTm9nJ5B0gwpNtflwrcZCT9uT6BFiEs5sYWB45piXg:uoQ-BeEJpcGZzOi8vYmFma3JlaWd5Z2U0MzNoZTZpaGpheWtqdzI3czRmbnl6YmU3dzR0NWFpd2Vld29ucnF3YTZoZ3RjbHk"
       },
-      "type": "AnchorObject",
       "generator": "https://w3id.org/orb#v0",
-      "url": "hl:uEiBL1RVIr2DdyRE5h6b8bPys-PuVs5mMPPC778OtklPa-w",
-      "witness": {
-        "@context": "https://www.w3.org/2018/credentials/v1",
-        "credentialSubject": {
-          "id": "hl:uEiBy8pPgN9eS3hpQAwpSwJJvm6Awpsnc8kR_fkbUPotehg"
-        },
-        "issuanceDate": "2021-01-27T09:30:10Z",
-        "issuer": "https://sally.example.com/services/anchor",
-		"id": "http://orb2.domain1.com/vc/3994cc26-555c-47f1-9890-058148c154f1",
+      "tag": [
+        {
+          "type": "Link",
+          "href": "hl:uEiDzOEQi2wRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
+          "rel": [
+            "witness"
+          ]
+        }
+      ],
+      "type": "AnchorObject",
+      "url": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw"
+    },
+    {
+      "contentObject": {
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://w3id.org/security/jws/v1"
+        ],
+        "credentialSubject": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
+        "id": "http://orb2.domain1.com/vc/3994cc26-555c-47f1-9890-058148c154f1",
+        "issuanceDate": "2021-10-14T18:32:17.894314751Z",
+        "issuer": "http://orb2.domain1.com",
         "proof": [
           {
-            "created": "2021-01-27T09:30:00Z",
-            "domain": "sally.example.com",
-            "jws": "eyJ...",
+            "created": "2021-10-14T18:32:17.91Z",
+            "domain": "http://orb.vct:8077/maple2020",
+            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..h3-0HC3L87TM0j0o3Nd0VLlalcVVphwOPsfdkCLZ4q-uL4z8eO2vQ4sobbtOtFpNNZlpIOQnaWJMX3Ch5Wh-AQ",
             "proofPurpose": "assertionMethod",
-            "type": "JsonWebSignature2020",
-            "verificationMethod": "did:example:abcd#key"
+            "type": "Ed25519Signature2018",
+            "verificationMethod": "did:web:orb.domain1.com#orb1key"
           },
           {
-            "created": "2021-01-27T09:30:05Z",
-            "domain": "https://witness1.example.com/ledgers/maple2021",
-            "jws": "eyJ...",
+            "created": "2021-10-14T18:32:18.09110265Z",
+            "domain": "https://orb.domain2.com",
+            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..DSL3zsltnh9dbSn3VNPb1C-6pKt6VOy-H1WadO5ZV2QZd3xZq3uRRhaShi9K1SzX-VaGPxs3gfbazJ-fpHVxBg",
             "proofPurpose": "assertionMethod",
-            "type": "JsonWebSignature2020",
-            "verificationMethod": "did:example:abcd#key"
+            "type": "Ed25519Signature2018",
+            "verificationMethod": "did:web:orb.domain2.com#orb2key"
           }
         ],
         "type": "VerifiableCredential"
-      }
+      },
+      "generator": "https://w3id.org/orb#v0",
+      "type": "AnchorObject",
+      "url": "hl:uEiDzOEQi2wRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw"
     }
   ],
   "attributedTo": "https://orb.domain1.com/services/orb",
@@ -1815,15 +1833,18 @@ const jsonAnchorEvent = `{
     "hl:uEiAsiwjaXOYDmOHxmvDl3Mx0TfJ0uCar5YXqumjFJUNIBg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBc2l3amFYT1lEbU9IeG12RGwzTXgwVGZKMHVDYXI1WVhxdW1qRkpVTklCZ3hCaXBmczovL2JhZmtyZWlibXJtZW51eGhnYW9tb2Q0bTI2ZHM1enRkdWp4emhqb2JndnBzeWwydjJuZGNza3EyaWF5",
     "hl:uEiAn3Y7USoP_lNVX-f0EEu1ajLymnqBJItiMARhKBzAKWg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBbjNZN1VTb1BfbE5WWC1mMEVFdTFhakx5bW5xQkpJdGlNQVJoS0J6QUtXZ3hCaXBmczovL2JhZmtyZWliaDN3aG5pc3VkNzZrbmt2N3o3dWNiZjNrMnJzNmtuaHZhamVybnJkYWJkYmZhb21ha2xp"
   ],
-  "published": "2021-01-27T09:30:10Z",
-  "type": "Info",
-  "url": "hl:uEiCJWrCq8ttsWob5UVueRQiQ_QUrocJY6ZA8BDgzgakuhg:uoQ-BeEJpcGZzOi8vYmFma3JlaWVqbGt5a3Y0dzNucm5pbjZrcmxvcGVrY2VxN3Vjc3hpb2NsZHV6YXBhZWhhenlka2pvcXk"
+  "published": "2021-10-14T18:32:17.888176489Z",
+  "type": "AnchorEvent",
+  "url": "hl:uEiDhdDIS_-_SWKoh5Y3KJ_sWpIoXZUPBeTBMCSBUKXpe5w:uoQ-BeEJpcGZzOi8vYmFma3JlaWhib3F6YmY3N3Ayam1rdWlwZnJ4ZmNwNnl3dXNmYm96a2R5ZjR0YXRhamVia2NzNnM2NDQ"
 }`
 
 //nolint: lll
 const jsonAnchorEventInvalidWitness = `{
-  "@context": "https://w3id.org/activityanchors/v1",
-  "anchors": "hl:uEiBL1RVIr2DdyRE5h6b8bPys-PuVs5mMPPC778OtklPa-w",
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://w3id.org/activityanchors/v1"
+  ],
+  "anchors": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
   "attachment": [
     {
       "contentObject": {
@@ -1831,22 +1852,37 @@ const jsonAnchorEventInvalidWitness = `{
           "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v0",
           "https://w3id.org/activityanchors#resources": [
             {
-              "id": "did:orb:uAAA:EiD6mH7iCLGjm9mhBr2TP_5_vRz6nyLYZ5E74xbZzrlmLg"
+              "ID": "did:orb:uAAA:EiAqm7CXVPxriNZv_A6GVCrqlmCmrUSGJ1YaheTzFxa_Fw"
             }
           ]
         },
-        "subject": "hl:uEiB1miJeUsG7PiLvFel8DKoluzDVl3OnpjKgAGZS588PXQ:uoQ-BeEJpcGZzOi8vYmFma3JlaWR2dGlyZjR1d2J4bTdjZjN5djVmNmF6a3JmeG15bmxmM3R1NnRkZmlhYW16am9wdHlwbHU"
+        "subject": "hl:uEiDYMTm9nJ5B0gwpNtflwrcZCT9uT6BFiEs5sYWB45piXg:uoQ-BeEJpcGZzOi8vYmFma3JlaWd5Z2U0MzNoZTZpaGpheWtqdzI3czRmbnl6YmU3dzR0NWFpd2Vld29ucnF3YTZoZ3RjbHk"
       },
-      "type": "AnchorObject",
       "generator": "https://w3id.org/orb#v0",
-      "url": "hl:uEiBL1RVIr2DdyRE5h6b8bPys-PuVs5mMPPC778OtklPa-w",
-      "witness": {
-        "@context": "https://www.w3.org/2018/credentials/v1",
-        "credentialSubject": {
-          "id": "hl:uEiBy8pPgN9eS3hpQAwpSwJJvm6Awpsnc8kR_fkbUPotehg"
-        },
+      "tag": [
+        {
+          "type": "Link",
+          "href": "hl:uEiDzOEQi2wRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
+          "rel": [
+            "witness"
+          ]
+        }
+      ],
+      "type": "AnchorObject",
+      "url": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw"
+    },
+    {
+      "contentObject": {
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://w3id.org/security/jws/v1"
+        ],
+        "credentialSubject": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
         "type": "VerifiableCredential"
-      }
+      },
+      "generator": "https://w3id.org/orb#v0",
+      "type": "AnchorObject",
+      "url": "hl:uEiDzOEQi2wRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw"
     }
   ],
   "attributedTo": "https://orb.domain1.com/services/orb",
@@ -1854,7 +1890,7 @@ const jsonAnchorEventInvalidWitness = `{
     "hl:uEiAsiwjaXOYDmOHxmvDl3Mx0TfJ0uCar5YXqumjFJUNIBg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBc2l3amFYT1lEbU9IeG12RGwzTXgwVGZKMHVDYXI1WVhxdW1qRkpVTklCZ3hCaXBmczovL2JhZmtyZWlibXJtZW51eGhnYW9tb2Q0bTI2ZHM1enRkdWp4emhqb2JndnBzeWwydjJuZGNza3EyaWF5",
     "hl:uEiAn3Y7USoP_lNVX-f0EEu1ajLymnqBJItiMARhKBzAKWg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBbjNZN1VTb1BfbE5WWC1mMEVFdTFhakx5bW5xQkpJdGlNQVJoS0J6QUtXZ3hCaXBmczovL2JhZmtyZWliaDN3aG5pc3VkNzZrbmt2N3o3dWNiZjNrMnJzNmtuaHZhamVybnJkYWJkYmZhb21ha2xp"
   ],
-  "published": "2021-01-27T09:30:10Z",
-  "type": "Info",
-  "url": "hl:uEiCJWrCq8ttsWob5UVueRQiQ_QUrocJY6ZA8BDgzgakuhg:uoQ-BeEJpcGZzOi8vYmFma3JlaWVqbGt5a3Y0dzNucm5pbjZrcmxvcGVrY2VxN3Vjc3hpb2NsZHV6YXBhZWhhenlka2pvcXk"
+  "published": "2021-10-14T18:32:17.888176489Z",
+  "type": "AnchorEvent",
+  "url": "hl:uEiDhdDIS_-_SWKoh5Y3KJ_sWpIoXZUPBeTBMCSBUKXpe5w:uoQ-BeEJpcGZzOi8vYmFma3JlaWhib3F6YmY3N3Ayam1rdWlwZnJ4ZmNwNnl3dXNmYm96a2R5ZjR0YXRhamVia2NzNnM2NDQ"
 }`

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -754,9 +754,6 @@ func newMockAnchorEvent(t *testing.T, payload *subject.Payload) *vocab.AnchorEve
 
 	const defVCContext = "https://www.w3.org/2018/credentials/v1"
 
-	contentObj, err := anchorevent.BuildContentObject(payload)
-	require.NoError(t, err)
-
 	vc := &verifiable.Credential{
 		Types:   []string{"VerifiableCredential"},
 		Context: []string{defVCContext},
@@ -769,7 +766,11 @@ func newMockAnchorEvent(t *testing.T, payload *subject.Payload) *vocab.AnchorEve
 		Issued: &util.TimeWrapper{Time: time.Now()},
 	}
 
-	act, err := anchorevent.BuildAnchorEvent(payload, contentObj, vc)
+	contentObj, err := anchorevent.BuildContentObject(payload)
+	require.NoError(t, err)
+
+	act, err := anchorevent.BuildAnchorEvent(payload, contentObj.GeneratorID, contentObj.Payload,
+		vocab.MustMarshalToDoc(vc))
 	require.NoError(t, err)
 
 	return act

--- a/pkg/orbclient/client_test.go
+++ b/pkg/orbclient/client_test.go
@@ -273,7 +273,8 @@ func newMockAnchorEvent(t *testing.T, payload *subject.Payload) *vocab.AnchorEve
 		Issued: &util.TimeWrapper{Time: time.Now()},
 	}
 
-	act, err := anchorevent.BuildAnchorEvent(payload, contentObj, vc)
+	act, err := anchorevent.BuildAnchorEvent(payload, contentObj.GeneratorID, contentObj.Payload,
+		vocab.MustMarshalToDoc(vc))
 	require.NoError(t, err)
 
 	return act

--- a/test/bdd/features/activitypub.feature
+++ b/test/bdd/features/activitypub.feature
@@ -147,7 +147,7 @@ Feature:
     # A 'Create' activity should have been posted to domain1's followers (domain2).
     When an HTTP GET is sent to "https://orb.domain2.com/services/orb/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
-    And the JSON path "orderedItems.#.id" of the response contains "${domain1IRI}/activities/7df49d38-d97a-4b1a-96f7-6e7a685fea9d"
+    And the JSON path "orderedItems.#.id" of the response contains "${domain1IRI}/activities/e9414c61-7b0f-4054-95c3-5c2ff1649a3a"
 
     # An 'Announce' activity should have been posted to domain2's followers (domain3).
     When an HTTP GET is sent to "https://orb.domain2.com/services/orb/outbox?page=true"
@@ -171,12 +171,12 @@ Feature:
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response does not contain "${domain3IRI}"
 
-    When an HTTP GET is sent to "https://orb.domain3.com/services/orb/shares?id=hl%3AuEiDX1dMubWFb55kQ-KWUo6GWChQ4oHRk5BT23ZL9UNSu7g%3AuoQ-BeEJpcGZzOi8vYmFma3JlaWhib3F6YmY3N3Ayam1rdWlwZnJ4ZmNwNnl3dXNmYm96a2R5ZjR0YXRhamVia2NzNnM2NDQ"
+    When an HTTP GET is sent to "https://orb.domain3.com/services/orb/shares?id=hl%3AuEiCYs2XYno8FGuqzbiQ6gBrg_hqpELV9pJaUA75Y0mATRw%3AuoQ-BeEJpcGZzOi8vYmFma3JlaWV5d25zNXJodXBhdW5vdm0zb2VxNWlhZ3hhN3lua3NlZnZwd3NqbmZhZHh6bW5leWF0aTQ"
     Then the JSON path "type" of the response equals "OrderedCollection"
     Then the JSON path "first" of the response is saved to variable "sharesFirstPage"
     When an HTTP GET is sent to "${sharesFirstPage}"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
-    And the JSON path "orderedItems.0.object.items.0.url" of the response equals "hl:uEiDX1dMubWFb55kQ-KWUo6GWChQ4oHRk5BT23ZL9UNSu7g:uoQ-BeEJpcGZzOi8vYmFma3JlaWhib3F6YmY3N3Ayam1rdWlwZnJ4ZmNwNnl3dXNmYm96a2R5ZjR0YXRhamVia2NzNnM2NDQ"
+    And the JSON path "orderedItems.0.object.items.0.url" of the response equals "hl:uEiCYs2XYno8FGuqzbiQ6gBrg_hqpELV9pJaUA75Y0mATRw:uoQ-BeEJpcGZzOi8vYmFma3JlaWV5d25zNXJodXBhdW5vdm0zb2VxNWlhZ3hhN3lua3NlZnZwd3NqbmZhZHh6bW5leWF0aTQ"
 
   @activitypub_invite_witness
   Scenario: invite witness/accept/undo
@@ -248,7 +248,7 @@ Feature:
     # The 'Offer' activity should be in the inbox of domain1.
     When an HTTP GET is sent to "https://orb.domain1.com/services/orb/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
-    And the JSON path "orderedItems.#.id" of the response contains "${domain2IRI}/activities/63b3d005-6cb6-673d-6379-18be1ee84973"
+    And the JSON path "orderedItems.#.id" of the response contains "${domain2IRI}/activities/50dddb40-5a5c-4a69-a8d0-49748a849d8d"
 
     And variable "undoInviteWitnessActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain2IRI}","to":"${domain1IRI}","object":{"actor":"${domain2IRI}","id":"${inviteWitnessID}","object":"${domain1IRI}","type":"Invite"}}'
     When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${undoInviteWitnessActivity}" of type "application/json"

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -300,7 +300,7 @@ Feature:
      And variable "anchorHash" is assigned the value "$hashlink(|${anchorLink}|).ResourceHash"
 
      When an HTTP GET is sent to "https://orb.domain1.com/cas/${anchorHash}"
-     Then the JSON path "attachment.0.witness.id" of the response is saved to variable "vcID"
+     Then the JSON path 'attachment.#(contentObject.type="VerifiableCredential").contentObject.id' of the response is saved to variable "vcID"
 
      When an HTTP GET is sent to "${vcID}"
      Then the JSON path "id" of the response equals "${vcID}"

--- a/test/bdd/fixtures/testdata/create_activity.json
+++ b/test/bdd/fixtures/testdata/create_activity.json
@@ -4,10 +4,10 @@
     "https://w3id.org/activityanchors/v1"
   ],
   "actor": "https://orb.domain1.com/services/orb",
-  "id": "https://orb.domain1.com/services/orb/activities/7df49d38-d97a-4b1a-96f7-6e7a685fea9d",
+  "id": "https://orb.domain1.com/services/orb/activities/e9414c61-7b0f-4054-95c3-5c2ff1649a3a",
   "object": {
     "@context": "https://w3id.org/activityanchors/v1",
-    "anchors": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
+    "anchors": "hl:uEiC3iwEPbEyFcVP8JwZ0sv3i9i-Fw4OLrX8PKleZYy9ZfQ",
     "attachment": [
       {
         "contentObject": {
@@ -15,52 +15,66 @@
             "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v0",
             "https://w3id.org/activityanchors#resources": [
               {
-                "ID": "did:orb:uAAA:EiAqm7CXVPxriNZv_A6GVCrqlmCmrUSGJ1YaheTzFxa_Fw"
+                "id": "did:orb:uAAA:EiBeUSGvi50wNlQUGMy4kRANNUfu4eHbGaAIDb1v63rCQg"
               }
             ]
           },
-          "subject": "hl:uEiDYMTm9nJ5B0gwpNtflwrcZCT9uT6BFiEs5sYWB45piXg:uoQ-BeEJpcGZzOi8vYmFma3JlaWd5Z2U0MzNoZTZpaGpheWtqdzI3czRmbnl6YmU3dzR0NWFpd2Vld29ucnF3YTZoZ3RjbHk"
+          "subject": "hl:uEiC5KDbwlfCVWVyI6QweF5yVzsXkAWHleUIZ0LvqmAmCsg:uoQ-BeEJpcGZzOi8vYmFma3JlaWZ6ZmEzcGJmcHFzdm12emNoamJxcGJwaGV2ejNjNmlhbGI0djR1ZWdvcXhwdmpxY21jd2k"
         },
         "generator": "https://w3id.org/orb#v0",
+        "tag": [
+          {
+            "href": "hl:uEiB7dnp4KR_LmSO_IqXMUquZzXuOEov9UzML-YoRWTZrrw",
+            "rel": [
+              "witness"
+            ],
+            "type": "Link"
+          }
+        ],
         "type": "AnchorObject",
-        "url": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
-        "witness": {
+        "url": "hl:uEiC3iwEPbEyFcVP8JwZ0sv3i9i-Fw4OLrX8PKleZYy9ZfQ"
+      },
+      {
+        "contentObject": {
           "@context": [
             "https://www.w3.org/2018/credentials/v1",
             "https://w3id.org/security/suites/jws-2020/v1"
           ],
-          "credentialSubject": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
-          "id": "http://orb2.domain1.com/vc/3994cc26-555c-47f1-9890-058148c154f1",
-          "issuanceDate": "2021-10-14T18:32:17.894314751Z",
-          "issuer": "http://orb2.domain1.com",
+          "credentialSubject": "hl:uEiC3iwEPbEyFcVP8JwZ0sv3i9i-Fw4OLrX8PKleZYy9ZfQ",
+          "id": "https://orb2.domain1.com/vc/1ccf16c8-36b9-4105-81f5-9ccb9d034bb7",
+          "issuanceDate": "2021-10-27T18:54:37.766459879Z",
+          "issuer": "https://orb2.domain1.com",
           "proof": [
             {
-              "created": "2021-10-14T18:32:17.91Z",
+              "created": "2021-10-27T18:54:37.779Z",
               "domain": "http://orb.vct:8077/maple2020",
-              "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..h3-0HC3L87TM0j0o3Nd0VLlalcVVphwOPsfdkCLZ4q-uL4z8eO2vQ4sobbtOtFpNNZlpIOQnaWJMX3Ch5Wh-AQ",
+              "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..vJSsy0TyjgFsmJmD9jV9lCkvYKErBu6EqnPb1PtUQ9a80VSXSG9K17a2lSMAIgkNkDN-dp93hZrDGcCfIZFkBQ",
               "proofPurpose": "assertionMethod",
               "type": "Ed25519Signature2018",
               "verificationMethod": "did:web:orb.domain1.com#orb1key"
             },
             {
-              "created": "2021-10-14T18:32:18.09110265Z",
+              "created": "2021-10-27T18:54:37.950767018Z",
               "domain": "https://orb.domain2.com",
-              "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..DSL3zsltnh9dbSn3VNPb1C-6pKt6VOy-H1WadO5ZV2QZd3xZq3uRRhaShi9K1SzX-VaGPxs3gfbazJ-fpHVxBg",
+              "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..HLG3TP_8PhN8youu-sT7kFpsHZEbnmQB0qG-meFFS_dhVGMd2mjQ5pJ7zJ29_V_RVGU1SEAg2r8OqIELmImbBg",
               "proofPurpose": "assertionMethod",
               "type": "Ed25519Signature2018",
               "verificationMethod": "did:web:orb.domain2.com#orb2key"
             }
           ],
           "type": "VerifiableCredential"
-        }
+        },
+        "generator": "https://w3id.org/orb#v0",
+        "type": "AnchorObject",
+        "url": "hl:uEiB7dnp4KR_LmSO_IqXMUquZzXuOEov9UzML-YoRWTZrrw"
       }
     ],
     "attributedTo": "https://orb.domain1.com/services/orb",
-    "published": "2021-10-14T18:32:17.888176489Z",
+    "published": "2021-10-27T18:54:37.761344046Z",
     "type": "AnchorEvent",
-    "url": "hl:uEiDX1dMubWFb55kQ-KWUo6GWChQ4oHRk5BT23ZL9UNSu7g:uoQ-BeEJpcGZzOi8vYmFma3JlaWhib3F6YmY3N3Ayam1rdWlwZnJ4ZmNwNnl3dXNmYm96a2R5ZjR0YXRhamVia2NzNnM2NDQ"
+    "url": "hl:uEiCYs2XYno8FGuqzbiQ6gBrg_hqpELV9pJaUA75Y0mATRw:uoQ-BeEJpcGZzOi8vYmFma3JlaWV5d25zNXJodXBhdW5vdm0zb2VxNWlhZ3hhN3lua3NlZnZwd3NqbmZhZHh6bW5leWF0aTQ"
   },
-  "published": "2021-10-14T18:32:18.333137249Z",
+  "published": "2021-10-27T18:54:38.173843394Z",
   "to": [
     "https://orb.domain1.com/services/orb/followers",
     "https://www.w3.org/ns/activitystreams#Public"

--- a/test/bdd/fixtures/testdata/offer_activity.json
+++ b/test/bdd/fixtures/testdata/offer_activity.json
@@ -1,12 +1,11 @@
 {
   "@context": "https://www.w3.org/ns/activitystreams",
   "actor": "https://orb.domain2.com/services/orb",
-  "startTime": "2021-03-31T01:30:10Z",
-  "endTime": "2029-03-31T23:31:10Z",
-  "id": "https://orb.domain2.com/services/orb/activities/63b3d005-6cb6-673d-6379-18be1ee84973",
+  "endTime": "2021-10-27T18:48:58.814910907Z",
+  "id": "https://orb.domain2.com/services/orb/activities/50dddb40-5a5c-4a69-a8d0-49748a849d8d",
   "object": {
     "@context": "https://w3id.org/activityanchors/v1",
-    "anchors": "hl:uEiAxs7s3L9HnxQgEdOYAFzDsFpgBRzF6ZBKFUBPl6IwGIQ",
+    "anchors": "hl:uEiCNTa0OSh4jUlPyl7Iy66Or6GBMbMy2NFod2TZoy8VF2Q",
     "attachment": [
       {
         "contentObject": {
@@ -14,43 +13,62 @@
             "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v0",
             "https://w3id.org/activityanchors#resources": [
               {
-                "ID": "did:orb:uAAA:EiAqm7CXVPxriNZv_A6GVCrqlmCmrUSGJ1YaheTzFxa_Fw"
+                "id": "did:orb:uAAA:EiCeAod7fzZbn2AJItn6m9K-jOiVrX1eB236EePVNVHYxA"
+              },
+              {
+                "id": "did:orb:uAAA:EiCjZqzYDBZzJuN86NhdpQjdLuofu0jrHJObYvYmzHJB1A"
               }
             ]
           },
-          "subject": "hl:uEiDYMTm9nJ5B0gwpNtflwrcZCT9uT6BFiEs5sYWB45piXg:uoQ-BeEJpcGZzOi8vYmFma3JlaWd5Z2U0MzNoZTZpaGpheWtqdzI3czRmbnl6YmU3dzR0NWFpd2Vld29ucnF3YTZoZ3RjbHk"
+          "subject": "hl:uEiACihcgBLnqmsxV2F2vuGoEo68klMpFxHnaxOk0IPjFKg:uoQ-BeEJpcGZzOi8vYmFma3JlaWFjcmlsc2FiZno1a25teXZveWx3eDNxMnFldW94c2pmZ2tpeGNodHd3ZTVlMmNiNmdmZmk"
         },
         "generator": "https://w3id.org/orb#v0",
+        "tag": [
+          {
+            "href": "hl:uEiDR4p9UnRaNieEHZ_7Mp29iMtXlYXHTU7R6sEVQiDqsaw",
+            "rel": [
+              "witness"
+            ],
+            "type": "Link"
+          }
+        ],
         "type": "AnchorObject",
-        "url": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
-        "witness": {
+        "url": "hl:uEiCNTa0OSh4jUlPyl7Iy66Or6GBMbMy2NFod2TZoy8VF2Q"
+      },
+      {
+        "contentObject": {
           "@context": [
             "https://www.w3.org/2018/credentials/v1",
             "https://w3id.org/security/suites/jws-2020/v1"
           ],
-          "credentialSubject": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
-          "id": "http://orb2.domain1.com/vc/3994cc26-555c-47f1-9890-058148c154f1",
-          "issuanceDate": "2021-10-14T18:32:17.894314751Z",
-          "issuer": "http://orb2.domain1.com",
-          "proof": [
-            {
-              "created": "2021-10-14T18:32:18.09110265Z",
-              "domain": "https://orb.domain2.com",
-              "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..DSL3zsltnh9dbSn3VNPb1C-6pKt6VOy-H1WadO5ZV2QZd3xZq3uRRhaShi9K1SzX-VaGPxs3gfbazJ-fpHVxBg",
-              "proofPurpose": "assertionMethod",
-              "type": "Ed25519Signature2018",
-              "verificationMethod": "did:web:orb.domain2.com#orb2key"
-            }
-          ],
+          "credentialSubject": "hl:uEiCNTa0OSh4jUlPyl7Iy66Or6GBMbMy2NFod2TZoy8VF2Q",
+          "id": "https://orb.domain1.com/vc/0b774746-92bb-4050-b19c-980de706f40a",
+          "issuanceDate": "2021-10-27T18:38:58.698048169Z",
+          "issuer": "https://orb.domain1.com",
+          "proof": {
+            "created": "2021-10-27T18:38:58.712Z",
+            "domain": "http://orb.vct:8077/maple2020",
+            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..8o87soi6tKXhqZwvJSvEEgtXUSYOsc7cmh_l5DN3i7nLVYHuVkwNEb7FAIyztoNVUuG-Szh2qvacME_L8biwAQ",
+            "proofPurpose": "assertionMethod",
+            "type": "Ed25519Signature2018",
+            "verificationMethod": "did:web:orb.domain1.com#orb1key"
+          },
           "type": "VerifiableCredential"
-        }
+        },
+        "generator": "https://w3id.org/orb#v0",
+        "type": "AnchorObject",
+        "url": "hl:uEiDR4p9UnRaNieEHZ_7Mp29iMtXlYXHTU7R6sEVQiDqsaw"
       }
     ],
     "attributedTo": "https://orb.domain1.com/services/orb",
-    "published": "2021-09-28T19:57:41.1487748Z",
+    "published": "2021-10-27T18:38:58.676797454Z",
     "type": "AnchorEvent"
   },
-  "to": ["https://orb.domain2.com/services/orb/witnesses","https://www.w3.org/ns/activitystreams#Public"],
+  "startTime": "2021-10-27T18:38:58.814910907Z",
   "target": "https://w3id.org/activityanchors#AnchorWitness",
+  "to": [
+    "https://www.w3.org/ns/activitystreams#Public",
+    "https://orb.domain1.com/services/orb/witnesses"
+  ],
   "type": "Offer"
 }


### PR DESCRIPTION
The witness (verifiable credential) is now in a separate, AnchorObject attachment of the AnchorEvent and a tag was added to the index AnchorObject to link to the witness AnchorObject attachment.

closes #841

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>