### PR TITLE
feat: Periodically update permit timestamp for long running tasks

### DIFF
--- a/pkg/activitypub/service/anchorsynctask/anchorsynctask.go
+++ b/pkg/activitypub/service/anchorsynctask/anchorsynctask.go
@@ -27,9 +27,8 @@ const logModule = "anchor_sync"
 var logger = log.New(logModule)
 
 const (
-	defaultInterval   = time.Minute
-	defaultMaxRunTime = 90 * time.Second
-	taskName          = "activity-sync"
+	defaultInterval = time.Minute
+	taskName        = "activity-sync"
 )
 
 type activityPubClient interface {
@@ -38,14 +37,13 @@ type activityPubClient interface {
 }
 
 type taskManager interface {
-	RegisterTask(taskType string, interval, maxRunTime time.Duration, task func())
+	RegisterTask(taskType string, interval time.Duration, task func())
 }
 
 // Config contains configuration parameters for the anchor event synchronization task.
 type Config struct {
 	ServiceIRI *url.URL
 	Interval   time.Duration
-	MaxRunTime time.Duration
 }
 
 type task struct {
@@ -65,20 +63,15 @@ func Register(cfg Config, taskMgr taskManager, apClient activityPubClient, apSto
 		return fmt.Errorf("create task: %w", err)
 	}
 
-	interval, maxRunTime := cfg.Interval, cfg.MaxRunTime
+	interval := cfg.Interval
 
 	if interval == 0 {
 		interval = defaultInterval
 	}
 
-	if maxRunTime == 0 {
-		maxRunTime = defaultMaxRunTime
-	}
+	logger.Infof("Registering activity-sync task - ServiceIRI: %s, Interval: %s.", cfg.ServiceIRI, interval)
 
-	logger.Infof("Registering activity-sync task - ServiceIRI: %s, Interval: %s, MaxRunTime: %s.",
-		cfg.ServiceIRI, interval, maxRunTime)
-
-	taskMgr.RegisterTask(taskName, interval, maxRunTime, t.run)
+	taskMgr.RegisterTask(taskName, interval, t.run)
 
 	return nil
 }

--- a/pkg/activitypub/service/mocks/taskmgr.gen.go
+++ b/pkg/activitypub/service/mocks/taskmgr.gen.go
@@ -7,30 +7,28 @@ import (
 )
 
 type TaskManager struct {
-	RegisterTaskStub        func(taskType string, interval, maxRunTime time.Duration, task func())
+	RegisterTaskStub        func(taskType string, interval time.Duration, task func())
 	registerTaskMutex       sync.RWMutex
 	registerTaskArgsForCall []struct {
-		taskType   string
-		interval   time.Duration
-		maxRunTime time.Duration
-		task       func()
+		taskType string
+		interval time.Duration
+		task     func()
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *TaskManager) RegisterTask(taskType string, interval time.Duration, maxRunTime time.Duration, task func()) {
+func (fake *TaskManager) RegisterTask(taskType string, interval time.Duration, task func()) {
 	fake.registerTaskMutex.Lock()
 	fake.registerTaskArgsForCall = append(fake.registerTaskArgsForCall, struct {
-		taskType   string
-		interval   time.Duration
-		maxRunTime time.Duration
-		task       func()
-	}{taskType, interval, maxRunTime, task})
-	fake.recordInvocation("RegisterTask", []interface{}{taskType, interval, maxRunTime, task})
+		taskType string
+		interval time.Duration
+		task     func()
+	}{taskType, interval, task})
+	fake.recordInvocation("RegisterTask", []interface{}{taskType, interval, task})
 	fake.registerTaskMutex.Unlock()
 	if fake.RegisterTaskStub != nil {
-		fake.RegisterTaskStub(taskType, interval, maxRunTime, task)
+		fake.RegisterTaskStub(taskType, interval, task)
 	}
 }
 
@@ -40,10 +38,10 @@ func (fake *TaskManager) RegisterTaskCallCount() int {
 	return len(fake.registerTaskArgsForCall)
 }
 
-func (fake *TaskManager) RegisterTaskArgsForCall(i int) (string, time.Duration, time.Duration, func()) {
+func (fake *TaskManager) RegisterTaskArgsForCall(i int) (string, time.Duration, func()) {
 	fake.registerTaskMutex.RLock()
 	defer fake.registerTaskMutex.RUnlock()
-	return fake.registerTaskArgsForCall[i].taskType, fake.registerTaskArgsForCall[i].interval, fake.registerTaskArgsForCall[i].maxRunTime, fake.registerTaskArgsForCall[i].task
+	return fake.registerTaskArgsForCall[i].taskType, fake.registerTaskArgsForCall[i].interval, fake.registerTaskArgsForCall[i].task
 }
 
 func (fake *TaskManager) Invocations() map[string][][]interface{} {

--- a/pkg/store/expiry/expiry.go
+++ b/pkg/store/expiry/expiry.go
@@ -16,12 +16,7 @@ import (
 
 const (
 	loggerModule = "expiry-service"
-	// When the Orb server with the expired data cleanup duty (permit holder) has not done it for an unusually
-	// long time (indicating it's down), another Orb server will take over the duty. This value multiplied by the
-	// configured interval time defines what an "unusually long time" is.
-	permitTimeLimitIntervalMultiplier = 3
-
-	taskName = "data-expiry"
+	taskName     = "data-expiry"
 )
 
 type logger interface {
@@ -32,7 +27,7 @@ type logger interface {
 }
 
 type taskManager interface {
-	RegisterTask(taskType string, interval, maxRunTime time.Duration, handler func())
+	RegisterTask(taskType string, interval time.Duration, handler func())
 }
 
 type registeredStore struct {
@@ -85,8 +80,7 @@ func NewService(scheduler taskManager, interval time.Duration) *Service {
 		registeredStores: make([]registeredStore, 0),
 	}
 
-	scheduler.RegisterTask(taskName, interval,
-		interval*permitTimeLimitIntervalMultiplier, s.deleteExpiredData)
+	scheduler.RegisterTask(taskName, interval, s.deleteExpiredData)
 
 	return s
 }

--- a/pkg/taskmgr/taskmgr_test.go
+++ b/pkg/taskmgr/taskmgr_test.go
@@ -134,7 +134,7 @@ func TestService(t *testing.T) {
 
 		taskMgr := New(coordinationStore, time.Millisecond)
 
-		taskMgr.RegisterTask("test-task", time.Millisecond, time.Millisecond, func() {
+		taskMgr.RegisterTask("test-task", time.Millisecond, func() {
 			t.Logf("Running test-task")
 		})
 
@@ -155,7 +155,7 @@ func TestService(t *testing.T) {
 
 		taskMgr := New(coordinationStore, time.Millisecond)
 
-		taskMgr.RegisterTask("test-task", time.Millisecond, time.Millisecond, func() {
+		taskMgr.RegisterTask("test-task", time.Millisecond, func() {
 			t.Logf("Running test-task")
 		})
 
@@ -186,7 +186,7 @@ func getTestExpiryServices(t *testing.T, coordinationStore storage.Store) (*Mana
 
 	log.SetLevel(service1LoggerModule, log.DEBUG)
 
-	taskMgr1.RegisterTask("test-task", time.Second, 2*time.Second, func() {
+	taskMgr1.RegisterTask("test-task", time.Second, func() {
 		taskMgr1.logger.Infof("Running test-task in task manager 1")
 
 		time.Sleep(time.Second)
@@ -204,7 +204,7 @@ func getTestExpiryServices(t *testing.T, coordinationStore storage.Store) (*Mana
 
 	log.SetLevel(service2LoggerModule, log.DEBUG)
 
-	taskMgr2.RegisterTask("test-task", time.Second, time.Second, func() {
+	taskMgr2.RegisterTask("test-task", time.Second, func() {
 		taskMgr2.logger.Infof("Running test-task in task manager 2")
 	})
 


### PR DESCRIPTION
For long running tasks, the timestamp on the permit is periodically updated to tell the other instances in the domain that the instance is still alive.

closes #915

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>