### PR TITLE
feat: Add handler to expiry service

### DIFF
--- a/pkg/store/witness/witness_test.go
+++ b/pkg/store/witness/witness_test.go
@@ -8,13 +8,21 @@ package witness
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
 
+	backoff "github.com/cenkalti/backoff/v4"
+	"github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb"
 	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
+	"github.com/hyperledger/aries-framework-go/spi/storage"
+	dctest "github.com/ory/dockertest/v3"
+	dc "github.com/ory/dockertest/v3/docker"
 	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"github.com/trustbloc/orb/pkg/anchor/proof"
 	"github.com/trustbloc/orb/pkg/internal/testutil"
@@ -26,6 +34,8 @@ const (
 	witness  = "witness"
 
 	expiryTime = 10 * time.Second
+
+	mongoDBConnString = "mongodb://localhost:27017"
 )
 
 func TestNew(t *testing.T) {
@@ -509,7 +519,7 @@ func TestStore_AddProof(t *testing.T) {
 			"failed to add proof for anchorID[id] and witness[witness]: put error")
 	})
 
-	t.Run("error - unmarshal anchored  witness error ", func(t *testing.T) {
+	t.Run("error - unmarshal anchored witness error ", func(t *testing.T) {
 		iterator := &mocks.Iterator{}
 
 		iterator.NextReturns(true, nil)
@@ -529,6 +539,113 @@ func TestStore_AddProof(t *testing.T) {
 		require.Contains(t, err.Error(),
 			"failed to unmarshal anchor witness from store value for anchorID[id]")
 	})
+}
+
+func TestStore_HandleExpiryKeys(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		err := pingMongoDB()
+		if err != nil {
+			pool, mongoDBResource := startMongoDBContainer(t)
+
+			defer func() {
+				if pool != nil && mongoDBResource != nil {
+					require.NoError(t, pool.Purge(mongoDBResource), "failed to purge MongoDB resource")
+				}
+			}()
+		}
+
+		mongoDBProvider, err := mongodb.NewProvider(mongoDBConnString)
+		require.NoError(t, err)
+
+		expiryService := testutil.GetExpiryService(t)
+
+		s, err := New(mongoDBProvider, expiryService, time.Second)
+		require.NoError(t, err)
+
+		s.delta = time.Second
+
+		expiryService.Start()
+
+		err = s.Put(anchorID, []*proof.WitnessProof{getTestWitness()})
+		require.NoError(t, err)
+
+		time.Sleep(3 * time.Second)
+	})
+
+	t.Run("error - failed to get tags (ignored)", func(t *testing.T) {
+		store := &mocks.Store{}
+		store.GetTagsReturns(nil, fmt.Errorf("tag error"))
+
+		provider := &mocks.Provider{}
+		provider.OpenStoreReturns(store, nil)
+
+		s, err := New(provider, testutil.GetExpiryService(t), expiryTime)
+		require.NoError(t, err)
+
+		err = s.HandleExpiredKeys("key")
+		require.NoError(t, err)
+	})
+
+	t.Run("error - failed to decode tag value (ignored)", func(t *testing.T) {
+		store := &mocks.Store{}
+		store.GetTagsReturns([]storage.Tag{{Name: anchorIndex, Value: "="}}, nil)
+
+		provider := &mocks.Provider{}
+		provider.OpenStoreReturns(store, nil)
+
+		s, err := New(provider, testutil.GetExpiryService(t), expiryTime)
+		require.NoError(t, err)
+
+		err = s.HandleExpiredKeys("key")
+		require.NoError(t, err)
+	})
+}
+
+func startMongoDBContainer(t *testing.T) (*dctest.Pool, *dctest.Resource) {
+	t.Helper()
+
+	pool, err := dctest.NewPool("")
+	require.NoError(t, err)
+
+	mongoDBResource, err := pool.RunWithOptions(&dctest.RunOptions{
+		Repository: "mongo",
+		Tag:        "4.0.0",
+		PortBindings: map[dc.Port][]dc.PortBinding{
+			"27017/tcp": {{HostIP: "", HostPort: "27017"}},
+		},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, waitForMongoDBToBeUp())
+
+	return pool, mongoDBResource
+}
+
+func waitForMongoDBToBeUp() error {
+	return backoff.Retry(pingMongoDB, backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second), 30))
+}
+
+func pingMongoDB() error {
+	var err error
+
+	clientOpts := options.Client().ApplyURI(mongoDBConnString)
+
+	mongoClient, err := mongo.NewClient(clientOpts)
+	if err != nil {
+		return err
+	}
+
+	err = mongoClient.Connect(context.Background())
+	if err != nil {
+		return err
+	}
+
+	db := mongoClient.Database("test")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	return db.Client().Ping(ctx, nil)
 }
 
 func getTestWitness() *proof.WitnessProof {


### PR DESCRIPTION
Add handler to expiry service such that it can inspect items to be deleted and take some action (e.g. log them in case they were not expected to be found)
Also, add expiry handler to witness store in order to log unsuccessful anchors (e.g. anchors that failed due to not having enough witnesess)

Closes #854

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>