### PR TITLE
feat: Ensure parent anchor events are processed

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -674,8 +674,9 @@ func startOrbServices(parameters *orbParameters) error {
 		apspi.WithProofHandler(proofHandler),
 		apspi.WithWitness(witness),
 		apspi.WithAnchorEventHandler(credential.New(
-			o.Publisher(), casResolver, orbDocumentLoader, monitoringSvc, parameters.maxWitnessDelay,
-		)),
+			o.Publisher(), casResolver, orbDocumentLoader, monitoringSvc,
+			parameters.maxWitnessDelay, anchorLinkStore),
+		),
 		apspi.WithInviteWitnessAuth(NewAcceptRejectHandler(activityhandler.InviteWitnessType, parameters.inviteWitnessAuthPolicy, configStore)),
 		apspi.WithFollowAuth(NewAcceptRejectHandler(activityhandler.FollowType, parameters.followAuthPolicy, configStore)),
 		apspi.WithAnchorEventAcknowledgementHandler(anchorEventHandler),

--- a/pkg/anchor/handler/credential/handler.go
+++ b/pkg/anchor/handler/credential/handler.go
@@ -20,12 +20,17 @@ import (
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
 	anchorinfo "github.com/trustbloc/orb/pkg/anchor/info"
 	"github.com/trustbloc/orb/pkg/anchor/util"
+	"github.com/trustbloc/orb/pkg/hashlink"
 )
 
 var logger = log.New("anchor-credential-handler")
 
 type monitoringSvc interface {
 	Watch(vc *verifiable.Credential, endTime time.Time, domain string, created time.Time) error
+}
+
+type anchorLinkStore interface {
+	GetLinks(anchorHash string) ([]*url.URL, error)
 }
 
 // AnchorEventHandler handles a new, published anchor credential.
