### PR TITLE
feat: MQ redelivery with backoff and maximum attempts

### DIFF
--- a/cmd/orb-cli/go.sum
+++ b/cmd/orb-cli/go.sum
@@ -123,11 +123,10 @@ github.com/Sectorbob/mlab-ns2 v0.0.0-20171030222938-d3aa0c295a8a/go.mod h1:D73UA
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
-github.com/ThreeDotsLabs/watermill v1.0.2/go.mod h1:vZCPh7eN0P7r2qKau4SfmcUZ83+3JXWkRl4BiWUlqFw=
 github.com/ThreeDotsLabs/watermill v1.1.0/go.mod h1:Qd1xNFxolCAHCzcMrm6RnjW0manbvN+DJVWc1MWRFlI=
-github.com/ThreeDotsLabs/watermill v1.2.0-rc.4 h1:hX8toeERHfnrZFvCXdWRQCYgoNExQoi5vtf5+rbGaA8=
-github.com/ThreeDotsLabs/watermill v1.2.0-rc.4/go.mod h1:sl2PSceOQJ8BreN60hCnU2WixFNOYJOQDY1J3hvyVCs=
-github.com/ThreeDotsLabs/watermill-amqp v1.1.1/go.mod h1:Qbu3JDlr6vIOxHJjhfsSHsrdF/ToJLYoaYek8X5Wnto=
+github.com/ThreeDotsLabs/watermill v1.2.0-rc.6 h1:wYybtpC+LMQCC8j3/D1BQPobWh0rZ4ZX57i3+zy7t8I=
+github.com/ThreeDotsLabs/watermill v1.2.0-rc.6/go.mod h1:QLZSaklpSZ/7yv288LL2DFOgCEi86VYEmQvzmaMlHoA=
+github.com/ThreeDotsLabs/watermill-amqp v1.1.3/go.mod h1:AnjfZlOKwWdDFQl23WCspiC1kewtqt5dognCKwvEk4M=
 github.com/ThreeDotsLabs/watermill-http v1.1.3/go.mod h1:mkQ9CC0pxTZerNwr281rBoOy355vYt/lePkmYSX/BRg=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=
 github.com/VictoriaMetrics/fastcache v1.5.7/go.mod h1:ptDBkNMQI4RtmVo8VS/XwRY6RoTu1dAWCbrk+6WsEM8=
@@ -226,6 +225,7 @@ github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oD
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
+github.com/cenkalti/backoff/v3 v3.2.2/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/cenkalti/backoff/v4 v4.0.2/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
 github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.1.1 h1:G2HAfAmvm/GcKan2oOQpBXOd2tT2G57ZnZGWa1PxPBQ=
@@ -377,6 +377,7 @@ github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32/go.mod h1:GIjDIg/heH
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-asn1-ber/asn1-ber v1.3.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
+github.com/go-chi/chi/v5 v5.0.4/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-chi/render v1.0.1/go.mod h1:pq4Rr7HbnsdaeHagklXub+p6Wd16Af5l9koip1OvJns=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -557,8 +558,9 @@ github.com/google/uuid v0.0.0-20161128191214-064e2069ce9c/go.mod h1:TIyPZe4Mgqvf
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/wire v0.3.0/go.mod h1:i1DMg/Lu8Sz5yYl25iOdmc5CT5qusaa+zmRWs16741s=
 github.com/googleapis/gax-go v2.0.2+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -627,6 +629,7 @@ github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iP
 github.com/hashicorp/go-msgpack v0.5.5/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.0.0/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-raftchunking v0.6.3-0.20191002164813-7e9e8525653a/go.mod h1:xbXnmKqX9/+RhPkJ4zrEx4738HacP72aaUPlT2RZ4sU=
@@ -898,8 +901,9 @@ github.com/libp2p/go-openssl v0.0.7 h1:eCAzdLejcNVBzP/iZM9vqHnQm+XyCEbSSIheIPRGN
 github.com/libp2p/go-openssl v0.0.7/go.mod h1:unDrJpgy3oFr+rqXsarWifmJuNnJR4chtO1HmaZjggc=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
-github.com/lithammer/shortuuid/v3 v3.0.4 h1:uj4xhotfY92Y1Oa6n6HUiFn87CdoEHYUlTy0+IgbLrs=
 github.com/lithammer/shortuuid/v3 v3.0.4/go.mod h1:RviRjexKqIzx/7r1peoAITm6m7gnif/h+0zmolKJjzw=
+github.com/lithammer/shortuuid/v3 v3.0.7 h1:trX0KTHy4Pbwo/6ia8fscyHoGA+mf1jWbPJVuvyJQQ8=
+github.com/lithammer/shortuuid/v3 v3.0.7/go.mod h1:vMk8ke37EmiewwolSO1NLW8vP4ZaKlRuDIi8tWWmAts=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -1221,6 +1225,7 @@ github.com/square/go-jose/v3 v3.0.0-20200630053402-0a67ce9b0693/go.mod h1:6hSY48
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
+github.com/streadway/amqp v1.0.0/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -1551,7 +1556,6 @@ golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/cmd/orb-driver/go.sum
+++ b/cmd/orb-driver/go.sum
@@ -123,11 +123,10 @@ github.com/Sectorbob/mlab-ns2 v0.0.0-20171030222938-d3aa0c295a8a/go.mod h1:D73UA
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
-github.com/ThreeDotsLabs/watermill v1.0.2/go.mod h1:vZCPh7eN0P7r2qKau4SfmcUZ83+3JXWkRl4BiWUlqFw=
 github.com/ThreeDotsLabs/watermill v1.1.0/go.mod h1:Qd1xNFxolCAHCzcMrm6RnjW0manbvN+DJVWc1MWRFlI=
-github.com/ThreeDotsLabs/watermill v1.2.0-rc.4 h1:hX8toeERHfnrZFvCXdWRQCYgoNExQoi5vtf5+rbGaA8=
-github.com/ThreeDotsLabs/watermill v1.2.0-rc.4/go.mod h1:sl2PSceOQJ8BreN60hCnU2WixFNOYJOQDY1J3hvyVCs=
-github.com/ThreeDotsLabs/watermill-amqp v1.1.1/go.mod h1:Qbu3JDlr6vIOxHJjhfsSHsrdF/ToJLYoaYek8X5Wnto=
+github.com/ThreeDotsLabs/watermill v1.2.0-rc.6 h1:wYybtpC+LMQCC8j3/D1BQPobWh0rZ4ZX57i3+zy7t8I=
+github.com/ThreeDotsLabs/watermill v1.2.0-rc.6/go.mod h1:QLZSaklpSZ/7yv288LL2DFOgCEi86VYEmQvzmaMlHoA=
+github.com/ThreeDotsLabs/watermill-amqp v1.1.3/go.mod h1:AnjfZlOKwWdDFQl23WCspiC1kewtqt5dognCKwvEk4M=
 github.com/ThreeDotsLabs/watermill-http v1.1.3/go.mod h1:mkQ9CC0pxTZerNwr281rBoOy355vYt/lePkmYSX/BRg=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=
 github.com/VictoriaMetrics/fastcache v1.5.7/go.mod h1:ptDBkNMQI4RtmVo8VS/XwRY6RoTu1dAWCbrk+6WsEM8=
@@ -226,6 +225,7 @@ github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oD
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
+github.com/cenkalti/backoff/v3 v3.2.2/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/cenkalti/backoff/v4 v4.0.2/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
 github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.1.1 h1:G2HAfAmvm/GcKan2oOQpBXOd2tT2G57ZnZGWa1PxPBQ=
@@ -376,6 +376,7 @@ github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32/go.mod h1:GIjDIg/heH
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-asn1-ber/asn1-ber v1.3.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
+github.com/go-chi/chi/v5 v5.0.4/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-chi/render v1.0.1/go.mod h1:pq4Rr7HbnsdaeHagklXub+p6Wd16Af5l9koip1OvJns=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -555,8 +556,9 @@ github.com/google/uuid v0.0.0-20161128191214-064e2069ce9c/go.mod h1:TIyPZe4Mgqvf
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/wire v0.3.0/go.mod h1:i1DMg/Lu8Sz5yYl25iOdmc5CT5qusaa+zmRWs16741s=
 github.com/googleapis/gax-go v2.0.2+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -625,6 +627,7 @@ github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iP
 github.com/hashicorp/go-msgpack v0.5.5/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.0.0/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-raftchunking v0.6.3-0.20191002164813-7e9e8525653a/go.mod h1:xbXnmKqX9/+RhPkJ4zrEx4738HacP72aaUPlT2RZ4sU=
@@ -893,8 +896,9 @@ github.com/libp2p/go-openssl v0.0.7 h1:eCAzdLejcNVBzP/iZM9vqHnQm+XyCEbSSIheIPRGN
 github.com/libp2p/go-openssl v0.0.7/go.mod h1:unDrJpgy3oFr+rqXsarWifmJuNnJR4chtO1HmaZjggc=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
-github.com/lithammer/shortuuid/v3 v3.0.4 h1:uj4xhotfY92Y1Oa6n6HUiFn87CdoEHYUlTy0+IgbLrs=
 github.com/lithammer/shortuuid/v3 v3.0.4/go.mod h1:RviRjexKqIzx/7r1peoAITm6m7gnif/h+0zmolKJjzw=
