### PR TITLE
fix: Create document store should return id with hint (if requested)

### DIFF
--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -364,6 +364,9 @@ Feature:
 
     Then client verifies resolved document
 
+    When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with equivalent did
+    Then check success response does NOT contain "canonicalId"
+
     Then mis-configured client fails to verify resolved document
 
     Then we wait 6 seconds


### PR DESCRIPTION
If client attempts to resolve document with equivalent ID (with https hint) from create document store then we will return that ID in resolution response.

Closes #913

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>