### PR TITLE
fix: Invalid objects for /liked REST endpoint

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -899,7 +899,7 @@ func startOrbServices(parameters *orbParameters) error {
 		aphandler.NewInbox(apEndpointCfg, apStore, apSigVerifier, activitypubspi.SortAscending),
 		aphandler.NewWitnesses(apEndpointCfg, apStore, apSigVerifier),
 		aphandler.NewWitnessing(apEndpointCfg, apStore, apSigVerifier),
-		aphandler.NewLiked(apEndpointCfg, apStore, apSigVerifier, activitypubspi.SortAscending),
+		aphandler.NewLiked(apEndpointCfg, apStore, apSigVerifier),
 		aphandler.NewLikes(apEndpointCfg, apStore, apSigVerifier, activitypubspi.SortAscending),
 		aphandler.NewShares(apEndpointCfg, apStore, apSigVerifier, activitypubspi.SortAscending),
 		aphandler.NewPostOutbox(apEndpointCfg, activityPubService.Outbox(), apStore, apSigVerifier),

--- a/pkg/activitypub/resthandler/activityhandler.go
+++ b/pkg/activitypub/resthandler/activityhandler.go
@@ -59,13 +59,6 @@ func NewLikes(cfg *Config, activityStore spi.Store, verifier signatureVerifier, 
 		getObjectIRIFromIDParam, getIDFromParam(cfg.ObjectIRI, LikesPath), verifier, sortOrder)
 }
 
-// NewLiked returns a new 'liked' REST handler that retrieves a service's 'Like' activities, i.e. the Like
-// activities that were posted by the given service.
-func NewLiked(cfg *Config, activityStore spi.Store, verifier signatureVerifier, sortOrder spi.SortOrder) *Activities {
-	return NewActivities(LikedPath, spi.Liked, cfg, activityStore,
-		getObjectIRI(cfg.ObjectIRI), getID("liked"), verifier, sortOrder)
-}
-
 type getIDFunc func(objectIRI *url.URL, req *http.Request) (*url.URL, error)
 
 type getObjectIRIFunc func(req *http.Request) (*url.URL, error)

