### PR TITLE
refactor: Created generic task scheduling service.

### DIFF
--- a/pkg/internal/testutil/mongodbtestutil/mongodbtestutil.go
+++ b/pkg/internal/testutil/mongodbtestutil/mongodbtestutil.go
@@ -1,0 +1,122 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mongodbtestutil
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	dctest "github.com/ory/dockertest/v3"
+	dc "github.com/ory/dockertest/v3/docker"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const startingPort = 27016
+
+var currentPort uint32 = startingPort //nolint:gochecknoglobals
+
+// StartMongoDB starts a MongoDB Docker container. The connection string is returned,
+// as well as a function that should be invoked to stop the Docker container when it is
+// no longer required.
+func StartMongoDB(t *testing.T) (connection string, stop func()) {
+	t.Helper()
+
+	pool, mongoDBResource, mongoDBConnString := startMongoDBContainer(t)
+
+	return mongoDBConnString, func() {
+		if pool != nil && mongoDBResource != nil {
+			require.NoError(t, pool.Purge(mongoDBResource))
+		}
+	}
+}
+
+func startMongoDBContainer(t *testing.T) (*dctest.Pool, *dctest.Resource, string) {
+	t.Helper()
+
+	pool, err := dctest.NewPool("")
+	require.NoError(t, err)
+
+	const maxAttempts = 3
+
+	for i := 0; i < maxAttempts; i++ {
+		// Always use a new port since the tests periodically complain about port already in use.
+		port := newPort()
+
+		mongoDBResource, err := pool.RunWithOptions(&dctest.RunOptions{
+			Repository: "mongo",
+			Tag:        "4.0.0",
+			PortBindings: map[dc.Port][]dc.PortBinding{
+				"27017/tcp": {
+					{HostIP: "", HostPort: fmt.Sprintf("%d", port)},
+				},
+			},
+		})
+		if err != nil {
+			if strings.Contains(err.Error(), "port is already allocated") {
+				t.Logf("Got error. Trying on another port: %s", err)
+
+				continue
+			}
+
+			t.Fatalf("Unable to start Docker container: %s", err)
+		}
+
+		connectionString := fmt.Sprintf("mongodb://localhost:%d", port)
+
+		require.NoError(t, waitForMongoDBToBeUp(t, connectionString))
+
+		return pool, mongoDBResource, connectionString
+	}
+
+	panic(fmt.Sprintf("Unable to start Docker container after %d attempts", maxAttempts))
+}
+
+func waitForMongoDBToBeUp(t *testing.T, mongoDBConnString string) error {
+	t.Helper()
+
+	return backoff.Retry(func() error {
+		t.Logf("Failed to ping MongoDB at %s. Retrying.", mongoDBConnString)
+
+		return pingMongoDB(t, mongoDBConnString)
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second), 5))
+}
+
+func pingMongoDB(t *testing.T, mongoDBConnString string) error {
+	t.Helper()
+
+	var err error
+
+	mongoClient, err := mongo.NewClient(options.Client().ApplyURI(mongoDBConnString))
+	if err != nil {
+		return err
+	}
+
+	err = mongoClient.Connect(context.Background())
+	if err != nil {
+		return err
+	}
+
+	db := mongoClient.Database("test")
+
+	const pingTimeout = 3 * time.Second
+
+	ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
+	defer cancel()
+
+	return db.Client().Ping(ctx, nil)
+}
+
+func newPort() uint32 {
+	return atomic.AddUint32(&currentPort, 1)
+}

--- a/pkg/internal/testutil/testutil.go
+++ b/pkg/internal/testutil/testutil.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/trustbloc/orb/internal/pkg/ldcontext"
 	"github.com/trustbloc/orb/pkg/store/expiry"
+	"github.com/trustbloc/orb/pkg/taskmgr"
 )
 
 // MustParseURL parses the given string and returns the URL.
