### PR TITLE
fix: Use local knowledge for DID anchor domain for resolution from anchor origin

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -327,7 +327,8 @@ func startOrbServices(parameters *orbParameters) error {
 	tlsConfig := &tls.Config{RootCAs: rootCAs, MinVersion: tls.VersionTLS12}
 
 	httpClient := &http.Client{
-		Timeout: time.Minute,
+		// TODO: we should have different timeout for connecting/dialing
+		Timeout: 5 * time.Second,
 		Transport: &http.Transport{
 			TLSClientConfig: tlsConfig,
 		},
@@ -738,12 +739,14 @@ func startOrbServices(parameters *orbParameters) error {
 	)
 
 	if parameters.verifyLatestFromAnchorOrigin {
+
 		operationDecorator := decorator.New(parameters.didNamespace,
 			parameters.externalEndpoint,
 			opProcessor,
 			endpointClient,
 			remoteresolver.New(t),
 		)
+
 		didDocHandlerOpts = append(didDocHandlerOpts, dochandler.WithOperationDecorator(operationDecorator))
 	}
 

--- a/pkg/document/mocks/endpointclient.gen.go
+++ b/pkg/document/mocks/endpointclient.gen.go
@@ -8,6 +8,19 @@ import (
 )
 
 type EndpointClient struct {
+	GetEndpointStub        func(string) (*models.Endpoint, error)
+	getEndpointMutex       sync.RWMutex
+	getEndpointArgsForCall []struct {
+		arg1 string
+	}
+	getEndpointReturns struct {
+		result1 *models.Endpoint
+		result2 error
+	}
+	getEndpointReturnsOnCall map[int]struct {
+		result1 *models.Endpoint
+		result2 error
+	}
 	GetEndpointFromAnchorOriginStub        func(string) (*models.Endpoint, error)
 	getEndpointFromAnchorOriginMutex       sync.RWMutex
 	getEndpointFromAnchorOriginArgsForCall []struct {
@@ -23,6 +36,69 @@ type EndpointClient struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *EndpointClient) GetEndpoint(arg1 string) (*models.Endpoint, error) {
+	fake.getEndpointMutex.Lock()
+	ret, specificReturn := fake.getEndpointReturnsOnCall[len(fake.getEndpointArgsForCall)]
+	fake.getEndpointArgsForCall = append(fake.getEndpointArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("GetEndpoint", []interface{}{arg1})
+	fake.getEndpointMutex.Unlock()
+	if fake.GetEndpointStub != nil {
+		return fake.GetEndpointStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.getEndpointReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *EndpointClient) GetEndpointCallCount() int {
+	fake.getEndpointMutex.RLock()
+	defer fake.getEndpointMutex.RUnlock()
+	return len(fake.getEndpointArgsForCall)
+}
+
+func (fake *EndpointClient) GetEndpointCalls(stub func(string) (*models.Endpoint, error)) {
+	fake.getEndpointMutex.Lock()
+	defer fake.getEndpointMutex.Unlock()
+	fake.GetEndpointStub = stub
+}
+
+func (fake *EndpointClient) GetEndpointArgsForCall(i int) string {
+	fake.getEndpointMutex.RLock()
+	defer fake.getEndpointMutex.RUnlock()
+	argsForCall := fake.getEndpointArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *EndpointClient) GetEndpointReturns(result1 *models.Endpoint, result2 error) {
+	fake.getEndpointMutex.Lock()
+	defer fake.getEndpointMutex.Unlock()
+	fake.GetEndpointStub = nil
+	fake.getEndpointReturns = struct {
+		result1 *models.Endpoint
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *EndpointClient) GetEndpointReturnsOnCall(i int, result1 *models.Endpoint, result2 error) {
+	fake.getEndpointMutex.Lock()
+	defer fake.getEndpointMutex.Unlock()
+	fake.GetEndpointStub = nil
+	if fake.getEndpointReturnsOnCall == nil {
+		fake.getEndpointReturnsOnCall = make(map[int]struct {
+			result1 *models.Endpoint
+			result2 error
+		})
+	}
+	fake.getEndpointReturnsOnCall[i] = struct {
+		result1 *models.Endpoint
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *EndpointClient) GetEndpointFromAnchorOrigin(arg1 string) (*models.Endpoint, error) {
@@ -91,6 +167,8 @@ func (fake *EndpointClient) GetEndpointFromAnchorOriginReturnsOnCall(i int, resu
 func (fake *EndpointClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.getEndpointMutex.RLock()
+	defer fake.getEndpointMutex.RUnlock()
 	fake.getEndpointFromAnchorOriginMutex.RLock()
 	defer fake.getEndpointFromAnchorOriginMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/pkg/document/updatehandler/decorator/decorator_test.go
+++ b/pkg/document/updatehandler/decorator/decorator_test.go
@@ -45,12 +45,12 @@ func TestOperationDecorator_Decorate(t *testing.T) {
 			PublishedOperations: []*operation.AnchoredOperation{
 				{Type: operation.TypeCreate, UniqueSuffix: suffix, CanonicalReference: "abc"},
 			},
+			AnchorOrigin: anchorOriginDomain,
 		}, nil)
 
 		endpointClient := &mocks.EndpointClient{}
-		endpointClient.GetEndpointFromAnchorOriginReturns(
+		endpointClient.GetEndpointReturns(
 			&models.Endpoint{
-				AnchorOrigin:        anchorOriginDomain,
 				ResolutionEndpoints: []string{fmt.Sprintf("%s/identifiers", anchorOriginDomain)},
 			}, nil)
 
@@ -59,6 +59,7 @@ func TestOperationDecorator_Decorate(t *testing.T) {
 			{Type: operation.TypeCreate, CanonicalReference: "abc"},
 		}
 		methodMetadata[document.PublishedOperationsProperty] = publishedOps
+		methodMetadata[document.AnchorOriginProperty] = anchorOriginDomain
 
 		docMetadata := make(document.Metadata)
 		docMetadata[document.MethodProperty] = methodMetadata
@@ -84,15 +85,15 @@ func TestOperationDecorator_Decorate(t *testing.T) {
 	t.Run("success - operation accepted (local domain equals anchor origin domain)", func(t *testing.T) {
 		processor := &mocks.OperationProcessor{}
 		processor.ResolveReturns(&protocol.ResolutionModel{
+			AnchorOrigin: domain,
 			PublishedOperations: []*operation.AnchoredOperation{
 				{Type: operation.TypeCreate, UniqueSuffix: suffix, CanonicalReference: "abc"},
 			},
 		}, nil)
 
 		endpointClient := &mocks.EndpointClient{}
-		endpointClient.GetEndpointFromAnchorOriginReturns(
+		endpointClient.GetEndpointReturns(
 			&models.Endpoint{
-				AnchorOrigin:        domain,
 				ResolutionEndpoints: []string{fmt.Sprintf("%s/identifiers", domain)},
 			}, nil)
 
@@ -130,12 +131,12 @@ func TestOperationDecorator_Decorate(t *testing.T) {
 			PublishedOperations: []*operation.AnchoredOperation{
 				{Type: operation.TypeCreate, UniqueSuffix: suffix, CanonicalReference: "abc"},
 			},
+			AnchorOrigin: anchorOriginDomain,
 		}, nil)
 
 		endpointClient := &mocks.EndpointClient{}
-		endpointClient.GetEndpointFromAnchorOriginReturns(
+		endpointClient.GetEndpointReturns(
 			&models.Endpoint{
-				AnchorOrigin:        anchorOriginDomain,
 				ResolutionEndpoints: []string{fmt.Sprintf("%s/identifiers", anchorOriginDomain)},
 			}, nil)
 
@@ -177,16 +178,129 @@ func TestOperationDecorator_Decorate(t *testing.T) {
 		require.NotNil(t, op)
 	})
 
-	t.Run("success - endpoint client error (ignored)", func(t *testing.T) {
+	t.Run("error - local anchor origin not a string", func(t *testing.T) {
 		processor := &mocks.OperationProcessor{}
 		processor.ResolveReturns(&protocol.ResolutionModel{
+			AnchorOrigin: 123,
 			PublishedOperations: []*operation.AnchoredOperation{
 				{Type: operation.TypeCreate, UniqueSuffix: suffix, CanonicalReference: "abc"},
 			},
 		}, nil)
 
 		endpointClient := &mocks.EndpointClient{}
-		endpointClient.GetEndpointFromAnchorOriginReturns(nil, fmt.Errorf("endpoint client error"))
+
+		handler := New(namespace, domain, processor, endpointClient, &mocks.RemoteResolver{})
+		require.NotNil(t, handler)
+
+		op, err := handler.Decorate(&operation.Operation{Type: operation.TypeUpdate, UniqueSuffix: suffix})
+		require.Error(t, err)
+		require.Nil(t, op)
+		require.Contains(t, err.Error(), "anchor origin is not a string in local result for suffix[suffix]")
+	})
+
+	t.Run("error - local and remote anchor origin don't match", func(t *testing.T) {
+		processor := &mocks.OperationProcessor{}
+		processor.ResolveReturns(&protocol.ResolutionModel{
+			PublishedOperations: []*operation.AnchoredOperation{
+				{Type: operation.TypeCreate, UniqueSuffix: suffix, CanonicalReference: "abc"},
+			},
+			AnchorOrigin: anchorOriginDomain,
+		}, nil)
+
+		endpointClient := &mocks.EndpointClient{}
+		endpointClient.GetEndpointReturns(
+			&models.Endpoint{
+				ResolutionEndpoints: []string{fmt.Sprintf("%s/identifiers", anchorOriginDomain)},
+			}, nil)
+
+		methodMetadata := make(map[string]interface{})
+		methodMetadata[document.AnchorOriginProperty] = "different.com"
+
+		publishedOps := []metadata.PublishedOperation{
+			{Type: operation.TypeCreate, CanonicalReference: "abc"},
+		}
+		methodMetadata[document.PublishedOperationsProperty] = publishedOps
+
+		docMetadata := make(document.Metadata)
+		docMetadata[document.MethodProperty] = methodMetadata
+
+		doc := make(document.Document)
+		doc["id"] = "id"
+
+		remoteResolver := &mocks.RemoteResolver{}
+		remoteResolver.ResolveDocumentFromResolutionEndpointsReturns(
+			&document.ResolutionResult{
+				Document:         doc,
+				DocumentMetadata: docMetadata,
+			}, nil)
+
+		handler := New(namespace, domain, processor, endpointClient, remoteResolver)
+		require.NotNil(t, handler)
+
+		op, err := handler.Decorate(&operation.Operation{Type: operation.TypeUpdate, UniqueSuffix: suffix})
+		require.Error(t, err)
+		require.Nil(t, op)
+		require.Contains(t, err.Error(),
+			"anchor origin has different anchor origin for this did - please re-submit your request at later time")
+	})
+
+	t.Run("error - remote anchor origin invalid", func(t *testing.T) {
+		processor := &mocks.OperationProcessor{}
+		processor.ResolveReturns(&protocol.ResolutionModel{
+			PublishedOperations: []*operation.AnchoredOperation{
+				{Type: operation.TypeCreate, UniqueSuffix: suffix, CanonicalReference: "abc"},
+			},
+			AnchorOrigin: anchorOriginDomain,
+		}, nil)
+
+		endpointClient := &mocks.EndpointClient{}
+		endpointClient.GetEndpointReturns(
+			&models.Endpoint{
+				ResolutionEndpoints: []string{fmt.Sprintf("%s/identifiers", anchorOriginDomain)},
+			}, nil)
+
+		methodMetadata := make(map[string]interface{})
+		methodMetadata[document.AnchorOriginProperty] = 123
+
+		publishedOps := []metadata.PublishedOperation{
+			{Type: operation.TypeCreate, CanonicalReference: "abc"},
+		}
+		methodMetadata[document.PublishedOperationsProperty] = publishedOps
+
+		docMetadata := make(document.Metadata)
+		docMetadata[document.MethodProperty] = methodMetadata
+
+		doc := make(document.Document)
+		doc["id"] = "id"
+
+		remoteResolver := &mocks.RemoteResolver{}
+		remoteResolver.ResolveDocumentFromResolutionEndpointsReturns(
+			&document.ResolutionResult{
+				Document:         doc,
+				DocumentMetadata: docMetadata,
+			}, nil)
+
+		handler := New(namespace, domain, processor, endpointClient, remoteResolver)
+		require.NotNil(t, handler)
+
+		op, err := handler.Decorate(&operation.Operation{Type: operation.TypeUpdate, UniqueSuffix: suffix})
+		require.Error(t, err)
+		require.Nil(t, op)
+		require.Contains(t, err.Error(),
+			"failed to retrieve DID's anchor origin from anchor origin domain: anchor origin property is not a string")
+	})
+
+	t.Run("success - endpoint client error (ignored)", func(t *testing.T) {
+		processor := &mocks.OperationProcessor{}
+		processor.ResolveReturns(&protocol.ResolutionModel{
+			AnchorOrigin: anchorOriginDomain,
+			PublishedOperations: []*operation.AnchoredOperation{
+				{Type: operation.TypeCreate, UniqueSuffix: suffix, CanonicalReference: "abc"},
+			},
+		}, nil)
+
+		endpointClient := &mocks.EndpointClient{}
+		endpointClient.GetEndpointReturns(nil, fmt.Errorf("endpoint client error"))
 
 		handler := New(namespace, domain, processor, endpointClient, &mocks.RemoteResolver{})
 		require.NotNil(t, handler)
@@ -209,65 +323,24 @@ func TestOperationDecorator_Decorate(t *testing.T) {
 		require.Contains(t, err.Error(), "operation processor error")
 	})
 
-	t.Run("success - remote resolver error", func(t *testing.T) {
-		processor := &mocks.OperationProcessor{}
-		processor.ResolveReturns(&protocol.ResolutionModel{
-			PublishedOperations: []*operation.AnchoredOperation{
-				{Type: operation.TypeCreate, UniqueSuffix: suffix, CanonicalReference: "abc"},
-			},
-		}, nil)
-
-		endpointClient := &mocks.EndpointClient{}
-		endpointClient.GetEndpointFromAnchorOriginReturns(
-			&models.Endpoint{
-				AnchorOrigin:        anchorOriginDomain,
-				ResolutionEndpoints: []string{fmt.Sprintf("%s/identifiers", anchorOriginDomain)},
-			}, nil)
-
-		publishedOps := []metadata.PublishedOperation{
-			{Type: operation.TypeCreate, CanonicalReference: "abc"},
-		}
-
-		methodMetadata := make(map[string]interface{})
-		methodMetadata[document.PublishedOperationsProperty] = publishedOps
-
-		docMetadata := make(document.Metadata)
-		docMetadata[document.MethodProperty] = methodMetadata
-
-		doc := make(document.Document)
-		doc["id"] = "id"
-
-		remoteResolver := &mocks.RemoteResolver{}
-		remoteResolver.ResolveDocumentFromResolutionEndpointsReturns(
-			&document.ResolutionResult{
-				Document:         doc,
-				DocumentMetadata: docMetadata,
-			}, nil)
-
-		handler := New(namespace, domain, processor, endpointClient, remoteResolver)
-		require.NotNil(t, handler)
-
-		op, err := handler.Decorate(&operation.Operation{UniqueSuffix: suffix})
-		require.NoError(t, err)
-		require.NotNil(t, op)
-	})
-
 	t.Run("error - anchor origin has additional operations", func(t *testing.T) {
 		processor := &mocks.OperationProcessor{}
 		processor.ResolveReturns(&protocol.ResolutionModel{
 			PublishedOperations: []*operation.AnchoredOperation{
 				{Type: operation.TypeCreate, UniqueSuffix: suffix, CanonicalReference: "abc"},
 			},
+			AnchorOrigin: anchorOriginDomain,
 		}, nil)
 
 		endpointClient := &mocks.EndpointClient{}
-		endpointClient.GetEndpointFromAnchorOriginReturns(
+		endpointClient.GetEndpointReturns(
 			&models.Endpoint{
-				AnchorOrigin:        anchorOriginDomain,
 				ResolutionEndpoints: []string{fmt.Sprintf("%s/identifiers", anchorOriginDomain)},
 			}, nil)
 
 		methodMetadata := make(map[string]interface{})
+		methodMetadata[document.AnchorOriginProperty] = anchorOriginDomain
+
 		publishedOps := []metadata.PublishedOperation{
 			{Type: operation.TypeCreate, CanonicalReference: "abc", TransactionTime: 1},
 			{Type: operation.TypeUpdate, CanonicalReference: "xyz", TransactionTime: 2},
@@ -301,16 +374,18 @@ func TestOperationDecorator_Decorate(t *testing.T) {
 		processor := &mocks.OperationProcessor{}
 		processor.ResolveReturns(&protocol.ResolutionModel{
 			PublishedOperations: []*operation.AnchoredOperation{{}},
+			AnchorOrigin:        anchorOriginDomain,
 		}, nil)
 
 		endpointClient := &mocks.EndpointClient{}
-		endpointClient.GetEndpointFromAnchorOriginReturns(
+		endpointClient.GetEndpointReturns(
 			&models.Endpoint{
-				AnchorOrigin:        anchorOriginDomain,
 				ResolutionEndpoints: []string{fmt.Sprintf("%s/identifiers", anchorOriginDomain)},
 			}, nil)
 
 		methodMetadata := make(map[string]interface{})
+		methodMetadata[document.AnchorOriginProperty] = anchorOriginDomain
+
 		unpublishedOps := []metadata.UnpublishedOperation{{Type: operation.TypeUpdate}}
 		methodMetadata[document.UnpublishedOperationsProperty] = unpublishedOps
 
@@ -340,18 +415,19 @@ func TestOperationDecorator_Decorate(t *testing.T) {
 			"anchor origin has unpublished operations - please re-submit your request at later time")
 	})
 
-	t.Run("error - internal server error", func(t *testing.T) {
+	t.Run("error - internal server error(local server has no published operations)", func(t *testing.T) {
 		processor := &mocks.OperationProcessor{}
-		processor.ResolveReturns(&protocol.ResolutionModel{}, nil)
+		processor.ResolveReturns(&protocol.ResolutionModel{AnchorOrigin: anchorOriginDomain}, nil)
 
 		endpointClient := &mocks.EndpointClient{}
-		endpointClient.GetEndpointFromAnchorOriginReturns(
+		endpointClient.GetEndpointReturns(
 			&models.Endpoint{
-				AnchorOrigin:        anchorOriginDomain,
 				ResolutionEndpoints: []string{fmt.Sprintf("%s/identifiers", anchorOriginDomain)},
 			}, nil)
 
 		methodMetadata := make(map[string]interface{})
+		methodMetadata[document.AnchorOriginProperty] = anchorOriginDomain
+
 		unpublishedOps := []metadata.UnpublishedOperation{{Type: operation.TypeUpdate}}
 		methodMetadata[document.UnpublishedOperationsProperty] = unpublishedOps
 
@@ -382,16 +458,17 @@ func TestOperationDecorator_Decorate(t *testing.T) {
 
 	t.Run("success - no published operations from anchor origin", func(t *testing.T) {
 		processor := &mocks.OperationProcessor{}
-		processor.ResolveReturns(&protocol.ResolutionModel{}, nil)
+		processor.ResolveReturns(&protocol.ResolutionModel{AnchorOrigin: anchorOriginDomain}, nil)
 
 		endpointClient := &mocks.EndpointClient{}
-		endpointClient.GetEndpointFromAnchorOriginReturns(
+		endpointClient.GetEndpointReturns(
 			&models.Endpoint{
-				AnchorOrigin:        anchorOriginDomain,
 				ResolutionEndpoints: []string{fmt.Sprintf("%s/identifiers", anchorOriginDomain)},
 			}, nil)
 
 		methodMetadata := make(map[string]interface{})
+		methodMetadata[document.AnchorOriginProperty] = anchorOriginDomain
+
 		unpublishedOps := []metadata.UnpublishedOperation{{Type: operation.TypeUpdate}}
 		methodMetadata[document.UnpublishedOperationsProperty] = unpublishedOps
 

--- a/pkg/document/util/util.go
+++ b/pkg/document/util/util.go
@@ -114,6 +114,26 @@ func GetMethodMetadata(metadata document.Metadata) (map[string]interface{}, erro
 	}
 }
 
+// GetAnchorOrigin returns anchor origin from document metadata.
+func GetAnchorOrigin(metadata document.Metadata) (string, error) {
+	methodMeta, err := GetMethodMetadata(metadata)
+	if err != nil {
+		return "", err
+	}
+
+	anchorOriginObj, ok := methodMeta[document.AnchorOriginProperty]
+	if !ok {
+		return "", fmt.Errorf("missing anchor origin property in method metadata")
+	}
+
+	anchorOrigin, ok := anchorOriginObj.(string)
+	if !ok {
+		return "", fmt.Errorf("anchor origin property is not a string")
+	}
+
+	return anchorOrigin, nil
+}
+
 func getOperationsByKey(methodMetadata map[string]interface{}, key string) ([]*operation.AnchoredOperation, error) {
 	opsObj, ok := methodMetadata[key]
 	if !ok {

--- a/pkg/document/util/util_test.go
+++ b/pkg/document/util/util_test.go
@@ -60,6 +60,53 @@ func TestBetweenStrings(t *testing.T) {
 	})
 }
 
+func TestGetAnchorOrigin(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		methodMetadata := make(map[string]interface{})
+		methodMetadata[document.AnchorOriginProperty] = "domain.com"
+
+		docMetadata := make(document.Metadata)
+		docMetadata[document.MethodProperty] = methodMetadata
+
+		anchorOrigin, err := GetAnchorOrigin(docMetadata)
+		require.NoError(t, err)
+		require.Equal(t, "domain.com", anchorOrigin)
+	})
+
+	t.Run("error - missing method metadata", func(t *testing.T) {
+		docMetadata := make(document.Metadata)
+
+		anchorOrigin, err := GetAnchorOrigin(docMetadata)
+		require.Error(t, err)
+		require.Empty(t, anchorOrigin)
+		require.Equal(t, "missing method metadata", err.Error())
+	})
+
+	t.Run("error - missing anchor origin", func(t *testing.T) {
+		methodMetadata := make(map[string]interface{})
+		docMetadata := make(document.Metadata)
+		docMetadata[document.MethodProperty] = methodMetadata
+
+		anchorOrigin, err := GetAnchorOrigin(docMetadata)
+		require.Error(t, err)
+		require.Empty(t, anchorOrigin)
+		require.Equal(t, "missing anchor origin property in method metadata", err.Error())
+	})
+
+	t.Run("error - wrong type for anchor origin", func(t *testing.T) {
+		methodMetadata := make(map[string]interface{})
+		methodMetadata[document.AnchorOriginProperty] = 123
+
+		docMetadata := make(document.Metadata)
+		docMetadata[document.MethodProperty] = methodMetadata
+
+		anchorOrigin, err := GetAnchorOrigin(docMetadata)
+		require.Error(t, err)
+		require.Empty(t, anchorOrigin)
+		require.Equal(t, "anchor origin property is not a string", err.Error())
+	})
+}
+
 func TestGetOperations(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		methodMetadata := make(map[string]interface{})

--- a/test/bdd/did_orb_steps.go
+++ b/test/bdd/did_orb_steps.go
@@ -355,6 +355,7 @@ func removeKeysAfterCommitment(keys []*ecdsa.PrivateKey, cmt string) ([]*ecdsa.P
 		}
 
 		if c == cmt {
+			logger.Infof("found key index '%d' of %d keys that corresponds to last successful commitment '%s'", index, len(keys), cmt)
 			return keys[:index+1], nil
 		}
 	}
@@ -564,7 +565,7 @@ func (d *DIDOrbSteps) removeServiceEndpointsFromDIDDocument(url, keyID string) e
 
 func (d *DIDOrbSteps) checkErrorResp(errorMsg string) error {
 	if !strings.Contains(d.resp.ErrorMsg, errorMsg) {
-		return fmt.Errorf(`error resp "%s" doesn't contain "%s"`, d.resp.ErrorMsg, errorMsg)
+		return fmt.Errorf(`error resp "%s" doesn't contain "%s" status: %d`, d.resp.ErrorMsg, errorMsg, d.resp.StatusCode)
 	}
 	return nil
 }
@@ -580,7 +581,7 @@ func (d *DIDOrbSteps) checkSuccessRespDoesntContain(msg string) error {
 func (d *DIDOrbSteps) checkSuccessResp(msg string, contains bool) error {
 	var err error
 
-	const maxRetries = 10
+	const maxRetries = 5
 
 	for i := 1; i <= maxRetries; i++ {
 		err = d.checkSuccessRespHelper(msg, contains)
@@ -593,7 +594,7 @@ func (d *DIDOrbSteps) checkSuccessResp(msg string, contains bool) error {
 			return err
 		}
 
-		time.Sleep(3 * time.Second)
+		time.Sleep(2 * time.Second)
 		logger.Infof("retrying check success response - attempt %d", i)
 
 		resolveErr := d.resolveDIDDocumentWithID(d.sidetreeURL, d.retryDID)


### PR DESCRIPTION
 We should use local knowledge of anchor origin instead of parsing batch files that have already been processed by local server. 

If there was an anchor origin change (anchor origin domain returned different anchor origin for DID) then we will:
- return local result during resolution 
- reject "update", "recover" and "deactivate" operations

Closes #882

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>