### PR TITLE
chore: Add startup parameters for ActivityPub cache sizes

### DIFF
--- a/cmd/orb-server/go.sum
+++ b/cmd/orb-server/go.sum
@@ -750,7 +750,6 @@ github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmK
 github.com/hyperledger/aries-framework-go v0.1.7-0.20210421203733-b5dfd703a8fc/go.mod h1:tBgxVOKcNero3QI21iNf3oxxHkgRMDOby937cqHEvW4=
 github.com/hyperledger/aries-framework-go v0.1.7-0.20210603210127-e57b8c94e3cf/go.mod h1:h6L+YoXtw90OZrH2IequxukIGwzfSpz8pUueQ9T5KqI=
 github.com/hyperledger/aries-framework-go v0.1.7-0.20210816113201-26c0665ef2b9/go.mod h1:VmoqKNXXyYN3R0ObcGA8ZBdbcmKZJFCakuZGDezi+GQ=
-github.com/hyperledger/aries-framework-go v0.1.7 h1:ZauGEVaBI4GnUDJcmbiCxbG/MHabMXMlAQee1B4nw8E=
 github.com/hyperledger/aries-framework-go v0.1.7/go.mod h1:uve8/q23AUnq4EM0vBkEr1lKZRC67q5RcaHXh0ZOt0Y=
 github.com/hyperledger/aries-framework-go v0.1.8-0.20211203093644-b7d189cc06f4 h1:UpRmhnvnqMZql8e2bS3HFah7bEUN5h318CLuQiQ7PYs=
 github.com/hyperledger/aries-framework-go v0.1.8-0.20211203093644-b7d189cc06f4/go.mod h1:uve8/q23AUnq4EM0vBkEr1lKZRC67q5RcaHXh0ZOt0Y=