@@ -104,8 +105,12 @@ func GetLoader(t *testing.T) *ld.DocumentLoader {
 func GetExpiryService(t *testing.T) *expiry.Service {
 	t.Helper()
 
+	const checkInterval = 500 * time.Millisecond
+
 	coordinationStore, err := mem.NewProvider().OpenStore("coordination")
 	require.NoError(t, err)
 
-	return expiry.NewService(time.Second, coordinationStore, "TestInstanceID")
+	taskMgr := taskmgr.New(coordinationStore, checkInterval)
+
+	return expiry.NewService(taskMgr, time.Second)
 }

--- a/pkg/protocolversion/versions/v1_0/factory/factory_test.go
+++ b/pkg/protocolversion/versions/v1_0/factory/factory_test.go
@@ -23,7 +23,6 @@ import (
 	orbmocks "github.com/trustbloc/orb/pkg/mocks"
 	"github.com/trustbloc/orb/pkg/protocolversion/mocks"
 	"github.com/trustbloc/orb/pkg/store/cas"
-	"github.com/trustbloc/orb/pkg/store/expiry"
 	storemocks "github.com/trustbloc/orb/pkg/store/mocks"
 	unpublishedopstore "github.com/trustbloc/orb/pkg/store/operation/unpublished"
 	webfingerclient "github.com/trustbloc/orb/pkg/webfinger/client"
@@ -45,11 +44,8 @@ func TestFactory_Create(t *testing.T) {
 	})
 
 	t.Run("success - with update store config", func(t *testing.T) {
-		coordinationStore, err := mem.NewProvider().OpenStore("coordination")
-		require.NoError(t, err)
-
 		updateDocumentStore, err := unpublishedopstore.New(storeProvider, time.Minute,
-			expiry.NewService(time.Millisecond, coordinationStore, "InstanceID"))
+			testutil.GetExpiryService(t))
 		require.NoError(t, err)
 
 		cfg := &config.Sidetree{

--- a/pkg/store/operation/unpublished/store_test.go
+++ b/pkg/store/operation/unpublished/store_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 
 	"github.com/trustbloc/orb/pkg/internal/testutil"
-	"github.com/trustbloc/orb/pkg/store/expiry"
 )
 
 func TestNew(t *testing.T) {
@@ -53,11 +52,8 @@ func TestStore_Put(t *testing.T) {
 			ErrGet: storage.ErrDataNotFound,
 		}}
 
-		coordinationStore, err := mem.NewProvider().OpenStore("coordination")
-		require.NoError(t, err)
-
 		s, err := New(storeProvider, time.Minute,
-			expiry.NewService(time.Millisecond, coordinationStore, "InstanceID"))
+			testutil.GetExpiryService(t))
 		require.NoError(t, err)
 
 		err = s.Put(&operation.AnchoredOperation{UniqueSuffix: "suffix"})

--- a/pkg/store/witness/witness_test.go
+++ b/pkg/store/witness/witness_test.go
@@ -8,34 +8,29 @@ package witness
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
 	"testing"
 	"time"
 
-	backoff "github.com/cenkalti/backoff/v4"
 	"github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb"
 	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
 	"github.com/hyperledger/aries-framework-go/spi/storage"
-	dctest "github.com/ory/dockertest/v3"
-	dc "github.com/ory/dockertest/v3/docker"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"github.com/trustbloc/orb/pkg/anchor/witness/proof"
 	"github.com/trustbloc/orb/pkg/internal/testutil"
+	"github.com/trustbloc/orb/pkg/internal/testutil/mongodbtestutil"
+	"github.com/trustbloc/orb/pkg/store/expiry"
 	"github.com/trustbloc/orb/pkg/store/mocks"
+	"github.com/trustbloc/orb/pkg/taskmgr"
 )
 
 const (
 	anchorID = "id"
 
 	expiryTime = 10 * time.Second
-
-	mongoDBConnString = "mongodb://localhost:27017"
 )
 
 func TestNew(t *testing.T) {
@@ -567,28 +562,25 @@ func TestStore_HandleExpiryKeys(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("success", func(t *testing.T) {
-		err := pingMongoDB()
-		if err != nil {
-			pool, mongoDBResource := startMongoDBContainer(t)
-
-			defer func() {
-				if pool != nil && mongoDBResource != nil {
-					require.NoError(t, pool.Purge(mongoDBResource), "failed to purge MongoDB resource")
-				}
-			}()
-		}
+		mongoDBConnString, stopMongo := mongodbtestutil.StartMongoDB(t)
+		defer stopMongo()
 
 		mongoDBProvider, err := mongodb.NewProvider(mongoDBConnString)
 		require.NoError(t, err)
 
-		expiryService := testutil.GetExpiryService(t)
+		coordinationStore, err := mem.NewProvider().OpenStore("coordination")
+		require.NoError(t, err)
+
+		taskMgr := taskmgr.New(coordinationStore, 500*time.Millisecond)
+
+		expiryService := expiry.NewService(taskMgr, time.Second)
 
 		s, err := New(mongoDBProvider, expiryService, time.Second)
 		require.NoError(t, err)
 
 		s.delta = time.Second
 
-		expiryService.Start()
+		taskMgr.Start()
 
 		err = s.Put(anchorID, []*proof.Witness{getTestWitness(testWitnessURL)})
 		require.NoError(t, err)
@@ -623,53 +615,6 @@ func TestStore_HandleExpiryKeys(t *testing.T) {
 		err = s.HandleExpiredKeys("key")
 		require.NoError(t, err)
 	})
-}
-
-func startMongoDBContainer(t *testing.T) (*dctest.Pool, *dctest.Resource) {
-	t.Helper()
-
-	pool, err := dctest.NewPool("")
-	require.NoError(t, err)
-
-	mongoDBResource, err := pool.RunWithOptions(&dctest.RunOptions{
-		Repository: "mongo",
-		Tag:        "4.0.0",
-		PortBindings: map[dc.Port][]dc.PortBinding{
-			"27017/tcp": {{HostIP: "", HostPort: "27017"}},
-		},
-	})
-	require.NoError(t, err)
-
-	require.NoError(t, waitForMongoDBToBeUp())
-
-	return pool, mongoDBResource
-}
-
-func waitForMongoDBToBeUp() error {
-	return backoff.Retry(pingMongoDB, backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second), 30))
-}
-
-func pingMongoDB() error {
-	var err error
-
-	clientOpts := options.Client().ApplyURI(mongoDBConnString)
-
-	mongoClient, err := mongo.NewClient(clientOpts)
-	if err != nil {
-		return err
-	}
-
-	err = mongoClient.Connect(context.Background())
-	if err != nil {
-		return err
-	}
-
-	db := mongoClient.Database("test")
-
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
-
-	return db.Client().Ping(ctx, nil)
 }
 
 func getTestWitness(witnessURI *url.URL) *proof.Witness {

--- a/pkg/taskmgr/taskmgr.go
+++ b/pkg/taskmgr/taskmgr.go
@@ -1,0 +1,309 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package taskmgr
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hyperledger/aries-framework-go/spi/storage"
+	"github.com/trustbloc/edge-core/pkg/log"
+
+	"github.com/trustbloc/orb/pkg/lifecycle"
+)
+
+const (
+	loggerModule          = "task-manager"
+	coordinationPermitKey = "task-permit"
+	defaultCheckInterval  = 10 * time.Second
+)
+
+type logger interface {
+	Debugf(msg string, args ...interface{})
+	Infof(msg string, args ...interface{})
+	Warnf(msg string, args ...interface{})
+	Errorf(msg string, args ...interface{})
+}
+
+type status = string
+
+const (
+	statusIdle    status = "idle"
+	statusRunning status = "running"
+)
+
+// permit is used as an entry within the coordination store to ensure that only one Orb instance
+// within a cluster has the duty of running tasks periodically.
+type permit struct {
+	// TaskID is the ID of the task that is being run.
+	TaskID string `json:"task_id"`
+	// CurrentHolder indicates which Orb server currently has the responsibility.
+	CurrentHolder string `json:"currentHolder"`
+	// Status indicates the current status (idle or running).
+	Status string `json:"status"`
+	// UpdatedTime indicates when the status was last updated.
+	UpdatedTime int64 `json:"updateTime"` // This is a Unix timestamp.
+}
+
+// Manager manages scheduled tasks which are run by exactly one server instance in an Orb domain.
+type Manager struct {
+	*lifecycle.Lifecycle
+
+	interval          time.Duration
+	tasks             map[string]*registration
+	done              chan struct{}
+	logger            logger
+	coordinationStore storage.Store
+	instanceID        string
+	mutex             sync.RWMutex
+}
+
+// New returns a new task manager.
+// coordinationStore is used for ensuring that only one Orb instance within a cluster has the duty of running scheduled
+// tasks (in order to avoid every instance doing the same work, which is wasteful). Every Orb instance
+// within the cluster needs to be connected to the same database for it to work correctly. Note that when initializing
+// Orb servers (or if the Orb server with the duty goes down) it is possible for multiple Orb instances to briefly
+// assign themselves the duty, but only for one round. This will automatically be resolved on
+// the next check and only one will end up with the duty from that point on. This situation should not be of concern
+// since a task should expect this situation.
+// You must register each task you want this service to run on using the Register method.
+// Start must be called to start the service and Stop should be called to stop it.
+func New(coordinationStore storage.Store, interval time.Duration) *Manager {
+	if interval <= 0 {
+		interval = defaultCheckInterval
+	}
+
+	s := &Manager{
+		interval:          interval,
+		done:              make(chan struct{}),
+		logger:            log.New(loggerModule),
+		coordinationStore: coordinationStore,
+		instanceID:        uuid.New().String(),
+		tasks:             make(map[string]*registration),
+	}
+
+	s.Lifecycle = lifecycle.New("task-manager",
+		lifecycle.WithStart(s.start),
+		lifecycle.WithStop(s.stop))
+
+	return s
+}
+
+// RegisterTask registers a task to be periodically run at the given interval. A task is considered to have been
+// running too long if the run time exceeds the given maxRunTime, at which point another server instance may take
+// over the duty of running tasks.
+func (s *Manager) RegisterTask(id string, interval, maxRunTime time.Duration, task func()) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.tasks[id] = &registration{
+		handle:     task,
+		id:         id,
+		interval:   interval,
+		maxRunTime: maxRunTime,
+	}
+}
+
+func (s *Manager) getTasks() []*registration {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	var tasks []*registration
+
+	for _, t := range s.tasks {
+		tasks = append(tasks, t)
+	}
+
+	return tasks
+}
+
+func (s *Manager) start() {
+	go func() {
+		s.logger.Infof("Started task manager.")
+
+		for {
+			select {
+			case <-time.After(s.interval):
+				for _, t := range s.getTasks() {
+					s.run(t)
+				}
+			case <-s.done:
+				s.logger.Debugf("Stopped task manager.")
+
+				return
+			}
+		}
+	}()
+}
+
+func (s *Manager) stop() {
+	close(s.done)
+}
+
+func (s *Manager) run(t *registration) {
+	if t.isRunning() {
+		s.logger.Debugf("Task is already running [%s]", t.id)
+
+		return
+	}
+
+	ok, err := s.shouldRun(t)
+	if err != nil {
+		s.logger.Warnf("An error occurred while checking if task [%s] should run: %s", t.id, err)
+
+		return
+	}
+
+	if !ok {
+		s.logger.Debugf("Not running task [%s]", t.id)
+
+		return
+	}
+
+	err = s.updatePermit(t.id, statusRunning)
+	if err != nil {
+		s.logger.Errorf("Failed to update permit for task [%s]: %s", t.id, err.Error())
+
+		return
+	}
+
+	// Run the task in a new Go routine.
+
+	go func(t *registration) {
+		s.logger.Debugf("Running task [%s]", t.id)
+
+		t.run()
+
+		err := s.updatePermit(t.id, statusIdle)
+		if err != nil {
+			s.logger.Errorf("Failed to update permit: %s", err.Error())
+		}
+
+		s.logger.Debugf("Finished running task [%s]", t.id)
+	}(t)
+}
+
+func (s *Manager) shouldRun(t *registration) (bool, error) {
+	currentPermitBytes, err := s.coordinationStore.Get(getPermitKey(t.id))
+	if err != nil {
+		if errors.Is(err, storage.ErrDataNotFound) {
+			s.logger.Infof("[%s] No existing permit found for task [%s]. I will take on the duty of running the task.",
+				s.instanceID, t.id)
+
+			return true, nil
+		}
+
+		return false, fmt.Errorf("get permit from DB for task [%s]: %w", t.id, err)
+	}
+
+	var currentPermit permit
+
+	err = json.Unmarshal(currentPermitBytes, &currentPermit)
+	if err != nil {
+		return false, fmt.Errorf("unmarshal permit for task [%s]: %w", t.id, err)
+	}
+
+	timeOfLastCleanup := time.Unix(currentPermit.UpdatedTime, 0)
+
+	// Time.Since uses Time.Now() to determine the current time to a fine degree of precision. Here we are checking the
+	// time since a specific Unix timestamp, which is a value that is effectively truncated to the nearest second.
+	// Thus, the result of this calculation should also be truncated down to the nearest second since that's all the
+	// precision we have. This also makes the log statements look cleaner since it won't display an excessive amount
+	// of (meaningless) precision.
+	timeSinceLastUpdate := time.Since(timeOfLastCleanup).Truncate(time.Second)
+
+	if currentPermit.CurrentHolder == s.instanceID {
+		if timeSinceLastUpdate < t.interval {
+			s.logger.Debugf("It's currently my duty to run task [%s] but it's not time to run the task since "+
+				"I last did this %s ago and the interval for this task is %s.", t.id, timeSinceLastUpdate, t.interval)
+
+			return false, nil
+		}
+
+		s.logger.Debugf("It's currently my duty to run task [%s]. I last did this %s ago. I will "+
+			"run the task and then update the permit timestamp.", t.id, timeSinceLastUpdate)
+
+		return true, nil
+	}
+
+	// The idea here is to only take away the task running responsibilities from the current permit holder if it's
+	// been an unusually long time since the current permit holder has performed a successful run. If that happens
+	// then it indicates that the other Orb server with the permit is down, so someone else needs to grab the permit
+	// and take over the duty of running scheduled tasks. Note that the assumption here is that all Orb servers
+	// within the cluster have the same interval setting (which they should).
+	if timeSinceLastUpdate > t.maxRunTime {
+		s.logger.Infof("The current permit holder (%s) for task [%s] has not performed a run in an "+
+			"unusually long time (%s ago which is longer than the configured maximum run time of %s). This indicates "+
+			"that %s may be down or not responding. I will take over and grab the permit.",
+			currentPermit.CurrentHolder, t.id, timeSinceLastUpdate, t.maxRunTime, currentPermit.CurrentHolder)
+
+		return true, nil
+	}
+
+	s.logger.Debugf("I will not run task [%s] since %s currently has the duty and did it recently "+
+		"(%s ago).", t.id, currentPermit.CurrentHolder, timeSinceLastUpdate.String())
+
+	return false, nil
+}
+
+func (s *Manager) updatePermit(taskID string, status status) error {
+	s.logger.Debugf("[%s] Updating the permit for task [%s] with the current time and status [%s].",
+		s.instanceID, taskID, status)
+
+	p := permit{
+		TaskID:        taskID,
+		CurrentHolder: s.instanceID,
+		Status:        status,
+		UpdatedTime:   time.Now().Unix(),
+	}
+
+	permitBytes, err := json.Marshal(p)
+	if err != nil {
+		return fmt.Errorf("failed to marshal permit: %w", err)
+	}
+
+	err = s.coordinationStore.Put(getPermitKey(taskID), permitBytes)
+	if err != nil {
+		return fmt.Errorf("failed to store permit: %w", err)
+	}
+
+	s.logger.Debugf("Permit successfully updated for task [%s] with status [%s].", taskID, status)
+
+	return nil
+}
+
+func getPermitKey(taskID string) string {
+	return coordinationPermitKey + "_" + taskID
+}
+
+type registration struct {
+	handle     func()
+	running    uint32
+	id         string
+	interval   time.Duration
+	maxRunTime time.Duration
+}
+
+func (r *registration) run() {
+	if !atomic.CompareAndSwapUint32(&r.running, 0, 1) {
+		// Already running.
+		return
+	}
+
+	r.handle()
+
+	atomic.StoreUint32(&r.running, 0)
+}
+
+func (r *registration) isRunning() bool {
+	return atomic.LoadUint32(&r.running) == 1
+}