+github.com/lithammer/shortuuid/v3 v3.0.7 h1:trX0KTHy4Pbwo/6ia8fscyHoGA+mf1jWbPJVuvyJQQ8=
+github.com/lithammer/shortuuid/v3 v3.0.7/go.mod h1:vMk8ke37EmiewwolSO1NLW8vP4ZaKlRuDIi8tWWmAts=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -1215,6 +1219,7 @@ github.com/square/go-jose/v3 v3.0.0-20200630053402-0a67ce9b0693/go.mod h1:6hSY48
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
+github.com/streadway/amqp v1.0.0/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -1545,7 +1550,6 @@ golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/cmd/orb-server/go.mod
+++ b/cmd/orb-server/go.mod
@@ -5,9 +5,9 @@
 module github.com/trustbloc/orb/cmd/orb-server
 
 require (
-	github.com/ThreeDotsLabs/watermill v1.2.0-rc.4
+	github.com/ThreeDotsLabs/watermill v1.2.0-rc.6
 	github.com/cenkalti/backoff/v4 v4.1.1
-	github.com/google/uuid v1.2.0
+	github.com/google/uuid v1.3.0
 	github.com/hyperledger/aries-framework-go v0.1.7
 	github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20210909220549-ce3a2ee13e22
 	github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211006214906-8ddae60cdd21

--- a/cmd/orb-server/go.sum
+++ b/cmd/orb-server/go.sum
@@ -126,12 +126,11 @@ github.com/Sectorbob/mlab-ns2 v0.0.0-20171030222938-d3aa0c295a8a/go.mod h1:D73UA
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
-github.com/ThreeDotsLabs/watermill v1.0.2/go.mod h1:vZCPh7eN0P7r2qKau4SfmcUZ83+3JXWkRl4BiWUlqFw=
 github.com/ThreeDotsLabs/watermill v1.1.0/go.mod h1:Qd1xNFxolCAHCzcMrm6RnjW0manbvN+DJVWc1MWRFlI=
-github.com/ThreeDotsLabs/watermill v1.2.0-rc.4 h1:hX8toeERHfnrZFvCXdWRQCYgoNExQoi5vtf5+rbGaA8=
-github.com/ThreeDotsLabs/watermill v1.2.0-rc.4/go.mod h1:sl2PSceOQJ8BreN60hCnU2WixFNOYJOQDY1J3hvyVCs=
-github.com/ThreeDotsLabs/watermill-amqp v1.1.1 h1:wlrYlQDf6ZgdYoVPbrBaOnSMqxkQJZXDS6qugIin4o0=
-github.com/ThreeDotsLabs/watermill-amqp v1.1.1/go.mod h1:Qbu3JDlr6vIOxHJjhfsSHsrdF/ToJLYoaYek8X5Wnto=
+github.com/ThreeDotsLabs/watermill v1.2.0-rc.6 h1:wYybtpC+LMQCC8j3/D1BQPobWh0rZ4ZX57i3+zy7t8I=
+github.com/ThreeDotsLabs/watermill v1.2.0-rc.6/go.mod h1:QLZSaklpSZ/7yv288LL2DFOgCEi86VYEmQvzmaMlHoA=
+github.com/ThreeDotsLabs/watermill-amqp v1.1.3 h1:g9Sh2yQe76WQDt2mAFxgzafCHAXBCf7PHkdISJRZa58=
+github.com/ThreeDotsLabs/watermill-amqp v1.1.3/go.mod h1:AnjfZlOKwWdDFQl23WCspiC1kewtqt5dognCKwvEk4M=
 github.com/ThreeDotsLabs/watermill-http v1.1.3 h1:2jHbbE+gbq7pKWBCtOxeHTWSBNrS44Oh7QOzuAeHH/g=
 github.com/ThreeDotsLabs/watermill-http v1.1.3/go.mod h1:mkQ9CC0pxTZerNwr281rBoOy355vYt/lePkmYSX/BRg=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=
@@ -231,8 +230,9 @@ github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oDpT4efm8tSYHXV5tHSdRvBet/b/QzxZ+XyyPehvm3A=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
-github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
+github.com/cenkalti/backoff/v3 v3.2.2 h1:cfUAAO3yvKMYKPrvhDuHSwQnhZNk/RMHKdZqKTxfm6M=
+github.com/cenkalti/backoff/v3 v3.2.2/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/cenkalti/backoff/v4 v4.0.2/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
 github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.1.1 h1:G2HAfAmvm/GcKan2oOQpBXOd2tT2G57ZnZGWa1PxPBQ=
@@ -390,6 +390,7 @@ github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aev
 github.com/go-asn1-ber/asn1-ber v1.3.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-chi/chi v4.0.2+incompatible h1:maB6vn6FqCxrpz4FqWdh4+lwpyZIQS7YEAUcHlgXVRs=
 github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
+github.com/go-chi/chi/v5 v5.0.4/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-chi/render v1.0.1 h1:4/5tis2cKaNdnv9zFLfXzcquC9HbeZgCnxGnKrltBS8=
 github.com/go-chi/render v1.0.1/go.mod h1:pq4Rr7HbnsdaeHagklXub+p6Wd16Af5l9koip1OvJns=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
@@ -577,8 +578,9 @@ github.com/google/uuid v0.0.0-20161128191214-064e2069ce9c/go.mod h1:TIyPZe4Mgqvf
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/wire v0.3.0/go.mod h1:i1DMg/Lu8Sz5yYl25iOdmc5CT5qusaa+zmRWs16741s=
 github.com/googleapis/gax-go v2.0.2+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -648,8 +650,9 @@ github.com/hashicorp/go-memdb v1.0.2/go.mod h1:I6dKdmYhZqU0RJSheVEWgTNWdVQH5QvTg
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-msgpack v0.5.5/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
-github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.0.0/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-raftchunking v0.6.3-0.20191002164813-7e9e8525653a/go.mod h1:xbXnmKqX9/+RhPkJ4zrEx4738HacP72aaUPlT2RZ4sU=
@@ -918,8 +921,9 @@ github.com/libp2p/go-openssl v0.0.7 h1:eCAzdLejcNVBzP/iZM9vqHnQm+XyCEbSSIheIPRGN
 github.com/libp2p/go-openssl v0.0.7/go.mod h1:unDrJpgy3oFr+rqXsarWifmJuNnJR4chtO1HmaZjggc=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
-github.com/lithammer/shortuuid/v3 v3.0.4 h1:uj4xhotfY92Y1Oa6n6HUiFn87CdoEHYUlTy0+IgbLrs=
 github.com/lithammer/shortuuid/v3 v3.0.4/go.mod h1:RviRjexKqIzx/7r1peoAITm6m7gnif/h+0zmolKJjzw=
+github.com/lithammer/shortuuid/v3 v3.0.7 h1:trX0KTHy4Pbwo/6ia8fscyHoGA+mf1jWbPJVuvyJQQ8=
+github.com/lithammer/shortuuid/v3 v3.0.7/go.mod h1:vMk8ke37EmiewwolSO1NLW8vP4ZaKlRuDIi8tWWmAts=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -1252,8 +1256,9 @@ github.com/square/go-jose/v3 v3.0.0-20200630053402-0a67ce9b0693 h1:wD1IWQwAhdWcl
 github.com/square/go-jose/v3 v3.0.0-20200630053402-0a67ce9b0693/go.mod h1:6hSY48PjDm4UObWmGLyJE9DxYVKTgR9kbCspXXJEhcU=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
-github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271 h1:WhxRHzgeVGETMlmVfqhRn8RIeeNoPr2Czh33I4Zdccw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
+github.com/streadway/amqp v1.0.0 h1:kuuDrUJFZL1QYL9hUNuCxNObNzB0bV/ZG5jV3RWAQgo=
+github.com/streadway/amqp v1.0.0/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -1591,7 +1596,6 @@ golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@
 module github.com/trustbloc/orb
 
 require (
-	github.com/ThreeDotsLabs/watermill v1.2.0-rc.4
-	github.com/ThreeDotsLabs/watermill-amqp v1.1.1
+	github.com/ThreeDotsLabs/watermill v1.2.0-rc.6
+	github.com/ThreeDotsLabs/watermill-amqp v1.1.3
 	github.com/ThreeDotsLabs/watermill-http v1.1.3
 	github.com/bluele/gcache v0.0.0-20190518031135-bc40bd653833
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
@@ -15,7 +15,7 @@ require (
 	github.com/fxamacker/cbor/v2 v2.3.0
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
-	github.com/google/uuid v1.2.0
+	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/hyperledger/aries-framework-go v0.1.7
 	github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211006214906-8ddae60cdd21
@@ -32,6 +32,7 @@ require (
 	github.com/prometheus/client_golang v1.11.0
 	github.com/rs/cors v1.7.0
 	github.com/sirupsen/logrus v1.7.0
+	github.com/streadway/amqp v1.0.0
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7
 	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211012203148-2f1d13fca175

--- a/go.sum
+++ b/go.sum
@@ -126,12 +126,11 @@ github.com/Sectorbob/mlab-ns2 v0.0.0-20171030222938-d3aa0c295a8a/go.mod h1:D73UA
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
-github.com/ThreeDotsLabs/watermill v1.0.2/go.mod h1:vZCPh7eN0P7r2qKau4SfmcUZ83+3JXWkRl4BiWUlqFw=
 github.com/ThreeDotsLabs/watermill v1.1.0/go.mod h1:Qd1xNFxolCAHCzcMrm6RnjW0manbvN+DJVWc1MWRFlI=
-github.com/ThreeDotsLabs/watermill v1.2.0-rc.4 h1:hX8toeERHfnrZFvCXdWRQCYgoNExQoi5vtf5+rbGaA8=
-github.com/ThreeDotsLabs/watermill v1.2.0-rc.4/go.mod h1:sl2PSceOQJ8BreN60hCnU2WixFNOYJOQDY1J3hvyVCs=
-github.com/ThreeDotsLabs/watermill-amqp v1.1.1 h1:wlrYlQDf6ZgdYoVPbrBaOnSMqxkQJZXDS6qugIin4o0=
-github.com/ThreeDotsLabs/watermill-amqp v1.1.1/go.mod h1:Qbu3JDlr6vIOxHJjhfsSHsrdF/ToJLYoaYek8X5Wnto=
+github.com/ThreeDotsLabs/watermill v1.2.0-rc.6 h1:wYybtpC+LMQCC8j3/D1BQPobWh0rZ4ZX57i3+zy7t8I=
+github.com/ThreeDotsLabs/watermill v1.2.0-rc.6/go.mod h1:QLZSaklpSZ/7yv288LL2DFOgCEi86VYEmQvzmaMlHoA=
+github.com/ThreeDotsLabs/watermill-amqp v1.1.3 h1:g9Sh2yQe76WQDt2mAFxgzafCHAXBCf7PHkdISJRZa58=
+github.com/ThreeDotsLabs/watermill-amqp v1.1.3/go.mod h1:AnjfZlOKwWdDFQl23WCspiC1kewtqt5dognCKwvEk4M=
 github.com/ThreeDotsLabs/watermill-http v1.1.3 h1:2jHbbE+gbq7pKWBCtOxeHTWSBNrS44Oh7QOzuAeHH/g=
 github.com/ThreeDotsLabs/watermill-http v1.1.3/go.mod h1:mkQ9CC0pxTZerNwr281rBoOy355vYt/lePkmYSX/BRg=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=
@@ -231,8 +230,9 @@ github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oDpT4efm8tSYHXV5tHSdRvBet/b/QzxZ+XyyPehvm3A=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
-github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
+github.com/cenkalti/backoff/v3 v3.2.2 h1:cfUAAO3yvKMYKPrvhDuHSwQnhZNk/RMHKdZqKTxfm6M=
+github.com/cenkalti/backoff/v3 v3.2.2/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/cenkalti/backoff/v4 v4.0.2/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
 github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.1.1 h1:G2HAfAmvm/GcKan2oOQpBXOd2tT2G57ZnZGWa1PxPBQ=
@@ -391,6 +391,7 @@ github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aev
 github.com/go-asn1-ber/asn1-ber v1.3.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-chi/chi v4.0.2+incompatible h1:maB6vn6FqCxrpz4FqWdh4+lwpyZIQS7YEAUcHlgXVRs=
 github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
+github.com/go-chi/chi/v5 v5.0.4/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-chi/render v1.0.1 h1:4/5tis2cKaNdnv9zFLfXzcquC9HbeZgCnxGnKrltBS8=
 github.com/go-chi/render v1.0.1/go.mod h1:pq4Rr7HbnsdaeHagklXub+p6Wd16Af5l9koip1OvJns=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
@@ -575,8 +576,9 @@ github.com/google/uuid v0.0.0-20161128191214-064e2069ce9c/go.mod h1:TIyPZe4Mgqvf
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/wire v0.3.0/go.mod h1:i1DMg/Lu8Sz5yYl25iOdmc5CT5qusaa+zmRWs16741s=
 github.com/googleapis/gax-go v2.0.2+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -645,8 +647,9 @@ github.com/hashicorp/go-memdb v1.0.2/go.mod h1:I6dKdmYhZqU0RJSheVEWgTNWdVQH5QvTg
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-msgpack v0.5.5/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
-github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.0.0/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-raftchunking v0.6.3-0.20191002164813-7e9e8525653a/go.mod h1:xbXnmKqX9/+RhPkJ4zrEx4738HacP72aaUPlT2RZ4sU=
@@ -914,8 +917,9 @@ github.com/libp2p/go-openssl v0.0.7 h1:eCAzdLejcNVBzP/iZM9vqHnQm+XyCEbSSIheIPRGN
 github.com/libp2p/go-openssl v0.0.7/go.mod h1:unDrJpgy3oFr+rqXsarWifmJuNnJR4chtO1HmaZjggc=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
-github.com/lithammer/shortuuid/v3 v3.0.4 h1:uj4xhotfY92Y1Oa6n6HUiFn87CdoEHYUlTy0+IgbLrs=
 github.com/lithammer/shortuuid/v3 v3.0.4/go.mod h1:RviRjexKqIzx/7r1peoAITm6m7gnif/h+0zmolKJjzw=
+github.com/lithammer/shortuuid/v3 v3.0.7 h1:trX0KTHy4Pbwo/6ia8fscyHoGA+mf1jWbPJVuvyJQQ8=
+github.com/lithammer/shortuuid/v3 v3.0.7/go.mod h1:vMk8ke37EmiewwolSO1NLW8vP4ZaKlRuDIi8tWWmAts=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -1245,8 +1249,9 @@ github.com/square/go-jose/v3 v3.0.0-20200630053402-0a67ce9b0693 h1:wD1IWQwAhdWcl
 github.com/square/go-jose/v3 v3.0.0-20200630053402-0a67ce9b0693/go.mod h1:6hSY48PjDm4UObWmGLyJE9DxYVKTgR9kbCspXXJEhcU=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
-github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271 h1:WhxRHzgeVGETMlmVfqhRn8RIeeNoPr2Czh33I4Zdccw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
+github.com/streadway/amqp v1.0.0 h1:kuuDrUJFZL1QYL9hUNuCxNObNzB0bV/ZG5jV3RWAQgo=
+github.com/streadway/amqp v1.0.0/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -1582,7 +1587,6 @@ golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/activitypub/service/service.go
+++ b/pkg/activitypub/service/service.go
@@ -30,8 +30,8 @@ import (
 )
 
 const (
-	inboxActivitiesTopic  = "inbox_activities"
-	outboxActivitiesTopic = "outbox_activities"
+	inboxActivitiesTopic  = "orb.activity.inbox"
+	outboxActivitiesTopic = "orb.activity.outbox"
 )
 
 // PubSub defines the functions for a publisher/subscriber.

--- a/pkg/anchor/anchorevent/generator/didorbgenerator/didorbgenerator.go
+++ b/pkg/anchor/anchorevent/generator/didorbgenerator/didorbgenerator.go
@@ -117,7 +117,7 @@ func (g *Generator) CreateContentObject(payload *subject.Payload) (vocab.Documen
 	var resources []*resource
 
 	for _, value := range payload.PreviousAnchors {
-		logger.Debugf("RESOURCE - Key [%s] Value [%s]", value.Suffix, value.Anchor)
+		logger.Debugf("Resource - Key [%s] Value [%s]", value.Suffix, value.Anchor)
 
 		var res *resource
 

--- a/pkg/anchor/vcpubsub/publisher.go
+++ b/pkg/anchor/vcpubsub/publisher.go
@@ -21,7 +21,7 @@ import (
 
 var logger = log.New("anchor")
 
-const anchorEventTopic = "anchor-event"
+const anchorEventTopic = "orb.anchor_event"
 
 type pubSub interface {
 	Publish(topic string, messages ...*message.Message) error

--- a/pkg/context/opqueue/opqueue.go
+++ b/pkg/context/opqueue/opqueue.go
@@ -24,7 +24,7 @@ import (
 
 var logger = log.New("sidetree_context")
 
-const topic = "opqueue"
+const topic = "orb.operation"
 
 type pubSub interface {
 	SubscribeWithOpts(ctx context.Context, topic string, opts ...spi.Option) (<-chan *message.Message, error)

--- a/pkg/observer/pubsub.go
+++ b/pkg/observer/pubsub.go
@@ -21,8 +21,8 @@ import (
 )
 
 const (
-	anchorTopic = "anchor"
-	didTopic    = "did"
+	anchorTopic = "orb.anchor"
+	didTopic    = "orb.did"
 )
 
 type (
@@ -148,7 +148,8 @@ func (h *PubSub) listen() {
 				return
 			}
 
-			logger.Debugf("Got new anchor credential message [%s]: %s", msg.UUID, msg.Payload)
+			logger.Debugf("Got new anchor credential message [%s], Metadata: %s, Payload %s",
+				msg.UUID, msg.Metadata, msg.Payload)
 
 			h.handleAnchorCredentialMessage(msg)
 

--- a/pkg/pubsub/amqp/amqppubsub.go
+++ b/pkg/pubsub/amqp/amqppubsub.go
@@ -9,6 +9,8 @@ package amqp
 import (
 	"context"
 	"fmt"
+	"math"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -16,6 +18,7 @@ import (
 	"github.com/ThreeDotsLabs/watermill-amqp/pkg/amqp"
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/cenkalti/backoff"
+	samqp "github.com/streadway/amqp"
 	"github.com/trustbloc/edge-core/pkg/log"
 
 	"github.com/trustbloc/orb/pkg/errors"
@@ -31,6 +34,29 @@ const (
 	defaultMaxConnectInterval         = 5 * time.Second
 	defaultMaxConnectElapsedTime      = 3 * time.Minute
 	defaultMaxConnectionSubscriptions = 1000
+
+	defaultMaxRedeliveryAttempts     = 10
+	defaultRedeliveryMultiplier      = 1.5
+	defaultRedeliveryInitialInterval = 2 * time.Second
+	defaultMaxRedeliveryInterval     = 30 * time.Second
+
+	exchange           = "orb"
+	redeliveryQueue    = "orb.redelivery"
+	redeliveryExchange = "orb.redelivery"
+	waitExchange       = "orb.wait"
+	waitQueue          = "orb.wait"
+	directExchangeType = "direct"
+
+	expiredReason = "expired"
+
+	metadataDeadLetterExchange   = "x-dead-letter-exchange"
+	metadataDeadLetterRoutingKey = "x-dead-letter-routing-key"
+	metadataDeath                = "x-death"
+	metadataFirstDeathQueue      = "x-first-death-queue"
+	metadataFirstDeathReason     = "x-first-death-reason"
+	metadataRedeliveryCount      = "orb-redelivery-count"
+	metadataQueue                = "orb-queue"
+	metadataExpiration           = "expiration"
 )
 
 // Config holds the configuration for the publisher/subscriber.
@@ -38,6 +64,10 @@ type Config struct {
 	URI                        string
 	MaxConnectRetries          uint64
 	MaxConnectionSubscriptions int
+	MaxRedeliveryAttempts      int
+	RedeliveryMultiplier       float64
+	RedeliveryInitialInterval  time.Duration
+	MaxRedeliveryInterval      time.Duration
 }
 
 type closeable interface {
@@ -49,12 +79,17 @@ type subscriber interface {
 	Subscribe(ctx context.Context, topic string) (<-chan *message.Message, error)
 }
 
+type initializingSubscriber interface {
+	subscriber
+	SubscribeInitialize(topic string) error
+}
+
 type publisher interface {
 	closeable
 	Publish(topic string, messages ...*message.Message) error
 }
 
-type subscriberFactory = func() (subscriber, error)
+type subscriberFactory = func() (initializingSubscriber, error)
 
 type publisherFactory = func() (publisher, error)
 
@@ -63,32 +98,58 @@ type PubSub struct {
 	*lifecycle.Lifecycle
 	Config
 
-	config            amqp.Config
-	subscriber        subscriber
-	publisher         publisher
-	pools             []*pooledSubscriber
-	mutex             sync.RWMutex
-	subscriberFactory subscriberFactory
-	createPublisher   publisherFactory
+	amqpConfig                  amqp.Config
+	amqpRedeliveryConfig        amqp.Config
+	amqpWaitConfig              amqp.Config
+	subscriber                  subscriber
+	publisher                   publisher
+	redeliverySubscriber        subscriber
+	waitSubscriber              initializingSubscriber
+	waitPublisher               publisher
+	pools                       []*pooledSubscriber
+	mutex                       sync.RWMutex
+	subscriberFactory           subscriberFactory
+	createPublisher             publisherFactory
+	redeliverySubscriberFactory subscriberFactory
+	waitSubscriberFactory       subscriberFactory
+	createWaitPublisher         publisherFactory
+	redeliveryChan              <-chan *message.Message
 }
 
 // New returns a new AMQP publisher/subscriber.
 func New(cfg Config) *PubSub {
-	if cfg.MaxConnectionSubscriptions == 0 {
-		cfg.MaxConnectionSubscriptions = defaultMaxConnectionSubscriptions
-	}
+	cfg = initConfig(cfg)
 
 	p := &PubSub{
-		Config: cfg,
-		config: amqp.NewDurableQueueConfig(cfg.URI),
+		Config:               cfg,
+		amqpConfig:           newQueueConfig(cfg.URI),
+		amqpRedeliveryConfig: newRedeliveryQueueConfig(cfg.URI),
+		amqpWaitConfig:       newWaitQueueConfig(cfg.URI),
 	}
 
 	p.Lifecycle = lifecycle.New("amqp",
 		lifecycle.WithStart(p.start),
 		lifecycle.WithStop(p.stop))
 
-	p.subscriberFactory = p.newSubscriber
-	p.createPublisher = p.newPublisher
+	p.subscriberFactory = func() (initializingSubscriber, error) {
+		return amqp.NewSubscriber(p.amqpConfig, wmlogger.New())
+	}
+
+	p.createPublisher = func() (publisher, error) {
+		return amqp.NewPublisher(p.amqpConfig, wmlogger.New())
+	}
+
+	p.redeliverySubscriberFactory = func() (initializingSubscriber, error) {
+		return amqp.NewSubscriber(p.amqpRedeliveryConfig, wmlogger.New())
+	}
+
+	p.waitSubscriberFactory = func() (initializingSubscriber, error) {
+		return amqp.NewSubscriber(p.amqpWaitConfig, wmlogger.New())
+	}
+
+	p.createWaitPublisher = func() (publisher, error) {
+		return amqp.NewPublisher(p.amqpWaitConfig, wmlogger.New())
+	}
 
 	// Start the service immediately.
 	p.Start()
@@ -167,10 +228,22 @@ func (p *PubSub) stop() {
 		logger.Warnf("Error closing publisher: %s", err)
 	}
 
+	if err := p.waitPublisher.Close(); err != nil {
+		logger.Warnf("Error closing wait publisher: %s", err)
+	}
+
 	logger.Debugf("Closing subscriber...")
 
 	if err := p.subscriber.Close(); err != nil {
 		logger.Warnf("Error closing subscriber: %s", err)
+	}
+
+	if err := p.redeliverySubscriber.Close(); err != nil {
+		logger.Warnf("Error closing redelivery subscriber: %s", err)
+	}
+
+	if err := p.waitSubscriber.Close(); err != nil {
+		logger.Warnf("Error closing wait subscriber: %s", err)
 	}
 
 	logger.Debugf("Closing pools...")
@@ -184,7 +257,7 @@ func (p *PubSub) stop() {
 }
 
 func (p *PubSub) start() {
-	logger.Infof("Connecting to message queue at %s", extractEndpoint(p.config.Connection.AmqpURI))
+	logger.Infof("Connecting to message queue at %s", extractEndpoint(p.amqpConfig.Connection.AmqpURI))
 
 	maxRetries := p.MaxConnectRetries
 	if maxRetries == 0 {
@@ -195,17 +268,35 @@ func (p *PubSub) start() {
 		func() error {
 			return p.connect()
 		},
-		backoff.WithMaxRetries(newBackOff(), maxRetries),
+		backoff.WithMaxRetries(newConnectBackOff(), maxRetries),
 		func(err error, duration time.Duration) {
 			logger.Debugf("Error connecting to AMQP service %s after %s: %s. Retrying...",
-				extractEndpoint(p.config.Connection.AmqpURI), duration, err)
+				extractEndpoint(p.amqpConfig.Connection.AmqpURI), duration, err)
 		},
 	)
 	if err != nil {
 		panic(fmt.Sprintf("Unable to connect to message queue after %d attempts", maxRetries))
 	}
 
-	logger.Infof("Successfully connected to message queue: %s", extractEndpoint(p.config.Connection.AmqpURI))
+	retryChan, err := p.redeliverySubscriber.Subscribe(context.Background(), redeliveryQueue)
+	if err != nil {
+		panic(fmt.Sprintf("Unable to subscribe to queue [%s]: %s", redeliveryQueue, err))
+	}
+
+	p.redeliveryChan = retryChan
+
+	// Initialize the wait queue so that it is created. This queue contains all messages that
+	// need to wait for redelivery. There are actually no subscribers to this queue. Messages in
+	// this queue have an expiration time, so when the message expires, it is automatically placed
+	// back on the redelivery queue.
+	err = p.waitSubscriber.SubscribeInitialize(waitQueue)
+	if err != nil {
+		panic(fmt.Sprintf("Unable to initialize to initialize queue [%s]: %s", redeliveryQueue, err))
+	}
+
+	go p.processRedeliveryQueue()
+
+	logger.Infof("Successfully connected to message queue: %s", extractEndpoint(p.amqpConfig.Connection.AmqpURI))
 }
 
 func (p *PubSub) connect() error {
@@ -217,18 +308,132 @@ func (p *PubSub) connect() error {
 	p.subscriber = newSubscriberMgr(p.MaxConnectionSubscriptions, p.subscriberFactory)
 	p.publisher = pub
 
+	p.redeliverySubscriber = newSubscriberMgr(p.MaxConnectionSubscriptions, p.redeliverySubscriberFactory)
+
+	pub, err = p.createWaitPublisher()
+	if err != nil {
+		return err
+	}
+
+	p.waitSubscriber = newSubscriberMgr(p.MaxConnectionSubscriptions, p.waitSubscriberFactory)
+	p.waitPublisher = pub
+
 	return nil
 }
 
-func (p *PubSub) newSubscriber() (subscriber, error) {
-	return amqp.NewSubscriber(p.config, wmlogger.New())
+/*
+processRedeliveryQueue processes messages from the 'redelivery' queue.
+The 'redelivery' queue is configured as the 'dead-letter-queue' for all queues in Orb. When a message is rejected by a
+subscriber, it is automatically sent to the 'redelivery' queue. The first time a message is rejected, the redelivery
+handler immediately redelivers the message to the original destination queue. If the message is rejected again, it is
+posted to a 'wait' queue and is given an expiration. The 'wait' queue has no subscribers, so the message will sit there
+until it expires. The 'redelivery' queue is also configured as the 'dead-letter-queue' for the 'wait' queue, so when the
+message expires, it is automatically sent back to the 'redelivery' queue and this handler processes the message again.
+If the message metadata, 'reason', is set to "expired" then it is posted to the original destination queue, otherwise
+(if reason is "rejected") it is posted back to the 'wait' queue with a bigger expiration. This process repeats until the
+maximum number of redelivery attempts has been reached, at which point redelivery for the message is aborted.
+*/
+func (p *PubSub) processRedeliveryQueue() {
+	logger.Infof("Starting message redelivery listener")
+
+	for msg := range p.redeliveryChan {
+		p.handleRedelivery(msg)
+	}
+
+	logger.Infof("Message redelivery listener stopped")
 }
 
-func (p *PubSub) newPublisher() (publisher, error) {
-	return amqp.NewPublisher(p.config, wmlogger.New())
+func (p *PubSub) handleRedelivery(msg *message.Message) {
+	logger.Debugf("Got new RETRY message [%s], Metadata: %s, Payload %s",
+		msg.UUID, msg.Metadata, msg.Payload)
+
+	queue, err := getQueue(msg)
+	if err != nil {
+		logger.Warnf("Error resolving queue for message [%s]: %s. Message will not be redelivered.", msg.UUID, err)
+
+		msg.Ack()
+
+		return
+	}
+
+	redeliveryAttempts := getRedeliveryAttempts(msg)
+
+	if redeliveryAttempts < p.MaxRedeliveryAttempts {
+		err = p.redeliver(msg, queue, redeliveryAttempts)
+		if err != nil {
+			logger.Errorf("Error redelivering message [%s]: %s. The message will be nacked and retried.", msg.UUID, err)
+
+			// Nack the message so that it may be retried.
+			msg.Nack()
+
+			return
+		}
+	} else {
+		logger.Errorf("Message [%s] will not be redelivered to queue [%s] since it has already been redelivered %d times",
+			msg.UUID, queue, redeliveryAttempts)
+	}
+
+	msg.Ack()
 }
 
-func newBackOff() backoff.BackOff {
+func (p *PubSub) redeliver(msg *message.Message, queue string, redeliveryAttempts int) error {
+	// Publish the message immediately on the first attempt and after every expiration.
+	if redeliveryAttempts == 0 || msg.Metadata[metadataFirstDeathReason] == expiredReason {
+		redeliveryAttempts++
+
+		err := p.publisher.Publish(queue,
+			newMessage(msg,
+				withQueue(queue),
+				withRedeliveryAttempts(redeliveryAttempts),
+			),
+		)
+		if err != nil {
+			return fmt.Errorf("publish message to queue [%s]: %w", queue, err)
+		}
+
+		logger.Infof("Successfully posted message [%s] for redelivery to queue [%s]", msg.UUID, queue)
+
+		return nil
+	}
+
+	expiration := p.getRedeliveryInterval(redeliveryAttempts)
+
+	// Post the message to the wait queue with the given expiration so that it isn't immediately redelivered.
+	err := p.waitPublisher.Publish(waitQueue,
+		newMessage(msg,
+			withQueue(queue),
+			withExpiration(expiration),
+		),
+	)
+	if err != nil {
+		return fmt.Errorf("publish message to queue [%s]: %w", waitQueue, err)
+	}
+
+	logger.Infof("Successfully posted message [%s] to queue [%s] with expiration %s for redelivery attempt %d",
+		msg.UUID, waitQueue, expiration, redeliveryAttempts)
+
+	return nil
+}
+
+func (p *PubSub) getRedeliveryInterval(attempts int) time.Duration {
+	if attempts == 0 {
+		return 0
+	}
+
+	if attempts == 1 {
+		return p.RedeliveryInitialInterval
+	}
+
+	interval := time.Duration(float64(p.RedeliveryInitialInterval) * math.Pow(p.RedeliveryMultiplier, float64(attempts-1)))
+
+	if interval > p.MaxRedeliveryInterval {
+		interval = p.MaxRedeliveryInterval
+	}
+
+	return interval
+}
+
+func newConnectBackOff() backoff.BackOff {
 	b := &backoff.ExponentialBackOff{
 		InitialInterval:     backoff.DefaultInitialInterval,
 		RandomizationFactor: backoff.DefaultRandomizationFactor,
@@ -244,7 +449,7 @@ func newBackOff() backoff.BackOff {
 }
 
 type subscriberInfo struct {
-	subscriber    subscriber
+	subscriber    initializingSubscriber
 	subscriptions int
 }
 
@@ -287,7 +492,16 @@ func (m *subscriberConnectionMgr) Subscribe(ctx context.Context, topic string) (
 	return s.Subscribe(ctx, topic)
 }
 
-func (m *subscriberConnectionMgr) get() (subscriber, error) {
+func (m *subscriberConnectionMgr) SubscribeInitialize(topic string) error {
+	s, err := m.get()
+	if err != nil {
+		return err
+	}
+
+	return s.SubscribeInitialize(topic)
+}
+
+func (m *subscriberConnectionMgr) get() (initializingSubscriber, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
@@ -330,4 +544,185 @@ func extractEndpoint(amqpURL string) string {
 	}
 
 	return path[j+1:]
+}
+
+func getRedeliveryAttempts(msg *message.Message) int {
+	var count int
+
+	countValue, ok := msg.Metadata[metadataRedeliveryCount]
+	if ok {
+		c, err := strconv.ParseInt(countValue, 10, 0)
+		if err != nil {
+			logger.Warnf("Message [%s] - Metadata [%s] is not a valid int. Redelivery count will be set to 0: %w",
+				msg.UUID, metadataRedeliveryCount)
+		} else {
+			count = int(c)
+		}
+	}
+
+	return count
+}
+
+func getQueue(msg *message.Message) (string, error) {
+	queue, ok := msg.Metadata[metadataQueue]
+	if ok {
+		return queue, nil
+	}
+
+	queue, ok = msg.Metadata[metadataFirstDeathQueue]
+	if ok {
+		return queue, nil
+	}
+
+	logger.Warnf("Message [%s] - Metadata [%s] not found. Message will not be redelivered.",
+		msg.UUID, metadataFirstDeathQueue)
+
+	return "", fmt.Errorf("metadata not found: %s", metadataFirstDeathReason)
+}
+
+type messageOptions struct {
+	queue              string
+	expiration         time.Duration
+	redeliveryAttempts int
+}
+
+type messageOpt func(*messageOptions)
+
+func withQueue(queue string) messageOpt {
+	return func(options *messageOptions) {
+		options.queue = queue
+	}
+}
+
+func withExpiration(expiration time.Duration) messageOpt {
+	return func(options *messageOptions) {
+		options.expiration = expiration
+	}
+}
+
+func withRedeliveryAttempts(attempts int) messageOpt {
+	return func(options *messageOptions) {
+		options.redeliveryAttempts = attempts
+	}
+}
+
+func newMessage(msg *message.Message, opts ...messageOpt) *message.Message {
+	options := &messageOptions{}
+
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	newMsg := msg.Copy()
+
+	// The metadata containing x-death info must be deleted since an error occurs when posting with this metadata.
+	delete(newMsg.Metadata, metadataDeath)
+
+	newMsg.Metadata.Set(metadataQueue, options.queue)
+
+	if options.expiration > 0 {
+		newMsg.Metadata.Set(metadataExpiration, options.expiration.String())
+	} else {
+		delete(newMsg.Metadata, metadataExpiration)
+	}
+
+	if options.redeliveryAttempts > 0 {
+		newMsg.Metadata.Set(metadataRedeliveryCount, strconv.FormatInt(int64(options.redeliveryAttempts), 10))
+	}
+
+	return newMsg
+}
+
+func newQueueConfig(amqpURI string) amqp.Config {
+	queueConfig := newDefaultQueueConfig(amqpURI)
+	queueConfig.Exchange = newAMQPExchangeConfig(exchange)
+	queueConfig.Queue = newAMQPQueueConfig(samqp.Table{
+		metadataDeadLetterRoutingKey: redeliveryQueue,
+		metadataDeadLetterExchange:   redeliveryExchange,
+	})
+
+	return queueConfig
+}
+
+func newRedeliveryQueueConfig(amqpURI string) amqp.Config {
+	queueConfig := newDefaultQueueConfig(amqpURI)
+	queueConfig.Exchange = newAMQPExchangeConfig(redeliveryExchange)
+	queueConfig.Consume = amqp.ConsumeConfig{
+		Qos:             amqp.QosConfig{PrefetchCount: 1},
+		NoRequeueOnNack: false, // Ensure that the message is re-queued if the server goes down before it is Acked.
+	}
+
+	return queueConfig
+}
+
+func newWaitQueueConfig(amqpURI string) amqp.Config {
+	queueConfig := newDefaultQueueConfig(amqpURI)
+	queueConfig.Exchange = newAMQPExchangeConfig(waitExchange)
+	queueConfig.Queue = newAMQPQueueConfig(samqp.Table{
+		metadataDeadLetterRoutingKey: redeliveryQueue,
+		metadataDeadLetterExchange:   redeliveryExchange,
+	})
+
+	return queueConfig
+}
+
+func newDefaultQueueConfig(amqpURI string) amqp.Config {
+	return amqp.Config{
+		Connection: amqp.ConnectionConfig{AmqpURI: amqpURI},
+		Marshaler:  &DefaultMarshaler{},
+		Queue:      newAMQPQueueConfig(nil),
+		QueueBind: amqp.QueueBindConfig{
+			GenerateRoutingKey: func(queue string) string { return queue },
+		},
+		Publish: amqp.PublishConfig{
+			GenerateRoutingKey: func(queue string) string { return queue },
+		},
+		Consume: amqp.ConsumeConfig{
+			Qos:             amqp.QosConfig{PrefetchCount: 1},
+			NoRequeueOnNack: true,
+		},
+		TopologyBuilder: &amqp.DefaultTopologyBuilder{},
+	}
+}
+
+func newAMQPExchangeConfig(exchange string) amqp.ExchangeConfig {
+	return amqp.ExchangeConfig{
+		GenerateName: func(topic string) string {
+			return exchange
+		},
+		Type:    directExchangeType,
+		Durable: true,
+	}
+}
+
+func newAMQPQueueConfig(args samqp.Table) amqp.QueueConfig {
+	return amqp.QueueConfig{
+		GenerateName: amqp.GenerateQueueNameTopicName,
+		Durable:      true,
+		Arguments:    args,
+	}
+}
+
+func initConfig(cfg Config) Config {
+	if cfg.MaxConnectionSubscriptions == 0 {
+		cfg.MaxConnectionSubscriptions = defaultMaxConnectionSubscriptions
+	}
+
+	if cfg.MaxRedeliveryAttempts == 0 {
+		cfg.MaxRedeliveryAttempts = defaultMaxRedeliveryAttempts
+	}
+
+	if cfg.RedeliveryMultiplier == 0 {
+		cfg.RedeliveryMultiplier = defaultRedeliveryMultiplier
+	}
+
+	if cfg.RedeliveryInitialInterval == 0 {
+		cfg.RedeliveryInitialInterval = defaultRedeliveryInitialInterval
+	}
+
+	if cfg.MaxRedeliveryInterval == 0 {
+		cfg.MaxRedeliveryInterval = defaultMaxRedeliveryInterval
+	}
+
+	return cfg
 }

--- a/pkg/pubsub/amqp/marshaler.go
+++ b/pkg/pubsub/amqp/marshaler.go
@@ -1,0 +1,240 @@
+/*
+MIT License
+
+Copyright (c) 2019 Three Dots Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package amqp
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+	"time"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/streadway/amqp"
+)
+
+const defaultMessageUUIDHeaderKey = "_watermill_message_uuid"
+
+// DefaultMarshaler is a modified version of the marshaller in watermill-amqp. This marshaller adds support for
+// dead-letter queue header values and also allows a message's expiration to be set in the header.
+type DefaultMarshaler struct {
+	// PostprocessPublishing can be used to make some extra processing with amqp.Publishing,
+	// for example add CorrelationId and ContentType:
+	//
+	//  amqp.DefaultMarshaler{
+	//		PostprocessPublishing: func(publishing stdAmqp.Publishing) stdAmqp.Publishing {
+	//			publishing.CorrelationId = "correlation"
+	//			publishing.ContentType = "application/json"
+	//
+	//			return publishing
+	//		},
+	//	}
+	PostprocessPublishing func(amqp.Publishing) amqp.Publishing
+
+	// When true, DeliveryMode will be not set to Persistent.
+	//
+	// DeliveryMode Transient means higher throughput, but messages will not be
+	// restored on broker restart. The delivery mode of publishings is unrelated
+	// to the durability of the queues they reside on. Transient messages will
+	// not be restored to durable queues, persistent messages will be restored to
+	// durable queues and lost on non-durable queues during server restart.
+	NotPersistentDeliveryMode bool
+
+	// Header used to store and read message UUID.
+	//
+	// If value is empty, defaultMessageUUIDHeaderKey value is used.
+	// If header doesn't exist, empty value is passed as message UUID.
+	MessageUUIDHeaderKey string
+}
+
+// Marshal marshals a message.
+func (d DefaultMarshaler) Marshal(msg *message.Message) (amqp.Publishing, error) {
+	headers := make(amqp.Table, len(msg.Metadata)+1) // metadata + plus uuid
+
+	for key, value := range msg.Metadata {
+		logger.Debugf("Metadata [%s]: %s", key, value)
+
+		if key == metadataExpiration {
+			logger.Debugf("Ignoring metadata [%s] since it will be set in the message directly", key)
+
+			continue
+		}
+
+		headerValue, err := unmarshalHeaderValue(value)
+		if err != nil {
+			return amqp.Publishing{}, fmt.Errorf("unmarshal value for metadata %s: %w", key, err)
+		}
+
+		headers[key] = headerValue
+	}
+
+	headers[d.computeMessageUUIDHeaderKey()] = msg.UUID
+
+	publishing := amqp.Publishing{
+		Body:       msg.Payload,
+		Headers:    headers,
+		Expiration: getExpiration(msg.Metadata),
+	}
+	if !d.NotPersistentDeliveryMode {
+		publishing.DeliveryMode = amqp.Persistent
+	}
+
+	if d.PostprocessPublishing != nil {
+		publishing = d.PostprocessPublishing(publishing)
+	}
+
+	return publishing, nil
+}
+
+// Unmarshal unmarshals a message.
+//nolint:gocritic
+func (d DefaultMarshaler) Unmarshal(amqpMsg amqp.Delivery) (*message.Message, error) {
+	msgUUIDStr, err := d.unmarshalMessageUUID(amqpMsg.Headers)
+	if err != nil {
+		return nil, err
+	}
+
+	msg := message.NewMessage(msgUUIDStr, amqpMsg.Body)
+	msg.Metadata = make(message.Metadata, len(amqpMsg.Headers)-1) // headers - minus uuid
+
+	for key, value := range amqpMsg.Headers {
+		if key == d.computeMessageUUIDHeaderKey() {
+			continue
+		}
+
+		logger.Debugf("Metadata [%s] is of type: %s", key, reflect.TypeOf(value))
+
+		msg.Metadata[key], err = marshalHeaderValue(value)
+		if err != nil {
+			return nil, fmt.Errorf("marshal header value for metadata [%s]: %w", key, err)
+		}
+	}
+
+	return msg, nil
+}
+
+func (d DefaultMarshaler) unmarshalMessageUUID(headers amqp.Table) (string, error) {
+	var msgUUIDStr string
+
+	msgUUID, hasMsgUUID := headers[d.computeMessageUUIDHeaderKey()]
+	if !hasMsgUUID {
+		return "", nil
+	}
+
+	msgUUIDStr, hasMsgUUID = msgUUID.(string)
+	if !hasMsgUUID {
+		return "", fmt.Errorf("message UUID is not a string, but: %#v", msgUUID)
+	}
+
+	return msgUUIDStr, nil
+}
+
+func (d DefaultMarshaler) computeMessageUUIDHeaderKey() string {
+	if d.MessageUUIDHeaderKey != "" {
+		return d.MessageUUIDHeaderKey
+	}
+
+	return defaultMessageUUIDHeaderKey
+}
+
+func marshalHeaderValue(value interface{}) (string, error) {
+	headerValue, ok := value.(string)
+	if ok {
+		return headerValue, nil
+	}
+
+	arrayValue, ok := value.([]interface{})
+	if !ok {
+		return "", fmt.Errorf("value is not a string or an array, but %#v", value)
+	}
+
+	// Marshal the table to JSON.
+	valueBytes, err := json.Marshal(arrayValue)
+	if err != nil {
+		return "", fmt.Errorf("marshal metadata: %w", err)
+	}
+
+	return string(valueBytes), nil
+}
+
+// unmarshalHeaderValue checks if the value is a JSON array value and, if so, unmarshals it and returns an array.
+// Otherwise the given string value is returned.
+func unmarshalHeaderValue(value string) (interface{}, error) {
+	var arrayValue []interface{}
+
+	err := json.Unmarshal([]byte(value), &arrayValue)
+	if err != nil {
+		// The header is a string.
+		return value, nil //nolint:nilerr
+	}
+
+	// The header is an array.
+
+	headerValue := make([]interface{}, len(arrayValue))
+
+	for i, value := range arrayValue {
+		tableValue, ok := value.(amqp.Table)
+		if ok {
+			headerValue[i] = tableValue
+		} else {
+			mapValue, ok := value.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("unsupported value type: %s", reflect.TypeOf(value))
+			}
+
+			tableValue = make(amqp.Table)
+			for k, v := range mapValue {
+				tableValue[k] = v
+			}
+
+			headerValue[i] = tableValue
+		}
+	}
+
+	return headerValue, nil
+}
+
+func getExpiration(metadata message.Metadata) string {
+	expirationValue, ok := metadata[metadataExpiration]
+	if !ok {
+		return ""
+	}
+
+	expirationDuration, err := time.ParseDuration(expirationValue)
+	if err == nil {
+		return strconv.FormatInt(expirationDuration.Milliseconds(), 10)
+	}
+
+	logger.Warnf("Invalid value [%s] for metadata [%s]: %s. No expiration will be set.",
+		expirationValue, metadataExpiration, err)
+
+	return ""
+}

--- a/pkg/pubsub/amqp/marshaler_test.go
+++ b/pkg/pubsub/amqp/marshaler_test.go
@@ -1,0 +1,198 @@
+/*
+MIT License
+
+Copyright (c) 2019 Three Dots Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package amqp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/ThreeDotsLabs/watermill"
+	"github.com/ThreeDotsLabs/watermill-amqp/pkg/amqp"
+	"github.com/ThreeDotsLabs/watermill/message"
+	stdAmqp "github.com/streadway/amqp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultMarshaler(t *testing.T) {
+	marshaler := DefaultMarshaler{}
+
+	msg := message.NewMessage(watermill.NewUUID(), []byte("payload"))
+	msg.Metadata.Set("foo", "bar")
+	msg.Metadata.Set("x-death",
+		`[{"count":1,"exchange":"some_exchange","queue":"some_queue","reason":"rejected","routing-keys":["some_queue"],"time":"2021-10-25T17:26:24Z"}]`) //nolint:lll
+
+	marshaled, err := marshaler.Marshal(msg)
+	require.NoError(t, err)
+
+	_, headerExists := marshaled.Headers[amqp.DefaultMessageUUIDHeaderKey]
+	assert.True(t, headerExists, "header %s doesn't exist", amqp.DefaultMessageUUIDHeaderKey)
+
+	header, headerExists := marshaled.Headers["x-death"]
+	require.True(t, headerExists, "header %s doesn't exist", "x-death")
+
+	require.NotNil(t, header)
+
+	arrHeader, ok := header.([]interface{})
+	require.True(t, ok)
+	require.Len(t, arrHeader, 1)
+
+	xDeathValues, ok := arrHeader[0].(stdAmqp.Table)
+	require.True(t, ok)
+
+	count, ok := xDeathValues["count"]
+	require.True(t, ok)
+	require.Equal(t, float64(1), count)
+
+	routingKeys, ok := xDeathValues["routing-keys"]
+	require.True(t, ok)
+
+	routingKeysArr, ok := routingKeys.([]interface{})
+	require.True(t, ok)
+	require.Len(t, routingKeysArr, 1)
+	require.Equal(t, "some_queue", routingKeysArr[0])
+
+	unmarshaledMsg, err := marshaler.Unmarshal(publishingToDelivery(&marshaled))
+	require.NoError(t, err)
+
+	assert.True(t, msg.Equals(unmarshaledMsg))
+	assert.Equal(t, marshaled.DeliveryMode, stdAmqp.Persistent)
+}
+
+func TestDefaultMarshaler_without_message_uuid(t *testing.T) {
+	marshaler := DefaultMarshaler{}
+
+	msg := message.NewMessage(watermill.NewUUID(), nil)
+	marshaled, err := marshaler.Marshal(msg)
+	require.NoError(t, err)
+
+	delete(marshaled.Headers, amqp.DefaultMessageUUIDHeaderKey)
+
+	unmarshaledMsg, err := marshaler.Unmarshal(publishingToDelivery(&marshaled))
+	require.NoError(t, err)
+
+	assert.Empty(t, unmarshaledMsg.UUID)
+}
+
+func TestDefaultMarshaler_configured_message_uuid_header(t *testing.T) {
+	headerKey := "custom_msg_uuid"
+	marshaler := DefaultMarshaler{MessageUUIDHeaderKey: headerKey}
+
+	msg := message.NewMessage(watermill.NewUUID(), nil)
+	marshaled, err := marshaler.Marshal(msg)
+	require.NoError(t, err)
+
+	_, headerExists := marshaled.Headers[headerKey]
+	assert.True(t, headerExists, "header %s doesn't exist", headerKey)
+
+	unmarshaledMsg, err := marshaler.Unmarshal(publishingToDelivery(&marshaled))
+	require.NoError(t, err)
+
+	assert.Equal(t, msg.UUID, unmarshaledMsg.UUID)
+}
+
+func TestDefaultMarshaler_not_persistent(t *testing.T) {
+	marshaler := DefaultMarshaler{NotPersistentDeliveryMode: true}
+
+	msg := message.NewMessage(watermill.NewUUID(), []byte("payload"))
+	msg.Metadata.Set("foo", "bar")
+
+	marshaled, err := marshaler.Marshal(msg)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, marshaled.DeliveryMode, 0)
+}
+
+func TestDefaultMarshaler_postprocess_publishing(t *testing.T) {
+	marshaler := DefaultMarshaler{
+		PostprocessPublishing: func(publishing stdAmqp.Publishing) stdAmqp.Publishing {
+			publishing.CorrelationId = "correlation"
+			publishing.ContentType = "application/json"
+
+			return publishing
+		},
+	}
+
+	msg := message.NewMessage(watermill.NewUUID(), []byte("payload"))
+	msg.Metadata.Set("foo", "bar")
+
+	marshaled, err := marshaler.Marshal(msg)
+	require.NoError(t, err)
+
+	assert.Equal(t, marshaled.CorrelationId, "correlation")
+	assert.Equal(t, marshaled.ContentType, "application/json")
+}
+
+func TestDefaultMarshaler_metadata(t *testing.T) {
+	marshaler := DefaultMarshaler{
+		PostprocessPublishing: func(publishing stdAmqp.Publishing) stdAmqp.Publishing {
+			publishing.CorrelationId = "correlation"
+			publishing.ContentType = "application/json"
+
+			return publishing
+		},
+	}
+
+	msg := message.NewMessage(watermill.NewUUID(), []byte("payload"))
+	msg.Metadata.Set("foo", "bar")
+	msg.Metadata.Set("x-death",
+		`[{"count":1,"exchange":"orb.exchange","queue":"outbox_activities","reason":"rejected","routing-keys":["outbox_activities"],"time":"2021-10-25T17:26:24Z"}]`) //nolint:lll
+
+	marshaled, err := marshaler.Marshal(msg)
+	require.NoError(t, err)
+
+	assert.Equal(t, marshaled.CorrelationId, "correlation")
+	assert.Equal(t, marshaled.ContentType, "application/json")
+}
+
+func publishingToDelivery(marshaled *stdAmqp.Publishing) stdAmqp.Delivery {
+	return stdAmqp.Delivery{
+		Body:    marshaled.Body,
+		Headers: marshaled.Headers,
+	}
+}
+
+func TestUnmarshal(t *testing.T) {
+	var arrayValue []interface{}
+
+	err := json.Unmarshal([]byte(`["value1","value2"]`), &arrayValue)
+	require.NoError(t, err)
+	require.Len(t, arrayValue, 2)
+
+	err = json.Unmarshal([]byte(`xxx`), &arrayValue)
+	require.Error(t, err)
+
+	err = json.Unmarshal([]byte(``), &arrayValue)
+	require.Error(t, err)
+
+	err = json.Unmarshal(nil, &arrayValue)
+	require.Error(t, err)
+}

--- a/pkg/pubsub/spi/spi.go
+++ b/pkg/pubsub/spi/spi.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package spi
 
 // UndeliverableTopic is the topic to which to post undeliverable messages.
-const UndeliverableTopic = "undeliverable_activities"
+const UndeliverableTopic = "orb.undeliverable.activities"
 
 // Options contains publisher/subscriber options.
 type Options struct {

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -56,399 +56,394 @@ Feature:
 
     Then we wait 3 seconds
 
-    @all
-    @discover_did_hashlink
-    Scenario: discover did (hashlink)
-      When client discover orb endpoints
+  @all
+  @discover_did_hashlink
+  Scenario: discover did (hashlink)
+    When client discover orb endpoints
 
       # orb-domain1 keeps accepting requests
-      When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to create DID document
-      Then check success response contains "#interimDID"
+    When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to create DID document
+    Then check success response contains "#interimDID"
 
-      Then we wait 2 seconds
-      When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with interim did
-      Then check success response contains "canonicalId"
+    Then we wait 2 seconds
+    When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with interim did
+    Then check success response contains "canonicalId"
 
-      When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with canonical did
-      Then check success response contains "#canonicalDID"
+    When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+    Then check success response contains "#canonicalDID"
 
-      When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to recover DID document
-      Then check for request success
-      Then we wait 2 seconds
+    When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to recover DID document
+    Then check for request success
+    Then we wait 2 seconds
 
-      When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with canonical did
-      Then check success response contains "recoveryKey"
-      Then check success response contains "#canonicalDID"
+    When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+    Then check success response contains "recoveryKey"
+    Then check success response contains "#canonicalDID"
 
       # resolve did in domain4 - it will trigger did discovery in different organisations
-      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with equivalent did
-      Then check error response contains "not found"
+    When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with equivalent did
+    Then check error response contains "not found"
 
-      Then we wait 3 seconds
-      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with equivalent did
-      Then check success response contains "#canonicalDID"
-      Then check success response contains "recoveryKey"
+    Then we wait 3 seconds
+    When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with equivalent did
+    Then check success response contains "#canonicalDID"
+    Then check success response contains "recoveryKey"
 
-      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did
-      Then check success response contains "#canonicalDID"
-      Then check success response contains "recoveryKey"
+    When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+    Then check success response contains "#canonicalDID"
+    Then check success response contains "recoveryKey"
 
-    @all
-    @discover_did_https
-    Scenario: discover did (https)
-      When client discover orb endpoints
+  @all
+  @discover_did_https
+  Scenario: discover did (https)
+    When client discover orb endpoints
 
       # orb-domain1 keeps accepting requests
-      When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to create DID document
-      Then check success response contains "#interimDID"
+    When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to create DID document
+    Then check success response contains "#interimDID"
 
-      Then we wait 2 seconds
-      When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with interim did
-      Then check success response contains "canonicalId"
+    Then we wait 2 seconds
+    When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with interim did
+    Then check success response contains "canonicalId"
 
-      When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with canonical did
-      Then check success response contains "#canonicalDID"
+    When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+    Then check success response contains "#canonicalDID"
 
-      When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to recover DID document
-      Then check for request success
-      Then we wait 2 seconds
+    When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to recover DID document
+    Then check for request success
+    Then we wait 2 seconds
 
-      When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with canonical did
-      Then check success response contains "recoveryKey"
-      Then check success response contains "#canonicalDID"
+    When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+    Then check success response contains "recoveryKey"
+    Then check success response contains "#canonicalDID"
 
       # resolve did in domain4 - it will trigger did discovery in different organisations
-      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with hint "https:orb.domain1.com"
-      Then check error response contains "not found"
+    When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with hint "https:orb.domain1.com"
+    Then check error response contains "not found"
 
-      Then we wait 3 seconds
-      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with hint "https:orb.domain1.com"
-      Then check success response contains "#canonicalDID"
-      Then check success response contains "recoveryKey"
+    Then we wait 3 seconds
+    When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with hint "https:orb.domain1.com"
+    Then check success response contains "#canonicalDID"
+    Then check success response contains "recoveryKey"
 
-      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did
-      Then check success response contains "#canonicalDID"
-      Then check success response contains "recoveryKey"
+    When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+    Then check success response contains "#canonicalDID"
+    Then check success response contains "recoveryKey"
 
-    @all
-    @discover_did_ipfs
-    Scenario: discover did (ipfs)
-      When client discover orb endpoints
+  @all
+  @discover_did_ipfs
+  Scenario: discover did (ipfs)
+    When client discover orb endpoints
 
       # orb-domain1 keeps accepting requests
-      When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to create DID document
-      Then check success response contains "#interimDID"
+    When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to create DID document
+    Then check success response contains "#interimDID"
 
-      Then we wait 2 seconds
-      When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with interim did
-      Then check success response contains "canonicalId"
+    Then we wait 2 seconds
+    When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with interim did
+    Then check success response contains "canonicalId"
 
-      When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with canonical did
-      Then check success response contains "#canonicalDID"
+    When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+    Then check success response contains "#canonicalDID"
 
-      When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to add public key with ID "firstKey" to DID document
-      Then check for request success
-      Then we wait 2 seconds
+    When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to add public key with ID "firstKey" to DID document
+    Then check for request success
+    Then we wait 2 seconds
 
-      When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with canonical did
-      Then check success response contains "firstKey"
-      Then check success response contains "#canonicalDID"
+    When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+    Then check success response contains "firstKey"
+    Then check success response contains "#canonicalDID"
 
       # resolve did in domain4 - it will trigger did discovery in different organisations
-      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with hint "ipfs"
-      Then check error response contains "not found"
+    When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with hint "ipfs"
+    Then check error response contains "not found"
 
-      Then we wait 3 seconds
-      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with hint "ipfs"
-      Then check success response contains "#canonicalDID"
-      Then check success response contains "firstKey"
+    Then we wait 3 seconds
+    When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with hint "ipfs"
+    Then check success response contains "#canonicalDID"
+    Then check success response contains "firstKey"
 
-      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did
-      Then check success response contains "#canonicalDID"
-      Then check success response contains "firstKey"
+    When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+    Then check success response contains "#canonicalDID"
+    Then check success response contains "firstKey"
 
-    @all
-    @resolve_from_anchor_origin
-    Scenario: discover did followed by resolve from anchor origin
-      When client discover orb endpoints
+  @all
+  @resolve_from_anchor_origin
+  Scenario: discover did followed by resolve from anchor origin
+    When client discover orb endpoints
 
       # create document in domain3
-      When client sends request to "https://orb.domain3.com/sidetree/v1/operations" to create DID document
-      Then check success response contains "#interimDID"
+    When client sends request to "https://orb.domain3.com/sidetree/v1/operations" to create DID document
+    Then check success response contains "#interimDID"
 
-      Then we wait 3 seconds
-      When client sends request to "https://orb.domain3.com/sidetree/v1/identifiers" to resolve DID document with interim did
-      Then check success response contains "canonicalId"
+    Then we wait 3 seconds
+    When client sends request to "https://orb.domain3.com/sidetree/v1/identifiers" to resolve DID document with interim did
+    Then check success response contains "canonicalId"
 
-      When client sends request to "https://orb.domain3.com/sidetree/v1/identifiers" to resolve DID document with canonical did
-      Then check success response contains "#canonicalDID"
+    When client sends request to "https://orb.domain3.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+    Then check success response contains "#canonicalDID"
 
       # resolve did in domain4 - it will trigger did discovery from domain3
-      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with hint "https:orb.domain3.com"
-      Then check error response contains "not found"
+    When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with hint "https:orb.domain3.com"
+    Then check error response contains "not found"
 
-      Then we wait 3 seconds
-      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did
-      Then check success response contains "#canonicalDID"
+    Then we wait 3 seconds
+    When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+    Then check success response contains "#canonicalDID"
 
       # update domain3 document
-      When client sends request to "https://orb.domain3.com/sidetree/v1/operations" to add public key with ID "firstKey" to DID document
-      Then check for request success
+    When client sends request to "https://orb.domain3.com/sidetree/v1/operations" to add public key with ID "firstKey" to DID document
+    Then check for request success
 
-      # resolution from domain4 will contain unpublished update operation from domain3
-      # because domain4 has resolve from anchor origin property set to true
-      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did
-      Then check success response contains "firstKey"
+    # resolution from domain4 will contain unpublished update operation from domain3
+    # because domain4 has resolve from anchor origin property set to true
+    When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+    Then check success response contains "firstKey"
 
-      # send an update operation to domain4 (anchor origin domain has unpublished operations)
-      When client sends request to "https://orb.domain4.com/sidetree/v1/operations" to add public key with ID "secondKey" to DID document
-      Then check error response contains "anchor origin has unpublished operations - please re-submit your request at later time"
+    # send an update operation to domain4 (anchor origin domain has unpublished operations)
+    When client sends request to "https://orb.domain4.com/sidetree/v1/operations" to add public key with ID "secondKey" to DID document
+    Then check error response contains "anchor origin has unpublished operations - please re-submit your request at later time"
 
-      # wait for domain3 to publish operation
-      Then we wait 3 seconds
+    # wait for domain3 to publish operation
+    Then we wait 5 seconds
 
-      # re-request resolution from domain4 that doesn't have published operation since it doesn't follow any domain
-      # response will contain published operation from anchor origin
-      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did
-      Then check success response contains "firstKey"
+    # re-request resolution from domain4 that doesn't have published operation since it doesn't follow any domain
+    # response will contain published operation from anchor origin
+    When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+    Then check success response contains "firstKey"
 
-      # send an update operation to domain4 (out of sync with anchor origin domain)
-      When client sends request to "https://orb.domain4.com/sidetree/v1/operations" to add public key with ID "secondKey" to DID document
-      Then check error response contains "anchor origin has additional published operations - please re-submit your request at later time"
+    # send an update operation to domain4 (out of sync with anchor origin domain)
+    When client sends request to "https://orb.domain4.com/sidetree/v1/operations" to add public key with ID "secondKey" to DID document
+    Then check error response contains "anchor origin has additional published operations - please re-submit your request at later time"
 
-    @all
-    @follow_anchor_writer_domain1
-    Scenario: domain2 server follows domain1 server (anchor writer)
+  @all
+  @follow_anchor_writer_domain1
+  Scenario: domain2 server follows domain1 server (anchor writer)
 
       # send create request to domain1
-      When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to create DID document
-      Then check success response contains "#interimDID"
+    When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to create DID document
+    Then check success response contains "#interimDID"
 
-      Then we wait 2 seconds
-      When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with interim did
-      Then check success response contains "#canonicalDID"
+    Then we wait 2 seconds
+    When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with interim did
+    Then check success response contains "#canonicalDID"
 
       # check that document is available on the first server of domain2
-      Then we wait 2 seconds
-      When client sends request to "https://orb.domain2.com/sidetree/v1/identifiers" to resolve DID document with canonical did
-      Then check success response contains "#canonicalDID"
+    Then we wait 2 seconds
+    When client sends request to "https://orb.domain2.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+    Then check success response contains "#canonicalDID"
 
-    @all
-    @follow_anchor_writer_domain2
-    Scenario: domain1 server follows domain2 server (anchor writer)
+  @all
+  @follow_anchor_writer_domain2
+  Scenario: domain1 server follows domain2 server (anchor writer)
 
       # send create request to domain2
-      When client sends request to "https://orb.domain2.com/sidetree/v1/operations" to create DID document
-      Then check success response contains "#interimDID"
+    When client sends request to "https://orb.domain2.com/sidetree/v1/operations" to create DID document
+    Then check success response contains "#interimDID"
 
-      Then we wait 2 seconds
-      When client sends request to "https://orb.domain2.com/sidetree/v1/identifiers" to resolve DID document with interim did
-      Then check success response contains "#canonicalDID"
+    Then we wait 2 seconds
+    When client sends request to "https://orb.domain2.com/sidetree/v1/identifiers" to resolve DID document with interim did
+    Then check success response contains "#canonicalDID"
 
       # check that document is available on the first server of domain1
-      Then we wait 2 seconds
-      When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with canonical did
-      Then check success response contains "#canonicalDID"
+    Then we wait 2 seconds
+    When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+    Then check success response contains "#canonicalDID"
 
       # check that document is available on the second server of domain1
-      When client sends request to "https://orb2.domain1.com/sidetree/v1/identifiers" to resolve DID document with canonical did
-      Then check success response contains "#canonicalDID"
+    When client sends request to "https://orb2.domain1.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+    Then check success response contains "#canonicalDID"
 
-    @all
-    @concurrent_requests_scenario
-    Scenario: concurrent requests plus server shutdown tests
+  @all
+  @concurrent_requests_scenario
+  Scenario: concurrent requests plus server shutdown tests
 
      # write batch of DIDs to multiple servers and check them
-     When client sends request to "https://orb2.domain1.com/sidetree/v1/operations,https://orb.domain2.com/sidetree/v1/operations" to create 50 DID documents using 10 concurrent requests
+    When client sends request to "https://orb2.domain1.com/sidetree/v1/operations,https://orb.domain2.com/sidetree/v1/operations" to create 50 DID documents using 10 concurrent requests
 
      # Stop orb2.domain1. The other instance in the domain should process any pending operations since
      # we're using a durable operation queue.
-     Then container "orb2-domain1" is stopped
-     And we wait 3 seconds
+    Then container "orb2-domain1" is stopped
+    And we wait 3 seconds
 
-     Then client sends request to "https://orb.domain1.com/sidetree/v1/identifiers,https://orb.domain2.com/sidetree/v1/identifiers" to verify the DID documents that were created
+    Then client sends request to "https://orb.domain1.com/sidetree/v1/identifiers,https://orb.domain2.com/sidetree/v1/identifiers" to verify the DID documents that were created
 
-     Then container "orb-domain1" is stopped
-     Then container "orb-domain2" is stopped
-     Then container "ipfs" is stopped
+    Then container "orb-domain1" is stopped
+    Then container "orb-domain2" is stopped
+    Then container "ipfs" is stopped
 
-     Then container "orb-domain1" is started
-     Then container "orb2-domain1" is started
-     Then container "orb-domain2" is started
-     Then container "ipfs" is started
+    Then container "orb-domain1" is started
+    Then container "orb2-domain1" is started
+    Then container "orb-domain2" is started
+    Then container "ipfs" is started
 
-     Then we wait 5 seconds
+    Then we wait 5 seconds
 
      # now that servers re-started we should check for DIDs that were created before shutdowns
-     Then client sends request to "https://orb.domain1.com/sidetree/v1/identifiers,https://orb2.domain1.com/sidetree/v1/identifiers,https://orb.domain2.com/sidetree/v1/identifiers" to verify the DID documents that were created
+    Then client sends request to "https://orb.domain1.com/sidetree/v1/identifiers,https://orb2.domain1.com/sidetree/v1/identifiers,https://orb.domain2.com/sidetree/v1/identifiers" to verify the DID documents that were created
 
      # write batch of DIDs to multiple servers again and check them
-     When client sends request to "https://orb.domain1.com/sidetree/v1/operations,https://orb2.domain1.com/sidetree/v1/operations,https://orb.domain2.com/sidetree/v1/operations" to create 50 DID documents using 10 concurrent requests
+    When client sends request to "https://orb.domain1.com/sidetree/v1/operations,https://orb2.domain1.com/sidetree/v1/operations,https://orb.domain2.com/sidetree/v1/operations" to create 50 DID documents using 10 concurrent requests
 
-     Then we wait 5 seconds
-     Then client sends request to "https://orb.domain1.com/sidetree/v1/identifiers,https://orb2.domain1.com/sidetree/v1/identifiers,https://orb.domain2.com/sidetree/v1/identifiers" to verify the DID documents that were created
+    Then we wait 5 seconds
+    Then client sends request to "https://orb.domain3.com/sidetree/v1/identifiers,https://orb.domain1.com/sidetree/v1/identifiers,https://orb2.domain1.com/sidetree/v1/identifiers,https://orb.domain2.com/sidetree/v1/identifiers" to verify the DID documents that were created
 
-     When an HTTP GET is sent to "https://orb.domain1.com/services/orb/liked?page=true"
-     Then the JSON path "type" of the response equals "OrderedCollectionPage"
-     And the JSON path "orderedItems" of the array response is not empty
-     And the JSON path "orderedItems.0.object.url" of the response is saved to variable "anchorLink"
-     And the JSON path "orderedItems.0" of the raw response is saved to variable "likeActivity"
-     And the JSON path "orderedItems.0.id" of the response is saved to variable "likeID"
-     And the JSON path "orderedItems.0.actor" of the response is saved to variable "likeActor"
-     And the JSON path "orderedItems.0.to" of the raw response is saved to variable "likeTo"
+    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/liked?page=true"
+    Then the JSON path "type" of the response equals "OrderedCollectionPage"
+    And the JSON path "orderedItems" of the array response is not empty
+    And the JSON path "orderedItems.0.object.url" of the response is saved to variable "anchorLink"
+    And the JSON path "orderedItems.0" of the raw response is saved to variable "likeActivity"
+    And the JSON path "orderedItems.0.id" of the response is saved to variable "likeID"
+    And the JSON path "orderedItems.0.actor" of the response is saved to variable "likeActor"
+    And the JSON path "orderedItems.0.to" of the raw response is saved to variable "likeTo"
 
-     And variable "anchorHash" is assigned the value "$hashlink(|${anchorLink}|).ResourceHash"
+    And variable "anchorHash" is assigned the value "$hashlink(|${anchorLink}|).ResourceHash"
 
-     When an HTTP GET is sent to "https://orb.domain1.com/cas/${anchorHash}"
-     Then the JSON path 'attachment.#(contentObject.type="VerifiableCredential").contentObject.id' of the response is saved to variable "vcID"
+    When an HTTP GET is sent to "https://orb.domain1.com/cas/${anchorHash}"
+    Then the JSON path 'attachment.#(contentObject.type="VerifiableCredential").contentObject.id' of the response is saved to variable "vcID"
 
-     When an HTTP GET is sent to "${vcID}"
-     Then the JSON path "id" of the response equals "${vcID}"
+    When an HTTP GET is sent to "${vcID}"
+    Then the JSON path "id" of the response equals "${vcID}"
 
-     When an HTTP GET is sent to "https://orb.domain2.com/services/orb/likes?id=${anchorLink}&page=true"
-     Then the JSON path "type" of the response equals "OrderedCollectionPage"
+    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/likes?id=${anchorLink}&page=true"
+    Then the JSON path "type" of the response equals "OrderedCollectionPage"
      # There should be two Like's:
      # 1 - From domain1 (which received the 'Create');
      # 2 - From domain3 (which received the 'Announce')
-     And the JSON path "orderedItems.#" of the response has 2 items
-     And the JSON path "orderedItems.#.actor" of the response contains "${domain1IRI}"
-     And the JSON path "orderedItems.#.actor" of the response contains "${domain3IRI}"
-     And the JSON path "orderedItems.0.object.url" of the response equals "${anchorLink}"
+    And the JSON path "orderedItems.#" of the response has 2 items
+    And the JSON path "orderedItems.#.actor" of the response contains "${domain1IRI}"
+    And the JSON path "orderedItems.#.actor" of the response contains "${domain3IRI}"
+    And the JSON path "orderedItems.0.object.url" of the response equals "${anchorLink}"
 
-     When an HTTP GET is sent to "https://orb.domain1.com/services/orb/likes?id=${anchorLink}&page=true"
-     Then the JSON path "type" of the response equals "OrderedCollectionPage"
+    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/likes?id=${anchorLink}&page=true"
+    Then the JSON path "type" of the response equals "OrderedCollectionPage"
      # There should be one Like:
      # 1 - From domain3 (which received the 'Announce')
-     And the JSON path "orderedItems.#" of the response has 1 items
-     And the JSON path "orderedItems.#.actor" of the response contains "${domain3IRI}"
-     And the JSON path "orderedItems.0.object.url" of the response equals "${anchorLink}"
+    And the JSON path "orderedItems.#" of the response has 1 items
+    And the JSON path "orderedItems.#.actor" of the response contains "${domain3IRI}"
+    And the JSON path "orderedItems.0.object.url" of the response equals "${anchorLink}"
 
-     Given variable "undoLikeActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${likeActor}","to":#{likeTo},"object":#{likeActivity}}'
-     When an HTTP POST is sent to "${likeActor}/outbox" with content "${undoLikeActivity}" of type "application/json"
+    Given variable "undoLikeActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${likeActor}","to":#{likeTo},"object":#{likeActivity}}'
+    When an HTTP POST is sent to "${likeActor}/outbox" with content "${undoLikeActivity}" of type "application/json"
 
-     Then we wait 2 seconds
+    Then we wait 2 seconds
 
-     When an HTTP GET is sent to "https://orb.domain1.com/services/orb/liked?page=true"
-     Then the JSON path "orderedItems.0.object.url" of the response does not contain "${anchorLink}"
+    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/liked?page=true"
+    Then the JSON path "orderedItems.0.object.url" of the response does not contain "${anchorLink}"
 
-     When an HTTP GET is sent to "https://orb.domain2.com/services/orb/likes?id=${anchorLink}&page=true"
-     Then the JSON path "orderedItems.#" of the response has 1 items
-     And the JSON path "orderedItems.#.actor" of the response contains "${domain3IRI}"
+    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/likes?id=${anchorLink}&page=true"
+    Then the JSON path "orderedItems.#" of the response has 1 items
+    And the JSON path "orderedItems.#.actor" of the response contains "${domain3IRI}"
 
-    @all
-    @enable_create_document_store_interim
-    Scenario: domain4 has create document store enabled (interim DID)
+  @all
+  @enable_create_document_store_interim
+  Scenario: domain4 has create document store enabled (interim DID)
 
-      When client sends request to "https://orb.domain4.com/sidetree/v1/operations" to create DID document
-      Then check success response contains "#interimDID"
-
-      # since domain4 has create document store enabled we are able to resolve did document immediately from the store
-      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with interim did
-      Then check success response contains "#interimDID"
-      Then check success response does NOT contain "canonicalId"
-
-      Then we wait 6 seconds
-      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with interim did
-      Then check success response contains "canonicalId"
-
-    @all
-    @enable_create_document_store_interim_with_hint
-    Scenario: domain4 has create document store enabled (interim DID with hint)
-
-      When client sends request to "https://orb.domain4.com/sidetree/v1/operations" to create DID document
-      Then check success response contains "#interimDID"
-
-      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve interim DID document with hint "https:orb.domain4.com"
-      Then check success response does NOT contain "canonicalId"
-
-    @local_cas
-    @enable_update_document_store
-    Scenario: domain4 has update document store enabled
-
-      When client sends request to "https://orb.domain4.com/sidetree/v1/operations" to create DID document
-      Then check success response contains "#interimDID"
+    When client sends request to "https://orb.domain4.com/sidetree/v1/operations" to create DID document
+    Then check success response contains "#interimDID"
 
       # since domain4 has create document store enabled we are able to resolve did document immediately from the store
-      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with interim did
-      Then check success response contains "#interimDID"
-      Then check success response does NOT contain "canonicalId"
+    When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with interim did
+    Then check success response contains "#interimDID"
+    Then check success response does NOT contain "canonicalId"
+
+    Then we wait 6 seconds
+    When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with interim did
+    Then check success response contains "canonicalId"
+
+  @all
+  @enable_create_document_store_interim_with_hint
+  Scenario: domain4 has create document store enabled (interim DID with hint)
+
+    When client sends request to "https://orb.domain4.com/sidetree/v1/operations" to create DID document
+    Then check success response contains "#interimDID"
+
+    When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve interim DID document with hint "https:orb.domain4.com"
+    Then check success response does NOT contain "canonicalId"
+
+  @local_cas
+  @enable_update_document_store
+  Scenario: domain4 has update document store enabled
+
+    When client sends request to "https://orb.domain4.com/sidetree/v1/operations" to create DID document
+    Then check success response contains "#interimDID"
+
+      # since domain4 has create document store enabled we are able to resolve did document immediately from the store
+    When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with interim did
+    Then check success response contains "#interimDID"
+    Then check success response does NOT contain "canonicalId"
 
       # re-try until create operation is published
-      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with interim did
-      Then check success response contains "canonicalId"
+    When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with interim did
+    Then check success response contains "canonicalId"
 
       # now that create is published we can update document
-      When client sends request to "https://orb.domain4.com/sidetree/v1/operations" to add public key with ID "firstKey" to DID document
-      Then check for request success
+    When client sends request to "https://orb.domain4.com/sidetree/v1/operations" to add public key with ID "firstKey" to DID document
+    Then check for request success
 
       # update request can be immediately resolved
-      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did
-      Then check success response contains "firstKey"
+    When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+    Then check success response contains "firstKey"
 
       # request second update while first one is pending - error expected
-      When client sends request to "https://orb.domain4.com/sidetree/v1/operations" to add public key with ID "secondKey" to DID document
-      Then check error response contains "pending operation found"
-      Then check error response contains "please re-submit your operation request at later time"
+    When client sends request to "https://orb.domain4.com/sidetree/v1/operations" to add public key with ID "secondKey" to DID document
+    Then check error response contains "pending operation found"
+    Then check error response contains "please re-submit your operation request at later time"
 
       # wait for pending operation to clear
-      Then we wait 6 seconds
+    Then we wait 6 seconds
 
       # re-send second update - since first one cleared it will be successful
-      When client sends request to "https://orb.domain4.com/sidetree/v1/operations" to add public key with ID "secondKey" to DID document
-      Then check for request success
+    When client sends request to "https://orb.domain4.com/sidetree/v1/operations" to add public key with ID "secondKey" to DID document
+    Then check for request success
 
       # resolve second update right away
-      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did
-      Then check success response contains "secondKey"
+    When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+    Then check success response contains "secondKey"
 
       # wait for pending operation (secondKey) to clear
-      Then we wait 6 seconds
+    Then we wait 6 seconds
 
-      # stop anchor origin for domain4 operations requests - document operation(s) will fail after they have been added
-      # because anchor event will not get enough proofs
-      Then container "orb-domain1" is stopped
-      And we wait 2 seconds
+      # stop all servers of anchor origin for domain4 operations requests - document operation(s) will fail after they have
+      # been added because anchor event will not get enough proofs
+    Then container "orb-domain1" is stopped
+    And container "orb2-domain1" is stopped
+    And we wait 2 seconds
 
       # update document
-      When client sends request to "https://orb.domain4.com/sidetree/v1/operations" to add public key with ID "thirdKey" to DID document
-      Then check for request success
+    When client sends request to "https://orb.domain4.com/sidetree/v1/operations" to add public key with ID "thirdKey" to DID document
+    Then check for request success
 
       # update request can be immediately resolved
-      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did
-      Then check success response contains "thirdKey"
+    When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+    Then check success response contains "thirdKey"
 
       # request another update while first one is pending - error expected
-      When client sends request to "https://orb.domain4.com/sidetree/v1/operations" to add public key with ID "fourthKey" to DID document
-      Then check error response contains "pending operation found"
-      Then check error response contains "please re-submit your operation request at later time"
-
-      # batch writer fails to write operation since anchor origin is down
-      Then we wait 6 seconds
-
-      # request second update while first one is pending - error expected because domain1 is down
-      When client sends request to "https://orb.domain4.com/sidetree/v1/operations" to add public key with ID "fourthKey" to DID document
-      Then check error response contains "pending operation found"
-      Then check error response contains "please re-submit your operation request at later time"
-
-      Then container "orb-domain1" is started
+    When client sends request to "https://orb.domain4.com/sidetree/v1/operations" to add public key with ID "fourthKey" to DID document
+    Then check error response contains "pending operation found"
+    Then check error response contains "please re-submit your operation request at later time"
 
       # wait for operation to expire
-      Then we wait 45 seconds
+    Then we wait 45 seconds
 
-      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did
-      Then check success response does NOT contain "thirdKey"
+    Then container "orb-domain1" is started
+    And container "orb2-domain1" is started
+    Then we wait 5 seconds
+
+    When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+    Then check success response does NOT contain "thirdKey"
 
       # third operation failed during batching - we need to send next operation request with last successful commitment
-      Then client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did and resets keys to last successful
+    Then client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did and resets keys to last successful
 
       # no more "pending operation found" error since the pending operation from above has since been deleted by the expiry service
-      When client sends request to "https://orb.domain4.com/sidetree/v1/operations" to add public key with ID "fourthKey" to DID document
-      Then check for request success
+    When client sends request to "https://orb.domain4.com/sidetree/v1/operations" to add public key with ID "fourthKey" to DID document
+    Then check for request success
 
-      Then we wait 2 seconds
+    Then we wait 2 seconds
 
-      When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did
-      Then check success response contains "fourthKey"
+    When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+    Then check success response contains "fourthKey"
 
   @local_cas
   @alternate_links_scenario

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -162,7 +162,10 @@ github.com/ThreeDotsLabs/watermill v1.0.2/go.mod h1:vZCPh7eN0P7r2qKau4SfmcUZ83+3
 github.com/ThreeDotsLabs/watermill v1.1.0/go.mod h1:Qd1xNFxolCAHCzcMrm6RnjW0manbvN+DJVWc1MWRFlI=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.4 h1:hX8toeERHfnrZFvCXdWRQCYgoNExQoi5vtf5+rbGaA8=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.4/go.mod h1:sl2PSceOQJ8BreN60hCnU2WixFNOYJOQDY1J3hvyVCs=
+github.com/ThreeDotsLabs/watermill v1.2.0-rc.6 h1:wYybtpC+LMQCC8j3/D1BQPobWh0rZ4ZX57i3+zy7t8I=
+github.com/ThreeDotsLabs/watermill v1.2.0-rc.6/go.mod h1:QLZSaklpSZ/7yv288LL2DFOgCEi86VYEmQvzmaMlHoA=
 github.com/ThreeDotsLabs/watermill-amqp v1.1.1/go.mod h1:Qbu3JDlr6vIOxHJjhfsSHsrdF/ToJLYoaYek8X5Wnto=
+github.com/ThreeDotsLabs/watermill-amqp v1.1.3/go.mod h1:AnjfZlOKwWdDFQl23WCspiC1kewtqt5dognCKwvEk4M=
 github.com/ThreeDotsLabs/watermill-http v1.1.3/go.mod h1:mkQ9CC0pxTZerNwr281rBoOy355vYt/lePkmYSX/BRg=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=
 github.com/VictoriaMetrics/fastcache v1.5.7/go.mod h1:ptDBkNMQI4RtmVo8VS/XwRY6RoTu1dAWCbrk+6WsEM8=
@@ -274,6 +277,7 @@ github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oD
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
+github.com/cenkalti/backoff/v3 v3.2.2/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/cenkalti/backoff/v4 v4.0.2/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
 github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.1.1 h1:G2HAfAmvm/GcKan2oOQpBXOd2tT2G57ZnZGWa1PxPBQ=
@@ -546,6 +550,7 @@ github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32/go.mod h1:GIjDIg/heH
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-asn1-ber/asn1-ber v1.3.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
+github.com/go-chi/chi/v5 v5.0.4/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-chi/render v1.0.1/go.mod h1:pq4Rr7HbnsdaeHagklXub+p6Wd16Af5l9koip1OvJns=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -829,6 +834,7 @@ github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.0.0/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-raftchunking v0.6.3-0.20191002164813-7e9e8525653a/go.mod h1:xbXnmKqX9/+RhPkJ4zrEx4738HacP72aaUPlT2RZ4sU=
@@ -1112,6 +1118,8 @@ github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-b
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/lithammer/shortuuid/v3 v3.0.4 h1:uj4xhotfY92Y1Oa6n6HUiFn87CdoEHYUlTy0+IgbLrs=
 github.com/lithammer/shortuuid/v3 v3.0.4/go.mod h1:RviRjexKqIzx/7r1peoAITm6m7gnif/h+0zmolKJjzw=
+github.com/lithammer/shortuuid/v3 v3.0.7 h1:trX0KTHy4Pbwo/6ia8fscyHoGA+mf1jWbPJVuvyJQQ8=
+github.com/lithammer/shortuuid/v3 v3.0.7/go.mod h1:vMk8ke37EmiewwolSO1NLW8vP4ZaKlRuDIi8tWWmAts=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -1500,6 +1508,7 @@ github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jW
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
+github.com/streadway/amqp v1.0.0/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=
 github.com/stretchr/objx v0.0.0-20180129172003-8a3f7159479f/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
Two new queues are added: redelivery and wait.

The 'redelivery' queue is configured as the 'dead-letter-queue' for all queues in Orb. When a message is rejected by a subscriber, it is automatically sent to the 'redelivery' queue. The first time a message is rejected, the redelivery handler immediately redelivers the message to the original destination queue. If the message is rejected again, it is posted to a 'wait' queue and is given an expiration. The 'wait' queue has no subscribers, so the message will sit there until it expires.

The 'redelivery' queue is also configured as the 'dead-letter-queue' for the 'wait' queue, so when the message expires, it is automatically sent back to the 'redelivery' queue and this handler processes the message again. If the message metadata, 'reason', is set to "expired" then it is posted to the original destination queue, otherwise (if reason is "rejected") it is posted back to the 'wait' queue with a bigger expiration. This process repeats until the maximum number of redelivery attempts has been reached, at which point redelivery for the message is aborted.

This PR also fixes some BDD tests that failed because of timing.

closes #803

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>