### PR TITLE
feat: Reuse AMQP connections for multiple publishers/subscribers

### DIFF
--- a/cmd/orb-cli/go.sum
+++ b/cmd/orb-cli/go.sum
@@ -126,7 +126,7 @@ github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrU
 github.com/ThreeDotsLabs/watermill v1.1.0/go.mod h1:Qd1xNFxolCAHCzcMrm6RnjW0manbvN+DJVWc1MWRFlI=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.6 h1:wYybtpC+LMQCC8j3/D1BQPobWh0rZ4ZX57i3+zy7t8I=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.6/go.mod h1:QLZSaklpSZ/7yv288LL2DFOgCEi86VYEmQvzmaMlHoA=
-github.com/ThreeDotsLabs/watermill-amqp v1.1.3/go.mod h1:AnjfZlOKwWdDFQl23WCspiC1kewtqt5dognCKwvEk4M=
+github.com/ThreeDotsLabs/watermill-amqp v1.1.4-0.20211104161030-4f337d77fb1f/go.mod h1:5RtpKNTriXCWQZ67YDg1G7qsphZoUue/EWOmQqTZi3Q=
 github.com/ThreeDotsLabs/watermill-http v1.1.3/go.mod h1:mkQ9CC0pxTZerNwr281rBoOy355vYt/lePkmYSX/BRg=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=
 github.com/VictoriaMetrics/fastcache v1.5.7/go.mod h1:ptDBkNMQI4RtmVo8VS/XwRY6RoTu1dAWCbrk+6WsEM8=

--- a/cmd/orb-driver/go.sum
+++ b/cmd/orb-driver/go.sum
@@ -126,7 +126,7 @@ github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrU
 github.com/ThreeDotsLabs/watermill v1.1.0/go.mod h1:Qd1xNFxolCAHCzcMrm6RnjW0manbvN+DJVWc1MWRFlI=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.6 h1:wYybtpC+LMQCC8j3/D1BQPobWh0rZ4ZX57i3+zy7t8I=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.6/go.mod h1:QLZSaklpSZ/7yv288LL2DFOgCEi86VYEmQvzmaMlHoA=
-github.com/ThreeDotsLabs/watermill-amqp v1.1.3/go.mod h1:AnjfZlOKwWdDFQl23WCspiC1kewtqt5dognCKwvEk4M=
+github.com/ThreeDotsLabs/watermill-amqp v1.1.4-0.20211104161030-4f337d77fb1f/go.mod h1:5RtpKNTriXCWQZ67YDg1G7qsphZoUue/EWOmQqTZi3Q=
 github.com/ThreeDotsLabs/watermill-http v1.1.3/go.mod h1:mkQ9CC0pxTZerNwr281rBoOy355vYt/lePkmYSX/BRg=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=
 github.com/VictoriaMetrics/fastcache v1.5.7/go.mod h1:ptDBkNMQI4RtmVo8VS/XwRY6RoTu1dAWCbrk+6WsEM8=

--- a/cmd/orb-server/go.sum
+++ b/cmd/orb-server/go.sum
@@ -129,8 +129,8 @@ github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrU
 github.com/ThreeDotsLabs/watermill v1.1.0/go.mod h1:Qd1xNFxolCAHCzcMrm6RnjW0manbvN+DJVWc1MWRFlI=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.6 h1:wYybtpC+LMQCC8j3/D1BQPobWh0rZ4ZX57i3+zy7t8I=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.6/go.mod h1:QLZSaklpSZ/7yv288LL2DFOgCEi86VYEmQvzmaMlHoA=