--- a/pkg/taskmgr/taskmgr_test.go
+++ b/pkg/taskmgr/taskmgr_test.go
@@ -1,0 +1,238 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package taskmgr
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb"
+	"github.com/hyperledger/aries-framework-go/component/storageutil/mock"
+	"github.com/hyperledger/aries-framework-go/spi/storage"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/edge-core/pkg/log"
+
+	"github.com/trustbloc/orb/pkg/internal/testutil/mongodbtestutil"
+)
+
+// Logs to a string that can be read later and also (optionally) logs to another logger.
+type stringLogger struct {
+	// If passthroughLogger is set, then log statements will also be passed through here so they can also be
+	// displayed in the console during the test.
+	passthroughLogger logger
+	log               string
+	lock              sync.Mutex
+}
+
+func (s *stringLogger) Debugf(msg string, args ...interface{}) {
+	if s.passthroughLogger != nil {
+		s.passthroughLogger.Debugf(msg, args...)
+	}
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.log += fmt.Sprintf(msg, args...)
+}
+
+func (s *stringLogger) Infof(msg string, args ...interface{}) {
+	if s.passthroughLogger != nil {
+		s.passthroughLogger.Infof(msg, args...)
+	}
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.log += fmt.Sprintf(msg, args...)
+}
+
+func (s *stringLogger) Warnf(msg string, args ...interface{}) {
+	if s.passthroughLogger != nil {
+		s.passthroughLogger.Warnf(msg, args...)
+	}
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.log += fmt.Sprintf(msg, args...)
+}
+
+func (s *stringLogger) Errorf(msg string, args ...interface{}) {
+	if s.passthroughLogger != nil {
+		s.passthroughLogger.Errorf(msg, args...)
+	}
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.log += fmt.Sprintf(msg, args...)
+}
+
+func (s *stringLogger) Read() string {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	return s.log
+}
+
+func TestService(t *testing.T) {
+	t.Run("Success, using multiple running services to "+
+		"simulate multiple Orb servers within a cluster. One fails part way through and the other "+
+		"takes over", func(t *testing.T) {
+		mongoDBConnString, stopMongo := mongodbtestutil.StartMongoDB(t)
+		defer stopMongo()
+
+		mongoDBProvider, err := mongodb.NewProvider(mongoDBConnString)
+		require.NoError(t, err)
+
+		defer func() {
+			require.NoError(t, mongoDBProvider.Close())
+		}()
+
+		coordinationStore, err := mongoDBProvider.OpenStore("orb-config")
+		require.NoError(t, err)
+
+		taskMgr1, taskMgr2 := getTestExpiryServices(t, coordinationStore)
+
+		taskMgr1.Start()
+
+		// Wait a second so that we can ensure that task manager 1 gets the permit and assigns itself the responsibility
+		// of running tasks. At the end of the test, we will be stopping task manager 1 and checking to
+		// see that task manager 2 is able to take over.
+		time.Sleep(time.Second)
+
+		require.Contains(t, taskMgr1.logger.(*stringLogger).Read(), "Running test-task in task manager 1")
+		require.NotContains(t, taskMgr2.logger.(*stringLogger).Read(), "Running test-task in task manager 2")
+
+		taskMgr2.Start()
+
+		// Wait for the task to run again in task manager 1.
+		time.Sleep(2 * time.Second)
+
+		// Stop task manager 1 and wait for task manager 2 to take over.
+		taskMgr1.Stop()
+
+		time.Sleep(3 * time.Second)
+
+		require.Contains(t, taskMgr2.logger.(*stringLogger).Read(), "Running test-task in task manager 2")
+
+		taskMgr2.Stop()
+	})
+
+	t.Run("Unexpected failure while getting the permit from the coordination store", func(t *testing.T) {
+		coordinationStore := &mock.Store{
+			ErrGet: errors.New("get error"),
+		}
+
+		taskMgr := New(coordinationStore, time.Millisecond)
+
+		taskMgr.RegisterTask("test-task", time.Millisecond, time.Millisecond, func() {
+			t.Logf("Running test-task")
+		})
+
+		logger := &stringLogger{}
+
+		taskMgr.logger = logger
+
+		taskMgr.Start()
+		defer taskMgr.Stop()
+
+		ensureLogContainsMessage(t, logger, "get permit from DB for task [test-task]: get error")
+	})
+
+	t.Run("Fail to unmarshal permit", func(t *testing.T) {
+		coordinationStore := &mock.Store{
+			GetReturn: []byte("not a valid expiredDataCleanupPermit"),
+		}
+
+		taskMgr := New(coordinationStore, time.Millisecond)
+
+		taskMgr.RegisterTask("test-task", time.Millisecond, time.Millisecond, func() {
+			t.Logf("Running test-task")
+		})
+
+		logger := &stringLogger{}
+
+		taskMgr.logger = logger
+
+		taskMgr.Start()
+		defer taskMgr.Stop()
+
+		ensureLogContainsMessage(t, logger,
+			"unmarshal permit for task [test-task]: invalid character 'o' in literal null")
+	})
+}
+
+// We return the started services so that the caller can call service.Stop on them when the test is done.
+// service2's logger is returned, so it can be examined later on in the test.
+func getTestExpiryServices(t *testing.T, coordinationStore storage.Store) (*Manager, *Manager) {
+	t.Helper()
+
+	taskMgr1 := New(coordinationStore, 500*time.Millisecond)
+
+	service1LoggerModule := "expiry-service1"
+
+	taskMgr1.logger = &stringLogger{
+		passthroughLogger: log.New(service1LoggerModule),
+	}
+
+	log.SetLevel(service1LoggerModule, log.DEBUG)
+
+	taskMgr1.RegisterTask("test-task", time.Second, 2*time.Second, func() {
+		taskMgr1.logger.Infof("Running test-task in task manager 1")
+
+		time.Sleep(time.Second)
+	})
+
+	taskMgr2 := New(coordinationStore, 500*time.Millisecond)
+
+	service2LoggerModule := "expiry-service2"
+
+	taskMgr2Logger := &stringLogger{
+		passthroughLogger: log.New(service2LoggerModule),
+	}
+
+	taskMgr2.logger = taskMgr2Logger
+
+	log.SetLevel(service2LoggerModule, log.DEBUG)
+
+	taskMgr2.RegisterTask("test-task", time.Second, time.Second, func() {
+		taskMgr2.logger.Infof("Running test-task in task manager 2")
+	})
+
+	return taskMgr1, taskMgr2
+}
+
+func ensureLogContainsMessage(t *testing.T, logger *stringLogger, expectedMessage string) {
+	t.Helper()
+
+	var logContents string
+
+	var logContainsMessage bool
+
+	for i := 0; i < 20; i++ {
+		time.Sleep(time.Millisecond * 2)
+
+		logContents = logger.Read()
+
+		logContainsMessage = strings.Contains(logContents, expectedMessage)
+
+		if logContainsMessage {
+			break
+		}
+	}
+
+	if !logContainsMessage {
+		require.FailNow(t, "The log did not contain the expected message.",
+			`Actual log contents: %s
+Expected message: %s`, logContents, expectedMessage)
+	}
+}


### PR DESCRIPTION
Refactored the expiry service to create a generic task scheduler that may run any task on a single instance in an Orb domain cluster.

Also created a common utility to start a MongoDB container during unit testing (since this code was copied in multiple places). The Docker container is always started on a unique port to prevent the occasional port conflict error.

closes #891

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>