### PR TITLE
feat: Add support for multiple operations per suffix in unpublished operation store

### DIFF
--- a/cmd/orb-cli/go.sum
+++ b/cmd/orb-cli/go.sum
@@ -1288,8 +1288,8 @@ github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7j
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164 h1:8lCeZoNsHZuWWp+wBbDPHbD+C2917xZkOh/etmEzkGM=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211207183256-1ae2fc0dadc7 h1:vbLvZS8RtyxvV+gWxOuBeYlOrIJJ/Zp9JtG5p5C2ilg=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211207183256-1ae2fc0dadc7/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/cmd/orb-driver/go.mod
+++ b/cmd/orb-driver/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7
 	github.com/trustbloc/orb v0.1.3-0.20210914173654-dab098ce4e32
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211207183256-1ae2fc0dadc7
 )
 
 replace github.com/trustbloc/orb => ../..

--- a/cmd/orb-driver/go.sum
+++ b/cmd/orb-driver/go.sum
@@ -1282,8 +1282,8 @@ github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7j
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164 h1:8lCeZoNsHZuWWp+wBbDPHbD+C2917xZkOh/etmEzkGM=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211207183256-1ae2fc0dadc7 h1:vbLvZS8RtyxvV+gWxOuBeYlOrIJJ/Zp9JtG5p5C2ilg=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211207183256-1ae2fc0dadc7/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/cmd/orb-server/go.mod
+++ b/cmd/orb-server/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7
 	github.com/trustbloc/orb v0.0.0
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211207183256-1ae2fc0dadc7
 )
 
 replace github.com/trustbloc/orb => ../..

--- a/cmd/orb-server/go.sum
+++ b/cmd/orb-server/go.sum
@@ -1299,8 +1299,8 @@ github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoi
 github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7jjHQo2gMGNPIRfhvn4aXQ0FYMrG9lRgQcvZKTviCGc=
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164 h1:8lCeZoNsHZuWWp+wBbDPHbD+C2917xZkOh/etmEzkGM=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211207183256-1ae2fc0dadc7 h1:vbLvZS8RtyxvV+gWxOuBeYlOrIJJ/Zp9JtG5p5C2ilg=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211207183256-1ae2fc0dadc7/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/streadway/amqp v1.0.0
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211207183256-1ae2fc0dadc7
 	github.com/trustbloc/vct v0.1.3
 	github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a // indirect
 	go.mongodb.org/mongo-driver v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -1292,8 +1292,8 @@ github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoi
 github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7jjHQo2gMGNPIRfhvn4aXQ0FYMrG9lRgQcvZKTviCGc=
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164 h1:8lCeZoNsHZuWWp+wBbDPHbD+C2917xZkOh/etmEzkGM=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211207183256-1ae2fc0dadc7 h1:vbLvZS8RtyxvV+gWxOuBeYlOrIJJ/Zp9JtG5p5C2ilg=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211207183256-1ae2fc0dadc7/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/pkg/store/operation/unpublished/store_test.go
+++ b/pkg/store/operation/unpublished/store_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 
 	"github.com/trustbloc/orb/pkg/internal/testutil"
+	"github.com/trustbloc/orb/pkg/store/mocks"
 )
 
 func TestNew(t *testing.T) {
@@ -42,8 +43,17 @@ func TestStore_Put(t *testing.T) {
 		s, err := New(mem.NewProvider(), time.Minute, testutil.GetExpiryService(t))
 		require.NoError(t, err)
 
-		err = s.Put(&operation.AnchoredOperation{UniqueSuffix: "suffix"})
+		err = s.Put(&operation.AnchoredOperation{UniqueSuffix: "suffix", OperationRequest: []byte(operationRequest)})
 		require.NoError(t, err)
+	})
+
+	t.Run("error - invalid operation", func(t *testing.T) {
+		s, err := New(mem.NewProvider(), time.Minute, testutil.GetExpiryService(t))
+		require.NoError(t, err)
+
+		err = s.Put(&operation.AnchoredOperation{UniqueSuffix: "suffix", OperationRequest: []byte("invalid")})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to generate key for unpublished operation for suffix[suffix]")
 	})
 
 	t.Run("error - store put", func(t *testing.T) {
@@ -56,36 +66,51 @@ func TestStore_Put(t *testing.T) {
 			testutil.GetExpiryService(t))
 		require.NoError(t, err)
 
-		err = s.Put(&operation.AnchoredOperation{UniqueSuffix: "suffix"})
+		err = s.Put(&operation.AnchoredOperation{UniqueSuffix: "suffix", OperationRequest: []byte(operationRequest)})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "error put")
 	})
 
