### PR TITLE
fix: Reject invalid "Undo" request

### DIFF
--- a/pkg/activitypub/resthandler/outboxhandler.go
+++ b/pkg/activitypub/resthandler/outboxhandler.go
@@ -107,7 +107,7 @@ func (h *Outbox) handlePost(w http.ResponseWriter, req *http.Request) { //nolint
 		if orberrors.IsBadRequest(err) {
 			logger.Debugf("[%s] Error posting activity: %s", h.endpoint, err)
 
-			h.writeResponse(w, http.StatusBadRequest, []byte(badRequestResponse))
+			h.writeResponse(w, http.StatusBadRequest, []byte(err.Error()))
 		} else {
 			logger.Errorf("[%s] Error posting activity: %s", h.endpoint, err)
 

--- a/pkg/activitypub/vocab/objecttype.go
+++ b/pkg/activitypub/vocab/objecttype.go
@@ -205,8 +205,33 @@ func (t *ObjectType) Tag() []*TagProperty {
 // Urls holds a collection of URLs.
 type Urls []*url.URL
 
-// Contains returns true if the collection of URLs contains the given URL.
-func (u Urls) Contains(v fmt.Stringer) bool {
+// Contains returns true if the collection of URLs contains the given URLs.
+func (u Urls) Contains(values ...fmt.Stringer) bool {
+	for _, v := range values {
+		if !u.contains(v) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Equals returns true if the given collection of URLs is the same as this one. (Order does not matter.)
+func (u Urls) Equals(urls Urls) bool {
+	if len(urls) != len(u) {
+		return false
+	}
+
+	for _, v := range urls {
+		if !u.contains(v) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (u Urls) contains(v fmt.Stringer) bool {
 	for _, iri := range u {
 		if iri.String() == v.String() {
 			return true

--- a/pkg/activitypub/vocab/objecttype_test.go
+++ b/pkg/activitypub/vocab/objecttype_test.go
@@ -18,7 +18,9 @@ import (
 
 func TestObjectType_WithoutDocument(t *testing.T) {
 	id := testutil.MustParseURL("http://sally.example.com/transactions/bafkreihwsn")
-	u := testutil.MustParseURL("http://sally.example.com/transactions/xyz")
+	u1 := testutil.MustParseURL("http://sally.example.com/transactions/abc")
+	u2 := testutil.MustParseURL("http://sally.example.com/transactions/def")
+	u3 := testutil.MustParseURL("http://sally.example.com/transactions/ghi")
 	to1 := testutil.MustParseURL("https://to1")
 	to2 := testutil.MustParseURL("https://to2")
 
@@ -28,7 +30,7 @@ func TestObjectType_WithoutDocument(t *testing.T) {
 
 	t.Run("NewObject", func(t *testing.T) {
 		obj := NewObject(
-			WithURL(u),
+			WithURL(u1, u2),
 			WithContext(ContextCredentials, ContextActivityAnchors),
 			WithType(TypeVerifiableCredential),
 			WithTo(to1, to2),
@@ -45,7 +47,10 @@ func TestObjectType_WithoutDocument(t *testing.T) {
 
 		require.Equal(t, id.String(), obj.ID().String())
 
-		require.True(t, obj.URL().Contains(u))
+		require.True(t, obj.URL().Contains(u1))
+		require.True(t, obj.URL().Equals(Urls{u1, u2}))
+		require.False(t, obj.URL().Equals(Urls{u1, u3}))
+		require.False(t, obj.URL().Equals(Urls{u1}))
 
 		typeProp := obj.Type()
 		require.NotNil(t, typeProp)
@@ -57,8 +62,7 @@ func TestObjectType_WithoutDocument(t *testing.T) {
 
 		to := obj.To()
 		require.Len(t, to, 2)
-		require.True(t, to.Contains(to1))
-		require.True(t, to.Contains(to2))
+		require.True(t, to.Contains(to1, to2))
 	})
 
 	t.Run("MarshalJSON", func(t *testing.T) {

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -43,6 +43,11 @@ func NewBadRequest(err error) error {
 	return &badRequest{err: err}
 }
 
+// NewBadRequestf returns a 'bad request' error in order to indicate to the caller that the request was invalid.
+func NewBadRequestf(format string, a ...interface{}) error {
+	return &badRequest{err: fmt.Errorf(format, a...)}
+}
+
 // IsBadRequest returns true if the given error is a 'bad request' error.
 func IsBadRequest(err error) bool {
 	return errors.As(err, &invalidRequestType)

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -24,6 +24,9 @@ func TestTransientError(t *testing.T) {
 	require.True(t, errors.Is(err, et))
 	require.False(t, IsTransient(ep))
 	require.EqualError(t, err, "got error: some transient error")
+
+	err = NewTransientf("some transient error")
+	require.True(t, IsTransient(err))
 }
 
 func TestBadRequestError(t *testing.T) {
@@ -36,4 +39,7 @@ func TestBadRequestError(t *testing.T) {
 	require.True(t, errors.Is(err, eir))
 	require.False(t, IsBadRequest(e))
 	require.EqualError(t, err, "got error: some bad request error")
+
+	err = NewBadRequestf("some bad request")
+	require.True(t, IsBadRequest(err))
 }

--- a/test/bdd/features/activitypub.feature
+++ b/test/bdd/features/activitypub.feature
@@ -266,7 +266,10 @@ Feature:
     And the JSON path "items" of the response contains "${domain1IRI}"
     And the JSON path "items" of the response does not contain "${domain3IRI}"
 
-    And variable "undoInviteWitnessActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain1IRI}","to":"${domain2IRI}","object":{"actor":"${domain1IRI}","id":"${inviteWitnessID}","object":"${domain2IRI}","type":"Invite"}}'
+    When variable "invalidUndoInviteWitnessActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain1IRI}","to":"${domain2IRI}","object":{"actor":"${domain1IRI}","id":"${inviteWitnessID}","object":"${domain2IRI}","type":"Invite"}}'
+    Then an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${invalidUndoInviteWitnessActivity}" of type "application/json" and the returned status code is 400
+
+    And variable "undoInviteWitnessActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain1IRI}","to":"${domain2IRI}","object":{"actor":"${domain1IRI}","id":"${inviteWitnessID}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain2IRI}","type":"Invite"}}'
     When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${undoInviteWitnessActivity}" of type "application/json"
 
     Then we wait 3 seconds
@@ -304,7 +307,7 @@ Feature:
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.id" of the response contains "${domain2IRI}/activities/a9e66de1-2f9c-4822-b321-07d8c36d31a4"
 
-    And variable "undoInviteWitnessActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain2IRI}","to":"${domain1IRI}","object":{"actor":"${domain2IRI}","id":"${inviteWitnessID}","object":"${domain1IRI}","type":"Invite"}}'
+    And variable "undoInviteWitnessActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain2IRI}","to":"${domain1IRI}","object":{"actor":"${domain2IRI}","id":"${inviteWitnessID}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain1IRI}","type":"Invite"}}'
     When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${undoInviteWitnessActivity}" of type "application/json"
 
     When an HTTP GET is sent to "https://orb.domain2.com/services/orb/witnessing?page=true"


### PR DESCRIPTION
The "Undo" activity is now validated against the original activity that is being undone. If it does not match then HTTP 400 (bad request) is the response.

closes #874

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>