### PR TITLE
feat: Use the DB to ensure reliability for the operation queue instead of the AMQP provider

### DIFF
--- a/cmd/orb-server/startcmd/params.go
+++ b/cmd/orb-server/startcmd/params.go
@@ -40,9 +40,9 @@ const (
 	defaultActivityPubClientCacheExpiration = time.Hour
 	defaultActivityPubIRICacheSize          = 100
 	defaultActivityPubIRICacheExpiration    = time.Hour
-
-	defaultFollowAuthType        = acceptAllPolicy
-	defaultInviteWitnessAuthType = acceptAllPolicy
+	defaultFollowAuthType                   = acceptAllPolicy
+	defaultInviteWitnessAuthType            = acceptAllPolicy
+	defaultMQOpPoolSize                     = 5
 
 	commonEnvVarUsageText = "Alternatively, this can be set with the following environment variable: "
 
@@ -1252,6 +1252,8 @@ func getMQParameters(cmd *cobra.Command) (mqURL string, mqOpPoolSize int, mqObse
 		if err != nil {
 			return "", 0, 0, 0, fmt.Errorf("invalid value for %s [%s]: %w", mqOpPoolFlagName, mqOpPoolStr, err)
 		}
+	} else {
+		mqOpPoolSize = defaultMQOpPoolSize
 	}
 
 	mqObserverPoolStr, err := cmdutils.GetUserSetVarFromString(cmd, mqObserverPoolFlagName, mqObserverPoolEnvKey, true)

--- a/cmd/orb-server/startcmd/params_test.go
+++ b/cmd/orb-server/startcmd/params_test.go
@@ -1104,7 +1104,7 @@ func TestGetMQParameters(t *testing.T) {
 		mqURL, mqOpPoolSize, mqObserverPoolSize, maxConnectionSubscriptions, err := getMQParameters(cmd)
 		require.NoError(t, err)
 		require.Equal(t, u, mqURL)
-		require.Equal(t, 0, mqOpPoolSize)
+		require.Equal(t, defaultMQOpPoolSize, mqOpPoolSize)
 		require.Equal(t, 0, mqObserverPoolSize)
 		require.Equal(t, mqDefaultMaxConnectionSubscriptions, maxConnectionSubscriptions)
 	})