--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -583,8 +583,10 @@ func startOrbServices(parameters *orbParameters) error {
 	apConfig := &apservice.Config{
 		ServiceEndpoint:        activityPubServicesPath,
 		ServiceIRI:             apServiceIRI,
-		MaxWitnessDelay:        parameters.maxWitnessDelay,
 		VerifyActorInSignature: parameters.httpSignaturesEnabled,
+		MaxWitnessDelay:        parameters.maxWitnessDelay,
+		IRICacheSize:           parameters.apIRICacheSize,
+		IRICacheExpiration:     parameters.apIRICacheExpiration,
 	}
 
 	apStore, err := createActivityPubStore(storeProviders.provider, apConfig.ServiceEndpoint)
@@ -602,8 +604,10 @@ func startOrbServices(parameters *orbParameters) error {
 		return fmt.Errorf("get public key: %w", err)
 	}
 
-	// TODO: Pass config from startup params
-	apClient := client.New(client.Config{}, t)
+	apClient := client.New(client.Config{
+		CacheSize:       parameters.apClientCacheSize,
+		CacheExpiration: parameters.apClientCacheExpiration,
+	}, t)
 
 	apSigVerifier := getActivityPubVerifier(parameters, km, cr, apClient)
 

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,6 @@ require (
 	github.com/piprate/json-gold v0.4.1-0.20210813112359-33b90c4ca86c
 	github.com/prometheus/client_golang v1.11.0
 	github.com/rs/cors v1.7.0
-	github.com/sirupsen/logrus v1.7.0
 	github.com/streadway/amqp v1.0.0
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7

--- a/go.sum
+++ b/go.sum
@@ -747,7 +747,6 @@ github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmK
 github.com/hyperledger/aries-framework-go v0.1.7-0.20210421203733-b5dfd703a8fc/go.mod h1:tBgxVOKcNero3QI21iNf3oxxHkgRMDOby937cqHEvW4=
 github.com/hyperledger/aries-framework-go v0.1.7-0.20210603210127-e57b8c94e3cf/go.mod h1:h6L+YoXtw90OZrH2IequxukIGwzfSpz8pUueQ9T5KqI=
 github.com/hyperledger/aries-framework-go v0.1.7-0.20210816113201-26c0665ef2b9/go.mod h1:VmoqKNXXyYN3R0ObcGA8ZBdbcmKZJFCakuZGDezi+GQ=
-github.com/hyperledger/aries-framework-go v0.1.7 h1:ZauGEVaBI4GnUDJcmbiCxbG/MHabMXMlAQee1B4nw8E=
 github.com/hyperledger/aries-framework-go v0.1.7/go.mod h1:uve8/q23AUnq4EM0vBkEr1lKZRC67q5RcaHXh0ZOt0Y=
 github.com/hyperledger/aries-framework-go v0.1.8-0.20211203093644-b7d189cc06f4 h1:UpRmhnvnqMZql8e2bS3HFah7bEUN5h318CLuQiQ7PYs=
 github.com/hyperledger/aries-framework-go v0.1.8-0.20211203093644-b7d189cc06f4/go.mod h1:uve8/q23AUnq4EM0vBkEr1lKZRC67q5RcaHXh0ZOt0Y=

--- a/pkg/activitypub/client/client.go
+++ b/pkg/activitypub/client/client.go
@@ -107,7 +107,7 @@ func New(cfg Config, t httpTransport) *Client {
 		cacheExpiration = defaultCacheExpiration
 	}
 
-	logger.Debugf("Creating IRI cache with size=%d, expiration=%s", cacheSize, cacheExpiration)
+	logger.Debugf("Creating actor cache with size=%d, expiration=%s", cacheSize, cacheExpiration)
 
 	c.actorCache = gcache.New(cacheSize).ARC().
 		Expiration(cacheExpiration).

--- a/pkg/activitypub/service/outbox/outbox.go
+++ b/pkg/activitypub/service/outbox/outbox.go
@@ -151,7 +151,7 @@ func New(cnfg *Config, s store.Store, pubSub pubSub, t httpTransport, activityHa
 		lifecycle.WithStop(h.stop),
 	)
 
-	logger.Debugf("Creating cache with size=%d, expiration=%s", cfg.CacheSize, cfg.CacheExpiration)
+	logger.Debugf("Creating IRI cache with size=%d, expiration=%s", cfg.CacheSize, cfg.CacheExpiration)
 
 	h.iriCache = gcache.New(cfg.CacheSize).ARC().
 		Expiration(cfg.CacheExpiration).

--- a/pkg/activitypub/service/service.go
+++ b/pkg/activitypub/service/service.go
@@ -51,6 +51,9 @@ type Config struct {
 
 	// MaxWitnessDelay is the maximum delay that the witnessed transaction becomes included into the ledger.
 	MaxWitnessDelay time.Duration
+
+	IRICacheSize       int
+	IRICacheExpiration time.Duration
 }
 
 // Service implements an ActivityPub service which has an inbox, outbox, and
@@ -90,6 +93,7 @@ type metricsProvider interface {
 }
 
 // New returns a new ActivityPub service.
+//nolint:funlen
 func New(cfg *Config, activityStore store.Store, t httpTransport, sigVerifier signatureVerifier,
 	pubSub PubSub, activityPubClient activityPubClient, resourceResolver resourceResolver,
 	m metricsProvider, handlerOpts ...spi.HandlerOpt) (*Service, error) {
@@ -107,6 +111,8 @@ func New(cfg *Config, activityStore store.Store, t httpTransport, sigVerifier si
 			ServiceIRI:       cfg.ServiceIRI,
 			Topic:            outboxActivitiesTopic,
 			RedeliveryConfig: cfg.RetryOpts,
+			CacheSize:        cfg.IRICacheSize,
+			CacheExpiration:  cfg.IRICacheExpiration,
 		},
 		activityStore, pubSub,
 		t, outboxHandler, activityPubClient, resourceResolver, m, handlerOpts...,

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -93,6 +93,18 @@ services:
       # to anchor a VC by a certain time.
       # Default value: 10s.
       - VCT_MONITORING_INTERVAL=15s
+      # ACTIVITYPUB_CLIENT_CACHE_SIZE sets the maximum size of an ActivityPub service and public key cache.
+      # Default value: 100
+      - ACTIVITYPUB_CLIENT_CACHE_SIZE=200
+      # ACTIVITYPUB_CLIENT_CACHE_EXPIRATION sets the expiration time of an ActivityPub service and public key cache.
+      # Default value: 1h (one hour)
+      - ACTIVITYPUB_CLIENT_CACHE_EXPIRATION=90s
+      # ACTIVITYPUB_IRI_CACHE_SIZE sets the maximum size of an ActivityPub actor IRI cache.
+      # Default value: 100
+      - ACTIVITYPUB_IRI_CACHE_SIZE=200
+      # ACTIVITYPUB_IRI_CACHE_EXPIRATION sets the expiration time of an ActivityPub actor IRI cache.
+      # Default value: 1h (one hour)
+      - ACTIVITYPUB_IRI_CACHE_EXPIRATION=90s
     ports:
       - 48326:443
       - 48327:48327
@@ -198,6 +210,18 @@ services:
       # to anchor a VC by a certain time.
       # Default value: 10s.
       - VCT_MONITORING_INTERVAL=15s
+      # ACTIVITYPUB_CLIENT_CACHE_SIZE sets the maximum size of an ActivityPub service and public key cache.
+      # Default value: 100
+      - ACTIVITYPUB_CLIENT_CACHE_SIZE=200
+      # ACTIVITYPUB_CLIENT_CACHE_EXPIRATION sets the expiration time of an ActivityPub service and public key cache.
+      # Default value: 1h (one hour)
+      - ACTIVITYPUB_CLIENT_CACHE_EXPIRATION=90s
+      # ACTIVITYPUB_IRI_CACHE_SIZE sets the maximum size of an ActivityPub actor IRI cache.
+      # Default value: 100
+      - ACTIVITYPUB_IRI_CACHE_SIZE=200
+      # ACTIVITYPUB_IRI_CACHE_EXPIRATION sets the expiration time of an ActivityPub actor IRI cache.
+      # Default value: 1h (one hour)
+      - ACTIVITYPUB_IRI_CACHE_EXPIRATION=90s
     ports:
       - 48526:443
       - 48527:48527


### PR DESCRIPTION
Added startup parameters for the actor/public-key cache, as well as the actor IRI cache in the Outbox.

closes #940

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>