### PR TITLE
feat: Add activities iterator to ActivityPub client

### DIFF
--- a/pkg/activitypub/client/client.go
+++ b/pkg/activitypub/client/client.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"sort"
 	"time"
 
 	"github.com/bluele/gcache"
@@ -32,10 +33,33 @@ const (
 // ErrNotFound is returned when the object is not found or the iterator has reached the end.
 var ErrNotFound = fmt.Errorf("not found")
 
-// ReferenceIterator iterates over all of the references in a result set.
+// Order is the order in which activities are returned.
+type Order string
+
+const (
+	// Forward indicates that activities should be returned in the same order that they were retrieved
+	// from the REST endpoint.
+	Forward Order = "forward"
+	// Reverse indicates that activities should be returned in reverse order that they were retrieved
+	// from the REST endpoint..
+	Reverse Order = "reverse"
+)
+
+// ReferenceIterator iterates over the references in a result set.
 type ReferenceIterator interface {
 	Next() (*url.URL, error)
 	TotalItems() int
+}
+
+// ActivityIterator iterates over the activities in a result set.
+type ActivityIterator interface {
+	// Next returns the next activity or the ErrNotFound error if no more items are available.
+	Next() (*vocab.ActivityType, error)
+	// TotalItems returns the total number of items available at the moment the iterator was created.
+	// This value remains constant throughout the lifetime of the iterator.
+	TotalItems() int
+	// CurrentPage returns the ID of the current page that the iterator is processing.
+	CurrentPage() *url.URL
 }
 
 type httpTransport interface {
@@ -164,12 +188,93 @@ func (c *Client) GetReferences(iri *url.URL) (ReferenceIterator, error) {
 
 	logger.Debugf("Got response from %s: %s", iri, respBytes)
 
-	items, firstPage, totalItems, err := unmarshalReference(respBytes)
+	objProps, firstPage, _, totalItems, err := unmarshalCollection(respBytes)
 	if err != nil {
 		return nil, fmt.Errorf("error unmarsalling response from %s: %w", iri, err)
 	}
 
-	return newIterator(items, firstPage, totalItems, c.get), nil
+	items := make([]*url.URL, len(objProps))
+
+	for i, prop := range objProps {
+		items[i] = prop.IRI()
+	}
+
+	return newReferenceIterator(items, firstPage, totalItems, c.get), nil
+}
+
+// GetActivities returns an iterator that reads activities at the given IRI. The IRI may reference a
+// Collection, OrderedCollection, CollectionPage, or OrderedCollectionPage.
+func (c *Client) GetActivities(iri *url.URL, order Order) (ActivityIterator, error) {
+	respBytes, err := c.get(iri)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response from %s: %w", iri, err)
+	}
+
+	logger.Debugf("Got response from %s: %s", iri, respBytes)
+
+	obj := &vocab.ObjectType{}
+
+	err = json.Unmarshal(respBytes, &obj)
+	if err != nil {
+		return nil, err
+	}
+
+	switch {
+	case obj.Type().IsAny(vocab.TypeCollection, vocab.TypeOrderedCollection):
+		return c.activityIteratorFromCollection(respBytes, order)
+	case obj.Type().IsAny(vocab.TypeCollectionPage, vocab.TypeOrderedCollectionPage):
+		return c.activityIteratorFromCollectionPage(respBytes, order)
+	default:
+		return nil, fmt.Errorf("invalid collection type %s", obj.Type())
+	}
+}
+
+func (c *Client) activityIteratorFromCollection(collBytes []byte, order Order) (ActivityIterator, error) {
+	_, first, last, totalItems, err := unmarshalCollection(collBytes)
+	if err != nil {
+		return nil, fmt.Errorf("unmarsal collection: %w", err)
+	}
+
+	switch order {
+	case Forward:
+		logger.Debugf("Creating forward activity iterator - next [%s], total [%d]", first, totalItems)
+
+		return newForwardActivityIterator(nil, nil, first, totalItems, c.get), nil
+	case Reverse:
+		logger.Debugf("Creating reverse activity iterator - next [%s], total [%d]", last, totalItems)
+
+		return newReverseActivityIterator(nil, nil, last, totalItems, c.get), nil
+	default:
+		return nil, fmt.Errorf("invalid order [%s]", order)
+	}
+}
+
+func (c *Client) activityIteratorFromCollectionPage(collBytes []byte, order Order) (ActivityIterator, error) {
+	page, err := unmarshalCollectionPage(collBytes)
+	if err != nil {
+		return nil, fmt.Errorf("unmarsal collection page: %w", err)
+	}
+
+	activities := make([]*vocab.ActivityType, len(page.items))
+
+	for i, prop := range page.items {
+		activities[i] = prop.Activity()
+	}
+
+	switch order {
+	case Forward:
+		logger.Debugf("Creating forward activity iterator - current [%s], items [%d], total [%d]",
+			page.current, len(activities), page.totalItems)
+
+		return newForwardActivityIterator(activities, page.current, page.next, page.totalItems, c.get), nil
+	case Reverse:
+		logger.Debugf("Creating reverse activity iterator - current [%s], items [%d], total [%d]",
+			page.current, len(activities), page.totalItems)
+
+		return newReverseActivityIterator(activities, page.current, page.prev, page.totalItems, c.get), nil
+	default:
+		return nil, fmt.Errorf("invalid order [%s]", order)
+	}
 }
 
 func (c *Client) get(iri *url.URL) ([]byte, error) {
@@ -209,7 +314,7 @@ type referenceIterator struct {
 	get          getFunc
 }
 
-func newIterator(items []*url.URL, nextPage *url.URL, totalItems int, retrieve getFunc) *referenceIterator {
+func newReferenceIterator(items []*url.URL, nextPage *url.URL, totalItems int, retrieve getFunc) *referenceIterator {
 	return &referenceIterator{
 		currentItems: items,
 		totalItems:   totalItems,
@@ -254,98 +359,14 @@ func (it *referenceIterator) getNextPage() error {
 
 	logger.Debugf("Got response from %s: %s", it.nextPage, respBytes)
 
-	refs, nextPage, err := unmarshalCollectionPage(respBytes)
+	page, err := unmarshalCollectionPage(respBytes)
 	if err != nil {
 		return err
 	}
 
-	logger.Debugf("Got page %s with %d items. Next page: %s", it.nextPage, len(refs), nextPage)
-
-	it.currentItems = refs
-	it.currentIndex = 0
-	it.nextPage = nextPage
-
-	return nil
-}
-
-func unmarshalReference(respBytes []byte) (items []*url.URL, nextPage *url.URL, totalCount int, err error) {
-	obj := &vocab.ObjectType{}
-
-	if err := json.Unmarshal(respBytes, &obj); err != nil {
-		return nil, nil, 0, err
-	}
-
-	switch {
-	case obj.Type().Is(vocab.TypeService):
-		actor := &vocab.ActorType{}
-		if err := json.Unmarshal(respBytes, actor); err != nil {
-			return nil, nil, 0, fmt.Errorf("invalid service in response: %w", err)
-		}
-
-		return []*url.URL{actor.ID().URL()}, nil, 1, nil
-
-	case obj.Type().Is(vocab.TypeCollection):
-		coll := &vocab.CollectionType{}
-		if err := json.Unmarshal(respBytes, coll); err != nil {
-			return nil, nil, 0, fmt.Errorf("invalid collection in response: %w", err)
-		}
-
-		return nil, coll.First(), coll.TotalItems(), nil
-
-	case obj.Type().Is(vocab.TypeOrderedCollection):
-		coll := &vocab.OrderedCollectionType{}
-		if err := json.Unmarshal(respBytes, coll); err != nil {
-			return nil, nil, 0, fmt.Errorf("invalid ordered collection in response: %w", err)
-		}
-
-		return nil, coll.First(), coll.TotalItems(), nil
-
-	default:
-		return nil, nil, 0, fmt.Errorf("expecting Service, Collection or OrderedCollection in response payload")
-	}
-}
-
-func unmarshalCollectionPage(respBytes []byte) ([]*url.URL, *url.URL, error) {
-	obj := &vocab.ObjectType{}
-
-	if err := json.Unmarshal(respBytes, &obj); err != nil {
-		return nil, nil, err
-	}
-
-	var items []*vocab.ObjectProperty
-
-	var next *url.URL
-
-	switch {
-	case obj.Type().Is(vocab.TypeCollectionPage):
-		coll := &vocab.CollectionPageType{}
-
-		err := json.Unmarshal(respBytes, coll)
-		if err != nil {
-			return nil, nil, fmt.Errorf("invalid collection page in response: %w", err)
-		}
-
-		next = coll.Next()
-		items = coll.Items()
-
-	case obj.Type().Is(vocab.TypeOrderedCollectionPage):
-		coll := &vocab.OrderedCollectionPageType{}
-
-		err := json.Unmarshal(respBytes, coll)
-		if err != nil {
-			return nil, nil, fmt.Errorf("invalid ordered collection page in response: %w", err)
-		}
-
-		next = coll.Next()
-		items = coll.Items()
-
-	default:
-		return nil, nil, fmt.Errorf("expecting CollectionPage or OrderedCollectionPage in response payload")
-	}
-
 	var refs []*url.URL
 
-	for _, item := range items {
+	for _, item := range page.items {
 		if item.IRI() != nil {
 			logger.Debugf("Adding %s to the recipient list", item.IRI())
 
@@ -355,5 +376,247 @@ func unmarshalCollectionPage(respBytes []byte) ([]*url.URL, *url.URL, error) {
 		}
 	}
 
-	return refs, next, nil
+	it.currentItems = refs
+	it.currentIndex = 0
+	it.nextPage = page.next
+
+	if len(it.currentItems) == 0 {
+		return ErrNotFound
+	}
+
+	return nil
+}
+
+type getNextIRIFunc func(next, prev *url.URL) *url.URL
+
+type appendFunc func(activities []*vocab.ActivityType, activity *vocab.ActivityType) []*vocab.ActivityType
+
+type activityIterator struct {
+	currentItems   []*vocab.ActivityType
+	currentPage    *url.URL
+	nextPage       *url.URL
+	totalItems     int
+	currentIndex   int
+	numProcessed   int
+	get            getFunc
+	getNext        getNextIRIFunc
+	appendActivity appendFunc
+}
+
+func newActivityIterator(items []*vocab.ActivityType, currentPage, nextPage *url.URL, totalItems int,
+	get getFunc, getNext getNextIRIFunc, appendActivity appendFunc) *activityIterator {
+	return &activityIterator{
+		currentItems:   items,
+		currentPage:    currentPage,
+		nextPage:       nextPage,
+		totalItems:     totalItems,
+		get:            get,
+		getNext:        getNext,
+		appendActivity: appendActivity,
+	}
+}
+
+func (it *activityIterator) CurrentPage() *url.URL {
+	return it.currentPage
+}
+
+func (it *activityIterator) Next() (*vocab.ActivityType, error) {
+	if it.numProcessed >= it.totalItems {
+		// All items were already processed. There may actually be additional items if we retrieve
+		// another page (since items keep being added in a running system) but we want to process
+		// only the items that were available when the iterator was created.
+		return nil, ErrNotFound
+	}
+
+	if it.currentIndex >= len(it.currentItems) {
+		err := it.getNextPage()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	item := it.currentItems[it.currentIndex]
+
+	it.currentIndex++
+	it.numProcessed++
+
+	return item, nil
+}
+
+func (it *activityIterator) TotalItems() int {
+	return it.totalItems
+}
+
+func (it *activityIterator) getNextPage() error {
+	if it.nextPage == nil {
+		logger.Debugf("No more pages")
+
+		return ErrNotFound
+	}
+
+	logger.Debugf("Retrieving next page %s", it.nextPage)
+
+	respBytes, err := it.get(it.nextPage)
+	if err != nil {
+		return fmt.Errorf("request to %s failed: %w", it.nextPage, err)
+	}
+
+	logger.Debugf("Got response from %s: %s", it.nextPage, respBytes)
+
+	page, err := unmarshalCollectionPage(respBytes)
+	if err != nil {
+		return err
+	}
+
+	var activities []*vocab.ActivityType
+
+	for _, item := range page.items {
+		if item.Activity() != nil {
+			logger.Debugf("Adding activity to the recipient list - ID [%s], Type %s",
+				item.Activity().ID(), item.Activity().Type())
+
+			activities = it.appendActivity(activities, item.Activity())
+		} else {
+			logger.Warnf("expecting activity item for collection but got %s", item.Type())
+		}
+	}
+
+	it.currentIndex = 0
+	it.currentItems = activities
+	it.currentPage = page.current
+	it.nextPage = it.getNext(page.next, page.prev)
+
+	if len(it.currentItems) == 0 {
+		return ErrNotFound
+	}
+
+	return nil
+}
+
+func newForwardActivityIterator(items []*vocab.ActivityType, currentPage, nextPage *url.URL,
+	totalItems int, retrieve getFunc) *activityIterator {
+	return newActivityIterator(items, currentPage, nextPage, totalItems, retrieve,
+		func(next, _ *url.URL) *url.URL {
+			return next
+		},
+		func(activities []*vocab.ActivityType, activity *vocab.ActivityType) []*vocab.ActivityType {
+			return append(activities, activity)
+		},
+	)
+}
+
+func newReverseActivityIterator(items []*vocab.ActivityType, currentPage, nextPage *url.URL,
+	totalItems int, retrieve getFunc) *activityIterator {
+	return newActivityIterator(reverseSort(items), currentPage, nextPage, totalItems, retrieve,
+		func(_, prev *url.URL) *url.URL {
+			return prev
+		},
+		func(activities []*vocab.ActivityType, activity *vocab.ActivityType) []*vocab.ActivityType {
+			// Prepend the activity since we're iterating in reverseSort order.
+			return append([]*vocab.ActivityType{activity}, activities...)
+		},
+	)
+}
+
+func unmarshalCollection(respBytes []byte) (items []*vocab.ObjectProperty, firstPage, lastPage *url.URL,
+	totalCount int, err error) {
+	obj := &vocab.ObjectType{}
+
+	if err := json.Unmarshal(respBytes, &obj); err != nil {
+		return nil, nil, nil, 0, err
+	}
+
+	switch {
+	case obj.Type().Is(vocab.TypeService):
+		actor := &vocab.ActorType{}
+		if err := json.Unmarshal(respBytes, actor); err != nil {
+			return nil, nil, nil, 0, fmt.Errorf("invalid service in response: %w", err)
+		}
+
+		return []*vocab.ObjectProperty{vocab.NewObjectProperty(vocab.WithIRI(actor.ID().URL()))},
+			nil, nil, 1, nil
+
+	case obj.Type().Is(vocab.TypeCollection):
+		coll := &vocab.CollectionType{}
+		if err := json.Unmarshal(respBytes, coll); err != nil {
+			return nil, nil, nil, 0, fmt.Errorf("invalid collection in response: %w", err)
+		}
+
+		return nil, coll.First(), coll.Last(), coll.TotalItems(), nil
+
+	case obj.Type().Is(vocab.TypeOrderedCollection):
+		coll := &vocab.OrderedCollectionType{}
+		if err := json.Unmarshal(respBytes, coll); err != nil {
+			return nil, nil, nil, 0,
+				fmt.Errorf("invalid ordered collection in response: %w", err)
+		}
+
+		return nil, coll.First(), coll.Last(), coll.TotalItems(), nil
+
+	default:
+		return nil, nil, nil, 0,
+			fmt.Errorf("expecting Service, Collection, OrderedCollection, CollectionPage, " +
+				"or OrderedCollectionPage in response payload")
+	}
+}
+
+type page struct {
+	items               []*vocab.ObjectProperty
+	current, next, prev *url.URL
+	totalItems          int
+}
+
+func unmarshalCollectionPage(respBytes []byte) (*page, error) {
+	obj := &vocab.ObjectType{}
+
+	if err := json.Unmarshal(respBytes, &obj); err != nil {
+		return nil, err
+	}
+
+	switch {
+	case obj.Type().Is(vocab.TypeCollectionPage):
+		coll := &vocab.CollectionPageType{}
+
+		err := json.Unmarshal(respBytes, coll)
+		if err != nil {
+			return nil, fmt.Errorf("invalid collection page in response: %w", err)
+		}
+
+		return &page{
+			items:      coll.Items(),
+			current:    coll.ID().URL(),
+			next:       coll.Next(),
+			prev:       coll.Prev(),
+			totalItems: coll.TotalItems(),
+		}, nil
+
+	case obj.Type().Is(vocab.TypeOrderedCollectionPage):
+		coll := &vocab.OrderedCollectionPageType{}
+
+		err := json.Unmarshal(respBytes, coll)
+		if err != nil {
+			return nil, fmt.Errorf("invalid ordered collection page in response: %w", err)
+		}
+
+		return &page{
+			items:      coll.Items(),
+			current:    coll.ID().URL(),
+			next:       coll.Next(),
+			prev:       coll.Prev(),
+			totalItems: coll.TotalItems(),
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("expecting CollectionPage or OrderedCollectionPage in response payload")
+	}
+}
+
+func reverseSort(items []*vocab.ActivityType) []*vocab.ActivityType {
+	sort.SliceStable(items,
+		func(i, j int) bool {
+			return i > j //nolint:gocritic
+		},
+	)
+
+	return items
 }

--- a/pkg/activitypub/client/util.go
+++ b/pkg/activitypub/client/util.go
@@ -9,6 +9,8 @@ package client
 import (
 	"errors"
 	"net/url"
+
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
 )
 
 // ReadReferences reads the references from the given iterator up to a maximum number
@@ -30,4 +32,25 @@ func ReadReferences(it ReferenceIterator, maxItems int) ([]*url.URL, error) {
 	}
 
 	return refs, nil
+}
+
+// ReadActivities reads the activities from the given iterator up to a maximum number
+// specified by maxItems. If maxItems <= 0 then all activities are read.
+func ReadActivities(it ActivityIterator, maxItems int) ([]*vocab.ActivityType, error) {
+	var activities []*vocab.ActivityType
+
+	for maxItems <= 0 || len(activities) < maxItems {
+		activity, err := it.Next()
+		if err != nil {
+			if errors.Is(err, ErrNotFound) {
+				break
+			}
+
+			return nil, err
+		}
+
+		activities = append(activities, activity)
+	}
+
+	return activities, nil
 }

--- a/pkg/activitypub/service/outbox/outbox_test.go
+++ b/pkg/activitypub/service/outbox/outbox_test.go
@@ -696,6 +696,7 @@ func handleMockCollection(t *testing.T, collID *url.URL, uris []*url.URL, w http
 	respBytes, err := json.Marshal(aptestutil.NewMockCollection(
 		collID,
 		testutil.NewMockID(collID, "?page=true"),
+		testutil.NewMockID(collID, "?page=true&page-num=1"),
 		len(uris),
 	))
 	require.NoError(t, err)
@@ -733,8 +734,13 @@ func handleMockCollectionPage(t *testing.T, collID *url.URL, uris []*url.URL,
 		next = testutil.NewMockID(collID, fmt.Sprintf("?page=true&page-num=%d", pageNum+1))
 	}
 
-	respBytes, err := json.Marshal(aptestutil.NewMockCollectionPage(id, next, collID,
-		len(uris), uris[from:to]...,
+	var items []*vocab.ObjectProperty
+	for _, uri := range uris[from:to] {
+		items = append(items, vocab.NewObjectProperty(vocab.WithIRI(uri)))
+	}
+
+	respBytes, err := json.Marshal(aptestutil.NewMockCollectionPage(id, next, nil, collID,
+		len(uris), items...,
 	))
 	require.NoError(t, err)
 

--- a/pkg/activitypub/vocab/collection.go
+++ b/pkg/activitypub/vocab/collection.go
@@ -27,11 +27,19 @@ type collectionType struct {
 
 // TotalItems returns the total number of items in the collection.
 func (t *CollectionType) TotalItems() int {
+	if t == nil || t.coll == nil {
+		return 0
+	}
+
 	return t.coll.TotalItems
 }
 
 // Items returns the items in the collection.
 func (t *CollectionType) Items() []*ObjectProperty {
+	if t == nil || t.coll == nil {
+		return nil
+	}
+
 	items := make([]*ObjectProperty, len(t.coll.Items))
 
 	for i, item := range t.coll.Items {
@@ -43,16 +51,28 @@ func (t *CollectionType) Items() []*ObjectProperty {
 
 // Current returns the current item.
 func (t *CollectionType) Current() *url.URL {
+	if t == nil || t.coll == nil || t.coll.Current == nil {
+		return nil
+	}
+
 	return t.coll.Current.u
 }
 
 // First returns a URL that may be used to retrieve the first item in the collection.
 func (t *CollectionType) First() *url.URL {
+	if t == nil || t.coll == nil || t.coll.First == nil {
+		return nil
+	}
+
 	return t.coll.First.u
 }
 
 // Last returns a URL that may be used to retrieve the last item in the collection.
 func (t *CollectionType) Last() *url.URL {
+	if t == nil || t.coll == nil || t.coll.Last == nil {
+		return nil
+	}
+
 	return t.coll.Last.u
 }
 

--- a/pkg/activitypub/vocab/collection_test.go
+++ b/pkg/activitypub/vocab/collection_test.go
@@ -18,6 +18,16 @@ import (
 
 var service1Inbox = testutil.MustParseURL("https://org1.com/services/service1/inbox")
 
+func TestNilCollection(t *testing.T) {
+	var coll *CollectionType
+
+	require.Nil(t, coll.Current())
+	require.Nil(t, coll.First())
+	require.Nil(t, coll.Last())
+	require.Empty(t, coll.Items())
+	require.Zero(t, coll.TotalItems())
+}
+
 func TestCollectionMarshal(t *testing.T) {
 	first := testutil.MustParseURL("https://org1.com/services/service1/inbox?page=true")
 	last := testutil.MustParseURL("https://org1.com/services/service1/inbox?page=true&end=true")

--- a/pkg/activitypub/vocab/collectionpage.go
+++ b/pkg/activitypub/vocab/collectionpage.go
@@ -43,16 +43,28 @@ func NewCollectionPage(items []*ObjectProperty, opts ...Opt) *CollectionPageType
 
 // PartOf return the URL of the collection of which this page is a part.
 func (t *CollectionPageType) PartOf() *url.URL {
+	if t == nil || t.collPage == nil || t.collPage.PartOf == nil {
+		return nil
+	}
+
 	return t.collPage.PartOf.URL()
 }
 
 // Next return the URL that may be used to retrieve the next page.
 func (t *CollectionPageType) Next() *url.URL {
+	if t == nil || t.collPage == nil || t.collPage.Next == nil {
+		return nil
+	}
+
 	return t.collPage.Next.URL()
 }
 
 // Prev return the URL that may be used to retrieve the previous page.
 func (t *CollectionPageType) Prev() *url.URL {
+	if t == nil || t.collPage == nil || t.collPage.Prev == nil {
+		return nil
+	}
+
 	return t.collPage.Prev.URL()
 }
 
@@ -96,16 +108,28 @@ func NewOrderedCollectionPage(items []*ObjectProperty, opts ...Opt) *OrderedColl
 
 // PartOf return the URL of the collection of which this page is a part.
 func (t *OrderedCollectionPageType) PartOf() *url.URL {
+	if t == nil || t.collPage == nil || t.collPage.PartOf == nil {
+		return nil
+	}
+
 	return t.collPage.PartOf.URL()
 }
 
 // Next return the URL that may be used to retrieve the next page.
 func (t *OrderedCollectionPageType) Next() *url.URL {
+	if t == nil || t.collPage == nil || t.collPage.Next == nil {
+		return nil
+	}
+
 	return t.collPage.Next.URL()
 }
 
 // Prev return the URL that may be used to retrieve the previous page.
 func (t *OrderedCollectionPageType) Prev() *url.URL {
+	if t == nil || t.collPage == nil || t.collPage.Prev == nil {
+		return nil
+	}
+
 	return t.collPage.Prev.URL()
 }
 

--- a/pkg/activitypub/vocab/collectionpage_test.go
+++ b/pkg/activitypub/vocab/collectionpage_test.go
@@ -16,6 +16,22 @@ import (
 	"github.com/trustbloc/orb/pkg/internal/testutil"
 )
 
+func TestNilCollectionPage(t *testing.T) {
+	var coll *CollectionPageType
+
+	require.Nil(t, coll.PartOf())
+	require.Nil(t, coll.Next())
+	require.Nil(t, coll.Prev())
+}
+
+func TestNilOrderedCollectionPage(t *testing.T) {
+	var coll *OrderedCollectionPageType
+
+	require.Nil(t, coll.PartOf())
+	require.Nil(t, coll.Next())
+	require.Nil(t, coll.Prev())
+}
+
 func TestCollectionPageMarshal(t *testing.T) {
 	collPage1 := testutil.MustParseURL("https://org1.com/services/service1/inbox?page=1")
 	collPage2 := testutil.MustParseURL("https://org1.com/services/service1/inbox?page=2")

--- a/pkg/activitypub/vocab/objectproperty.go
+++ b/pkg/activitypub/vocab/objectproperty.go
@@ -202,7 +202,7 @@ func (p *ObjectProperty) UnmarshalJSON(bytes []byte) error {
 	case obj.object.Type.Is(TypeOrderedCollection):
 		err = p.unmarshalOrderedCollection(bytes)
 
-	case obj.object.Type.IsAny(TypeFollow, TypeAccept, TypeReject, TypeOffer, TypeLike, TypeInvite):
+	case obj.object.Type.IsActivity():
 		err = p.unmarshalActivity(bytes)
 
 	case obj.object.Type.Is(TypeAnchorObject):

--- a/pkg/activitypub/vocab/typeproperty.go
+++ b/pkg/activitypub/vocab/typeproperty.go
@@ -110,6 +110,12 @@ func (p *TypeProperty) IsAny(types ...Type) bool {
 	return false
 }
 
+// IsActivity returns true if the type is an ActivityPub Activity.
+func (p *TypeProperty) IsActivity() bool {
+	return p.IsAny(TypeFollow, TypeAccept, TypeReject, TypeOffer, TypeLike, TypeInvite,
+		TypeCreate, TypeAnnounce, TypeUndo)
+}
+
 func (p *TypeProperty) is(t Type) bool {
 	for _, pt := range p.types {
 		if pt == t {

--- a/pkg/internal/aptestutil/aptestutil.go
+++ b/pkg/internal/aptestutil/aptestutil.go
@@ -79,56 +79,49 @@ func NewMockPublicKey(serviceIRI *url.URL) *vocab.PublicKeyType {
 }
 
 // NewMockCollection returns a mock 'Collection' with the given ID and items.
-func NewMockCollection(id, first *url.URL, totalItems int) *vocab.CollectionType {
+func NewMockCollection(id, first, last *url.URL, totalItems int) *vocab.CollectionType {
 	return vocab.NewCollection(nil,
 		vocab.WithContext(vocab.ContextActivityStreams),
 		vocab.WithID(id),
 		vocab.WithTotalItems(totalItems),
 		vocab.WithFirst(first),
+		vocab.WithLast(last),
 	)
 }
 
 // NewMockOrderedCollection returns a mock 'OrderedCollection' with the given ID and items.
-func NewMockOrderedCollection(id, first *url.URL, totalItems int) *vocab.OrderedCollectionType {
+func NewMockOrderedCollection(id, first, last *url.URL, totalItems int) *vocab.OrderedCollectionType {
 	return vocab.NewOrderedCollection(nil,
 		vocab.WithContext(vocab.ContextActivityStreams),
 		vocab.WithID(id),
 		vocab.WithTotalItems(totalItems),
 		vocab.WithFirst(first),
+		vocab.WithLast(last),
 	)
 }
 
 // NewMockCollectionPage returns a mock 'CollectionPage' with the given ID and items.
-func NewMockCollectionPage(id, next, collID *url.URL, totalItems int, iris ...*url.URL) *vocab.CollectionPageType {
-	var items []*vocab.ObjectProperty
-
-	for _, iri := range iris {
-		items = append(items, vocab.NewObjectProperty(vocab.WithIRI(iri)))
-	}
-
+func NewMockCollectionPage(id, next, prev, collID *url.URL, totalItems int,
+	items ...*vocab.ObjectProperty) *vocab.CollectionPageType {
 	return vocab.NewCollectionPage(items,
 		vocab.WithContext(vocab.ContextActivityStreams),
 		vocab.WithID(id),
 		vocab.WithPartOf(collID),
 		vocab.WithNext(next),
+		vocab.WithPrev(prev),
 		vocab.WithTotalItems(totalItems),
 	)
 }
 
 // NewMockOrderedCollectionPage returns a mock 'OrderedCollectionPage' with the given ID and items.
-func NewMockOrderedCollectionPage(id, next, collID *url.URL, totalItems int,
-	iris ...*url.URL) *vocab.OrderedCollectionPageType {
-	var items []*vocab.ObjectProperty
-
-	for _, iri := range iris {
-		items = append(items, vocab.NewObjectProperty(vocab.WithIRI(iri)))
-	}
-
+func NewMockOrderedCollectionPage(id, next, prev, collID *url.URL, totalItems int,
+	items ...*vocab.ObjectProperty) *vocab.OrderedCollectionPageType {
 	return vocab.NewOrderedCollectionPage(items,
 		vocab.WithContext(vocab.ContextActivityStreams),
 		vocab.WithID(id),
 		vocab.WithPartOf(collID),
 		vocab.WithNext(next),
+		vocab.WithPrev(prev),
 		vocab.WithTotalItems(totalItems),
 	)
 }


### PR DESCRIPTION
Added function, GetActivities, to the ActivityPub client so that a server may retrieve activities from another server via a REST endpoint (e.g. https://domain1/services/orb/outbox). The function returns an iterator that iterates over the items in either forward or reverse order.

closes #901

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>