### PR TITLE
feat: Select minimum number of witnesses based on policy

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -685,6 +685,7 @@ func startOrbServices(parameters *orbParameters) error {
 		MonitoringSvc:    monitoringSvc,
 		ActivityStore:    apStore,
 		WitnessStore:     witnessProofStore,
+		WitnessPolicy:    witnessPolicy,
 		WFClient:         wfClient,
 		DocumentLoader:   orbDocumentLoader,
 		VCStore:          vcStore,

--- a/pkg/anchor/witness/policy/config/parser.go
+++ b/pkg/anchor/witness/policy/config/parser.go
@@ -20,7 +20,8 @@ type WitnessPolicyConfig struct {
 	MinPercentSystem int
 	MinPercentBatch  int
 
-	Operator operatorFnc
+	OperatorFnc operatorFnc
+	Operator    string
 
 	LogRequired bool
 }
@@ -51,7 +52,8 @@ func Parse(policy string) (*WitnessPolicyConfig, error) {
 	wp := &WitnessPolicyConfig{
 		MinPercentBatch:  maxPercent,
 		MinPercentSystem: maxPercent,
-		Operator:         and,
+		OperatorFnc:      and,
+		Operator:         AND,
 	}
 
 	if policy == "" {
@@ -85,9 +87,11 @@ func (wp *WitnessPolicyConfig) processToken(token string) error {
 	case t == LogRequired:
 		wp.LogRequired = true
 	case t == AND:
-		wp.Operator = and
+		wp.OperatorFnc = and
+		wp.Operator = AND
 	case t == OR:
-		wp.Operator = or
+		wp.OperatorFnc = or
+		wp.Operator = OR
 	default:
 		return fmt.Errorf("rule not supported: %s", token)
 	}
@@ -169,8 +173,8 @@ func (wp *WitnessPolicyConfig) processMinPercent(token string) error {
 }
 
 func (wp *WitnessPolicyConfig) String() string {
-	return fmt.Sprintf("minBatch:%d, minSystem:%d, percentBatch:%d, percentSystem:%d, log:%t",
-		wp.MinNumberBatch, wp.MinNumberSystem, wp.MinPercentBatch, wp.MinPercentSystem, wp.LogRequired)
+	return fmt.Sprintf("minBatch:%d, minSystem:%d, percentBatch:%d, percentSystem:%d, operator: %s, log:%t",
+		wp.MinNumberBatch, wp.MinNumberSystem, wp.MinPercentBatch, wp.MinPercentSystem, wp.Operator, wp.LogRequired)
 }
 
 func and(a, b bool) bool {

--- a/pkg/anchor/witness/policy/config/parser_test.go
+++ b/pkg/anchor/witness/policy/config/parser_test.go
@@ -23,7 +23,7 @@ func TestParse(t *testing.T) {
 		require.Equal(t, 100, wp.MinPercentBatch)
 		require.Equal(t, 100, wp.MinPercentSystem)
 		require.Equal(t, false, wp.LogRequired)
-		require.Equal(t, and(true, false), wp.Operator(true, false))
+		require.Equal(t, and(true, false), wp.OperatorFnc(true, false))
 
 		require.NotEmpty(t, wp.String())
 	})
@@ -46,7 +46,7 @@ func TestParse_OutOf(t *testing.T) {
 		require.Equal(t, 2, wp.MinNumberSystem)
 		require.Equal(t, 100, wp.MinPercentBatch)
 		require.Equal(t, 100, wp.MinPercentSystem)
-		require.Equal(t, and(true, false), wp.Operator(true, false))
+		require.Equal(t, and(true, false), wp.OperatorFnc(true, false))
 	})
 
 	t.Run("success - OutOf policy for batch", func(t *testing.T) {
@@ -58,7 +58,7 @@ func TestParse_OutOf(t *testing.T) {
 		require.Equal(t, 0, wp.MinNumberSystem)
 		require.Equal(t, 100, wp.MinPercentBatch)
 		require.Equal(t, 100, wp.MinPercentSystem)
-		require.Equal(t, and(true, false), wp.Operator(true, false))
+		require.Equal(t, and(true, false), wp.OperatorFnc(true, false))
 	})
 
 	t.Run("success - OutOf policy for batch", func(t *testing.T) {
@@ -70,7 +70,7 @@ func TestParse_OutOf(t *testing.T) {
 		require.Equal(t, 3, wp.MinNumberSystem)
 		require.Equal(t, 100, wp.MinPercentBatch)
 		require.Equal(t, 100, wp.MinPercentSystem)
-		require.Equal(t, and(true, false), wp.Operator(true, false))
+		require.Equal(t, and(true, false), wp.OperatorFnc(true, false))
 	})
 
 	t.Run("error - first argument for OutOf policy must be an integer", func(t *testing.T) {
@@ -105,7 +105,7 @@ func TestParse_MinPercent(t *testing.T) {
 		require.Equal(t, 0, wp.MinNumberSystem)
 		require.Equal(t, 70, wp.MinPercentBatch)
 		require.Equal(t, 100, wp.MinPercentSystem)
-		require.Equal(t, and(true, false), wp.Operator(true, false))
+		require.Equal(t, and(true, false), wp.OperatorFnc(true, false))
 	})
 
 	t.Run("success - MinPercent policy for batch and system", func(t *testing.T) {
@@ -117,7 +117,7 @@ func TestParse_MinPercent(t *testing.T) {
 		require.Equal(t, 0, wp.MinNumberSystem)
 		require.Equal(t, 70, wp.MinPercentBatch)
 		require.Equal(t, 30, wp.MinPercentSystem)
-		require.Equal(t, or(true, false), wp.Operator(true, false))
+		require.Equal(t, or(true, false), wp.OperatorFnc(true, false))
 	})
 
 	t.Run("error - role 'invalid' not supported for MinPercent policy", func(t *testing.T) {
@@ -160,6 +160,6 @@ func TestParse_LogRequired(t *testing.T) {
 		require.Equal(t, 100, wp.MinPercentBatch)
 		require.Equal(t, 100, wp.MinPercentSystem)
 		require.Equal(t, true, wp.LogRequired)
-		require.Equal(t, and(true, false), wp.Operator(true, false))
+		require.Equal(t, and(true, false), wp.OperatorFnc(true, false))
 	})
 }

--- a/pkg/anchor/witness/policy/selector/random/selector.go
+++ b/pkg/anchor/witness/policy/selector/random/selector.go
@@ -1,0 +1,60 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package random
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/trustbloc/orb/pkg/anchor/witness/proof"
+)
+
+// New returns new random selector.
+func New() *Selector {
+	rand.Seed(time.Now().UnixNano())
+
+	return &Selector{}
+}
+
+// Selector implements random selection of n out of m witnesses.
+type Selector struct{}
+
+// Select selects n witnesses out of provided list of witnesses.
+func (s *Selector) Select(witnesses []*proof.Witness, n int) ([]*proof.Witness, error) {
+	l := len(witnesses)
+
+	if n > l {
+		return nil, fmt.Errorf("unable to select %d witnesses from witness array of length %d", n, len(witnesses))
+	}
+
+	if n == l {
+		return witnesses, nil
+	}
+
+	max := len(witnesses)
+
+	var selected []*proof.Witness
+
+	uniqueIndexes := make(map[int]bool)
+
+	for i := 0; i < n; i++ {
+		for {
+			i := rand.Intn(max) //nolint:gosec
+
+			if _, ok := uniqueIndexes[i]; !ok {
+				uniqueIndexes[i] = true
+
+				selected = append(selected, witnesses[i])
+
+				break
+			}
+		}
+	}
+
+	return selected, nil
+}

--- a/pkg/anchor/witness/policy/selector/random/selector_test.go
+++ b/pkg/anchor/witness/policy/selector/random/selector_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package random
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/pkg/anchor/witness/proof"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		s := New()
+		require.NotNil(t, s)
+	})
+}
+
+func TestSelect(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		s := New()
+		require.NotNil(t, s)
+
+		witnesses := []*proof.Witness{{}, {}, {}, {}}
+
+		selected, err := s.Select(witnesses, 3)
+		require.NoError(t, err)
+		require.Equal(t, 3, len(selected))
+	})
+
+	t.Run("success", func(t *testing.T) {
+		s := New()
+		require.NotNil(t, s)
+
+		witnesses := []*proof.Witness{{}, {}}
+
+		selected, err := s.Select(witnesses, 2)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(selected))
+	})
+
+	t.Run("error", func(t *testing.T) {
+		s := New()
+		require.NotNil(t, s)
+
+		selected, err := s.Select(nil, 2)
+		require.Error(t, err)
+		require.Empty(t, selected)
+		require.Contains(t, err.Error(), "unable to select 2 witnesses from witness array of length 0")
+	})
+}