-github.com/ThreeDotsLabs/watermill-amqp v1.1.3 h1:g9Sh2yQe76WQDt2mAFxgzafCHAXBCf7PHkdISJRZa58=
-github.com/ThreeDotsLabs/watermill-amqp v1.1.3/go.mod h1:AnjfZlOKwWdDFQl23WCspiC1kewtqt5dognCKwvEk4M=
+github.com/ThreeDotsLabs/watermill-amqp v1.1.4-0.20211104161030-4f337d77fb1f h1:qp8UJVaMmyVSju15pkJvhdCE5LEaasDnWLAlZpm6R5E=
+github.com/ThreeDotsLabs/watermill-amqp v1.1.4-0.20211104161030-4f337d77fb1f/go.mod h1:5RtpKNTriXCWQZ67YDg1G7qsphZoUue/EWOmQqTZi3Q=
 github.com/ThreeDotsLabs/watermill-http v1.1.3 h1:2jHbbE+gbq7pKWBCtOxeHTWSBNrS44Oh7QOzuAeHH/g=
 github.com/ThreeDotsLabs/watermill-http v1.1.3/go.mod h1:mkQ9CC0pxTZerNwr281rBoOy355vYt/lePkmYSX/BRg=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ module github.com/trustbloc/orb
 
 require (
 	github.com/ThreeDotsLabs/watermill v1.2.0-rc.6
-	github.com/ThreeDotsLabs/watermill-amqp v1.1.3
+	github.com/ThreeDotsLabs/watermill-amqp v1.1.4-0.20211104161030-4f337d77fb1f
 	github.com/ThreeDotsLabs/watermill-http v1.1.3
 	github.com/bluele/gcache v0.0.0-20190518031135-bc40bd653833
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrU
 github.com/ThreeDotsLabs/watermill v1.1.0/go.mod h1:Qd1xNFxolCAHCzcMrm6RnjW0manbvN+DJVWc1MWRFlI=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.6 h1:wYybtpC+LMQCC8j3/D1BQPobWh0rZ4ZX57i3+zy7t8I=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.6/go.mod h1:QLZSaklpSZ/7yv288LL2DFOgCEi86VYEmQvzmaMlHoA=
-github.com/ThreeDotsLabs/watermill-amqp v1.1.3 h1:g9Sh2yQe76WQDt2mAFxgzafCHAXBCf7PHkdISJRZa58=
-github.com/ThreeDotsLabs/watermill-amqp v1.1.3/go.mod h1:AnjfZlOKwWdDFQl23WCspiC1kewtqt5dognCKwvEk4M=
+github.com/ThreeDotsLabs/watermill-amqp v1.1.4-0.20211104161030-4f337d77fb1f h1:qp8UJVaMmyVSju15pkJvhdCE5LEaasDnWLAlZpm6R5E=
+github.com/ThreeDotsLabs/watermill-amqp v1.1.4-0.20211104161030-4f337d77fb1f/go.mod h1:5RtpKNTriXCWQZ67YDg1G7qsphZoUue/EWOmQqTZi3Q=
 github.com/ThreeDotsLabs/watermill-http v1.1.3 h1:2jHbbE+gbq7pKWBCtOxeHTWSBNrS44Oh7QOzuAeHH/g=
 github.com/ThreeDotsLabs/watermill-http v1.1.3/go.mod h1:mkQ9CC0pxTZerNwr281rBoOy355vYt/lePkmYSX/BRg=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=

--- a/pkg/activitypub/service/vct/vct.go
+++ b/pkg/activitypub/service/vct/vct.go
@@ -21,6 +21,7 @@ import (
 	"github.com/trustbloc/vct/pkg/client/vct"
 	"github.com/trustbloc/vct/pkg/controller/command"
 
+	orberrors "github.com/trustbloc/orb/pkg/errors"
 	"github.com/trustbloc/orb/pkg/vcsigner"
 )
 
@@ -113,6 +114,11 @@ func (c *Client) addProof(anchorCred []byte, timestamp int64) (*verifiable.Crede
 		verifiable.WithJSONLDDocumentLoader(c.documentLoader),
 	)
 	if err != nil {
+		if strings.Contains(err.Error(), "http request unsuccessful") {
+			// The server is probably down. Return a transient error so that it may be retried.
+			return nil, orberrors.NewTransient(fmt.Errorf("http error during parse credential: %w", err))
+		}
+
 		return nil, fmt.Errorf("parse credential: %w", err)
 	}
 

--- a/test/bdd/did_orb_steps.go
+++ b/test/bdd/did_orb_steps.go
@@ -564,7 +564,7 @@ func (d *DIDOrbSteps) removeServiceEndpointsFromDIDDocument(url, keyID string) e
 
 func (d *DIDOrbSteps) checkErrorResp(errorMsg string) error {
 	if !strings.Contains(d.resp.ErrorMsg, errorMsg) {
-		return fmt.Errorf("error resp %s doesn't contain %s", d.resp.ErrorMsg, errorMsg)
+		return fmt.Errorf(`error resp "%s" doesn't contain "%s"`, d.resp.ErrorMsg, errorMsg)
 	}
 	return nil
 }

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -166,6 +166,7 @@ github.com/ThreeDotsLabs/watermill v1.2.0-rc.6 h1:wYybtpC+LMQCC8j3/D1BQPobWh0rZ4
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.6/go.mod h1:QLZSaklpSZ/7yv288LL2DFOgCEi86VYEmQvzmaMlHoA=
 github.com/ThreeDotsLabs/watermill-amqp v1.1.1/go.mod h1:Qbu3JDlr6vIOxHJjhfsSHsrdF/ToJLYoaYek8X5Wnto=
 github.com/ThreeDotsLabs/watermill-amqp v1.1.3/go.mod h1:AnjfZlOKwWdDFQl23WCspiC1kewtqt5dognCKwvEk4M=
+github.com/ThreeDotsLabs/watermill-amqp v1.1.4-0.20211104161030-4f337d77fb1f/go.mod h1:5RtpKNTriXCWQZ67YDg1G7qsphZoUue/EWOmQqTZi3Q=
 github.com/ThreeDotsLabs/watermill-http v1.1.3/go.mod h1:mkQ9CC0pxTZerNwr281rBoOy355vYt/lePkmYSX/BRg=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=
 github.com/VictoriaMetrics/fastcache v1.5.7/go.mod h1:ptDBkNMQI4RtmVo8VS/XwRY6RoTu1dAWCbrk+6WsEM8=


### PR DESCRIPTION
A single AMQP connection is reused for publishers and subscribers. This reduces the total number of connections, which lowers RabbitMQ resources consumed. Once the channel limit of the connection is reached, a new connection is created for additional subscribers/publishers.

closes #856

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>