@@ -35,6 +40,8 @@ type AnchorEventHandler struct {
 	maxDelay        time.Duration
 	documentLoader  ld.DocumentLoader
 	monitoringSvc   monitoringSvc
+	anchorLinkStore anchorLinkStore
+	unmarshal       func(data []byte, v interface{}) error
 }
 
 type casResolver interface {
@@ -47,13 +54,16 @@ type anchorPublisher interface {
 
 // New creates new credential handler.
 func New(anchorPublisher anchorPublisher, casResolver casResolver,
-	documentLoader ld.DocumentLoader, monitoringSvc monitoringSvc, maxDelay time.Duration) *AnchorEventHandler {
+	documentLoader ld.DocumentLoader, monitoringSvc monitoringSvc,
+	maxDelay time.Duration, anchorLinkStore anchorLinkStore) *AnchorEventHandler {
 	return &AnchorEventHandler{
 		anchorPublisher: anchorPublisher,
 		maxDelay:        maxDelay,
 		casResolver:     casResolver,
 		documentLoader:  documentLoader,
 		monitoringSvc:   monitoringSvc,
+		anchorLinkStore: anchorLinkStore,
+		unmarshal:       json.Unmarshal,
 	}
 }
 
@@ -92,11 +102,11 @@ func (h *AnchorEventHandler) HandleAnchorEvent(actor, anchorEventRef *url.URL,
 	anchorEvent *vocab.AnchorEventType) error {
 	logger.Debugf("Received request from [%s] for anchor event URL [%s]", actor, anchorEventRef)
 
-	var err error
-
 	var anchorEventBytes []byte
 
 	if anchorEvent != nil {
+		var err error
+
 		anchorEventBytes, err = canonicalizer.MarshalCanonical(anchorEvent)
 		if err != nil {
 			return fmt.Errorf("marshal anchor event: %w", err)
@@ -105,19 +115,49 @@ func (h *AnchorEventHandler) HandleAnchorEvent(actor, anchorEventRef *url.URL,
 
 	anchorEventBytes, localHL, err := h.casResolver.Resolve(nil, anchorEventRef.String(), anchorEventBytes)
 	if err != nil {
-		return fmt.Errorf("failed to resolve anchor credential: %w", err)
+		return fmt.Errorf("failed to resolve anchor event [%s]: %w", anchorEventRef, err)
 	}
 
 	if anchorEvent == nil {
 		anchorEvent = &vocab.AnchorEventType{}
 
-		err = json.Unmarshal(anchorEventBytes, anchorEvent)
+		err = h.unmarshal(anchorEventBytes, anchorEvent)
 		if err != nil {
 			return fmt.Errorf("unmarshal anchor event: %w", err)
 		}
 	}
 
-	vc, err := util.VerifiableCredentialFromAnchorEvent(anchorEvent,
+	// Make sure that all parents/grandparents of this anchor event are processed.
+	err = h.ensureParentAnchorsAreProcessed(anchorEventRef, anchorEvent)
+	if err != nil {
+		return fmt.Errorf("ensure unprocessed parents are processed for %s: %w", anchorEventRef, err)
+	}
+
+	var attributedTo string
+	if actor != nil {
+		attributedTo = actor.String()
+	}
+
+	logger.Infof("Processing anchor event [%s]", anchorEventRef)
+
+	// Now process the latest anchor event.
+	err = h.processAnchorEvent(&anchorInfo{
+		anchorEvent: anchorEvent,
+		AnchorInfo: &anchorinfo.AnchorInfo{
+			Hashlink:      anchorEventRef.String(),
+			LocalHashlink: localHL,
+			AttributedTo:  attributedTo,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("process anchor event %s: %w", anchorEventRef, err)
+	}
+
+	return nil
+}
+
+func (h *AnchorEventHandler) processAnchorEvent(anchorInfo *anchorInfo) error {
+	vc, err := util.VerifiableCredentialFromAnchorEvent(anchorInfo.anchorEvent,
 		verifiable.WithDisabledProofCheck(),
 		verifiable.WithJSONLDDocumentLoader(h.documentLoader),
 	)
@@ -141,11 +181,149 @@ func (h *AnchorEventHandler) HandleAnchorEvent(actor, anchorEventRef *url.URL,
 		}
 	}
 
-	return h.anchorPublisher.PublishAnchor(
-		&anchorinfo.AnchorInfo{
-			Hashlink:      anchorEventRef.String(),
-			LocalHashlink: localHL,
-			AttributedTo:  actor.String(),
-		},
-	)
+	return h.anchorPublisher.PublishAnchor(anchorInfo.AnchorInfo)
+}
+
+// ensureParentAnchorsAreProcessed checks all ancestors (parents, grandparents, etc.) of the given anchor event
+// and processes all that have not yet been processed.
+func (h *AnchorEventHandler) ensureParentAnchorsAreProcessed(anchorEventRef *url.URL,
+	anchorEvent *vocab.AnchorEventType) error {
+	unprocessedParents, err := h.getUnprocessedParentAnchorEvents(anchorEventRef.String(), anchorEvent)
+	if err != nil {
+		return fmt.Errorf("get unprocessed parent anchor events for %s: %w", anchorEventRef, err)
+	}
+
+	logger.Debugf("Processing %d parents of anchor event %s: %s",
+		len(unprocessedParents), anchorEventRef, unprocessedParents)
+
+	for _, parentAnchorInfo := range unprocessedParents {
+		logger.Infof("Processing parent of anchor event [%s]: [%s]",
+			anchorEventRef, parentAnchorInfo.Hashlink)
+
+		err = h.processAnchorEvent(parentAnchorInfo)
+		if err != nil {
+			return fmt.Errorf("process anchor event %s: %w", parentAnchorInfo.Hashlink, err)
+		}
+	}
+
+	return nil
+}
+
+// getUnprocessedParentAnchorEvents returns all unprocessed ancestors (parents, grandparents, etc.) of the given
+// anchor event, sorted by oldest to newest.
+func (h *AnchorEventHandler) getUnprocessedParentAnchorEvents(
+	hl string, anchorEvent *vocab.AnchorEventType) (anchorInfoSlice, error) {
+	logger.Debugf("Getting unprocessed parents of anchor event [%s]", hl)
+
+	var unprocessed []*anchorInfo
+
+	for _, parentHL := range anchorEvent.Parent() {
+		if containsAnchorEvent(unprocessed, parentHL.String()) {
+			logger.Debugf("Not adding parent of anchor event [%s] to the unprocessed list since it has already been added: [%s]",
+				hl, parentHL)
+
+			continue
+		}
+
+		logger.Debugf("Checking parent of anchor event [%s] to see if it has been processed [%s]", hl, parentHL)
+
+		isProcessed, err := h.isAnchorEventProcessed(parentHL)
+		if err != nil {
+			return nil, fmt.Errorf("is anchor event processed [%s]: %w", parentHL, err)
+		}
+
+		if isProcessed {
+			logger.Debugf("Parent of anchor event [%s] was already processed [%s]", hl, parentHL)
+
+			continue
+		}
+
+		anchorEventBytes, localHL, err := h.casResolver.Resolve(nil, parentHL.String(), nil)
+		if err != nil {
+			return nil, fmt.Errorf("resolve anchor event [%s]: %w", parentHL, err)
+		}
+
+		parentAnchorEvent := &vocab.AnchorEventType{}
+
+		err = h.unmarshal(anchorEventBytes, parentAnchorEvent)
+		if err != nil {
+			return nil, fmt.Errorf("unmarshal anchor event: %w", err)
+		}
+
+		logger.Debugf("Adding parent of anchor event [%s] to the unprocessed list [%s]", hl, parentHL)
+
+		// Add the parent to the head of the list since it needs to be processed first.
+		unprocessed = append([]*anchorInfo{
+			{
+				anchorEvent: parentAnchorEvent,
+				AnchorInfo: &anchorinfo.AnchorInfo{
+					Hashlink:      parentHL.String(),
+					LocalHashlink: localHL,
+				},
+			},
+		}, unprocessed...)
+
+		ancestorAnchorEvents, err := h.getUnprocessedParentAnchorEvents(parentHL.String(), parentAnchorEvent)
+		if err != nil {
+			return nil, fmt.Errorf("get unprocessed anchor events for parent [%s]: %w", parentHL, err)
+		}
+
+		prependAnchorEvents(unprocessed, ancestorAnchorEvents)
+	}
+
+	return unprocessed, nil
+}
+
+func prependAnchorEvents(existingAnchors, newAnchors []*anchorInfo) {
+	for _, anchor := range newAnchors {
+		if !containsAnchorEvent(existingAnchors, anchor.Hashlink) {
+			// Add the ancestor to the head of the list since it needs to be processed first.
+			existingAnchors = append([]*anchorInfo{anchor}, existingAnchors...)
+		}
+	}
+}
+
+func containsAnchorEvent(existingAnchors []*anchorInfo, hl string) bool {
+	for _, anchor := range existingAnchors {
+		if anchor.Hashlink == hl {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (h *AnchorEventHandler) isAnchorEventProcessed(hl *url.URL) (bool, error) {
+	hash, err := hashlink.GetResourceHashFromHashLink(hl.String())
+	if err != nil {
+		return false, fmt.Errorf("parse hashlink: %w", err)
+	}
+
+	links, err := h.anchorLinkStore.GetLinks(hash)
+	if err != nil {
+		return false, fmt.Errorf("get anchor event: %w", err)
+	}
+
+	return len(links) > 0, nil
+}
+
+type anchorInfo struct {
+	*anchorinfo.AnchorInfo
+	anchorEvent *vocab.AnchorEventType
+}
+
+type anchorInfoSlice []*anchorInfo
+
+func (s anchorInfoSlice) String() string {
+	msg := "["
+
+	for i, ai := range s {
+		if i > 0 {
+			msg += ", "
+		}
+
+		msg += ai.Hashlink
+	}
+
+	return msg + "]"
 }

--- a/pkg/anchor/handler/credential/handler_test.go
+++ b/pkg/anchor/handler/credential/handler_test.go
@@ -8,8 +8,10 @@ package credential
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -17,6 +19,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
 	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/edge-core/pkg/log"
 
 	"github.com/trustbloc/orb/pkg/activitypub/client/transport"
 	"github.com/trustbloc/orb/pkg/activitypub/resthandler"
@@ -30,6 +33,7 @@ import (
 	"github.com/trustbloc/orb/pkg/hashlink"
 	"github.com/trustbloc/orb/pkg/internal/testutil"
 	orbmocks "github.com/trustbloc/orb/pkg/mocks"
+	mocks2 "github.com/trustbloc/orb/pkg/protocolversion/mocks"
 	"github.com/trustbloc/orb/pkg/store/cas"
 	"github.com/trustbloc/orb/pkg/webcas"
 	webfingerclient "github.com/trustbloc/orb/pkg/webfinger/client"
@@ -37,89 +41,13 @@ import (
 
 //go:generate counterfeiter -o ../../mocks/anchorPublisher.gen.go --fake-name AnchorPublisher . anchorPublisher
 
-//nolint:lll
-const sampleAnchorEvent = `{
-  "@context": [
-    "https://www.w3.org/ns/activitystreams",
-    "https://w3id.org/activityanchors/v1"
-  ],
-  "index": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
-  "attachment": [
-    {
-      "contentObject": {
-        "properties": {
-          "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v0",
-          "https://w3id.org/activityanchors#resources": [
-            {
-              "ID": "did:orb:uAAA:EiAqm7CXVPxriNZv_A6GVCrqlmCmrUSGJ1YaheTzFxa_Fw"
-            }
-          ]
-        },
-        "subject": "hl:uEiDYMTm9nJ5B0gwpNtflwrcZCT9uT6BFiEs5sYWB45piXg:uoQ-BeEJpcGZzOi8vYmFma3JlaWd5Z2U0MzNoZTZpaGpheWtqdzI3czRmbnl6YmU3dzR0NWFpd2Vld29ucnF3YTZoZ3RjbHk"
-      },
-      "generator": "https://w3id.org/orb#v0",
-      "tag": [
-        {
-          "type": "Link",
-          "href": "hl:uEiDzOEQi2wRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
-          "rel": [
-            "witness"
-          ]
-        }
-      ],
-      "type": "AnchorObject",
-      "url": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw"
-    },
-    {
-      "contentObject": {
-        "@context": [
-          "https://www.w3.org/2018/credentials/v1",
-          "https://w3id.org/security/jws/v1"
-        ],
-        "credentialSubject": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
-        "id": "http://orb2.domain1.com/vc/3994cc26-555c-47f1-9890-058148c154f1",
-        "issuanceDate": "2021-10-14T18:32:17.894314751Z",
-        "issuer": "http://orb2.domain1.com",
-        "proof": [
-          {
-            "created": "2021-10-14T18:32:17.91Z",
-            "domain": "http://orb.vct:8077/maple2020",
-            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..h3-0HC3L87TM0j0o3Nd0VLlalcVVphwOPsfdkCLZ4q-uL4z8eO2vQ4sobbtOtFpNNZlpIOQnaWJMX3Ch5Wh-AQ",
-            "proofPurpose": "assertionMethod",
-            "type": "Ed25519Signature2018",
-            "verificationMethod": "did:web:orb.domain1.com#orb1key"
-          },
-          {
-            "created": "2021-10-14T18:32:18.09110265Z",
-            "domain": "https://orb.domain2.com",
-            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..DSL3zsltnh9dbSn3VNPb1C-6pKt6VOy-H1WadO5ZV2QZd3xZq3uRRhaShi9K1SzX-VaGPxs3gfbazJ-fpHVxBg",
-            "proofPurpose": "assertionMethod",
-            "type": "Ed25519Signature2018",
-            "verificationMethod": "did:web:orb.domain2.com#orb2key"
-          }
-        ],
-        "type": "VerifiableCredential"
-      },
-      "generator": "https://w3id.org/orb#v0",
-      "type": "AnchorObject",
-      "url": "hl:uEiDzOEQi2wRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw"
-    }
-  ],
-  "attributedTo": "https://orb.domain1.com/services/orb",
-  "parent": [
-    "hl:uEiAsiwjaXOYDmOHxmvDl3Mx0TfJ0uCar5YXqumjFJUNIBg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBc2l3amFYT1lEbU9IeG12RGwzTXgwVGZKMHVDYXI1WVhxdW1qRkpVTklCZ3hCaXBmczovL2JhZmtyZWlibXJtZW51eGhnYW9tb2Q0bTI2ZHM1enRkdWp4emhqb2JndnBzeWwydjJuZGNza3EyaWF5",
-    "hl:uEiAn3Y7USoP_lNVX-f0EEu1ajLymnqBJItiMARhKBzAKWg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBbjNZN1VTb1BfbE5WWC1mMEVFdTFhakx5bW5xQkpJdGlNQVJoS0J6QUtXZ3hCaXBmczovL2JhZmtyZWliaDN3aG5pc3VkNzZrbmt2N3o3dWNiZjNrMnJzNmtuaHZhamVybnJkYWJkYmZhb21ha2xp"
-  ],
-  "published": "2021-10-14T18:32:17.888176489Z",
-  "type": "AnchorEvent",
-  "url": "hl:uEiDhdDIS_-_SWKoh5Y3KJ_sWpIoXZUPBeTBMCSBUKXpe5w:uoQ-BeEJpcGZzOi8vYmFma3JlaWhib3F6YmY3N3Ayam1rdWlwZnJ4ZmNwNnl3dXNmYm96a2R5ZjR0YXRhamVia2NzNnM2NDQ"
-}`
-
 func TestNew(t *testing.T) {
 	newAnchorEventHandler(t, createInMemoryCAS(t))
 }
 
 func TestAnchorCredentialHandler(t *testing.T) {
+	log.SetLevel("anchor-credential-handler", log.DEBUG)
+
 	actor := testutil.MustParseURL("https://domain1.com/services/orb")
 
 	t.Run("Success - embedded anchor event", func(t *testing.T) {
@@ -148,7 +76,7 @@ func TestAnchorCredentialHandler(t *testing.T) {
 	})
 
 	t.Run("Parse created time (error)", func(t *testing.T) {
-		cred := strings.Replace(sampleAnchorEvent, "2021-10-14T18:32:17.91Z", "2021-27T09:30:00Z", 1)
+		cred := strings.Replace(sampleAnchorEvent, "2021-11-29T15:21:03.074Z", "2021-27T09:30:00Z", 1)
 
 		anchorEvent := &vocab.AnchorEventType{}
 		require.NoError(t, json.Unmarshal([]byte(cred), anchorEvent))
@@ -202,6 +130,156 @@ func TestAnchorCredentialHandler(t *testing.T) {
 	})
 }
 
+func TestGetUnprocessedParentAnchorEvents(t *testing.T) {
+	const (
+		parentHL      = "hl:uEiCQhpLcjhOV_tDVibUfPbkhjJM_FUYwQ9AuAHahoAGxyg:uoQ-BeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQ1FocExjamhPVl90RFZpYlVmUGJraGpKTV9GVVl3UTlBdUFIYWhvQUd4eWc" //nolint:lll
+		grandparentHL = "hl:uEiCQhpLcjhOV_tDVibUfPbkhjJM_FUYwQ9AuAHahoAGxyg:uoQ-BeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQ1FocExjamhPVl90RFZpYlVmUGJraGpKTV9GVVl3UTlBdUFIYWhvQUd4eWc" //nolint:lll
+	)
+
+	t.Run("All parents processed -> Success", func(t *testing.T) {
+		casResolver := &mocks2.CASResolver{}
+		anchorLinkStore := &orbmocks.AnchorLinkStore{}
+
+		handler := New(&anchormocks.AnchorPublisher{}, casResolver, testutil.GetLoader(t),
+			&mocks.MonitoringService{}, time.Second, anchorLinkStore)
+		require.NotNil(t, handler)
+
+		anchorEvent := &vocab.AnchorEventType{}
+
+		require.NoError(t, json.Unmarshal([]byte(sampleParentAnchorEvent), anchorEvent))
+
+		anchorLinkStore.GetLinksReturns([]*url.URL{vocab.MustParseURL(grandparentHL)}, nil)
+
+		parents, err := handler.getUnprocessedParentAnchorEvents(parentHL, anchorEvent)
+		require.NoError(t, err)
+		require.Empty(t, parents)
+	})
+
+	t.Run("One parent unprocessed -> Success", func(t *testing.T) {
+		casResolver := &mocks2.CASResolver{}
+		anchorLinkStore := &orbmocks.AnchorLinkStore{}
+
+		handler := New(&anchormocks.AnchorPublisher{}, casResolver, testutil.GetLoader(t),
+			&mocks.MonitoringService{}, time.Second, anchorLinkStore)
+		require.NotNil(t, handler)
+
+		anchorEvent := &vocab.AnchorEventType{}
+
+		require.NoError(t, json.Unmarshal([]byte(sampleParentAnchorEvent), anchorEvent))
+
+		anchorLinkStore.GetLinksReturns(nil, nil)
+
+		casResolver.ResolveReturns([]byte(testutil.GetCanonical(t, sampleGrandparentAnchorEvent)), grandparentHL, nil)
+
+		parents, err := handler.getUnprocessedParentAnchorEvents(parentHL, anchorEvent)
+		require.NoError(t, err)
+		require.Len(t, parents, 1)
+	})
+
+	t.Run("Duplicate parents -> Success", func(t *testing.T) {
+		casResolver := &mocks2.CASResolver{}
+		anchorLinkStore := &orbmocks.AnchorLinkStore{}
+
+		handler := New(&anchormocks.AnchorPublisher{}, casResolver, testutil.GetLoader(t),
+			&mocks.MonitoringService{}, time.Second, anchorLinkStore)
+		require.NotNil(t, handler)
+
+		anchorEvent := vocab.NewAnchorEvent(
+			vocab.WithParent(vocab.MustParseURL(grandparentHL), vocab.MustParseURL(grandparentHL)),
+		)
+
+		anchorLinkStore.GetLinksReturns(nil, nil)
+
+		casResolver.ResolveReturns([]byte(testutil.GetCanonical(t, sampleGrandparentAnchorEvent)), grandparentHL, nil)
+
+		parents, err := handler.getUnprocessedParentAnchorEvents(parentHL, anchorEvent)
+		require.NoError(t, err)
+		require.Len(t, parents, 1)
+	})
+
+	t.Run("Unmarshal -> Error", func(t *testing.T) {
+		casResolver := &mocks2.CASResolver{}
+		anchorLinkStore := &orbmocks.AnchorLinkStore{}
+
+		handler := New(&anchormocks.AnchorPublisher{}, casResolver, testutil.GetLoader(t),
+			&mocks.MonitoringService{}, time.Second, anchorLinkStore)
+		require.NotNil(t, handler)
+
+		errExpected := errors.New("injected unmarshal error")
+
+		handler.unmarshal = func(data []byte, v interface{}) error {
+			return errExpected
+		}
+
+		anchorEvent := &vocab.AnchorEventType{}
+
+		require.NoError(t, json.Unmarshal([]byte(sampleParentAnchorEvent), anchorEvent))
+
+		anchorLinkStore.GetLinksReturns(nil, nil)
+
+		casResolver.ResolveReturns([]byte(testutil.GetCanonical(t, sampleGrandparentAnchorEvent)), grandparentHL, nil)
+
+		_, err := handler.getUnprocessedParentAnchorEvents(parentHL, anchorEvent)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+	})
+
+	t.Run("Invalid parent hashlink -> Error", func(t *testing.T) {
+		casResolver := &mocks2.CASResolver{}
+		anchorLinkStore := &orbmocks.AnchorLinkStore{}
+
+		handler := New(&anchormocks.AnchorPublisher{}, casResolver, testutil.GetLoader(t),
+			&mocks.MonitoringService{}, time.Second, anchorLinkStore)
+		require.NotNil(t, handler)
+
+		anchorEvent := vocab.NewAnchorEvent(vocab.WithParent(vocab.MustParseURL("udp://invalid")))
+
+		anchorLinkStore.GetLinksReturns(nil, nil)
+
+		_, err := handler.getUnprocessedParentAnchorEvents(parentHL, anchorEvent)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "must start with 'hl:' prefix")
+	})
+
+	t.Run("GetLinks -> Error", func(t *testing.T) {
+		casResolver := &mocks2.CASResolver{}
+		anchorLinkStore := &orbmocks.AnchorLinkStore{}
+
+		handler := New(&anchormocks.AnchorPublisher{}, casResolver, testutil.GetLoader(t),
+			&mocks.MonitoringService{}, time.Second, anchorLinkStore)
+		require.NotNil(t, handler)
+
+		anchorEvent := vocab.NewAnchorEvent(vocab.WithParent(vocab.MustParseURL(grandparentHL)))
+
+		errExpected := errors.New("injected GetLinks error")
+
+		anchorLinkStore.GetLinksReturns(nil, errExpected)
+
+		_, err := handler.getUnprocessedParentAnchorEvents(parentHL, anchorEvent)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+	})
+
+	t.Run("CAS Resolver -> Error", func(t *testing.T) {
+		casResolver := &mocks2.CASResolver{}
+		anchorLinkStore := &orbmocks.AnchorLinkStore{}
+
+		handler := New(&anchormocks.AnchorPublisher{}, casResolver, testutil.GetLoader(t),
+			&mocks.MonitoringService{}, time.Second, anchorLinkStore)
+		require.NotNil(t, handler)
+
+		anchorEvent := vocab.NewAnchorEvent(vocab.WithParent(vocab.MustParseURL(grandparentHL)))
+
+		errExpected := errors.New("injected Resolve error")
+
+		casResolver.ResolveReturns(nil, "", errExpected)
+
+		_, err := handler.getUnprocessedParentAnchorEvents(parentHL, anchorEvent)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+	})
+}
+
 func newAnchorEventHandler(t *testing.T,
 	client extendedcasclient.Client) *AnchorEventHandler {
 	t.Helper()
@@ -213,19 +291,256 @@ func newAnchorEventHandler(t *testing.T,
 			webfingerclient.New(), "https"),
 		&orbmocks.MetricsProvider{})
 
-	anchorCredentialHandler := New(&anchormocks.AnchorPublisher{}, casResolver, testutil.GetLoader(t),
-		&mocks.MonitoringService{}, time.Second)
-	require.NotNil(t, anchorCredentialHandler)
+	anchorLinkStore := &orbmocks.AnchorLinkStore{}
 
-	return anchorCredentialHandler
+	anchorEventHandler := New(&anchormocks.AnchorPublisher{}, casResolver, testutil.GetLoader(t),
+		&mocks.MonitoringService{}, time.Second, anchorLinkStore)
+	require.NotNil(t, anchorEventHandler)
+
+	return anchorEventHandler
 }
 
 func createInMemoryCAS(t *testing.T) extendedcasclient.Client {
 	t.Helper()
 
-	casClient, err := cas.New(mem.NewProvider(), "https://domain.com/cas", nil, &orbmocks.MetricsProvider{}, 0)
-
+	casClient, err := cas.New(mem.NewProvider(), "https://orb.domain1.com/cas", nil,
+		&orbmocks.MetricsProvider{}, 0)
 	require.NoError(t, err)
+
+	resourceHash, err := casClient.Write([]byte(testutil.GetCanonical(t, sampleParentAnchorEvent)))
+	require.NoError(t, err)
+
+	t.Logf("Stored parent anchor: %s", resourceHash)
+
+	resourceHash, err = casClient.Write([]byte(testutil.GetCanonical(t, sampleGrandparentAnchorEvent)))
+	require.NoError(t, err)
+
+	t.Logf("Stored grandparent anchor: %s", resourceHash)
 
 	return casClient
 }
+
+//nolint:lll
+const sampleAnchorEvent = `{
+  "@context": "https://w3id.org/activityanchors/v1",
+  "attachment": [
+    {
+      "contentObject": {
+        "properties": {
+          "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v0",
+          "https://w3id.org/activityanchors#resources": [
+            {
+              "id": "did:orb:uEiCPBh27UFpxQq1Sdw-YoyH9n7yPD7AktxAlBGWlMFfGMQ:EiCQNQ4L1bBFtgaFk4FS4kzLyO3gIO15tXn2j0T5EEu2UQ",
+              "previousAnchor": "hl:uEiCPBh27UFpxQq1Sdw-YoyH9n7yPD7AktxAlBGWlMFfGMQ"
+            },
+            {
+              "id": "did:orb:uEiCPBh27UFpxQq1Sdw-YoyH9n7yPD7AktxAlBGWlMFfGMQ:EiAN8R3Na3wa_jkqWRHa3GCXlTrVKlXn4UTecMMkjcdAMQ",
+              "previousAnchor": "hl:uEiCPBh27UFpxQq1Sdw-YoyH9n7yPD7AktxAlBGWlMFfGMQ"
+            }
+          ]
+        },
+        "subject": "hl:uEiB4iWYoR-AfG2-GysgPxs7djSc4zIU08GZu8Y1eEQQDrg:uoQ-BeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQjRpV1lvUi1BZkcyLUd5c2dQeHM3ZGpTYzR6SVUwOEdadThZMWVFUVFEcmc"
+      },
+      "generator": "https://w3id.org/orb#v0",
+      "tag": [
+        {
+          "href": "hl:uEiDqa7j0CTWIUIsndfR1jJwzYdO-31CcUS08e9APyot_-Q",
+          "rel": [
+            "witness"
+          ],
+          "type": "Link"
+        }
+      ],
+      "type": "AnchorObject",
+      "url": "hl:uEiBZijGgA16VhYUjoZFUO2ALWjJeuNP1ylWbG1iEQ6ggiQ"
+    },
+    {
+      "contentObject": {
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://w3id.org/security/suites/jws-2020/v1"
+        ],
+        "credentialSubject": "hl:uEiBZijGgA16VhYUjoZFUO2ALWjJeuNP1ylWbG1iEQ6ggiQ",
+        "id": "https://orb.domain1.com/vc/9c070be5-e08e-4ade-b210-40ea7eb6b3c8",
+        "issuanceDate": "2021-11-29T15:21:03.0624724Z",
+        "issuer": "https://orb.domain1.com",
+        "proof": [
+          {
+            "created": "2021-11-29T15:21:03.074Z",
+            "domain": "http://orb.vct:8077/maple2020",
+            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..q6Qmujh7C6wJFIL0-hajFTpszGOzvd4GasFwXawdUwMa-emLuoVM8qaEBw0C-3GqNWsS0EzgfMTcL-djPte9Dg",
+            "proofPurpose": "assertionMethod",
+            "type": "Ed25519Signature2018",
+            "verificationMethod": "did:web:orb.domain1.com#orb1key"
+          },
+          {
+            "created": "2021-11-29T15:21:03.1786462Z",
+            "domain": "https://orb.domain2.com",
+            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..q10AkIUmg39QbfiIllvWFVhPVvJeFuCiQzWDdifQ7AdFDmQjchffmTX1MugTYbO5J_dpnZLTfPjXf4XZWIU2AQ",
+            "proofPurpose": "assertionMethod",
+            "type": "Ed25519Signature2018",
+            "verificationMethod": "did:web:orb.domain2.com#orb2key"
+          }
+        ],
+        "type": "VerifiableCredential"
+      },
+      "generator": "https://w3id.org/orb#v0",
+      "type": "AnchorObject",
+      "url": "hl:uEiDqa7j0CTWIUIsndfR1jJwzYdO-31CcUS08e9APyot_-Q"
+    }
+  ],
+  "attributedTo": "https://orb.domain1.com/services/orb",
+  "index": "hl:uEiBZijGgA16VhYUjoZFUO2ALWjJeuNP1ylWbG1iEQ6ggiQ",
+  "parent": "hl:uEiCPBh27UFpxQq1Sdw-YoyH9n7yPD7AktxAlBGWlMFfGMQ:uoQ-BeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQ1BCaDI3VUZweFFxMVNkdy1Zb3lIOW43eVBEN0FrdHhBbEJHV2xNRmZHTVE",
+  "published": "2021-11-29T15:21:03.0620444Z",
+  "type": "AnchorEvent"
+}`
+
+//nolint:lll
+const sampleParentAnchorEvent = `{
+  "@context": "https://w3id.org/activityanchors/v1",
+  "attachment": [
+    {
+      "contentObject": {
+        "properties": {
+          "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v0",
+          "https://w3id.org/activityanchors#resources": [
+            {
+              "id": "did:orb:uEiCQhpLcjhOV_tDVibUfPbkhjJM_FUYwQ9AuAHahoAGxyg:EiAN8R3Na3wa_jkqWRHa3GCXlTrVKlXn4UTecMMkjcdAMQ",
+              "previousAnchor": "hl:uEiCQhpLcjhOV_tDVibUfPbkhjJM_FUYwQ9AuAHahoAGxyg"
+            },
+            {
+              "id": "did:orb:uEiCQhpLcjhOV_tDVibUfPbkhjJM_FUYwQ9AuAHahoAGxyg:EiCQNQ4L1bBFtgaFk4FS4kzLyO3gIO15tXn2j0T5EEu2UQ",
+              "previousAnchor": "hl:uEiCQhpLcjhOV_tDVibUfPbkhjJM_FUYwQ9AuAHahoAGxyg"
+            }
+          ]
+        },
+        "subject": "hl:uEiDSfb9B3JJzjHj61vSfM7pYPsl1tKTSTIB9kjEKdQCBWw:uoQ-BeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpRFNmYjlCM0pKempIajYxdlNmTTdwWVBzbDF0S1RTVElCOWtqRUtkUUNCV3c"
+      },
+      "generator": "https://w3id.org/orb#v0",
+      "tag": [
+        {
+          "href": "hl:uEiAQZHVlPe0To_t9Mz-K__W6Bf2owOASxjZMdz3EM1akrA",
+          "rel": [
+            "witness"
+          ],
+          "type": "Link"
+        }
+      ],
+      "type": "AnchorObject",
+      "url": "hl:uEiDvP1yOfMsF5JYqFH_F4QX12_IOwp9tNRjsRl4fZrofSQ"
+    },
+    {
+      "contentObject": {
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://w3id.org/security/suites/jws-2020/v1"
+        ],
+        "credentialSubject": "hl:uEiDvP1yOfMsF5JYqFH_F4QX12_IOwp9tNRjsRl4fZrofSQ",
+        "id": "https://orb.domain1.com/vc/ec1c7fc7-7941-4178-ab58-7f0f8e18b8dc",
+        "issuanceDate": "2021-11-29T15:20:57.9755326Z",
+        "issuer": "https://orb.domain1.com",
+        "proof": [
+          {
+            "created": "2021-11-29T15:20:57.983Z",
+            "domain": "http://orb.vct:8077/maple2020",
+            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..2Hgmb6c6r8RCnJ1Wf7EmhUBoZ73oEoqrb1kETEyNcox27OP1R3fzpq-DoyELbk7fO8to8L241D0bbx9nyzZNAA",
+            "proofPurpose": "assertionMethod",
+            "type": "Ed25519Signature2018",
+            "verificationMethod": "did:web:orb.domain1.com#orb1key"
+          },
+          {
+            "created": "2021-11-29T15:20:58.0907253Z",
+            "domain": "https://orb.domain2.com",
+            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..D5gxR0LGQIsltpKvm4Fwm63xy47ThBP-eJROqxXoEPAwTgMM5_zhGxTK1n_XdEpXg3jtd6VGzzsh86HU50dfBw",
+            "proofPurpose": "assertionMethod",
+            "type": "Ed25519Signature2018",
+            "verificationMethod": "did:web:orb.domain2.com#orb2key"
+          }
+        ],
+        "type": "VerifiableCredential"
+      },
+      "generator": "https://w3id.org/orb#v0",
+      "type": "AnchorObject",
+      "url": "hl:uEiAQZHVlPe0To_t9Mz-K__W6Bf2owOASxjZMdz3EM1akrA"
+    }
+  ],
+  "attributedTo": "https://orb.domain1.com/services/orb",
+  "index": "hl:uEiDvP1yOfMsF5JYqFH_F4QX12_IOwp9tNRjsRl4fZrofSQ",
+  "parent": "hl:uEiCQhpLcjhOV_tDVibUfPbkhjJM_FUYwQ9AuAHahoAGxyg:uoQ-BeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQ1FocExjamhPVl90RFZpYlVmUGJraGpKTV9GVVl3UTlBdUFIYWhvQUd4eWc",
+  "published": "2021-11-29T15:20:57.975214Z",
+  "type": "AnchorEvent"
+}`
+
+//nolint:lll
+const sampleGrandparentAnchorEvent = `{
+  "@context": "https://w3id.org/activityanchors/v1",
+  "attachment": [
+    {
+      "contentObject": {
+        "properties": {
+          "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v0",
+          "https://w3id.org/activityanchors#resources": [
+            {
+              "id": "did:orb:uAAA:EiAN8R3Na3wa_jkqWRHa3GCXlTrVKlXn4UTecMMkjcdAMQ"
+            },
+            {
+              "id": "did:orb:uAAA:EiCQNQ4L1bBFtgaFk4FS4kzLyO3gIO15tXn2j0T5EEu2UQ"
+            }
+          ]
+        },
+        "subject": "hl:uEiCH0q3MEo8iI-tpO-oPYKpAxt_J0CPGZCknwobkmM2d3A:uoQ-BeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQ0gwcTNNRW84aUktdHBPLW9QWUtwQXh0X0owQ1BHWkNrbndvYmttTTJkM0E"
+      },
+      "generator": "https://w3id.org/orb#v0",
+      "tag": [
+        {
+          "href": "hl:uEiAK350M8UQQlUS6f4hKeWzi5iYvw6n3c96doONIAZe0pQ",
+          "rel": [
+            "witness"
+          ],
+          "type": "Link"
+        }
+      ],
+      "type": "AnchorObject",
+      "url": "hl:uEiDvX0mmtBDXE9AswkkfEMOXniSQ_SIbN57Kz8XfV03lUA"
+    },
+    {
+      "contentObject": {
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://w3id.org/security/suites/jws-2020/v1"
+        ],
+        "credentialSubject": "hl:uEiDvX0mmtBDXE9AswkkfEMOXniSQ_SIbN57Kz8XfV03lUA",
+        "id": "https://orb.domain1.com/vc/433284e4-9891-4bf8-ad01-85de12a15ed8",
+        "issuanceDate": "2021-11-29T15:20:55.9382235Z",
+        "issuer": "https://orb.domain1.com",
+        "proof": [
+          {
+            "created": "2021-11-29T15:20:55.947Z",
+            "domain": "http://orb.vct:8077/maple2020",
+            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..qILZ-0Dk__TbxKYNQJmictTDlCQvPMZK-g9ONCSEz58NYQI3tS4qbyvRrtTWeT84x8Rm4vpb2EDqxQv2pi6cAA",
+            "proofPurpose": "assertionMethod",
+            "type": "Ed25519Signature2018",
+            "verificationMethod": "did:web:orb.domain1.com#orb1key"
+          },
+          {
+            "created": "2021-11-29T15:20:56.0750857Z",
+            "domain": "https://orb.domain2.com",
+            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..H_OTWQxSx7pypRjGd9q9IOBiDueQO9oJGq0GFZMUQBLLCZYsx5fp1B54yoKHg6_AmwgJOAKgfUIiHuEekcA3BA",
+            "proofPurpose": "assertionMethod",
+            "type": "Ed25519Signature2018",
+            "verificationMethod": "did:web:orb.domain2.com#orb2key"
+          }
+        ],
+        "type": "VerifiableCredential"
+      },
+      "generator": "https://w3id.org/orb#v0",
+      "type": "AnchorObject",
+      "url": "hl:uEiAK350M8UQQlUS6f4hKeWzi5iYvw6n3c96doONIAZe0pQ"
+    }
+  ],
+  "attributedTo": "https://orb.domain1.com/services/orb",
+  "index": "hl:uEiDvX0mmtBDXE9AswkkfEMOXniSQ_SIbN57Kz8XfV03lUA",
+  "published": "2021-11-29T15:20:55.9326576Z",
+  "type": "AnchorEvent"
+}`

--- a/pkg/anchor/writer/writer.go
+++ b/pkg/anchor/writer/writer.go
@@ -240,13 +240,13 @@ func (c *Writer) WriteAnchor(anchor string, attachments []*protocol.AnchorDocume
 
 	c.metrics.WriteAnchorSignLocalStoreTime(time.Since(storeStartTime))
 
-	logger.Debugf("signed and stored anchor event %s for anchor: %s", anchorEvent.Index().String(), anchor)
+	logger.Debugf("signed and stored anchor event %s for anchor: %s", anchorEvent.Index(), anchor)
 
 	// send an offer activity to witnesses (request witnessing anchor credential from non-local witness logs)
 	err = c.postOfferActivity(anchorEvent, batchWitnesses)
 	if err != nil {
 		return fmt.Errorf("failed to post new offer activity for anchor event %s: %w",
-			anchorEvent.URL(), err)
+			anchorEvent.Index(), err)
 	}
 
 	return nil

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     environment:
       - ORB_SYNC_TIMEOUT=3
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
-      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=info:DEBUG
+      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:DEBUG
       - ORB_VCT_URL=http://orb.vct:8077/maple2020
       - ORB_HOST_URL=172.20.0.23:443
       - ORB_HOST_METRICS_URL=172.20.0.23:48327
@@ -106,7 +106,7 @@ services:
     environment:
       - ORB_SYNC_TIMEOUT=3
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
-      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=info:DEBUG
+      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:DEBUG
       - ORB_VCT_URL=http://orb.vct:8077/maple2020
       - ORB_HOST_URL=172.20.0.2:443
       - ORB_HOST_METRICS_URL=172.20.0.2:48527
@@ -216,7 +216,7 @@ services:
     environment:
       - ORB_SYNC_TIMEOUT=3
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
-      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=info:DEBUG
+      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:DEBUG
       - ORB_HOST_URL=172.20.0.4:80
       - ORB_HOST_METRICS_URL=172.20.0.4:48827
       - ORB_PRIVATE_KEY=9kRTh70Ut0MKPeHY3Gdv/pi8SACx6dFjaEiIHf7JDugPpXBnCHVvRbgdzYbWfCGsXdvh/Zct+AldKG4bExjHXg
@@ -302,7 +302,7 @@ services:
     environment:
       - ORB_SYNC_TIMEOUT=3
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
-      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=info:DEBUG
+      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:DEBUG
       - ORB_HOST_URL=172.20.0.5:80
       - ORB_HOST_METRICS_URL=172.20.0.5:48927
       - ORB_PRIVATE_KEY=9kRTh70Ut0MKPeHY3Gdv/pi8SACx6dFjaEiIHf7JDugPpXBnCHVvRbgdzYbWfCGsXdvh/Zct+AldKG4bExjHXg
@@ -388,7 +388,7 @@ services:
     environment:
       - ORB_SYNC_TIMEOUT=3
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
-      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=info:DEBUG
+      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:DEBUG
       - ORB_PRIVATE_KEY=9kRTh70Ut0MKPeHY3Gdv/pi8SACx6dFjaEiIHf7JDugPpXBnCHVvRbgdzYbWfCGsXdvh/Zct+AldKG4bExjHXg
       - ORB_KEY_ID=orb3key
       - ORB_HOST_URL=172.20.0.6:443
@@ -483,7 +483,7 @@ services:
     environment:
       - ORB_SYNC_TIMEOUT=3
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
-      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=info:DEBUG
+      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:DEBUG
       - ORB_HOST_URL=172.20.0.7:443
       - ORB_HOST_METRICS_URL=172.20.0.7:48727
       - ORB_PRIVATE_KEY=9kRTh70Ut0MKPeHY3Gdv/pi8SACx6dFjaEiIHf7JDugPpXBnCHVvRbgdzYbWfCGsXdvh/Zct+AldKG4bExjHXg


### PR DESCRIPTION
The anchor event handler now checks all parent anchor events and ensures that they are also processed.

closes #902

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>