--- a/pkg/anchor/witness/proof/proof.go
+++ b/pkg/anchor/witness/proof/proof.go
@@ -18,6 +18,10 @@ type Witness struct {
 	HasLog bool
 }
 
+func (wf *Witness) String() string {
+	return fmt.Sprintf("{type:%s, witness:%s, log:%t}", wf.Type, wf.URI, wf.HasLog)
+}
+
 // WitnessProof contains anchor index witness proof.
 type WitnessProof struct {
 	Type   WitnessType

--- a/pkg/anchor/witness/proof/proof_test.go
+++ b/pkg/anchor/witness/proof/proof_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package proof
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		testURI, err := url.Parse("http://domain.com/service")
+		require.NoError(t, err)
+
+		w := &Witness{Type: WitnessTypeBatch, URI: testURI, HasLog: true}
+		require.Equal(t, w.String(), "{type:batch, witness:http://domain.com/service, log:true}")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		testURI, err := url.Parse("http://domain.com/service")
+		require.NoError(t, err)
+
+		wp := &WitnessProof{Type: WitnessTypeBatch, URI: testURI, HasLog: true, Proof: []byte("proof")}
+		require.Equal(t, wp.String(), "{type:batch, witness:http://domain.com/service, log:true, proof:proof}")
+	})
+}


### PR DESCRIPTION
Batch writer should select minimum number of witnesses based on policy.
First selector will be random selector.

Closes #866

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>