### PR TITLE
chore: Add metrics for document resolution

### DIFF
--- a/pkg/mocks/metricsprovider.go
+++ b/pkg/mocks/metricsprovider.go
@@ -185,3 +185,31 @@ func (m *MetricsProvider) SignerSign(value time.Duration) {
 // SignerAddLinkedDataProof records add data linked proof.
 func (m *MetricsProvider) SignerAddLinkedDataProof(value time.Duration) {
 }
+
+// ResolveDocumentLocallyTime records resolving document locally.
+func (m *MetricsProvider) ResolveDocumentLocallyTime(value time.Duration) {
+}
+
+// GetAnchorOriginEndpointTime records getting anchor origin endpoint information.
+func (m *MetricsProvider) GetAnchorOriginEndpointTime(value time.Duration) {
+}
+
+// ResolveDocumentFromAnchorOriginTime records resolving document from anchor origin.
+func (m *MetricsProvider) ResolveDocumentFromAnchorOriginTime(value time.Duration) {
+}
+
+// DeleteDocumentFromCreateDocumentStoreTime records deleting document from create document store.
+func (m *MetricsProvider) DeleteDocumentFromCreateDocumentStoreTime(value time.Duration) {
+}
+
+// ResolveDocumentFromCreateDocumentStoreTime records resolving document from create document store.
+func (m *MetricsProvider) ResolveDocumentFromCreateDocumentStoreTime(value time.Duration) {
+}
+
+// VerifyCIDTime records verifying CID for document resolution.
+func (m *MetricsProvider) VerifyCIDTime(value time.Duration) {
+}
+
+// RequestDiscoveryTime records the time it takes to request discovery.
+func (m *MetricsProvider) RequestDiscoveryTime(value time.Duration) {
+}


### PR DESCRIPTION
Add metrics for document resolution:
- resolving document locally
- getting anchor origin endpoint info
- resolving document from anchor origin
- deleting document from create document store
- resolving document from create document store
- verifying CID for document resolution
- request discovery

Closes #938

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>