### PR TITLE
chore: Add canonical ID and anchor origin to resolution equality check

### DIFF
--- a/pkg/document/resolvehandler/resolvehandler.go
+++ b/pkg/document/resolvehandler/resolvehandler.go
@@ -277,7 +277,7 @@ func checkResponses(anchorOrigin, local *document.ResolutionResult) error {
 		return err
 	}
 
-	return equalCommitments(anchorOrigin.DocumentMetadata, local.DocumentMetadata)
+	return equalMetadata(anchorOrigin.DocumentMetadata, local.DocumentMetadata)
 }
 
 func equalDocuments(anchorOrigin, local document.Document) error {
@@ -299,7 +299,7 @@ func equalDocuments(anchorOrigin, local document.Document) error {
 	return nil
 }
 
-func equalCommitments(anchorOrigin, local document.Metadata) error {
+func equalMetadata(anchorOrigin, local document.Metadata) error {
 	anchorOriginMethodMetadata, err := util.GetMethodMetadata(anchorOrigin)
 	if err != nil {
 		return fmt.Errorf("unable to get anchor origin metadata: %w", err)
@@ -318,6 +318,16 @@ func equalCommitments(anchorOrigin, local document.Metadata) error {
 	err = checkCommitment(anchorOriginMethodMetadata, localMethodMetadata, document.RecoveryCommitmentProperty)
 	if err != nil {
 		return fmt.Errorf("anchor origin and local recovery commitments don't match: %w", err)
+	}
+
+	if anchorOriginMethodMetadata[document.AnchorOriginProperty] != localMethodMetadata[document.AnchorOriginProperty] {
+		return fmt.Errorf("anchor origin[%s] and local[%s] anchor origins don't match",
+			anchorOriginMethodMetadata[document.AnchorOriginProperty], localMethodMetadata[document.AnchorOriginProperty])
+	}
+
+	if anchorOrigin[document.CanonicalIDProperty] != local[document.CanonicalIDProperty] {
+		return fmt.Errorf("anchor origin[%s] and local[%s] canonical IDs don't match",
+			anchorOrigin[document.CanonicalIDProperty], local[document.CanonicalIDProperty])
 	}
 
 	return nil

--- a/pkg/orbclient/resolutionverifier/resolutionverifier.go
+++ b/pkg/orbclient/resolutionverifier/resolutionverifier.go
@@ -232,7 +232,7 @@ func checkResponses(input, resolved *document.ResolutionResult) error {
 		return err
 	}
 
-	return equalCommitments(input.DocumentMetadata, resolved.DocumentMetadata)
+	return equalMetadata(input.DocumentMetadata, resolved.DocumentMetadata)
 }
 
 func equalDocuments(input, resolved document.Document) error {
@@ -254,7 +254,7 @@ func equalDocuments(input, resolved document.Document) error {
 	return nil
 }
 
-func equalCommitments(input, resolved document.Metadata) error {
+func equalMetadata(input, resolved document.Metadata) error {
 	inputMethodMetadata, err := util.GetMethodMetadata(input)
 	if err != nil {
 		return fmt.Errorf("unable to get input metadata: %w", err)
@@ -273,6 +273,16 @@ func equalCommitments(input, resolved document.Metadata) error {
 	err = checkCommitment(inputMethodMetadata, resolvedMethodMetadata, document.RecoveryCommitmentProperty)
 	if err != nil {
 		return fmt.Errorf("input and resolved recovery commitments don't match: %w", err)
+	}
+
+	if inputMethodMetadata[document.AnchorOriginProperty] != resolvedMethodMetadata[document.AnchorOriginProperty] {
+		return fmt.Errorf("input[%s] and resolved[%s] anchor origins don't match",
+			inputMethodMetadata[document.AnchorOriginProperty], resolvedMethodMetadata[document.AnchorOriginProperty])
+	}
+
+	if input[document.CanonicalIDProperty] != resolved[document.CanonicalIDProperty] {
+		return fmt.Errorf("input[%s] and resolved[%s] canonical IDs don't match",
+			input[document.CanonicalIDProperty], resolved[document.CanonicalIDProperty])
 	}
 
 	return nil

--- a/pkg/orbclient/resolutionverifier/resolutionverifier_test.go
+++ b/pkg/orbclient/resolutionverifier/resolutionverifier_test.go
@@ -22,6 +22,8 @@ import (
 const (
 	recoveryCommitment = "recovery-commitment"
 	updateCommitment   = "update-commitment"
+
+	anchorOriginDomain = "https://anchor-origin.domain.com"
 )
 
 func TestResolveVerifier_Verify(t *testing.T) {
@@ -206,27 +208,29 @@ func TestEqualDocuments(t *testing.T) {
 	})
 }
 
-func TestEqualCommitments(t *testing.T) {
+func TestEqualMetadata(t *testing.T) {
 	methodMetadata := make(map[string]interface{})
 	methodMetadata[document.RecoveryCommitmentProperty] = recoveryCommitment
 	methodMetadata[document.UpdateCommitmentProperty] = updateCommitment
+	methodMetadata[document.AnchorOriginProperty] = anchorOriginDomain
 
 	docMetadata := make(document.Metadata)
 	docMetadata[document.MethodProperty] = methodMetadata
+	docMetadata[document.CanonicalIDProperty] = "canonical-id"
 
 	t.Run("success", func(t *testing.T) {
-		err := equalCommitments(docMetadata, docMetadata)
+		err := equalMetadata(docMetadata, docMetadata)
 		require.NoError(t, err)
 	})
 
 	t.Run("error - input missing method metadata", func(t *testing.T) {
-		err := equalCommitments(make(document.Metadata), docMetadata)
+		err := equalMetadata(make(document.Metadata), docMetadata)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unable to get input metadata: missing method metadata")
 	})
 
 	t.Run("error - resolved missing method metadata", func(t *testing.T) {
-		err := equalCommitments(docMetadata, make(document.Metadata))
+		err := equalMetadata(docMetadata, make(document.Metadata))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unable to get resolved metadata: missing method metadata")
 	})
@@ -238,7 +242,7 @@ func TestEqualCommitments(t *testing.T) {
 		docMD := make(document.Metadata)
 		docMD[document.MethodProperty] = md
 
-		err := equalCommitments(docMetadata, docMD)
+		err := equalMetadata(docMetadata, docMD)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "missing 'updateCommitment' in resolved method metadata")
 	})
@@ -250,7 +254,7 @@ func TestEqualCommitments(t *testing.T) {
 		docMD := make(document.Metadata)
 		docMD[document.MethodProperty] = md
 
-		err := equalCommitments(docMetadata, docMD)
+		err := equalMetadata(docMetadata, docMD)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "missing 'recoveryCommitment' in resolved method metadata")
 	})
@@ -263,7 +267,7 @@ func TestEqualCommitments(t *testing.T) {
 		docMD := make(document.Metadata)
 		docMD[document.MethodProperty] = md
 
-		err := equalCommitments(docMetadata, docMD)
+		err := equalMetadata(docMetadata, docMD)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "input and resolved update commitments don't match")
 	})
@@ -276,9 +280,40 @@ func TestEqualCommitments(t *testing.T) {
 		docMD := make(document.Metadata)
 		docMD[document.MethodProperty] = md
 
-		err := equalCommitments(docMetadata, docMD)
+		err := equalMetadata(docMetadata, docMD)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "input and resolved recovery commitments don't match")
+	})
+
+	t.Run("error - different anchor origins", func(t *testing.T) {
+		md := make(map[string]interface{})
+		md[document.RecoveryCommitmentProperty] = recoveryCommitment
+		md[document.UpdateCommitmentProperty] = updateCommitment
+		md[document.AnchorOriginProperty] = "https://other.domain.com"
+
+		docMD := make(document.Metadata)
+		docMD[document.MethodProperty] = md
+
+		err := equalMetadata(docMetadata, docMD)
+		require.Error(t, err)
+		require.Contains(t, err.Error(),
+			"input[https://anchor-origin.domain.com] and resolved[https://other.domain.com] anchor origins don't match")
+	})
+
+	t.Run("error - different canonical ID", func(t *testing.T) {
+		md := make(map[string]interface{})
+		md[document.RecoveryCommitmentProperty] = recoveryCommitment
+		md[document.UpdateCommitmentProperty] = updateCommitment
+		md[document.AnchorOriginProperty] = anchorOriginDomain
+
+		docMD := make(document.Metadata)
+		docMD[document.MethodProperty] = md
+		docMD[document.CanonicalIDProperty] = "other-canonical-id"
+
+		err := equalMetadata(docMetadata, docMD)
+		require.Error(t, err)
+		require.Contains(t, err.Error(),
+			"input[canonical-id] and resolved[other-canonical-id] canonical IDs don't match")
 	})
 }
 


### PR DESCRIPTION
Canonical ID and anchor origin are now part of checks for equality of resolutions results for both server and client.

Closes #951

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>