--- a/pkg/activitypub/resthandler/activityhandler_test.go
+++ b/pkg/activitypub/resthandler/activityhandler_test.go
@@ -698,19 +698,19 @@ func TestLiked_Handler(t *testing.T) {
 
 	for _, a := range liked {
 		require.NoError(t, activityStore.AddActivity(a))
-		require.NoError(t, activityStore.AddReference(spi.Liked, serviceIRI, a.ID().URL()))
+		require.NoError(t, activityStore.AddReference(spi.Liked, serviceIRI, a.Object().AnchorEvent().URL()[0]))
 	}
 
 	cfg := &Config{
 		BasePath:  basePath,
 		ObjectIRI: serviceIRI,
-		PageSize:  2,
+		PageSize:  5,
 	}
 
 	verifier := &mocks.SignatureVerifier{}
 	verifier.VerifyRequestReturns(true, serviceIRI, nil)
 
-	h := NewLiked(cfg, activityStore, verifier, spi.SortDescending)
+	h := NewLiked(cfg, activityStore, verifier)
 	require.NotNil(t, h)
 
 	t.Run("Main page -> Success", func(t *testing.T) {
@@ -1325,53 +1325,24 @@ const (
 
 	likedJSON = `{
   "@context": "https://www.w3.org/ns/activitystreams",
-  "id": "https://example1.com/services/orb/liked",
-  "type": "OrderedCollection",
-  "totalItems": 19,
   "first": "https://example1.com/services/orb/liked?page=true",
-  "last": "https://example1.com/services/orb/liked?page=true&page-num=0"
+  "id": "https://example1.com/services/orb/liked",
+  "last": "https://example1.com/services/orb/liked?page=true&page-num=3",
+  "totalItems": 19,
+  "type": "OrderedCollection"
 }`
 
 	//nolint:lll
 	likedFirstPageJSON = `{
   "@context": "https://www.w3.org/ns/activitystreams",
-  "id": "https://example1.com/services/orb/liked?page=true&page-num=9",
-  "next": "https://example1.com/services/orb/liked?page=true&page-num=8",
+  "id": "https://example1.com/services/orb/liked?page=true&page-num=0",
+  "next": "https://example1.com/services/orb/liked?page=true&page-num=1",
   "orderedItems": [
-    {
-      "@context": "https://www.w3.org/ns/activitystreams",
-      "actor": "https://example1.com/services/orb",
-      "id": "https://example18.com/activities/like_activity_18",
-      "object": {
-        "@context": "https://w3id.org/activityanchors/v1",
-        "type": "AnchorEvent",
-        "url": "hl:uEiCsFp-ft8tI1DFGbXs78tw-HS561mMPa3Z6GsGAHElrNQ:uoQ-CeE1odHRwczovL3NhbGx5LmV4YW1wbGUuY29tL2Nhcy91RWlDc0ZwLWZ0OHRJMURGR2JYczc4dHctSFM1NjFtTVBhM1o2R3NHQUhFbHJOUXhCaXBmczovL2JhZmtyZWlmbWMycHo3bjZsamRrZGNydG5wbTU3ZnhiNmR1eGh2dnRkYjV2eG02cTJ5Z2FieXNsbGd1"
-      },
-      "published": "2021-01-27T09:30:10Z",
-      "result": {
-        "@context": "https://w3id.org/activityanchors/v1",
-        "type": "AnchorEvent",
-        "url": "hl:uEiCsFp-ft8tI1DFGbXs78tw-JS571mMPa3Z6GsGAHElrNQ:uoQ-CeE1odHRwczovL3NhbGx5LmV4YW1wbGUuY29tL2Nhcy91RWlDc0ZwLWZ0OHRJMURGR2JYczc4dHctSFM1NjFtTVBhM1o2R3NHQUhFbHJOUXhCaXBmczovL2JhZmtyZWlmbWMycHo3bjZsamRrZGNydG5wbTU3ZnhiNmR1eGh2dnRkYjV2eG02cTJ5Z2FieXNsbGd1"
-      },
-      "type": "Like"
-    },
-    {
-      "@context": "https://www.w3.org/ns/activitystreams",
-      "actor": "https://example1.com/services/orb",
-      "id": "https://example17.com/activities/like_activity_17",
-      "object": {
-        "@context": "https://w3id.org/activityanchors/v1",
-        "type": "AnchorEvent",
-        "url": "hl:uEiCsFp-ft8tI1DFGbXs78tw-HS561mMPa3Z6GsGAHElrNQ:uoQ-CeE1odHRwczovL3NhbGx5LmV4YW1wbGUuY29tL2Nhcy91RWlDc0ZwLWZ0OHRJMURGR2JYczc4dHctSFM1NjFtTVBhM1o2R3NHQUhFbHJOUXhCaXBmczovL2JhZmtyZWlmbWMycHo3bjZsamRrZGNydG5wbTU3ZnhiNmR1eGh2dnRkYjV2eG02cTJ5Z2FieXNsbGd1"
-      },
-      "published": "2021-01-27T09:30:10Z",
-      "result": {
-        "@context": "https://w3id.org/activityanchors/v1",
-        "type": "AnchorEvent",
-        "url": "hl:uEiCsFp-ft8tI1DFGbXs78tw-JS571mMPa3Z6GsGAHElrNQ:uoQ-CeE1odHRwczovL3NhbGx5LmV4YW1wbGUuY29tL2Nhcy91RWlDc0ZwLWZ0OHRJMURGR2JYczc4dHctSFM1NjFtTVBhM1o2R3NHQUhFbHJOUXhCaXBmczovL2JhZmtyZWlmbWMycHo3bjZsamRrZGNydG5wbTU3ZnhiNmR1eGh2dnRkYjV2eG02cTJ5Z2FieXNsbGd1"
-      },
-      "type": "Like"
-    }
+    "hl:uEiCsFp-ft8tI1DFGbXs78tw-HS561mMPa3Z6GsGAHElrNQ:uoQ-CeE1odHRwczovL3NhbGx5LmV4YW1wbGUuY29tL2Nhcy91RWlDc0ZwLWZ0OHRJMURGR2JYczc4dHctSFM1NjFtTVBhM1o2R3NHQUhFbHJOUXhCaXBmczovL2JhZmtyZWlmbWMycHo3bjZsamRrZGNydG5wbTU3ZnhiNmR1eGh2dnRkYjV2eG02cTJ5Z2FieXNsbGd1",
+    "hl:uEiCsFp-ft8tI1DFGbXs78tw-HS561mMPa3Z6GsGAHElrNQ:uoQ-CeE1odHRwczovL3NhbGx5LmV4YW1wbGUuY29tL2Nhcy91RWlDc0ZwLWZ0OHRJMURGR2JYczc4dHctSFM1NjFtTVBhM1o2R3NHQUhFbHJOUXhCaXBmczovL2JhZmtyZWlmbWMycHo3bjZsamRrZGNydG5wbTU3ZnhiNmR1eGh2dnRkYjV2eG02cTJ5Z2FieXNsbGd1",
+    "hl:uEiCsFp-ft8tI1DFGbXs78tw-HS561mMPa3Z6GsGAHElrNQ:uoQ-CeE1odHRwczovL3NhbGx5LmV4YW1wbGUuY29tL2Nhcy91RWlDc0ZwLWZ0OHRJMURGR2JYczc4dHctSFM1NjFtTVBhM1o2R3NHQUhFbHJOUXhCaXBmczovL2JhZmtyZWlmbWMycHo3bjZsamRrZGNydG5wbTU3ZnhiNmR1eGh2dnRkYjV2eG02cTJ5Z2FieXNsbGd1",
+    "hl:uEiCsFp-ft8tI1DFGbXs78tw-HS561mMPa3Z6GsGAHElrNQ:uoQ-CeE1odHRwczovL3NhbGx5LmV4YW1wbGUuY29tL2Nhcy91RWlDc0ZwLWZ0OHRJMURGR2JYczc4dHctSFM1NjFtTVBhM1o2R3NHQUhFbHJOUXhCaXBmczovL2JhZmtyZWlmbWMycHo3bjZsamRrZGNydG5wbTU3ZnhiNmR1eGh2dnRkYjV2eG02cTJ5Z2FieXNsbGd1",
+    "hl:uEiCsFp-ft8tI1DFGbXs78tw-HS561mMPa3Z6GsGAHElrNQ:uoQ-CeE1odHRwczovL3NhbGx5LmV4YW1wbGUuY29tL2Nhcy91RWlDc0ZwLWZ0OHRJMURGR2JYczc4dHctSFM1NjFtTVBhM1o2R3NHQUhFbHJOUXhCaXBmczovL2JhZmtyZWlmbWMycHo3bjZsamRrZGNydG5wbTU3ZnhiNmR1eGh2dnRkYjV2eG02cTJ5Z2FieXNsbGd1"
   ],
   "totalItems": 19,
   "type": "OrderedCollectionPage"

--- a/pkg/activitypub/resthandler/referencehandler.go
+++ b/pkg/activitypub/resthandler/referencehandler.go
@@ -41,6 +41,13 @@ func NewWitnessing(cfg *Config, activityStore spi.Store, verifier signatureVerif
 		getObjectIRI(cfg.ObjectIRI), getID("witnessing"), verifier)
 }
 
+// NewLiked returns a new 'liked' REST handler that retrieves the references of all the anchor events that
+// this service liked.
+func NewLiked(cfg *Config, activityStore spi.Store, verifier signatureVerifier) *Reference {
+	return NewReference(LikedPath, spi.Liked, spi.SortAscending, true, cfg, activityStore,
+		getObjectIRI(cfg.ObjectIRI), getID("liked"), verifier)
+}
+
 type createCollectionFunc func(items []*vocab.ObjectProperty, opts ...vocab.Opt) interface{}
 
 type signatureVerifier interface {

--- a/pkg/activitypub/service/activityhandler/activityhandler_test.go
+++ b/pkg/activitypub/service/activityhandler/activityhandler_test.go
@@ -3011,7 +3011,7 @@ func TestHandler_OutboxHandleLikeActivity(t *testing.T) {
 		refs, err := storeutil.ReadReferences(it, -1)
 		require.NoError(t, err)
 		require.NotEmpty(t, refs)
-		require.Equal(t, like.ID().String(), refs[0].String())
+		require.Equal(t, like.Object().AnchorEvent().URL()[0].String(), refs[0].String())
 	})
 
 	t.Run("No anchor ref", func(t *testing.T) {

--- a/pkg/activitypub/service/activityhandler/inboxhandler.go
+++ b/pkg/activitypub/service/activityhandler/inboxhandler.go
@@ -722,8 +722,7 @@ func (h *Inbox) handleLikeActivity(like *vocab.ActivityType) error {
 
 	logger.Debugf("[%s] Storing activity in the 'Likes' collection: %s", h.ServiceName, refURL)
 
-	if err := h.store.AddReference(store.Like, refURL, like.ID().URL(),
-		store.WithActivityType(like.Type().Types()[0])); err != nil {
+	if err := h.store.AddReference(store.Like, refURL, like.ID().URL()); err != nil {
 		return orberrors.NewTransient(fmt.Errorf("add activity to 'Likes' collection: %w", err))
 	}
 

--- a/pkg/activitypub/service/activityhandler/outboxhandler.go
+++ b/pkg/activitypub/service/activityhandler/outboxhandler.go
@@ -122,12 +122,11 @@ func (h *handler) handleLikeActivity(like *vocab.ActivityType) error {
 		return errors.New("no anchor reference URL in 'Like' activity")
 	}
 
-	logger.Debugf("[%s] Storing activity in the 'Liked' collection: %s", h.ServiceName, ref.URL())
+	logger.Debugf("[%s] Storing anchor reference in the 'Liked' collection: %s", h.ServiceName, ref.URL())
 
-	err := h.store.AddReference(store.Liked, h.ServiceIRI, like.ID().URL(),
-		store.WithActivityType(like.Type().Types()[0]))
+	err := h.store.AddReference(store.Liked, h.ServiceIRI, ref.URL()[0])
 	if err != nil {
-		return orberrors.NewTransient(fmt.Errorf("add activity to 'Liked' collection: %w", err))
+		return orberrors.NewTransient(fmt.Errorf("add anchor reference to 'Liked' collection: %w", err))
 	}
 
 	return nil

--- a/test/bdd/common_steps.go
+++ b/test/bdd/common_steps.go
@@ -941,6 +941,7 @@ func (d *CommonSteps) RegisterSteps(s *godog.Suite) {
 	s.Step(`^the JSON path "([^"]*)" of the numeric response is saved to variable "([^"]*)"$`, d.jsonPathOfNumericResponseSavedToVar)
 	s.Step(`^the JSON path "([^"]*)" of the boolean response is saved to variable "([^"]*)"$`, d.jsonPathOfBoolResponseSavedToVar)
 	s.Step(`^the JSON path "([^"]*)" of the raw response is saved to variable "([^"]*)"$`, d.jsonPathOfRawResponseSavedToVar)
+	s.Step(`^the JSON path '([^']*)' of the raw response is saved to variable "([^"]*)"$`, d.jsonPathOfRawResponseSavedToVar)
 	s.Step(`^the JSON path "([^"]*)" of the response is not empty$`, d.jsonPathOfResponseNotEmpty)
 	s.Step(`^the JSON path "([^"]*)" of the array response is not empty$`, d.jsonPathOfArrayResponseNotEmpty)
 	s.Step(`^the value of the JSON string response is saved to variable "([^"]*)"$`, d.valueOfJSONStringResponseSavedToVar)

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -306,11 +306,7 @@ Feature:
     When an HTTP GET is sent to "https://orb.domain1.com/services/orb/liked?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems" of the array response is not empty
-    And the JSON path "orderedItems.0.object.url" of the response is saved to variable "anchorLink"
-    And the JSON path "orderedItems.0" of the raw response is saved to variable "likeActivity"
-    And the JSON path "orderedItems.0.id" of the response is saved to variable "likeID"
-    And the JSON path "orderedItems.0.actor" of the response is saved to variable "likeActor"
-    And the JSON path "orderedItems.0.to" of the raw response is saved to variable "likeTo"
+    And the JSON path "orderedItems.0" of the response is saved to variable "anchorLink"
 
     And variable "anchorHash" is assigned the value "$hashlink(|${anchorLink}|).ResourceHash"
 
@@ -329,6 +325,7 @@ Feature:
     And the JSON path "orderedItems.#.actor" of the response contains "${domain1IRI}"
     And the JSON path "orderedItems.#.actor" of the response contains "${domain3IRI}"
     And the JSON path "orderedItems.0.object.url" of the response equals "${anchorLink}"
+    And the JSON path 'orderedItems.#(actor="https://orb.domain1.com/services/orb")' of the raw response is saved to variable "likeActivity"
 
     When an HTTP GET is sent to "https://orb.domain1.com/services/orb/likes?id=${anchorLink}&page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
@@ -338,8 +335,8 @@ Feature:
     And the JSON path "orderedItems.#.actor" of the response contains "${domain3IRI}"
     And the JSON path "orderedItems.0.object.url" of the response equals "${anchorLink}"
 
-    Given variable "undoLikeActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${likeActor}","to":#{likeTo},"object":#{likeActivity}}'
-    When an HTTP POST is sent to "${likeActor}/outbox" with content "${undoLikeActivity}" of type "application/json"
+    Given variable "undoLikeActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain1IRI}","to":"${domain2IRI}","object":#{likeActivity}}'
+    When an HTTP POST is sent to "${domain1IRI}/outbox" with content "${undoLikeActivity}" of type "application/json"
 
     Then we wait 2 seconds
 


### PR DESCRIPTION
The ActivityPub /liked collection now returns a collection of hashlinks of anchor events that were 'liked' by the local service as opposed to a collection of activities.

closes #933

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>