### PR TITLE
fix: Don't wait for batch cut when adding new operation

### DIFF
--- a/cmd/orb-cli/go.sum
+++ b/cmd/orb-cli/go.sum
@@ -1289,8 +1289,8 @@ github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7j
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213183208-6c70ab53e04b h1:TH3e9H1Emo+vViMazVLcp+MQ8lElVjUv6vrCX7y8nDs=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213183208-6c70ab53e04b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213221646-4720139c68a9 h1:j/gdSV78JHLQ63mwE0kvz4OghGWygSNNBRAhsdhTuYg=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213221646-4720139c68a9/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/cmd/orb-driver/go.mod
+++ b/cmd/orb-driver/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7
 	github.com/trustbloc/orb v0.1.3-0.20210914173654-dab098ce4e32
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213183208-6c70ab53e04b
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213221646-4720139c68a9
 )
 
 replace github.com/trustbloc/orb => ../..

--- a/cmd/orb-driver/go.sum
+++ b/cmd/orb-driver/go.sum
@@ -1283,8 +1283,8 @@ github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7j
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213183208-6c70ab53e04b h1:TH3e9H1Emo+vViMazVLcp+MQ8lElVjUv6vrCX7y8nDs=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213183208-6c70ab53e04b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213221646-4720139c68a9 h1:j/gdSV78JHLQ63mwE0kvz4OghGWygSNNBRAhsdhTuYg=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213221646-4720139c68a9/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/cmd/orb-server/go.mod
+++ b/cmd/orb-server/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7
 	github.com/trustbloc/orb v0.0.0
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213183208-6c70ab53e04b
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213221646-4720139c68a9
 )
 
 replace github.com/trustbloc/orb => ../..

--- a/cmd/orb-server/go.sum
+++ b/cmd/orb-server/go.sum
@@ -1300,8 +1300,8 @@ github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoi
 github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7jjHQo2gMGNPIRfhvn4aXQ0FYMrG9lRgQcvZKTviCGc=
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213183208-6c70ab53e04b h1:TH3e9H1Emo+vViMazVLcp+MQ8lElVjUv6vrCX7y8nDs=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213183208-6c70ab53e04b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213221646-4720139c68a9 h1:j/gdSV78JHLQ63mwE0kvz4OghGWygSNNBRAhsdhTuYg=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213221646-4720139c68a9/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/streadway/amqp v1.0.0
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213183208-6c70ab53e04b
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213221646-4720139c68a9
 	github.com/trustbloc/vct v0.1.3
 	github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a // indirect
 	go.mongodb.org/mongo-driver v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -1293,8 +1293,8 @@ github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoi
 github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7jjHQo2gMGNPIRfhvn4aXQ0FYMrG9lRgQcvZKTviCGc=
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213183208-6c70ab53e04b h1:TH3e9H1Emo+vViMazVLcp+MQ8lElVjUv6vrCX7y8nDs=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213183208-6c70ab53e04b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213221646-4720139c68a9 h1:j/gdSV78JHLQ63mwE0kvz4OghGWygSNNBRAhsdhTuYg=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213221646-4720139c68a9/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/tidwall/gjson v1.7.4
 	github.com/trustbloc/orb v0.1.4-0.20211008191555-789f5f021da4
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213183208-6c70ab53e04b
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213221646-4720139c68a9
 )
 
 replace github.com/trustbloc/orb => ../../

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -1554,8 +1554,8 @@ github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/sidetree-core-go v0.7.1-0.20211001153855-238da75965f8/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213183208-6c70ab53e04b h1:TH3e9H1Emo+vViMazVLcp+MQ8lElVjUv6vrCX7y8nDs=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213183208-6c70ab53e04b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213221646-4720139c68a9 h1:j/gdSV78JHLQ63mwE0kvz4OghGWygSNNBRAhsdhTuYg=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20211213221646-4720139c68a9/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=


### PR DESCRIPTION
Updated to the latest sidetree-core-go which provides a performance optimization such that adding new operations doesn't ever have to wait for a batch to be cut.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>