-	t.Run("error - store get", func(t *testing.T) {
-		storeProvider := &mockstore.Provider{OpenStoreReturn: &mockstore.Store{
-			ErrGet: fmt.Errorf("random get error"),
-		}}
-
-		s, err := New(storeProvider, time.Minute, testutil.GetExpiryService(t))
-		require.NoError(t, err)
-
-		err = s.Put(&operation.AnchoredOperation{UniqueSuffix: "suffix"})
-		require.Error(t, err)
-		require.Contains(t, err.Error(),
-			"unable to check for pending operations for suffix[suffix], please re-submit your operation request at later time: random get error") // nolint:lll
-	})
-
-	t.Run("error - consecutive put", func(t *testing.T) {
+	t.Run("success - consecutive put(different operations)", func(t *testing.T) {
 		s, err := New(mem.NewProvider(), time.Minute, testutil.GetExpiryService(t))
 		require.NoError(t, err)
 
-		err = s.Put(&operation.AnchoredOperation{UniqueSuffix: "suffix"})
+		first := &operation.AnchoredOperation{
+			UniqueSuffix:     "suffix",
+			OperationRequest: []byte(operationRequest),
+		}
+
+		second := &operation.AnchoredOperation{
+			UniqueSuffix:     "suffix",
+			OperationRequest: []byte(secondOperationRequest),
+		}
+
+		err = s.Put(first)
 		require.NoError(t, err)
 
-		err = s.Put(&operation.AnchoredOperation{UniqueSuffix: "suffix"})
-		require.Error(t, err)
-		require.Contains(t, err.Error(),
-			"pending operation found for suffix[suffix], please re-submit your operation request at later time")
+		err = s.Put(second)
+		require.NoError(t, err)
+
+		ops, err := s.Get("suffix")
+		require.NoError(t, err)
+		require.Len(t, ops, 2)
+	})
+
+	t.Run("success - consecutive put(same operation, overridden)", func(t *testing.T) {
+		s, err := New(mem.NewProvider(), time.Minute, testutil.GetExpiryService(t))
+		require.NoError(t, err)
+
+		op := &operation.AnchoredOperation{UniqueSuffix: "suffix", OperationRequest: []byte(operationRequest)}
+
+		err = s.Put(op)
+		require.NoError(t, err)
+
+		err = s.Put(op)
+		require.NoError(t, err)
+
+		ops, err := s.Get("suffix")
+		require.NoError(t, err)
+		require.Len(t, ops, 1)
 	})
 }
 
@@ -94,12 +119,12 @@ func TestStore_Get(t *testing.T) {
 		s, err := New(mem.NewProvider(), time.Minute, testutil.GetExpiryService(t))
 		require.NoError(t, err)
 
-		err = s.Put(&operation.AnchoredOperation{UniqueSuffix: "suffix"})
+		err = s.Put(&operation.AnchoredOperation{UniqueSuffix: "suffix", OperationRequest: []byte(operationRequest)})
 		require.NoError(t, err)
 
-		op, err := s.Get("suffix")
+		ops, err := s.Get("suffix")
 		require.NoError(t, err)
-		require.Equal(t, op.UniqueSuffix, "suffix")
+		require.Equal(t, ops[0].UniqueSuffix, "suffix")
 	})
 
 	t.Run("error - operation without suffix", func(t *testing.T) {
@@ -111,9 +136,9 @@ func TestStore_Get(t *testing.T) {
 		require.Contains(t, err.Error(), "failed to save unpublished operation: suffix is empty")
 	})
 
-	t.Run("error - from store get", func(t *testing.T) {
+	t.Run("error - query error", func(t *testing.T) {
 		storeProvider := &mockstore.Provider{OpenStoreReturn: &mockstore.Store{
-			ErrGet: fmt.Errorf("error get"),
+			ErrQuery: fmt.Errorf("query error"),
 		}}
 
 		s, err := New(storeProvider, time.Minute, testutil.GetExpiryService(t))
@@ -121,26 +146,82 @@ func TestStore_Get(t *testing.T) {
 
 		op, err := s.Get("suffix")
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "error get")
+		require.Contains(t, err.Error(), "query error")
 		require.Nil(t, op)
 	})
 
-	t.Run("error - unmarshal operation", func(t *testing.T) {
+	t.Run("error - suffix not found", func(t *testing.T) {
 		provider := mem.NewProvider()
-
-		store, err := provider.OpenStore(nameSpace)
-		require.NoError(t, err)
-
-		err = store.Put("suffix", []byte("not-json"))
-		require.NoError(t, err)
 
 		s, err := New(provider, time.Minute, testutil.GetExpiryService(t))
 		require.NoError(t, err)
 
 		op, err := s.Get("suffix")
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to unmarshal unpublished operation for suffix[suffix]")
+		require.Contains(t, err.Error(), "suffix[suffix] not found in the unpublished operation store")
 		require.Nil(t, op)
+	})
+
+	t.Run("error - iterator next() error", func(t *testing.T) {
+		iterator := &mocks.Iterator{}
+		iterator.NextReturns(false, fmt.Errorf("iterator next() error"))
+
+		store := &mocks.Store{}
+		store.QueryReturns(iterator, nil)
+
+		provider := &mocks.Provider{}
+		provider.OpenStoreReturns(store, nil)
+
+		s, err := New(provider, time.Minute, testutil.GetExpiryService(t))
+		require.NoError(t, err)
+
+		ops, err := s.Get("suffix")
+		require.Error(t, err)
+		require.Nil(t, ops)
+		require.Contains(t, err.Error(), "iterator next() error")
+	})
+
+	t.Run("error - iterator value() error", func(t *testing.T) {
+		iterator := &mocks.Iterator{}
+
+		iterator.NextReturns(true, nil)
+		iterator.ValueReturns(nil, fmt.Errorf("iterator value() error"))
+
+		store := &mocks.Store{}
+		store.QueryReturns(iterator, nil)
+
+		provider := &mocks.Provider{}
+		provider.OpenStoreReturns(store, nil)
+
+		s, err := New(provider, time.Minute, testutil.GetExpiryService(t))
+		require.NoError(t, err)
+
+		ops, err := s.Get("suffix")
+		require.Error(t, err)
+		require.Nil(t, ops)
+		require.Contains(t, err.Error(), "iterator value() error")
+	})
+
+	t.Run("error - unmarshal unpublished operation error", func(t *testing.T) {
+		iterator := &mocks.Iterator{}
+
+		iterator.NextReturns(true, nil)
+		iterator.ValueReturns([]byte("not-json"), nil)
+
+		store := &mocks.Store{}
+		store.QueryReturns(iterator, nil)
+
+		provider := &mocks.Provider{}
+		provider.OpenStoreReturns(store, nil)
+
+		s, err := New(provider, time.Minute, testutil.GetExpiryService(t))
+		require.NoError(t, err)
+
+		ops, err := s.Get("suffix")
+		require.Error(t, err)
+		require.Nil(t, ops)
+		require.Contains(t, err.Error(),
+			"failed to unmarshal unpublished operation from store value for suffix[suffix]")
 	})
 }
 
@@ -149,11 +230,24 @@ func TestStore_Delete(t *testing.T) {
 		s, err := New(mem.NewProvider(), time.Minute, testutil.GetExpiryService(t))
 		require.NoError(t, err)
 
-		err = s.Put(&operation.AnchoredOperation{UniqueSuffix: "suffix"})
+		op := &operation.AnchoredOperation{UniqueSuffix: "suffix", OperationRequest: []byte(operationRequest)}
+
+		err = s.Put(op)
 		require.NoError(t, err)
 
-		err = s.Delete("suffix")
+		err = s.Delete(op)
 		require.NoError(t, err)
+	})
+
+	t.Run("error - unexpected request format", func(t *testing.T) {
+		s, err := New(mem.NewProvider(), time.Minute, testutil.GetExpiryService(t))
+		require.NoError(t, err)
+
+		op := &operation.AnchoredOperation{UniqueSuffix: "suffix", OperationRequest: []byte("invalid")}
+
+		err = s.Delete(op)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to generate key for unpublished operation for suffix[suffix]")
 	})
 
 	t.Run("error - from store delete", func(t *testing.T) {
@@ -164,7 +258,9 @@ func TestStore_Delete(t *testing.T) {
 		s, err := New(storeProvider, time.Minute, testutil.GetExpiryService(t))
 		require.NoError(t, err)
 
-		err = s.Delete("suffix")
+		op := &operation.AnchoredOperation{UniqueSuffix: "suffix", OperationRequest: []byte(operationRequest)}
+
+		err = s.Delete(op)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "delete error")
 	})
@@ -175,10 +271,12 @@ func TestStore_DeleteAll(t *testing.T) {
 		s, err := New(mem.NewProvider(), time.Minute, testutil.GetExpiryService(t))
 		require.NoError(t, err)
 
-		err = s.Put(&operation.AnchoredOperation{UniqueSuffix: "suffix"})
+		op := &operation.AnchoredOperation{UniqueSuffix: "suffix", OperationRequest: []byte(operationRequest)}
+
+		err = s.Put(op)
 		require.NoError(t, err)
 
-		err = s.DeleteAll([]string{"suffix"})
+		err = s.DeleteAll([]*operation.AnchoredOperation{op})
 		require.NoError(t, err)
 	})
 
@@ -190,6 +288,17 @@ func TestStore_DeleteAll(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("error - unexpected request format", func(t *testing.T) {
+		s, err := New(mem.NewProvider(), time.Minute, testutil.GetExpiryService(t))
+		require.NoError(t, err)
+
+		op := &operation.AnchoredOperation{UniqueSuffix: "suffix", OperationRequest: []byte("invalid")}
+
+		err = s.DeleteAll([]*operation.AnchoredOperation{op})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to generate key for unpublished operation for suffix[suffix]")
+	})
+
 	t.Run("error - from store batch", func(t *testing.T) {
 		storeProvider := &mockstore.Provider{OpenStoreReturn: &mockstore.Store{
 			ErrBatch: fmt.Errorf("batch error"),
@@ -198,8 +307,75 @@ func TestStore_DeleteAll(t *testing.T) {
 		s, err := New(storeProvider, time.Minute, testutil.GetExpiryService(t))
 		require.NoError(t, err)
 
-		err = s.DeleteAll([]string{"suffix"})
+		op := &operation.AnchoredOperation{UniqueSuffix: "suffix", OperationRequest: []byte(operationRequest)}
+
+		err = s.DeleteAll([]*operation.AnchoredOperation{op})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "batch error")
 	})
 }
+
+//nolint:lll
+const operationRequest = `
+{
+  "delta": {
+    "patches": [
+      {
+        "action": "add-public-keys",
+        "publicKeys": [
+          {
+            "id": "fourthKey",
+            "publicKeyJwk": {
+              "crv": "P-256K",
+              "kty": "EC",
+              "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+              "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
+            },
+            "purposes": [
+              "authentication"
+            ],
+            "type": "JsonWebKey2020"
+          }
+        ]
+      }
+    ],
+    "updateCommitment": "EiCGuEvI_J7zWChGb_uPScy34VWb0Gz3apRsaNVV_CLOBw"
+  },
+  "didSuffix": "EiA9MRGXT74LCs0t0rBXnv-bzbt9QXqwJamTAJeh7KYJPg",
+  "revealValue": "EiD_DtWj7epHsTfUU7BiB-birenqx1YYhFGnedw7HYOKhg",
+  "signedData": "eyJhbGciOiJFUzI1NiJ9.eyJhbmNob3JGcm9tIjoxNjM4ODk5MzUwLCJhbmNob3JVbnRpbCI6MTYzODg5OTY1MCwiZGVsdGFIYXNoIjoiRWlDOFpKUXFHNEdLMUtZTjZIZ2VKNkFkM014TVEzLWFIVXBuWVlSN21IS0tGdyIsInVwZGF0ZUtleSI6eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6ImFCLW92RDlKdjhYV1ZqRm53Y0Q1WmlhakdRdTU5bDVxR0pZcTlveFpSYTgiLCJ5IjoiTGJqRE53amRXYXRNdTJpUW9TN2VVNHN1QTZ2NnAwZWNYTDk1aHZReEJsNCJ9fQ.6f79xW74ZOghUYRErDhGYLhpfxlnA3KIkELvew4uOwOCh5IWSeuK6k3oAnjbrxw91pcYWuo-d1s62yLvqCT38Q",
+  "type": "update"
+}`
+
+//nolint:lll
+const secondOperationRequest = `
+{
+  "delta": {
+    "patches": [
+      {
+        "action": "add-public-keys",
+        "publicKeys": [
+          {
+            "id": "fourthKey",
+            "publicKeyJwk": {
+              "crv": "P-256K",
+              "kty": "EC",
+              "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+              "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
+            },
+            "purposes": [
+              "authentication"
+            ],
+            "type": "JsonWebKey2020"
+          }
+        ]
+      }
+    ],
+    "updateCommitment": "EiAl8yc-V3SJ1Cr14IrWsz3iDFozdKAxFNPoLRu3AMlfBA"
+  },
+  "didSuffix": "EiAoFYojQW6itYlNqU9Ru_MwkLcpYa25ntl77p7vqkK9Tg",
+  "revealValue": "EiBWIb9qHE1AaHslb8jUVu_0Wg3cSLTCIMn1MsM3zzHA_g",
+  "signedData": "eyJhbGciOiJFUzI1NiJ9.eyJhbmNob3JGcm9tIjoxNjM3MjgxMzYwLCJhbmNob3JVbnRpbCI6MTYzNzI4MTY2MCwiZGVsdGFIYXNoIjoiRWlBRllucElZcEYwUnZoMzVjMEFCQUJRSTBiNzBoX1h4WHRudTd6TjF2VUo2QSIsInVwZGF0ZUtleSI6eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6InZadjNrYVdaalJVMFVidUctOWtNVjExZHlOOFhMZTF2NjQ3WDZDZmt5ZUUiLCJ5Ijoia0NOdFY3a0xyS1J1ZmxNTVhkQmVaZlROMEtUV2gtcmFNOVJEQk1ROV9ZNCJ9fQ.0NGxM0r8UdBmwiujxNUjQ24PaSpCPa14fYj_vfitFo4QJR8RlbErVxV-J9aXtAKpHZxqgqki749nLipS9EsVIg",
+  "type": "update"
+}
+`

--- a/pkg/versions/1_0/txnprocessor/txnprocessor_test.go
+++ b/pkg/versions/1_0/txnprocessor/txnprocessor_test.go
@@ -239,6 +239,6 @@ type mockUnpublishedOpsStore struct {
 	DeleteAllErr error
 }
 
-func (m *mockUnpublishedOpsStore) DeleteAll(_ []string) error {
+func (m *mockUnpublishedOpsStore) DeleteAll(_ []*operation.AnchoredOperation) error {
 	return m.DeleteAllErr
 }

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/tidwall/gjson v1.7.4
 	github.com/trustbloc/orb v0.1.4-0.20211008191555-789f5f021da4
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211207183256-1ae2fc0dadc7
 )
 
 replace github.com/trustbloc/orb => ../../

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -1553,8 +1553,8 @@ github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/sidetree-core-go v0.7.1-0.20211001153855-238da75965f8/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164 h1:8lCeZoNsHZuWWp+wBbDPHbD+C2917xZkOh/etmEzkGM=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211203214327-2a9ceb1ce164/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211207183256-1ae2fc0dadc7 h1:vbLvZS8RtyxvV+gWxOuBeYlOrIJJ/Zp9JtG5p5C2ilg=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211207183256-1ae2fc0dadc7/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=


### PR DESCRIPTION
Included:

- remove current constraint for one operation per suffix in unpublished operation store
- implement multiple operations per suffix in unpublished operation store
- update sidetree-core and BDD tests

Closes #926

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>