--- a/pkg/activitypub/service/anchorsynctask/anchorsynctask_test.go
+++ b/pkg/activitypub/service/anchorsynctask/anchorsynctask_test.go
@@ -33,7 +33,7 @@ func TestRegister(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		require.NoError(t, Register(
 			Config{},
-			mocks.NewTaskManager(), &mocks.ActivityPubClient{},
+			mocks.NewTaskManager("anchor-sync"), &mocks.ActivityPubClient{},
 			memstore.New("service1"), storage.NewMockStoreProvider(),
 			func() spi.InboxHandler {
 				return nil
@@ -50,7 +50,7 @@ func TestRegister(t *testing.T) {
 
 		err := Register(
 			Config{},
-			mocks.NewTaskManager(), &mocks.ActivityPubClient{},
+			mocks.NewTaskManager("anchor-sync"), &mocks.ActivityPubClient{},
 			memstore.New("service1"), p,
 			func() spi.InboxHandler {
 				return nil

--- a/pkg/activitypub/service/monitoring/monitoring_test.go
+++ b/pkg/activitypub/service/monitoring/monitoring_test.go
@@ -38,7 +38,7 @@ const (
 )
 
 func TestNew(t *testing.T) {
-	taskMgr := mocks.NewTaskManager()
+	taskMgr := mocks.NewTaskManager("vct-monitor")
 
 	client, err := New(mem.NewProvider(), nil, nil, nil, taskMgr, time.Second)
 	require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestClient_Watch(t *testing.T) {
 	httpClient := &http.Client{Timeout: time.Second}
 
 	t.Run("Expired", func(t *testing.T) {
-		taskMgr := mocks.NewTaskManager()
+		taskMgr := mocks.NewTaskManager("vct-monitor")
 
 		taskMgr.Start()
 		defer taskMgr.Stop()
@@ -88,7 +88,7 @@ func TestClient_Watch(t *testing.T) {
 	t.Run("Escape to queue (two entities)", func(t *testing.T) {
 		db := mem.NewProvider()
 
-		taskMgr := mocks.NewTaskManager()
+		taskMgr := mocks.NewTaskManager("vct-monitor")
 
 		taskMgr.Start()
 		defer taskMgr.Stop()
@@ -132,7 +132,7 @@ func TestClient_Watch(t *testing.T) {
 			dl = testutil.GetLoader(t)
 		)
 
-		taskMgr := mocks.NewTaskManager()
+		taskMgr := mocks.NewTaskManager("vct-monitor")
 
 		taskMgr.Start()
 		defer taskMgr.Stop()
@@ -175,7 +175,7 @@ func TestClient_Watch(t *testing.T) {
 			dl = testutil.GetLoader(t)
 		)
 
-		taskMgr := mocks.NewTaskManager()
+		taskMgr := mocks.NewTaskManager("vct-monitor")
 
 		taskMgr.Start()
 		defer taskMgr.Stop()
@@ -227,7 +227,7 @@ func TestClient_Watch(t *testing.T) {
 
 		dl := testutil.GetLoader(t)
 
-		taskMgr := mocks.NewTaskManager()
+		taskMgr := mocks.NewTaskManager("vct-monitor")
 
 		taskMgr.Start()
 		defer taskMgr.Stop()
@@ -301,7 +301,7 @@ func TestClient_Watch(t *testing.T) {
 
 		dl := testutil.GetLoader(t)
 
-		taskMgr := mocks.NewTaskManager()
+		taskMgr := mocks.NewTaskManager("vct-monitor")
 
 		taskMgr.Start()
 		defer taskMgr.Stop()
@@ -353,7 +353,7 @@ func TestClient_Watch(t *testing.T) {
 			dl = testutil.GetLoader(t)
 		)
 
-		taskMgr := mocks.NewTaskManager()
+		taskMgr := mocks.NewTaskManager("vct-monitor")
 
 		client, err := New(db, dl, wfClient, httpMock(func(req *http.Request) (*http.Response, error) {
 			return &http.Response{
@@ -386,7 +386,7 @@ func TestClient_Watch(t *testing.T) {
 			dl = testutil.GetLoader(t)
 		)
 
-		taskMgr := mocks.NewTaskManager()
+		taskMgr := mocks.NewTaskManager("vct-monitor")
 
 		client, err := New(db, dl, wfClient, httpMock(func(req *http.Request) (*http.Response, error) {
 			return &http.Response{
@@ -419,7 +419,7 @@ func TestClient_Watch(t *testing.T) {
 			dl = testutil.GetLoader(t)
 		)
 
-		taskMgr := mocks.NewTaskManager()
+		taskMgr := mocks.NewTaskManager("vct-monitor")
 
 		notFoundWebfingerClient := wfclient.New(wfclient.WithHTTPClient(
 			httpMock(func(req *http.Request) (*http.Response, error) {
@@ -455,7 +455,7 @@ func TestClient_Watch(t *testing.T) {
 			dl = testutil.GetLoader(t)
 		)
 
-		taskMgr := mocks.NewTaskManager()
+		taskMgr := mocks.NewTaskManager("vct-monitor")
 
 		noLegerTypeWebfingerClient := wfclient.New(wfclient.WithHTTPClient(
 			httpMock(func(req *http.Request) (*http.Response, error) {
@@ -491,7 +491,7 @@ func TestClient_Watch(t *testing.T) {
 			dl = testutil.GetLoader(t)
 		)
 
-		taskMgr := mocks.NewTaskManager()
+		taskMgr := mocks.NewTaskManager("vct-monitor")
 
 		wrongLegerTypeWebfingerClient := wfclient.New(wfclient.WithHTTPClient(
 			httpMock(func(req *http.Request) (*http.Response, error) {

--- a/pkg/context/opqueue/opqueue.go
+++ b/pkg/context/opqueue/opqueue.go
@@ -15,16 +15,30 @@ import (
 
 	"github.com/ThreeDotsLabs/watermill"
 	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/google/uuid"
+	"github.com/hyperledger/aries-framework-go/spi/storage"
 	"github.com/trustbloc/edge-core/pkg/log"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 
 	"github.com/trustbloc/orb/pkg/lifecycle"
 	"github.com/trustbloc/orb/pkg/pubsub/spi"
+	"github.com/trustbloc/orb/pkg/store/expiry"
 )
 
 var logger = log.New("sidetree_context")
 
-const topic = "orb.operation"
+const (
+	topic          = "orb.operation"
+	taskID         = "op-queue-monitorOtherServers"
+	storeName      = "op-queue"
+	tagOpExpiry    = "ExpiryTime"
+	tagOpQueueTask = "Task"
+	tagServerID    = "ServerID"
+
+	defaultInterval             = 10 * time.Second
+	defaultTaskExpirationFactor = 2
+	defaultOpCleanupFactor      = 5
+)
 
 type pubSub interface {
 	SubscribeWithOpts(ctx context.Context, topic string, opts ...spi.Option) (<-chan *message.Message, error)
@@ -33,7 +47,7 @@ type pubSub interface {
 }
 
 type operationMessage struct {
-	msg       *message.Message
+	id        string
 	op        *operation.QueuedOperationAtTime
 	timeAdded time.Time
 }
@@ -42,50 +56,122 @@ type metricsProvider interface {
 	AddOperationTime(value time.Duration)
 	BatchCutTime(value time.Duration)
 	BatchRollbackTime(value time.Duration)
-	BatchAckTime(value time.Duration)
-	BatchNackTime(value time.Duration)
 	BatchSize(value float64)
+}
+
+type taskManager interface {
+	InstanceID() string
+	RegisterTask(taskID string, interval time.Duration, task func())
+}
+
+type dataExpiryService interface {
+	Register(store storage.Store, expiryTagName, storeName string, opts ...expiry.Option)
+}
+
+type opQueueTask struct {
+	// ServerID is the unique ID of the server instance.
+	ServerID string `json:"serverID"`
+	// UpdatedTime indicates when the status was last updated.
+	UpdatedTime int64 `json:"updateTaskTime"` // This is a Unix timestamp.
 }
 
 // Config contains configuration parameters for the operation queue.
 type Config struct {
+	// PoolSize is the number of AMQP subscribers that are listening for operation messages.
 	PoolSize uint
+	// TaskMonitorInterval is the interval (period) in which operation queue tasks from other server instances
+	// are monitored.
+	TaskMonitorInterval time.Duration
+	// TaskExpiration is the maximum time that an operation queue task can exist in the database before it is
+	// considered to have expired. At which point, any other server instance may delete the task and take over
+	// processing of all operations associated with the task.
+	TaskExpiration time.Duration
+	// OpExpiration is the age that a pending operation in the database is considered to have expired, after which the
+	// operation is deleted. Operations should be deleted during normal processing but, in case it isn't deleted,
+	// the data expiry service will delete the operations that are older than this value.
+	OpExpiration time.Duration
 }
 
 // Queue implements an operation queue that uses a publisher/subscriber.
 type Queue struct {
 	*lifecycle.Lifecycle
 
-	pubSub        pubSub
-	msgChan       <-chan *message.Message
-	mutex         sync.RWMutex
-	pending       []*operationMessage
-	jsonMarshal   func(interface{}) ([]byte, error)
-	jsonUnmarshal func(data []byte, v interface{}) error
-	metrics       metricsProvider
+	pubSub              pubSub
+	msgChan             <-chan *message.Message
+	mutex               sync.RWMutex
+	pending             []*operationMessage
+	marshal             func(interface{}) ([]byte, error)
+	unmarshal           func(data []byte, v interface{}) error
+	metrics             metricsProvider
+	serverInstanceID    string
+	store               storage.Store
+	taskMonitorInterval time.Duration
+	taskExpiration      time.Duration
+	opExpiration        time.Duration
+	taskMgr             taskManager
+	expiryService       dataExpiryService
 }
 
 // New returns a new operation queue.
-func New(cfg Config, pubSub pubSub, metrics metricsProvider) (*Queue, error) {
+func New(cfg Config, pubSub pubSub, p storage.Provider, taskMgr taskManager,
+	expiryService dataExpiryService, metrics metricsProvider) (*Queue, error) {
 	msgChan, err := pubSub.SubscribeWithOpts(context.Background(), topic, spi.WithPool(cfg.PoolSize))
 	if err != nil {
 		return nil, fmt.Errorf("subscribe to topic [%s]: %w", topic, err)
 	}
 
-	q := &Queue{
-		pubSub:        pubSub,
-		msgChan:       msgChan,
-		jsonMarshal:   json.Marshal,
-		jsonUnmarshal: json.Unmarshal,
-		metrics:       metrics,
+	s, err := p.OpenStore(storeName)
+	if err != nil {
+		return nil, fmt.Errorf("open store: %w", err)
 	}
 
-	q.Lifecycle = lifecycle.New("operation-queue",
-		lifecycle.WithStart(q.start),
-		lifecycle.WithStop(q.stop),
-	)
+	err = p.SetStoreConfig(storeName, storage.StoreConfiguration{TagNames: []string{tagOpQueueTask, tagOpExpiry}})
+	if err != nil {
+		return nil, fmt.Errorf("failed to set store configuration: %w", err)
+	}
 
-	q.Start()
+	taskMonitorInterval := cfg.TaskMonitorInterval
+	if taskMonitorInterval == 0 {
+		taskMonitorInterval = defaultInterval
+	}
+
+	taskExpiration := cfg.TaskExpiration
+	if taskExpiration == 0 {
+		// Set the task expiration to a factor of the monitoring interval. So, if the monitoring interval is 10s and
+		// the expiration factor is 2 then the task is considered to have expired after 20s.
+		taskExpiration = taskMonitorInterval * defaultTaskExpirationFactor
+	}
+
+	opExpiration := cfg.OpExpiration
+	if opExpiration == 0 {
+		// Set the cleanup interval to a factor of the task expiration interval. So, if the task expiration interval
+		// is 20s and the cleanup factor is 5 then the operation is considered to have expired after 100s.
+		opExpiration = taskExpiration * defaultOpCleanupFactor
+	}
+
+	q := &Queue{
+		pubSub:              pubSub,
+		msgChan:             msgChan,
+		marshal:             json.Marshal,
+		unmarshal:           json.Unmarshal,
+		metrics:             metrics,
+		serverInstanceID:    taskMgr.InstanceID(),
+		store:               s,
+		taskExpiration:      taskExpiration,
+		opExpiration:        opExpiration,
+		taskMonitorInterval: taskMonitorInterval,
+		taskMgr:             taskMgr,
+		expiryService:       expiryService,
+	}
+
+	q.Lifecycle = lifecycle.New("operation-queue", lifecycle.WithStart(q.start))
+
+	logger.Infof("[%s] Storing new operation queue task.", q.serverInstanceID)
+
+	err = q.updateTaskTime()
+	if err != nil {
+		return nil, fmt.Errorf("update operation queue task time: %w", err)
+	}
 
 	return q, nil
 }
@@ -102,7 +188,7 @@ func (q *Queue) Add(op *operation.QueuedOperation, protocolVersion uint64) (uint
 		q.metrics.AddOperationTime(time.Since(startTime))
 	}()
 
-	b, err := q.jsonMarshal(
+	b, err := q.marshal(
 		&operation.QueuedOperationAtTime{
 			QueuedOperation: *op,
 			ProtocolVersion: protocolVersion,
@@ -121,12 +207,7 @@ func (q *Queue) Add(op *operation.QueuedOperation, protocolVersion uint64) (uint
 		return 0, fmt.Errorf("publish queued operation: %w", err)
 	}
 
-	q.mutex.RLock()
-	defer q.mutex.RUnlock()
-
-	// Return the current pending operations which does not include the new operation (since it hasn't
-	// been processed yet). This is OK since the resulting value isn't currently used.
-	return uint(len(q.pending)), nil
+	return 0, nil
 }
 
 // Peek returns (up to) the given number of operations from the head of the queue but does not remove them.
@@ -143,20 +224,19 @@ func (q *Queue) Peek(num uint) (operation.QueuedOperationsAtTime, error) {
 		n = len(q.pending)
 	}
 
-	return asQueuedOperations(q.pending[0:n]), nil
+	items := q.pending[0:n]
+
+	logger.Debugf("[%s] Peeked %d operations", q.serverInstanceID, len(items))
+
+	return q.asQueuedOperations(items), nil
 }
 
 // Remove removes (up to) the given number of items from the head of the queue.
 // Returns the actual number of items that were removed and the new length of the queue.
-// Each removed message is acknowledged, indicating that it was successfully processed. If the
-// server goes down with messages still in the queue then, if using a durable message queue, the messages
-// will be delivered to another server instance which is processing from the same queue.
 func (q *Queue) Remove(num uint) (ops operation.QueuedOperationsAtTime, ack func() uint, nack func(), err error) {
 	if q.State() != lifecycle.StateStarted {
 		return nil, nil, nil, lifecycle.ErrNotStarted
 	}
-
-	startTime := time.Now()
 
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
@@ -175,7 +255,9 @@ func (q *Queue) Remove(num uint) (ops operation.QueuedOperationsAtTime, ack func
 	items := q.pending[0:n]
 	q.pending = q.pending[n:]
 
-	return asQueuedOperations(items), q.newAckFunc(items, startTime), q.newNackFunc(items, startTime), nil
+	logger.Debugf("[%s] Removed %d operations", q.serverInstanceID, len(items))
+
+	return q.asQueuedOperations(items), q.newCommitFunc(items), q.newRollbackFunc(items), nil
 }
 
 // Len returns the length of the pending queue.
@@ -191,43 +273,38 @@ func (q *Queue) Len() uint {
 }
 
 func (q *Queue) start() {
+	q.taskMgr.RegisterTask(taskID, q.taskMonitorInterval, q.monitorOtherServers)
+
+	q.expiryService.Register(q.store, tagOpExpiry, storeName)
+
 	go q.listen()
 
 	logger.Infof("Started operation queue")
 }
 
-func (q *Queue) stop() {
-	q.mutex.RLock()
-
-	logger.Debugf("Stopping operation queue with %d pending operations...", len(q.pending))
-
-	items := make([]*operationMessage, len(q.pending))
-
-	for i, item := range q.pending {
-		items[i] = item
-	}
-
-	q.mutex.RUnlock()
-
-	logger.Debugf("... nacking %d pending pending...", len(items))
-
-	for _, item := range items {
-		logger.Debugf("Nacking item [%s] - [%s]", item.msg.UUID)
-
-		item.msg.Nack()
-	}
-
-	logger.Debugf("...stopped operation queue.")
-}
-
 func (q *Queue) listen() {
 	logger.Debugf("Starting message listener")
 
-	for msg := range q.msgChan {
-		q.handleMessage(msg)
-	}
+	ticker := time.NewTicker(q.taskMonitorInterval)
 
-	logger.Debugf("Message listener stopped")
+	for {
+		select {
+		case msg, ok := <-q.msgChan:
+			if !ok {
+				logger.Debugf("Message listener stopped")
+
+				return
+			}
+
+			q.handleMessage(msg)
+
+		case <-ticker.C:
+			// Update the task time so that other instances don't think I'm down.
+			if err := q.updateTaskTime(); err != nil {
+				logger.Warnf("Error updating time on operation queue task: %w", err)
+			}
+		}
+	}
 }
 
 func (q *Queue) handleMessage(msg *message.Message) {
@@ -235,7 +312,7 @@ func (q *Queue) handleMessage(msg *message.Message) {
 
 	op := &operation.QueuedOperationAtTime{}
 
-	err := q.jsonUnmarshal(msg.Payload, op)
+	err := q.unmarshal(msg.Payload, op)
 	if err != nil {
 		logger.Errorf("Error unmarshalling operation: %s", err)
 
@@ -245,36 +322,53 @@ func (q *Queue) handleMessage(msg *message.Message) {
 		return
 	}
 
+	id := uuid.New().String()
+
+	err = q.store.Put(id, msg.Payload,
+		storage.Tag{
+			Name:  tagServerID,
+			Value: q.serverInstanceID,
+		},
+		storage.Tag{
+			Name:  tagOpExpiry,
+			Value: fmt.Sprintf("%d", time.Now().Add(q.opExpiration).Unix()),
+		},
+	)
+	if err != nil {
+		logger.Warnf("Error storing operation info. The message will be nacked and retried: %w", err)
+
+		msg.Nack()
+
+		return
+	}
+
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
 
-	logger.Debugf("Adding operation message to pending queue [%s] - DID [%s]", msg.UUID, op.UniqueSuffix)
+	logger.Debugf("[%s] Adding operation to pending queue [%s] - DID [%s]",
+		q.serverInstanceID, id, op.UniqueSuffix)
 
-	// Add the message to our in-memory queue but don't acknowledge it yet. The message
-	// will be acknowledged when Remove() is called.
 	q.pending = append(q.pending, &operationMessage{
-		msg:       msg,
+		id:        id,
 		op:        op,
 		timeAdded: time.Now(),
 	})
+
+	msg.Ack()
 }
 
-func (q *Queue) newAckFunc(items []*operationMessage, startTime time.Time) func() uint {
+func (q *Queue) newCommitFunc(items []*operationMessage) func() uint {
 	return func() uint {
-		logger.Infof("Acking %d operation messages...", len(items))
+		logger.Infof("Committed %d operation messages...", len(items))
 
-		// Acknowledge all of the messages that were processed.
-		for _, opMsg := range items {
-			opMsg.msg.Ack()
-
-			logger.Infof("Acknowledged message [%s] - DID [%s]", opMsg.msg.UUID, opMsg.op.UniqueSuffix)
+		if err := q.deleteOperations(items); err != nil {
+			logger.Errorf("[%s] Error deleting pending operations: %s", q.serverInstanceID, err)
+		} else {
+			logger.Debugf("[%s] Deleted %d operations", q.serverInstanceID, len(items))
 		}
 
 		// Batch cut time is the time since the first operation was added (which is the oldest operation in the batch).
 		q.metrics.BatchCutTime(time.Since(items[0].timeAdded))
-
-		// Batch Ack time is the time it took to acknowledge all of the MQ messages.
-		q.metrics.BatchAckTime(time.Since(startTime))
 
 		q.metrics.BatchSize(float64(len(items)))
 
@@ -285,35 +379,226 @@ func (q *Queue) newAckFunc(items []*operationMessage, startTime time.Time) func(
 	}
 }
 
-func (q *Queue) newNackFunc(items []*operationMessage, startTime time.Time) func() {
+func (q *Queue) newRollbackFunc(items []*operationMessage) func() {
 	return func() {
-		logger.Infof("Nacking %d operation messages...", len(items))
+		logger.Infof("%d operations were rolled back. Re-posting...", len(items))
 
-		// Send an Nack for all of the messages that were removed so that they may be retried.
-		for _, opMsg := range items {
-			opMsg.msg.Nack()
+		for _, op := range items {
+			if _, err := q.Add(&op.op.QueuedOperation, op.op.ProtocolVersion); err != nil {
+				logger.Errorf("Error re-posting operation [%s]", op.id)
 
-			logger.Infof("Nacked message [%s] - DID [%s]", opMsg.msg.UUID, opMsg.op.UniqueSuffix)
+				return
+			}
 		}
 
-		// Batch rollback time is the time since the first operation was added (which is the oldest operation in the batch).
-		q.metrics.BatchRollbackTime(time.Since(items[0].timeAdded))
+		if err := q.deleteOperations(items); err != nil {
+			logger.Errorf("Error deleting operations: %s. Some (or all) of the operations "+
+				"will be left in the database and potentially reprocessed (which should be harmless). "+
+				"The operations should be deleted (at some point) by the data expiry service.", err)
+		}
 
-		// Batch Ack time is the time it took to nack all of the MQ messages.
-		q.metrics.BatchNackTime(time.Since(startTime))
+		// Batch rollback time is the time since the first operation was added (which is the
+		// oldest operation in the batch).
+		q.metrics.BatchRollbackTime(time.Since(items[0].timeAdded))
 	}
 }
 
-func asQueuedOperations(opMsgs []*operationMessage) []*operation.QueuedOperationAtTime {
+func (q *Queue) monitorOtherServers() {
+	it, err := q.store.Query(tagOpQueueTask)
+	if err != nil {
+		logger.Warnf("Error querying for operation queue tasks: %w", err)
+
+		return
+	}
+
+	defer storage.Close(it, logger)
+
+	for {
+		task, ok, err := q.nextTask(it)
+		if err != nil {
+			logger.Warnf("Error getting next operation queue task: %w", err)
+
+			return
+		}
+
+		if !ok {
+			break
+		}
+
+		if task.ServerID == q.serverInstanceID {
+			// This is our queue task. Nothing to do.
+			continue
+		}
+
+		// This is not our task. Check to see if the server is still alive.
+		timeSinceLastUpdate := time.Since(time.Unix(task.UpdatedTime, 0)).Truncate(time.Second)
+
+		if timeSinceLastUpdate > q.taskExpiration {
+			logger.Warnf("[%s] Operation queue task [%s] was last updated %s ago which is longer than the expiry %s. "+
+				"Assuming the server is dead and re-posting any outstanding operations to the queue.",
+				q.serverInstanceID, task.ServerID, timeSinceLastUpdate, q.taskExpiration)
+
+			err = q.repostOperations(task.ServerID)
+			if err != nil {
+				logger.Warnf("[%s] Error reposting operations for server instance [%s]: %s",
+					q.serverInstanceID, task.ServerID, err)
+
+				return
+			}
+		}
+	}
+}
+
+func (q *Queue) deleteOperations(items []*operationMessage) error {
+	batchOperations := make([]storage.Operation, len(items))
+
+	for i, item := range items {
+		batchOperations[i] = storage.Operation{
+			Key: item.id,
+		}
+	}
+
+	if err := q.store.Batch(batchOperations); err != nil {
+		return fmt.Errorf("delete %d pending operations: %w", len(items), err)
+	}
+
+	return nil
+}
+
+func (q *Queue) asQueuedOperations(opMsgs []*operationMessage) []*operation.QueuedOperationAtTime {
 	ops := make([]*operation.QueuedOperationAtTime, len(opMsgs))
 
-	logger.Debugf("Returning %d queued operations:", len(opMsgs))
+	logger.Debugf("[%s] Returning %d queued operations:", q.serverInstanceID, len(opMsgs))
 
 	for i, opMsg := range opMsgs {
-		logger.Debugf("- Msg [%s], DID [%s]", opMsg.msg.UUID, opMsg.op.UniqueSuffix)
+		logger.Debugf("[%s] - Msg [%s], DID [%s]", q.serverInstanceID, opMsg.id, opMsg.op.UniqueSuffix)
 
 		ops[i] = opMsg.op
 	}
 
 	return ops
+}
+
+func (q *Queue) updateTaskTime() error {
+	task := &opQueueTask{
+		ServerID:    q.serverInstanceID,
+		UpdatedTime: time.Now().Unix(),
+	}
+
+	taskBytes, err := q.marshal(task)
+	if err != nil {
+		return fmt.Errorf("marshal operation queue task: %w", err)
+	}
+
+	err = q.store.Put(q.serverInstanceID, taskBytes, storage.Tag{Name: tagOpQueueTask})
+	if err != nil {
+		return fmt.Errorf("store operation queue task: %w", err)
+	}
+
+	return nil
+}
+
+func (q *Queue) repostOperations(serverID string) error {
+	it, err := q.store.Query(fmt.Sprintf("%s:%s", tagServerID, serverID))
+	if err != nil {
+		return fmt.Errorf("query operations with tag [%s]: %w", serverID, err)
+	}
+
+	defer storage.Close(it, logger)
+
+	var batchOperations []storage.Operation
+
+	for {
+		id, op, ok, e := q.nextOperation(it)
+		if e != nil {
+			return fmt.Errorf("get nextOperation operation: %w", err)
+		}
+
+		if !ok {
+			break
+		}
+
+		logger.Debugf("[%s] Re-posting operation [%s] for suffix [%s]", q.serverInstanceID, id, op.UniqueSuffix)
+
+		_, e = q.Add(&op.QueuedOperation, op.ProtocolVersion)
+		if e != nil {
+			return fmt.Errorf("unmarshal operation [%s]: %w", id, e)
+		}
+
+		batchOperations = append(batchOperations, storage.Operation{Key: id})
+	}
+
+	logger.Infof("[%s] Deleting operation queue task [%s]", q.serverInstanceID, serverID)
+
+	if len(batchOperations) > 0 {
+		logger.Infof("[%s] Deleting %d operations for queue task [%s]",
+			q.serverInstanceID, len(batchOperations), serverID)
+
+		err = q.store.Batch(batchOperations)
+		if err != nil {
+			return fmt.Errorf("delete operations: %w", err)
+		}
+	}
+
+	err = q.store.Delete(serverID)
+	if err != nil {
+		return fmt.Errorf("delete operation queue task [%s]: %w", q.serverInstanceID, err)
+	}
+
+	return nil
+}
+
+func (q *Queue) nextTask(it storage.Iterator) (*opQueueTask, bool, error) {
+	ok, err := it.Next()
+	if err != nil {
+		return nil, false, fmt.Errorf("get next operation queue tesk: %w", err)
+	}
+
+	if !ok {
+		return nil, false, nil
+	}
+
+	opBytes, err := it.Value()
+	if err != nil {
+		return nil, false, fmt.Errorf("get next operation queue tesk: %w", err)
+	}
+
+	task := &opQueueTask{}
+
+	err = q.unmarshal(opBytes, task)
+	if err != nil {
+		return nil, false, fmt.Errorf("unmarshal operation queue tesk: %w", err)
+	}
+
+	return task, true, nil
+}
+
+func (q *Queue) nextOperation(it storage.Iterator) (string, *operation.QueuedOperationAtTime, bool, error) {
+	ok, err := it.Next()
+	if err != nil {
+		return "", nil, false, fmt.Errorf("get next operation: %w", err)
+	}
+
+	if !ok {
+		return "", nil, false, nil
+	}
+
+	id, err := it.Key()
+	if err != nil {
+		return "", nil, false, fmt.Errorf("get operation ID from iterator: %w", err)
+	}
+
+	opBytes, err := it.Value()
+	if err != nil {
+		return "", nil, false, fmt.Errorf("get operation [%s]: %w", id, err)
+	}
+
+	op := &operation.QueuedOperationAtTime{}
+
+	err = q.unmarshal(opBytes, op)
+	if err != nil {
+		return "", nil, false, fmt.Errorf("unmarshal operation [%s]: %w", id, err)
+	}
+
+	return id, op, true, nil
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -47,8 +47,6 @@ const (
 	opQueueAddOperationTimeMetric  = "add_operation_seconds"
 	opQueueBatchCutTimeMetric      = "batch_cut_seconds"
 	opQueueBatchRollbackTimeMetric = "batch_rollback_seconds"
-	opQueueBatchAckTimeMetric      = "batch_ack_seconds"
-	opQueueBatchNackTimeMetric     = "batch_nack_seconds"
 	opQueueBatchSizeMetric         = "batch_size"
 
 	// Observer.
@@ -168,8 +166,6 @@ type Metrics struct {
 	opqueueAddOperationTime  prometheus.Histogram
 	opqueueBatchCutTime      prometheus.Histogram
 	opqueueBatchRollbackTime prometheus.Histogram
-	opqueueBatchAckTime      prometheus.Histogram
-	opqueueBatchNackTime     prometheus.Histogram
 	opqueueBatchSize         prometheus.Gauge
 
 	observerProcessAnchorTime prometheus.Histogram
@@ -264,8 +260,6 @@ func newMetrics() *Metrics { //nolint:funlen,gocyclo,cyclop
 		opqueueAddOperationTime:                      newOpQueueAddOperationTime(),
 		opqueueBatchCutTime:                          newOpQueueBatchCutTime(),
 		opqueueBatchRollbackTime:                     newOpQueueBatchRollbackTime(),
-		opqueueBatchAckTime:                          newOpQueueBatchAckTime(),
-		opqueueBatchNackTime:                         newOpQueueBatchNackTime(),
 		opqueueBatchSize:                             newOpQueueBatchSize(),
 		observerProcessAnchorTime:                    newObserverProcessAnchorTime(),
 		observerProcessDIDTime:                       newObserverProcessDIDTime(),
@@ -327,8 +321,7 @@ func newMetrics() *Metrics { //nolint:funlen,gocyclo,cyclop
 		m.anchorWriteSignWithLocalWitnessTime, m.anchorWriteSignWithServerKeyTime, m.anchorWriteSignLocalWitnessLogTime,
 		m.anchorWriteSignLocalStoreTime, m.anchorWriteSignLocalWatchTime,
 		m.opqueueAddOperationTime, m.opqueueBatchCutTime, m.opqueueBatchRollbackTime,
-		m.opqueueBatchAckTime, m.opqueueBatchNackTime, m.opqueueBatchSize,
-		m.observerProcessAnchorTime, m.observerProcessDIDTime,
+		m.opqueueBatchSize, m.observerProcessAnchorTime, m.observerProcessDIDTime,
 		m.casWriteTime, m.casResolveTime, m.casCacheHitCount,
 		m.docCreateUpdateTime, m.docResolveTime,
 		m.vctWitnessAddProofVCTNilTimes, m.vctWitnessAddVCTimes, m.vctWitnessAddProofTimes,
@@ -550,20 +543,6 @@ func (m *Metrics) BatchRollbackTime(value time.Duration) {
 	m.opqueueBatchRollbackTime.Observe(value.Seconds())
 
 	logger.Debugf("BatchRollback time: %s", value)
-}
-
-// BatchAckTime records the time to acknowledge all of the operations that are removed from the queue.
-func (m *Metrics) BatchAckTime(value time.Duration) {
-	m.opqueueBatchAckTime.Observe(value.Seconds())
-
-	logger.Debugf("BatchAck time: %s", value)
-}
-
-// BatchNackTime records the time to nack all of the operations that are to be placed back on the queue.
-func (m *Metrics) BatchNackTime(value time.Duration) {
-	m.opqueueBatchNackTime.Observe(value.Seconds())
-
-	logger.Debugf("BatchNack time: %s", value)
 }
 
 // BatchSize records the size of an operation batch.
@@ -1127,22 +1106,6 @@ func newOpQueueBatchRollbackTime() prometheus.Histogram {
 		operationQueue, opQueueBatchRollbackTimeMetric,
 		"The time (in seconds) that it takes to roll back an operation batch (in case of a transient error). "+
 			"The duration is from the time that the first operation was added to the time that the batch was cut.",
-		nil,
-	)
-}
-
-func newOpQueueBatchAckTime() prometheus.Histogram {
-	return newHistogram(
-		operationQueue, opQueueBatchAckTimeMetric,
-		"The time (in seconds) that it takes to acknowledge all of the operations that are removed from the queue.",
-		nil,
-	)
-}
-
-func newOpQueueBatchNackTime() prometheus.Histogram {
-	return newHistogram(
-		operationQueue, opQueueBatchNackTimeMetric,
-		"The time (in seconds) that it takes to nack all of the operations that are to be placed back on the queue.",
 		nil,
 	)
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -41,8 +41,6 @@ func TestMetrics(t *testing.T) {
 		require.NotPanics(t, func() { m.AddOperationTime(time.Second) })
 		require.NotPanics(t, func() { m.BatchCutTime(time.Second) })
 		require.NotPanics(t, func() { m.BatchRollbackTime(time.Second) })
-		require.NotPanics(t, func() { m.BatchAckTime(time.Second) })
-		require.NotPanics(t, func() { m.BatchNackTime(time.Second) })
 		require.NotPanics(t, func() { m.BatchSize(float64(500)) })
 		require.NotPanics(t, func() { m.ProcessAnchorTime(time.Second) })
 		require.NotPanics(t, func() { m.ProcessDIDTime(time.Second) })

--- a/pkg/mocks/metricsprovider.go
+++ b/pkg/mocks/metricsprovider.go
@@ -108,14 +108,6 @@ func (m *MetricsProvider) CASWriteTime(value time.Duration) {
 func (m *MetricsProvider) CASResolveTime(value time.Duration) {
 }
 
-// BatchAckTime records the time to acknowledge all of the operations that are removed from the queue.
-func (m *MetricsProvider) BatchAckTime(value time.Duration) {
-}
-
-// BatchNackTime records the time to nack all of the operations that are to be placed back on the queue.
-func (m *MetricsProvider) BatchNackTime(value time.Duration) {
-}
-
 // WitnessAnchorCredentialTime records the time it takes for a verifiable credential to gather proofs from all
 // required witnesses (according to witness policy). The start time is when the verifiable credential is issued
 // and the end time is the time that the witness policy is satisfied.

--- a/pkg/taskmgr/taskmgr.go
+++ b/pkg/taskmgr/taskmgr.go
@@ -98,6 +98,11 @@ func New(coordinationStore storage.Store, interval time.Duration) *Manager {
 	return s
 }
 
+// InstanceID returns the unique ID of this server instance.
+func (s *Manager) InstanceID() string {
+	return s.instanceID
+}
+
 // RegisterTask registers a task to be periodically run at the given interval.
 func (s *Manager) RegisterTask(id string, interval time.Duration, task func()) {
 	s.mutex.Lock()

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -39,8 +39,8 @@ services:
       - IPFS_URL=ipfs:5001
       - IPFS_TIMEOUT=10s
       - MQ_URL=amqp://${RABBITMQ_USERNAME}:${RABBITMQ_PASSWORD}@orb.mq.domain1.com:5672/
-      # MQ_OP_POOL specifies the number of subscribers that concurrently process messages in the operation queue.
-      - MQ_OP_POOL=20
+      # MQ_OP_POOL specifies the number of subscribers that concurrently process messages in the operation queue (default 5).
+      - MQ_OP_POOL=10
       # MQ_OBSERVER_POOL specifies the number of subscribers that concurrently process messages from the observer queue (default 5).
       - MQ_OBSERVER_POOL=5
       - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
@@ -156,8 +156,8 @@ services:
       - IPFS_URL=ipfs:5001
       - IPFS_TIMEOUT=10s
       - MQ_URL=amqp://${RABBITMQ_USERNAME}:${RABBITMQ_PASSWORD}@orb.mq.domain1.com:5672/
-      # MQ_OP_POOL specifies the number of subscribers that concurrently process messages in the operation queue.
-      - MQ_OP_POOL=20
+      # MQ_OP_POOL specifies the number of subscribers that concurrently process messages in the operation queue (default 5).
+      - MQ_OP_POOL=10
       # MQ_OBSERVER_POOL specifies the number of subscribers that concurrently process messages from the observer queue (default 5).
       - MQ_OBSERVER_POOL=5
       - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
@@ -283,8 +283,8 @@ services:
       - IPFS_URL=ipfs:5001
       - IPFS_TIMEOUT=10s
       - MQ_URL=amqp://${RABBITMQ_USERNAME}:${RABBITMQ_PASSWORD}@orb.mq.domain2.com:5672/
-      # MQ_OP_POOL specifies the number of subscribers that concurrently process messages in the operation queue.
-      - MQ_OP_POOL=20
+      # MQ_OP_POOL specifies the number of subscribers that concurrently process messages in the operation queue (default 5).
+      # - MQ_OP_POOL=5
       # MQ_OBSERVER_POOL specifies the number of subscribers that concurrently process messages from the observer queue (default 5).
       - MQ_OBSERVER_POOL=5
       - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
@@ -377,8 +377,8 @@ services:
       - IPFS_URL=ipfs:5001
       - IPFS_TIMEOUT=10s
       - MQ_URL=amqp://${RABBITMQ_USERNAME}:${RABBITMQ_PASSWORD}@orb.mq.domain2.com:5672/
-      # MQ_OP_POOL specifies the number of subscribers that concurrently process messages in the operation queue.
-      - MQ_OP_POOL=20
+      # MQ_OP_POOL specifies the number of subscribers that concurrently process messages in the operation queue (default 5).
+      # - MQ_OP_POOL=5
       # MQ_OBSERVER_POOL specifies the number of subscribers that concurrently process messages from the observer queue (default 5).
       - MQ_OBSERVER_POOL=5
       - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
@@ -474,8 +474,8 @@ services:
       - IPFS_URL=ipfs:5001
       - IPFS_TIMEOUT=10s
       - MQ_URL=amqp://${RABBITMQ_USERNAME}:${RABBITMQ_PASSWORD}@orb.mq.domain3.com:5672/
-      # MQ_OP_POOL specifies the number of subscribers that concurrently process messages in the operation queue.
-      - MQ_OP_POOL=20
+      # MQ_OP_POOL specifies the number of subscribers that concurrently process messages in the operation queue (default 5).
+      # - MQ_OP_POOL=5
       # MQ_OBSERVER_POOL specifies the number of subscribers that concurrently process messages from the observer queue (default 5).
       - MQ_OBSERVER_POOL=5
       - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
@@ -577,8 +577,8 @@ services:
       - IPFS_URL=ipfs:5001
       - IPFS_TIMEOUT=10s
       - MQ_URL=amqp://${RABBITMQ_USERNAME}:${RABBITMQ_PASSWORD}@orb.mq.domain4.com:5672/
-      # MQ_OP_POOL specifies the number of subscribers that concurrently process messages in the operation queue.
-      - MQ_OP_POOL=20
+      # MQ_OP_POOL specifies the number of subscribers that concurrently process messages in the operation queue (default 5).
+      # - MQ_OP_POOL=5
       # MQ_OBSERVER_POOL specifies the number of subscribers that concurrently process messages from the observer queue (default 5).
       - MQ_OBSERVER_POOL=3
       - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
@@ -682,8 +682,8 @@ services:
       - IPFS_URL=ipfs:5001
       - IPFS_TIMEOUT=10s
       - MQ_URL=amqp://${RABBITMQ_USERNAME}:${RABBITMQ_PASSWORD}@orb.mq.domain5.com:5672/
-      # MQ_OP_POOL specifies the number of subscribers that concurrently process messages in the operation queue.
-      - MQ_OP_POOL=20
+      # MQ_OP_POOL specifies the number of subscribers that concurrently process messages in the operation queue (default 5).
+      # - MQ_OP_POOL=5
       # MQ_OBSERVER_POOL specifies the number of subscribers that concurrently process messages from the observer queue (default 5).
       - MQ_OBSERVER_POOL=5
       - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500


### PR DESCRIPTION
An operation processed from the message queue is now stored in the database and immediately acknowledged (as opposed to waiting for the batch to be cut before acknowledging). This strategy reduces the number of subscribers required to process a batch and therefore reduces the resources required by an AMQP provider. Background Go routines monitor the operation queue tasks and operations such that queue tasks from one server instance that are stale are re-posted by another server instance, and really old operations are deleted from the database. The default value of the MQ subscriber queue is now set to 5. So, instead of 5000 MQ subscribers that were previously required to process a batch of 5000, the default is now 5 (although it still works if this value is set to 1).

closes #944

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>