### PR TITLE
chore: Refactor batch writer witness collection

### DIFF
--- a/pkg/anchor/handler/proof/handler.go
+++ b/pkg/anchor/handler/proof/handler.go
@@ -66,7 +66,7 @@ type WitnessProofHandler struct {
 }
 
 type witnessStore interface {
-	AddProof(anchorID, witness string, p []byte) error
+	AddProof(anchorID string, witness *url.URL, p []byte) error
 	Get(anchorID string) ([]*proofapi.WitnessProof, error)
 }
 
@@ -126,7 +126,7 @@ func (h *WitnessProofHandler) HandleProof(witness *url.URL, anchors string, endT
 		return fmt.Errorf("failed to retrieve anchor anchor event [%s]: %w", anchors, err)
 	}
 
-	err = h.WitnessStore.AddProof(anchors, witness.String(), proof)
+	err = h.WitnessStore.AddProof(anchors, witness, proof)
 	if err != nil {
 		return fmt.Errorf("failed to add witness[%s] proof for anchor event [%s]: %w", witness.String(), anchors, err)
 	}

--- a/pkg/anchor/handler/proof/handler_test.go
+++ b/pkg/anchor/handler/proof/handler_test.go
@@ -84,9 +84,9 @@ func TestWitnessProofHandler(t *testing.T) {
 		witnessStore, err := witness.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
-		// prepare witness store with 'empty' witness proofs
-		emptyWitnessProofs := []*proofapi.WitnessProof{{Type: proofapi.WitnessTypeSystem, Witness: witnessIRI.String()}}
-		err = witnessStore.Put(ae.Index().String(), emptyWitnessProofs)
+		// prepare witness store
+		witnesses := []*proofapi.Witness{{Type: proofapi.WitnessTypeSystem, URI: witnessIRI}}
+		err = witnessStore.Put(ae.Index().String(), witnesses)
 		require.NoError(t, err)
 
 		providers := &Providers{
@@ -133,8 +133,8 @@ func TestWitnessProofHandler(t *testing.T) {
 		witnessStore, err := witness.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
-		// prepare witness store with 'empty' witness proofs
-		emptyWitnessProofs := []*proofapi.WitnessProof{{Type: proofapi.WitnessTypeSystem, Witness: witnessIRI.String()}}
+		// prepare witness store
+		emptyWitnessProofs := []*proofapi.Witness{{Type: proofapi.WitnessTypeSystem, URI: witnessIRI}}
 		err = witnessStore.Put(ae.Index().String(), emptyWitnessProofs)
 		require.NoError(t, err)
 
@@ -212,8 +212,8 @@ func TestWitnessProofHandler(t *testing.T) {
 			StatusStore:      vcStatusStore,
 			MonitoringSvc:    &mocks.MonitoringService{},
 			WitnessStore: &mockWitnessStore{WitnessProof: []*proofapi.WitnessProof{{
-				Type:    proofapi.WitnessTypeSystem,
-				Witness: "witness",
+				Type: proofapi.WitnessTypeSystem,
+				URI:  witnessIRI,
 			}}},
 			WitnessPolicy: &mockWitnessPolicy{eval: true},
 			Metrics:       &orbmocks.MetricsProvider{},
@@ -240,9 +240,9 @@ func TestWitnessProofHandler(t *testing.T) {
 		witnessStore, err := witness.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
-		// prepare witness store with 'empty' witness proofs
-		emptyWitnessProofs := []*proofapi.WitnessProof{{Type: proofapi.WitnessTypeSystem, Witness: witnessIRI.String()}}
-		err = witnessStore.Put(ae.Index().String(), emptyWitnessProofs)
+		// prepare witness store
+		witnesses := []*proofapi.Witness{{Type: proofapi.WitnessTypeSystem, URI: witnessIRI}}
+		err = witnessStore.Put(ae.Index().String(), witnesses)
 		require.NoError(t, err)
 
 		witnessPolicy, err := policy.New(configStore, defaultPolicyCacheExpiry)
@@ -283,9 +283,9 @@ func TestWitnessProofHandler(t *testing.T) {
 		witnessStore, err := witness.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
-		// prepare witness store with 'empty' witness proofs
-		emptyWitnessProofs := []*proofapi.WitnessProof{{Type: proofapi.WitnessTypeSystem, Witness: witnessIRI.String()}}
-		err = witnessStore.Put(ae.Index().String(), emptyWitnessProofs)
+		// prepare witness store
+		witnesses := []*proofapi.Witness{{Type: proofapi.WitnessTypeSystem, URI: witnessIRI}}
+		err = witnessStore.Put(ae.Index().String(), witnesses)
 		require.NoError(t, err)
 
 		witnessPolicy, err := policy.New(configStore, defaultPolicyCacheExpiry)
@@ -327,9 +327,9 @@ func TestWitnessProofHandler(t *testing.T) {
 		witnessStore, err := witness.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
-		// prepare witness store with 'empty' witness proofs
-		emptyWitnessProofs := []*proofapi.WitnessProof{{Type: proofapi.WitnessTypeSystem, Witness: witnessIRI.String()}}
-		err = witnessStore.Put(ae.Index().String(), emptyWitnessProofs)
+		// prepare witness store
+		witnesses := []*proofapi.Witness{{Type: proofapi.WitnessTypeSystem, URI: witnessIRI}}
+		err = witnessStore.Put(ae.Index().String(), witnesses)
 		require.NoError(t, err)
 
 		witnessPolicy, err := policy.New(configStore, defaultPolicyCacheExpiry)
@@ -370,9 +370,9 @@ func TestWitnessProofHandler(t *testing.T) {
 		witnessStore, err := witness.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
-		// prepare witness store with 'empty' witness proofs
-		emptyWitnessProofs := []*proofapi.WitnessProof{{Type: proofapi.WitnessTypeSystem, Witness: witnessIRI.String()}}
-		err = witnessStore.Put(ae.Index().String(), emptyWitnessProofs)
+		// prepare witness store
+		witnesses := []*proofapi.Witness{{Type: proofapi.WitnessTypeSystem, URI: witnessIRI}}
+		err = witnessStore.Put(ae.Index().String(), witnesses)
 		require.NoError(t, err)
 
 		witnessPolicy, err := policy.New(configStore, defaultPolicyCacheExpiry)
@@ -632,7 +632,7 @@ type mockWitnessStore struct {
 	GetErr       error
 }
 
-func (w *mockWitnessStore) AddProof(vcID, witnessID string, proof []byte) error {
+func (w *mockWitnessStore) AddProof(_ string, _ *url.URL, _ []byte) error {
 	if w.AddProofErr != nil {
 		return w.AddProofErr
 	}
@@ -640,7 +640,7 @@ func (w *mockWitnessStore) AddProof(vcID, witnessID string, proof []byte) error 
 	return nil
 }
 
-func (w *mockWitnessStore) Get(vcID string) ([]*proofapi.WitnessProof, error) {
+func (w *mockWitnessStore) Get(_ string) ([]*proofapi.WitnessProof, error) {
 	if w.GetErr != nil {
 		return nil, w.GetErr
 	}

--- a/pkg/anchor/policy/policy_test.go
+++ b/pkg/anchor/policy/policy_test.go
@@ -8,6 +8,7 @@ package policy
 
 import (
 	"fmt"
+	"net/url"
 	"testing"
 	"time"
 
@@ -59,6 +60,21 @@ func TestNew(t *testing.T) {
 }
 
 func TestEvaluate(t *testing.T) {
+	witnessURL, err := url.Parse("https://domain.com/service")
+	require.NoError(t, err)
+
+	batchWitnessURL, err := url.Parse("https://batch.com/service")
+	require.NoError(t, err)
+
+	systemWitnessURL, err := url.Parse("https://system.com/service")
+	require.NoError(t, err)
+
+	batchWitness2URL, err := url.Parse("https://other.batch.com/service")
+	require.NoError(t, err)
+
+	systemWitness2URL, err := url.Parse("https://other.system.com/service")
+	require.NoError(t, err)
+
 	t.Run("success - default policy satisfied (100% batch and 100% system)", func(t *testing.T) {
 		configStore, err := mem.NewProvider().OpenStore(configStoreName)
 		require.NoError(t, err)
@@ -69,14 +85,14 @@ func TestEvaluate(t *testing.T) {
 
 		witnessProofs := []*proof.WitnessProof{
 			{
-				Type:    proof.WitnessTypeBatch,
-				Witness: "witness-1",
-				Proof:   []byte("proof"),
+				Type:  proof.WitnessTypeBatch,
+				URI:   witnessURL,
+				Proof: []byte("proof"),
 			},
 			{
-				Type:    proof.WitnessTypeSystem,
-				Witness: "witness-1",
-				Proof:   []byte("proof"),
+				Type:  proof.WitnessTypeSystem,
+				URI:   witnessURL,
+				Proof: []byte("proof"),
 			},
 		}
 
@@ -98,16 +114,16 @@ func TestEvaluate(t *testing.T) {
 
 		witnessProofs := []*proof.WitnessProof{
 			{
-				Type:    proof.WitnessTypeBatch,
-				Witness: "batch-witness",
-				Proof:   []byte("proof"),
-				HasLog:  true,
+				Type:   proof.WitnessTypeBatch,
+				URI:    batchWitnessURL,
+				Proof:  []byte("proof"),
+				HasLog: true,
 			},
 			{
-				Type:    proof.WitnessTypeSystem,
-				Witness: "system-witness",
-				Proof:   []byte("proof"),
-				HasLog:  true,
+				Type:   proof.WitnessTypeSystem,
+				URI:    systemWitnessURL,
+				Proof:  []byte("proof"),
+				HasLog: true,
 			},
 		}
 
@@ -129,16 +145,16 @@ func TestEvaluate(t *testing.T) {
 
 		witnessProofs := []*proof.WitnessProof{
 			{
-				Type:    proof.WitnessTypeBatch,
-				Witness: "batch-witness",
-				Proof:   []byte("proof"),
-				HasLog:  false,
+				Type:   proof.WitnessTypeBatch,
+				URI:    batchWitnessURL,
+				Proof:  []byte("proof"),
+				HasLog: false,
 			},
 			{
-				Type:    proof.WitnessTypeSystem,
-				Witness: "system-witness",
-				Proof:   []byte("proof"),
-				HasLog:  true,
+				Type:   proof.WitnessTypeSystem,
+				URI:    systemWitnessURL,
+				Proof:  []byte("proof"),
+				HasLog: true,
 			},
 		}
 
@@ -160,28 +176,28 @@ func TestEvaluate(t *testing.T) {
 
 		witnessProofs := []*proof.WitnessProof{
 			{
-				Type:    proof.WitnessTypeBatch,
-				Witness: "batch-witness",
-				Proof:   []byte("proof"),
-				HasLog:  true,
+				Type:   proof.WitnessTypeBatch,
+				URI:    batchWitnessURL,
+				Proof:  []byte("proof"),
+				HasLog: true,
 			},
 			{
-				Type:    proof.WitnessTypeBatch,
-				Witness: "batch-witness-2",
-				Proof:   []byte("proof"),
-				HasLog:  false,
+				Type:   proof.WitnessTypeBatch,
+				URI:    batchWitness2URL,
+				Proof:  []byte("proof"),
+				HasLog: false,
 			},
 			{
-				Type:    proof.WitnessTypeSystem,
-				Witness: "system-witness",
-				Proof:   []byte("proof"),
-				HasLog:  true,
+				Type:   proof.WitnessTypeSystem,
+				URI:    systemWitnessURL,
+				Proof:  []byte("proof"),
+				HasLog: true,
 			},
 			{
-				Type:    proof.WitnessTypeSystem,
-				Witness: "system-witness-2",
-				Proof:   []byte("proof"),
-				HasLog:  false,
+				Type:   proof.WitnessTypeSystem,
+				URI:    systemWitness2URL,
+				Proof:  []byte("proof"),
+				HasLog: false,
 			},
 		}
 
@@ -203,10 +219,10 @@ func TestEvaluate(t *testing.T) {
 
 		witnessProofs := []*proof.WitnessProof{
 			{
-				Type:    proof.WitnessTypeSystem,
-				Witness: "system-witness",
-				Proof:   []byte("proof"),
-				HasLog:  false,
+				Type:   proof.WitnessTypeSystem,
+				URI:    systemWitnessURL,
+				Proof:  []byte("proof"),
+				HasLog: false,
 			},
 		}
 
@@ -228,16 +244,16 @@ func TestEvaluate(t *testing.T) {
 
 		witnessProofs := []*proof.WitnessProof{
 			{
-				Type:    proof.WitnessTypeSystem,
-				Witness: "system-witness",
-				Proof:   []byte("proof"),
-				HasLog:  false,
+				Type:   proof.WitnessTypeSystem,
+				URI:    systemWitnessURL,
+				Proof:  []byte("proof"),
+				HasLog: false,
 			},
 			{
-				Type:    proof.WitnessTypeBatch,
-				Witness: "batch-witness",
-				Proof:   []byte("proof"),
-				HasLog:  true,
+				Type:   proof.WitnessTypeBatch,
+				URI:    batchWitnessURL,
+				Proof:  []byte("proof"),
+				HasLog: true,
 			},
 		}
 
@@ -259,16 +275,16 @@ func TestEvaluate(t *testing.T) {
 
 		witnessProofs := []*proof.WitnessProof{
 			{
-				Type:    proof.WitnessTypeSystem,
-				Witness: "system-witness",
-				Proof:   []byte("proof"),
-				HasLog:  true,
+				Type:   proof.WitnessTypeSystem,
+				URI:    systemWitnessURL,
+				Proof:  []byte("proof"),
+				HasLog: true,
 			},
 			{
-				Type:    proof.WitnessTypeBatch,
-				Witness: "batch-witness",
-				Proof:   []byte("proof"),
-				HasLog:  true,
+				Type:   proof.WitnessTypeBatch,
+				URI:    batchWitnessURL,
+				Proof:  []byte("proof"),
+				HasLog: true,
 			},
 		}
 
@@ -290,16 +306,16 @@ func TestEvaluate(t *testing.T) {
 
 		witnessProofs := []*proof.WitnessProof{
 			{
-				Type:    proof.WitnessTypeSystem,
-				Witness: "system-witness",
-				Proof:   []byte("proof"),
-				HasLog:  false,
+				Type:   proof.WitnessTypeSystem,
+				URI:    systemWitnessURL,
+				Proof:  []byte("proof"),
+				HasLog: false,
 			},
 			{
-				Type:    proof.WitnessTypeBatch,
-				Witness: "batch-witness",
-				Proof:   []byte("proof"),
-				HasLog:  true,
+				Type:   proof.WitnessTypeBatch,
+				URI:    batchWitnessURL,
+				Proof:  []byte("proof"),
+				HasLog: true,
 			},
 		}
 
@@ -318,20 +334,20 @@ func TestEvaluate(t *testing.T) {
 
 		witnessProofs := []*proof.WitnessProof{
 			{
-				Type:    proof.WitnessTypeBatch,
-				Witness: "batch-witness-1",
+				Type: proof.WitnessTypeBatch,
+				URI:  batchWitnessURL,
 			},
 			{
-				Type:    proof.WitnessTypeBatch,
-				Witness: "batch-witness-2",
+				Type: proof.WitnessTypeBatch,
+				URI:  batchWitness2URL,
 			},
 			{
-				Type:    proof.WitnessTypeSystem,
-				Witness: "system-witness-1",
+				Type: proof.WitnessTypeSystem,
+				URI:  systemWitnessURL,
 			},
 			{
-				Type:    proof.WitnessTypeSystem,
-				Witness: "system-witness-2",
+				Type: proof.WitnessTypeSystem,
+				URI:  systemWitness2URL,
 			},
 		}
 
@@ -353,22 +369,22 @@ func TestEvaluate(t *testing.T) {
 
 		witnessProofs := []*proof.WitnessProof{
 			{
-				Type:    proof.WitnessTypeBatch,
-				Witness: "batch-witness-1",
-				Proof:   []byte("proof"),
+				Type:  proof.WitnessTypeBatch,
+				URI:   batchWitnessURL,
+				Proof: []byte("proof"),
 			},
 			{
-				Type:    proof.WitnessTypeBatch,
-				Witness: "batch-witness-2",
-				Proof:   []byte("proof"),
+				Type:  proof.WitnessTypeBatch,
+				URI:   batchWitness2URL,
+				Proof: []byte("proof"),
 			},
 			{
-				Type:    proof.WitnessTypeSystem,
-				Witness: "system-witness-1",
+				Type: proof.WitnessTypeSystem,
+				URI:  systemWitnessURL,
 			},
 			{
-				Type:    proof.WitnessTypeSystem,
-				Witness: "system-witness-2",
+				Type: proof.WitnessTypeSystem,
+				URI:  systemWitness2URL,
 			},
 		}
 
@@ -390,23 +406,23 @@ func TestEvaluate(t *testing.T) {
 
 		witnessProofs := []*proof.WitnessProof{
 			{
-				Type:    proof.WitnessTypeBatch,
-				Witness: "batch-witness-1",
-				Proof:   []byte("proof"),
+				Type:  proof.WitnessTypeBatch,
+				URI:   batchWitnessURL,
+				Proof: []byte("proof"),
 			},
 			{
-				Type:    proof.WitnessTypeBatch,
-				Witness: "batch-witness-2",
-				Proof:   []byte("proof"),
+				Type:  proof.WitnessTypeBatch,
+				URI:   batchWitness2URL,
+				Proof: []byte("proof"),
 			},
 			{
-				Type:    proof.WitnessTypeSystem,
-				Witness: "system-witness-1",
-				Proof:   []byte("proof"),
+				Type:  proof.WitnessTypeSystem,
+				URI:   systemWitnessURL,
+				Proof: []byte("proof"),
 			},
 			{
-				Type:    proof.WitnessTypeSystem,
-				Witness: "system-witness-2",
+				Type: proof.WitnessTypeSystem,
+				URI:  systemWitness2URL,
 			},
 		}
 
@@ -428,58 +444,22 @@ func TestEvaluate(t *testing.T) {
 
 		witnessProofs := []*proof.WitnessProof{
 			{
-				Type:    proof.WitnessTypeBatch,
-				Witness: "batch-witness-1",
-				Proof:   []byte("proof"),
+				Type:  proof.WitnessTypeBatch,
+				URI:   batchWitnessURL,
+				Proof: []byte("proof"),
 			},
 			{
-				Type:    proof.WitnessTypeBatch,
-				Witness: "batch-witness-2",
+				Type: proof.WitnessTypeBatch,
+				URI:  batchWitness2URL,
 			},
 			{
-				Type:    proof.WitnessTypeSystem,
-				Witness: "system-witness-1",
-				Proof:   []byte("proof"),
+				Type:  proof.WitnessTypeSystem,
+				URI:   systemWitnessURL,
+				Proof: []byte("proof"),
 			},
 			{
-				Type:    proof.WitnessTypeSystem,
-				Witness: "system-witness-2",
-			},
-		}
-
-		ok, err := wp.Evaluate(witnessProofs)
-		require.NoError(t, err)
-		require.Equal(t, true, ok)
-	})
-
-	t.Run("success - policy satisfied (50% batch witness proofs or 50% system witness proofs)", func(t *testing.T) {
-		configStore, err := mem.NewProvider().OpenStore(configStoreName)
-		require.NoError(t, err)
-
-		err = configStore.Put(WitnessPolicyKey, []byte(`"MinPercent(50,system) OR MinPercent(50,batch)"`))
-		require.NoError(t, err)
-
-		wp, err := New(configStore, defaultPolicyCacheExpiry)
-		require.NoError(t, err)
-		require.NotNil(t, wp)
-
-		witnessProofs := []*proof.WitnessProof{
-			{
-				Type:    proof.WitnessTypeBatch,
-				Witness: "batch-witness-1",
-				Proof:   []byte("proof"),
-			},
-			{
-				Type:    proof.WitnessTypeBatch,
-				Witness: "batch-witness-2",
-			},
-			{
-				Type:    proof.WitnessTypeSystem,
-				Witness: "system-witness-1",
-			},
-			{
-				Type:    proof.WitnessTypeSystem,
-				Witness: "system-witness-2",
+				Type: proof.WitnessTypeSystem,
+				URI:  systemWitness2URL,
 			},
 		}
 
@@ -501,17 +481,53 @@ func TestEvaluate(t *testing.T) {
 
 		witnessProofs := []*proof.WitnessProof{
 			{
-				Type:    proof.WitnessTypeBatch,
-				Witness: "batch-witness-1",
-				Proof:   []byte("proof"),
+				Type:  proof.WitnessTypeBatch,
+				URI:   batchWitnessURL,
+				Proof: []byte("proof"),
 			},
 			{
-				Type:    proof.WitnessTypeBatch,
-				Witness: "batch-witness-2",
+				Type: proof.WitnessTypeBatch,
+				URI:  batchWitness2URL,
 			},
 			{
-				Type:    proof.WitnessTypeSystem,
-				Witness: "system-witness-1",
+				Type: proof.WitnessTypeSystem,
+				URI:  systemWitnessURL,
+			},
+			{
+				Type: proof.WitnessTypeSystem,
+				URI:  systemWitness2URL,
+			},
+		}
+
+		ok, err := wp.Evaluate(witnessProofs)
+		require.NoError(t, err)
+		require.Equal(t, true, ok)
+	})
+
+	t.Run("success - policy satisfied (50% batch witness proofs or 50% system witness proofs)", func(t *testing.T) {
+		configStore, err := mem.NewProvider().OpenStore(configStoreName)
+		require.NoError(t, err)
+
+		err = configStore.Put(WitnessPolicyKey, []byte(`"MinPercent(50,system) OR MinPercent(50,batch)"`))
+		require.NoError(t, err)
+
+		wp, err := New(configStore, defaultPolicyCacheExpiry)
+		require.NoError(t, err)
+		require.NotNil(t, wp)
+
+		witnessProofs := []*proof.WitnessProof{
+			{
+				Type:  proof.WitnessTypeBatch,
+				URI:   batchWitnessURL,
+				Proof: []byte("proof"),
+			},
+			{
+				Type: proof.WitnessTypeBatch,
+				URI:  batchWitness2URL,
+			},
+			{
+				Type: proof.WitnessTypeSystem,
+				URI:  systemWitnessURL,
 			},
 		}
 
@@ -533,23 +549,23 @@ func TestEvaluate(t *testing.T) {
 
 		witnessProofs := []*proof.WitnessProof{
 			{
-				Type:    proof.WitnessTypeBatch,
-				Witness: "batch-witness-1",
-				Proof:   []byte("proof"),
+				Type:  proof.WitnessTypeBatch,
+				URI:   batchWitnessURL,
+				Proof: []byte("proof"),
 			},
 			{
-				Type:    proof.WitnessTypeBatch,
-				Witness: "batch-witness-2",
-				Proof:   []byte("proof"),
+				Type:  proof.WitnessTypeBatch,
+				URI:   batchWitness2URL,
+				Proof: []byte("proof"),
 			},
 			{
-				Type:    proof.WitnessTypeSystem,
-				Witness: "system-witness-1",
-				Proof:   []byte("proof"),
+				Type:  proof.WitnessTypeSystem,
+				URI:   systemWitnessURL,
+				Proof: []byte("proof"),
 			},
 			{
-				Type:    proof.WitnessTypeSystem,
-				Witness: "system-witness-2",
+				Type: proof.WitnessTypeSystem,
+				URI:  systemWitness2URL,
 			},
 		}
 
@@ -571,9 +587,9 @@ func TestEvaluate(t *testing.T) {
 
 		witnessProofs := []*proof.WitnessProof{
 			{
-				Type:    proof.WitnessTypeBatch,
-				Witness: "batch-witness-1",
-				Proof:   []byte("proof"),
+				Type:  proof.WitnessTypeBatch,
+				URI:   batchWitnessURL,
+				Proof: []byte("proof"),
 			},
 		}
 
@@ -595,9 +611,9 @@ func TestEvaluate(t *testing.T) {
 
 		witnessProofs := []*proof.WitnessProof{
 			{
-				Type:    proof.WitnessTypeSystem,
-				Witness: "system-witness-1",
-				Proof:   []byte("proof"),
+				Type:  proof.WitnessTypeSystem,
+				URI:   systemWitnessURL,
+				Proof: []byte("proof"),
 			},
 		}
 
@@ -619,13 +635,13 @@ func TestEvaluate(t *testing.T) {
 
 		witnessProofs := []*proof.WitnessProof{
 			{
-				Type:    proof.WitnessTypeBatch,
-				Witness: "batch-witness-1",
+				Type: proof.WitnessTypeBatch,
+				URI:  batchWitnessURL,
 			},
 			{
-				Type:    proof.WitnessTypeSystem,
-				Witness: "system-witness-1",
-				Proof:   []byte("proof"),
+				Type:  proof.WitnessTypeSystem,
+				URI:   systemWitnessURL,
+				Proof: []byte("proof"),
 			},
 		}
 
@@ -663,14 +679,14 @@ func TestEvaluate(t *testing.T) {
 
 		witnessProofs := []*proof.WitnessProof{
 			{
-				Type:    proof.WitnessTypeBatch,
-				Witness: "witness-1",
-				Proof:   []byte("proof"),
+				Type:  proof.WitnessTypeBatch,
+				URI:   witnessURL,
+				Proof: []byte("proof"),
 			},
 			{
-				Type:    proof.WitnessTypeSystem,
-				Witness: "witness-1",
-				Proof:   []byte("proof"),
+				Type:  proof.WitnessTypeSystem,
+				URI:   witnessURL,
+				Proof: []byte("proof"),
 			},
 		}
 

--- a/pkg/anchor/proof/proof.go
+++ b/pkg/anchor/proof/proof.go
@@ -6,18 +6,28 @@ SPDX-License-Identifier: Apache-2.0
 
 package proof
 
-import "fmt"
+import (
+	"fmt"
+	"net/url"
+)
 
-// WitnessProof contains anchor credential witness proof.
+// Witness contains info about witness.
+type Witness struct {
+	Type   WitnessType
+	URI    *url.URL
+	HasLog bool
+}
+
+// WitnessProof contains anchor index witness proof.
 type WitnessProof struct {
-	Type    WitnessType
-	Witness string
-	Proof   []byte
-	HasLog  bool
+	Type   WitnessType
+	URI    *url.URL
+	HasLog bool
+	Proof  []byte
 }
 
 func (wf *WitnessProof) String() string {
-	return fmt.Sprintf("{type:%s, witness:%s, log:%t, proof:%s}", wf.Type, wf.Witness, wf.HasLog, string(wf.Proof))
+	return fmt.Sprintf("{type:%s, witness:%s, log:%t, proof:%s}", wf.Type, wf.URI, wf.HasLog, string(wf.Proof))
 }
 
 // WitnessType defines valid values for witness type.


### PR DESCRIPTION
Refactor batch writer witnesses collection for offer activity:  send individual system witness URLs instead of one preconfigured 'system' witness URL that points to system witnesses collection. Required in order to send only a subset of witnesses (as per policy) in the future.

Closes #861

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>