### PR TITLE
chore: Add BDD test for consecutive updates

### DIFF
--- a/cmd/orb-cli/go.sum
+++ b/cmd/orb-cli/go.sum
@@ -483,6 +483,7 @@ github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
+github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -1286,8 +1287,8 @@ github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7j
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211124193658-d5f6ccf1e554 h1:UjDfkuIws52zeyApANh4MaWNHwR5snQulG3iBfFX3Z0=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211124193658-d5f6ccf1e554/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164 h1:8lCeZoNsHZuWWp+wBbDPHbD+C2917xZkOh/etmEzkGM=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/cmd/orb-driver/go.mod
+++ b/cmd/orb-driver/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7
 	github.com/trustbloc/orb v0.1.3-0.20210914173654-dab098ce4e32
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211124193658-d5f6ccf1e554
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164
 )
 
 replace github.com/trustbloc/orb => ../..

--- a/cmd/orb-driver/go.sum
+++ b/cmd/orb-driver/go.sum
@@ -481,6 +481,7 @@ github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
+github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -1280,8 +1281,8 @@ github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7j
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211124193658-d5f6ccf1e554 h1:UjDfkuIws52zeyApANh4MaWNHwR5snQulG3iBfFX3Z0=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211124193658-d5f6ccf1e554/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164 h1:8lCeZoNsHZuWWp+wBbDPHbD+C2917xZkOh/etmEzkGM=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/cmd/orb-server/go.mod
+++ b/cmd/orb-server/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7
 	github.com/trustbloc/orb v0.0.0
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211124193658-d5f6ccf1e554
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164
 )
 
 replace github.com/trustbloc/orb => ../..

--- a/cmd/orb-server/go.sum
+++ b/cmd/orb-server/go.sum
@@ -1298,8 +1298,8 @@ github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoi
 github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7jjHQo2gMGNPIRfhvn4aXQ0FYMrG9lRgQcvZKTviCGc=
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211124193658-d5f6ccf1e554 h1:UjDfkuIws52zeyApANh4MaWNHwR5snQulG3iBfFX3Z0=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211124193658-d5f6ccf1e554/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164 h1:8lCeZoNsHZuWWp+wBbDPHbD+C2917xZkOh/etmEzkGM=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/streadway/amqp v1.0.0
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211124193658-d5f6ccf1e554
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164
 	github.com/trustbloc/vct v0.1.3
 	github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a // indirect
 	go.mongodb.org/mongo-driver v1.7.4

--- a/go.sum
+++ b/go.sum
@@ -1291,8 +1291,8 @@ github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoi
 github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7jjHQo2gMGNPIRfhvn4aXQ0FYMrG9lRgQcvZKTviCGc=
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211124193658-d5f6ccf1e554 h1:UjDfkuIws52zeyApANh4MaWNHwR5snQulG3iBfFX3Z0=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211124193658-d5f6ccf1e554/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164 h1:8lCeZoNsHZuWWp+wBbDPHbD+C2917xZkOh/etmEzkGM=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/test/bdd/did_orb_steps.go
+++ b/test/bdd/did_orb_steps.go
@@ -619,7 +619,9 @@ func (d *DIDOrbSteps) checkSuccessRespDoesntContain(msg string) error {
 func (d *DIDOrbSteps) checkSuccessResp(msg string, contains bool) error {
 	var err error
 
-	const maxRetries = 5
+	const maxRetries = 10
+
+	initialSleep := 350 // in milliseconds
 
 	for i := 1; i <= maxRetries; i++ {
 		err = d.checkSuccessRespHelper(msg, contains)
@@ -632,7 +634,12 @@ func (d *DIDOrbSteps) checkSuccessResp(msg string, contains bool) error {
 			return err
 		}
 
-		time.Sleep(2 * time.Second)
+		if i <= 5 {
+			time.Sleep(time.Duration(initialSleep) * time.Millisecond)
+		} else {
+			time.Sleep(time.Duration(i*initialSleep) * time.Millisecond)
+		}
+
 		logger.Infof("retrying check success response - attempt %d", i)
 
 		resolveErr := d.resolveDIDDocumentWithID(d.sidetreeURL, d.retryDID)

--- a/test/bdd/features/did-sidetree.feature
+++ b/test/bdd/features/did-sidetree.feature
@@ -174,6 +174,31 @@ Feature:
       When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with canonical did
       Then check success response does NOT contain "newKey"
 
+      # three consecutive updates test: it will be handled in three batches
+
+      When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to add public key with ID "firstKey" to DID document
+      Then check for request success
+
+      When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to add public key with ID "secondKey" to DID document
+      Then check for request success
+
+      When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to add public key with ID "thirdKey" to DID document
+      Then check for request success
+
+      When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+      Then check success response contains "firstKey"
+      Then check success response does NOT contain "secondKey"
+
+      When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+      Then check success response contains "firstKey"
+      Then check success response contains "secondKey"
+      Then check success response does NOT contain "thirdKey"
+
+      When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+      Then check success response contains "firstKey"
+      Then check success response contains "secondKey"
+      Then check success response contains "thirdKey"
+
     @create_add_remove_services
     Scenario: add and remove service endpoints
       Given the authorization bearer token for "GET" requests to path "/sidetree/v1/identifiers" is set to "READ_TOKEN"

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/tidwall/gjson v1.7.4
 	github.com/trustbloc/orb v0.1.4-0.20211008191555-789f5f021da4
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211124193658-d5f6ccf1e554
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164
 )
 
 replace github.com/trustbloc/orb => ../../

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -1552,8 +1552,8 @@ github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/sidetree-core-go v0.7.1-0.20211001153855-238da75965f8/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211124193658-d5f6ccf1e554 h1:UjDfkuIws52zeyApANh4MaWNHwR5snQulG3iBfFX3Z0=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211124193658-d5f6ccf1e554/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164 h1:8lCeZoNsHZuWWp+wBbDPHbD+C2917xZkOh/etmEzkGM=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=


### PR DESCRIPTION
Add BDD test for consecutive updates, second update will be processed in the next batch.

Closes #919

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>