### PR TITLE
chore: Amalgamate ActivityPub reference databases

### DIFF
--- a/cmd/orb-cli/go.sum
+++ b/cmd/orb-cli/go.sum
@@ -744,8 +744,8 @@ github.com/hyperledger/aries-framework-go v0.1.8-0.20211203093644-b7d189cc06f4 h
 github.com/hyperledger/aries-framework-go v0.1.8-0.20211203093644-b7d189cc06f4/go.mod h1:uve8/q23AUnq4EM0vBkEr1lKZRC67q5RcaHXh0ZOt0Y=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20210909220549-ce3a2ee13e22/go.mod h1:FtlFhPHMyLORgrPpvWSmEQSNhLiwAQ4V6rqNPfuDj0o=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20210909220549-ce3a2ee13e22/go.mod h1:aiO9mXZBykIEwmgp9sSdpMuTw0P7b+ZFUltcIB9ZccY=
-github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211206201819-d0e0ac91edf1 h1:uHoQbb1CV2XoK9sZDx/8JyCfhNbSgOLyYg+m+yZYUdc=
-github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211206201819-d0e0ac91edf1/go.mod h1:Yzjzj3YfU3A5NdDeAkymVOqtlWfR32dEt8BYWlAcgcA=
+github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211219215001-23cd75276fdc h1:VI3JX0ymIkI5amU2sKP+25EuopLjkDvUHfmJ/jsPFK0=
+github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211219215001-23cd75276fdc/go.mod h1:Yzjzj3YfU3A5NdDeAkymVOqtlWfR32dEt8BYWlAcgcA=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mysql v0.0.0-20210909220549-ce3a2ee13e22/go.mod h1:bShq2cEzJcCEFkYIlQATTVldlOfyYvmnVPAdUSfCDm4=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/orb v0.0.0-20210915134807-3e19121646a4 h1:YSj2e2/2ckFPKB6kxwBNRZCVS1xlDWQj/kW8WD+5eSI=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/orb v0.0.0-20210915134807-3e19121646a4/go.mod h1:KGQrAfEy/oFbFn2En7FKHO4zx0SUsR9C8oRGwg6HsG8=

--- a/cmd/orb-driver/go.sum
+++ b/cmd/orb-driver/go.sum
@@ -742,8 +742,8 @@ github.com/hyperledger/aries-framework-go v0.1.8-0.20211203093644-b7d189cc06f4 h
 github.com/hyperledger/aries-framework-go v0.1.8-0.20211203093644-b7d189cc06f4/go.mod h1:uve8/q23AUnq4EM0vBkEr1lKZRC67q5RcaHXh0ZOt0Y=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20210909220549-ce3a2ee13e22/go.mod h1:FtlFhPHMyLORgrPpvWSmEQSNhLiwAQ4V6rqNPfuDj0o=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20210909220549-ce3a2ee13e22/go.mod h1:aiO9mXZBykIEwmgp9sSdpMuTw0P7b+ZFUltcIB9ZccY=
-github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211206201819-d0e0ac91edf1 h1:uHoQbb1CV2XoK9sZDx/8JyCfhNbSgOLyYg+m+yZYUdc=
-github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211206201819-d0e0ac91edf1/go.mod h1:Yzjzj3YfU3A5NdDeAkymVOqtlWfR32dEt8BYWlAcgcA=
+github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211219215001-23cd75276fdc h1:VI3JX0ymIkI5amU2sKP+25EuopLjkDvUHfmJ/jsPFK0=
+github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211219215001-23cd75276fdc/go.mod h1:Yzjzj3YfU3A5NdDeAkymVOqtlWfR32dEt8BYWlAcgcA=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mysql v0.0.0-20210909220549-ce3a2ee13e22/go.mod h1:bShq2cEzJcCEFkYIlQATTVldlOfyYvmnVPAdUSfCDm4=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/orb v0.0.0-20210915134807-3e19121646a4 h1:YSj2e2/2ckFPKB6kxwBNRZCVS1xlDWQj/kW8WD+5eSI=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/orb v0.0.0-20210915134807-3e19121646a4/go.mod h1:KGQrAfEy/oFbFn2En7FKHO4zx0SUsR9C8oRGwg6HsG8=

--- a/cmd/orb-server/go.mod
+++ b/cmd/orb-server/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/hyperledger/aries-framework-go v0.1.8-0.20211203093644-b7d189cc06f4
 	github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20210909220549-ce3a2ee13e22
-	github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211206201819-d0e0ac91edf1
+	github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211219215001-23cd75276fdc
 	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210910143505-343c246c837c
 	github.com/hyperledger/aries-framework-go/spi v0.0.0-20211206182816-9cdcbcd09dc2
 	github.com/piprate/json-gold v0.4.1-0.20210813112359-33b90c4ca86c

--- a/cmd/orb-server/go.sum
+++ b/cmd/orb-server/go.sum
@@ -756,8 +756,8 @@ github.com/hyperledger/aries-framework-go v0.1.8-0.20211203093644-b7d189cc06f4/g
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20210909220549-ce3a2ee13e22 h1:dzRPCOUIU/RKlGSGJsqpBh0uHOjMN4LC/c25fs7nnlE=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20210909220549-ce3a2ee13e22/go.mod h1:FtlFhPHMyLORgrPpvWSmEQSNhLiwAQ4V6rqNPfuDj0o=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20210909220549-ce3a2ee13e22/go.mod h1:aiO9mXZBykIEwmgp9sSdpMuTw0P7b+ZFUltcIB9ZccY=
-github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211206201819-d0e0ac91edf1 h1:uHoQbb1CV2XoK9sZDx/8JyCfhNbSgOLyYg+m+yZYUdc=
-github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211206201819-d0e0ac91edf1/go.mod h1:Yzjzj3YfU3A5NdDeAkymVOqtlWfR32dEt8BYWlAcgcA=
+github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211219215001-23cd75276fdc h1:VI3JX0ymIkI5amU2sKP+25EuopLjkDvUHfmJ/jsPFK0=
+github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211219215001-23cd75276fdc/go.mod h1:Yzjzj3YfU3A5NdDeAkymVOqtlWfR32dEt8BYWlAcgcA=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mysql v0.0.0-20210909220549-ce3a2ee13e22/go.mod h1:bShq2cEzJcCEFkYIlQATTVldlOfyYvmnVPAdUSfCDm4=
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20210520055214-ae429bb89bf7/go.mod h1:7D+Y5J9cIsUrMGFAsIED+3bAPNjxp6ggXo0/kT5N6BI=
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20210807121559-b41545a4f1e8/go.mod h1:00tdiDIlEdmcLuN/5zSr3NI8AycnvRMMt4M07VSqiqw=

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/hyperledger/aries-framework-go v0.1.8-0.20211203093644-b7d189cc06f4
-	github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211206201819-d0e0ac91edf1
+	github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211219215001-23cd75276fdc
 	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210910143505-343c246c837c
 	github.com/hyperledger/aries-framework-go/spi v0.0.0-20211206182816-9cdcbcd09dc2
 	github.com/igor-pavlenko/httpsignatures-go v0.0.21

--- a/go.sum
+++ b/go.sum
@@ -752,8 +752,8 @@ github.com/hyperledger/aries-framework-go v0.1.8-0.20211203093644-b7d189cc06f4 h
 github.com/hyperledger/aries-framework-go v0.1.8-0.20211203093644-b7d189cc06f4/go.mod h1:uve8/q23AUnq4EM0vBkEr1lKZRC67q5RcaHXh0ZOt0Y=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20210909220549-ce3a2ee13e22/go.mod h1:FtlFhPHMyLORgrPpvWSmEQSNhLiwAQ4V6rqNPfuDj0o=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20210909220549-ce3a2ee13e22/go.mod h1:aiO9mXZBykIEwmgp9sSdpMuTw0P7b+ZFUltcIB9ZccY=
-github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211206201819-d0e0ac91edf1 h1:uHoQbb1CV2XoK9sZDx/8JyCfhNbSgOLyYg+m+yZYUdc=
-github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211206201819-d0e0ac91edf1/go.mod h1:Yzjzj3YfU3A5NdDeAkymVOqtlWfR32dEt8BYWlAcgcA=
+github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211219215001-23cd75276fdc h1:VI3JX0ymIkI5amU2sKP+25EuopLjkDvUHfmJ/jsPFK0=
+github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211219215001-23cd75276fdc/go.mod h1:Yzjzj3YfU3A5NdDeAkymVOqtlWfR32dEt8BYWlAcgcA=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mysql v0.0.0-20210909220549-ce3a2ee13e22/go.mod h1:bShq2cEzJcCEFkYIlQATTVldlOfyYvmnVPAdUSfCDm4=
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20210520055214-ae429bb89bf7/go.mod h1:7D+Y5J9cIsUrMGFAsIED+3bAPNjxp6ggXo0/kT5N6BI=
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20210807121559-b41545a4f1e8/go.mod h1:00tdiDIlEdmcLuN/5zSr3NI8AycnvRMMt4M07VSqiqw=

--- a/pkg/activitypub/resthandler/activityhandler_test.go
+++ b/pkg/activitypub/resthandler/activityhandler_test.go
@@ -936,7 +936,7 @@ func TestGetActivities(t *testing.T) {
 		OpenStoreReturn: &mock.Store{
 			QueryReturn: &mock.Iterator{ErrTotalItems: errors.New("total items error")},
 		},
-	}, false)
+	}, true)
 	require.NoError(t, err)
 
 	activitiesHandler := Activities{handler: &handler{AuthHandler: &AuthHandler{activityStore: store}}}
@@ -951,7 +951,7 @@ func TestActivityHandlerGetPage(t *testing.T) {
 		OpenStoreReturn: &mock.Store{
 			QueryReturn: &mock.Iterator{ErrTotalItems: errors.New("total items error")},
 		},
-	}, false)
+	}, true)
 	require.NoError(t, err)
 
 	mockActivityIterator, err := ariesStore.QueryActivities(&spi.Criteria{})

--- a/pkg/activitypub/resthandler/referencehandler_test.go
+++ b/pkg/activitypub/resthandler/referencehandler_test.go
@@ -478,7 +478,7 @@ func TestGetReference(t *testing.T) {
 		OpenStoreReturn: &mock.Store{
 			QueryReturn: &mock.Iterator{ErrTotalItems: errors.New("total items error")},
 		},
-	}, false)
+	}, true)
 	require.NoError(t, err)
 
 	referenceHandler := Reference{
@@ -496,7 +496,7 @@ func TestReferenceHandlerGetPage(t *testing.T) {
 		OpenStoreReturn: &mock.Store{
 			QueryReturn: &mock.Iterator{ErrTotalItems: errors.New("total items error")},
 		},
-	}, false)
+	}, true)
 	require.NoError(t, err)
 
 	referenceHandler := Reference{

--- a/pkg/activitypub/service/activityhandler/inboxhandler.go
+++ b/pkg/activitypub/service/activityhandler/inboxhandler.go
@@ -254,8 +254,7 @@ func (h *Inbox) validateActivity(activity *vocab.ActivityType, getTargetIRI func
 }
 
 func (h *Inbox) acceptActor(activity *vocab.ActivityType, actor *vocab.ActorType, refType store.ReferenceType) error {
-	if err := h.store.AddReference(refType, h.ServiceIRI, actor.ID().URL(),
-		store.WithActivityType(activity.Type().Types()[0])); err != nil {
+	if err := h.store.AddReference(refType, h.ServiceIRI, actor.ID().URL()); err != nil {
 		return orberrors.NewTransient(fmt.Errorf("unable to store reference: %w", err))
 	}
 
@@ -316,7 +315,7 @@ func (h *Inbox) handleAccept(accept *vocab.ActivityType, refType store.Reference
 		return fmt.Errorf("actor %s is already in the '%s' collection", accept.Actor(), refType)
 	}
 
-	err = h.store.AddReference(refType, h.ServiceIRI, accept.Actor(), store.WithActivityType(accept.Type().Types()[0]))
+	err = h.store.AddReference(refType, h.ServiceIRI, accept.Actor())
 	if err != nil {
 		return orberrors.NewTransient(fmt.Errorf("handle accept '%s' activity %s: %w", refType, accept.ID(), err))
 	}
@@ -688,8 +687,7 @@ func (h *Inbox) handleAnnounceCollection(announce *vocab.ActivityType, items []*
 		logger.Debugf("[%s] Adding 'Announce' [%s] to shares of anchor event [%s]",
 			h.ServiceIRI, announce.ID(), anchorEventID)
 
-		err := h.store.AddReference(store.Share, anchorEventID, announce.ID().URL(),
-			store.WithActivityType(announce.Type().Types()[0]))
+		err := h.store.AddReference(store.Share, anchorEventID, announce.ID().URL())
 		if err != nil {
 			// This isn't a fatal error so just log a warning.
 			logger.Warnf("[%s] Error adding 'Announce' activity %s to 'shares' of anchor event %s: %s",
@@ -791,8 +789,7 @@ func (h *Inbox) announceAnchorEventRef(create *vocab.ActivityType) error {
 
 	logger.Debugf("[%s] Adding 'Announce' %s to shares of %s", h.ServiceIRI, announce.ID(), anchorEventURL)
 
-	err = h.store.AddReference(store.Share, anchorEventURL, activityID,
-		store.WithActivityType(create.Type().Types()[0]))
+	err = h.store.AddReference(store.Share, anchorEventURL, activityID)
 	if err != nil {
 		logger.Warnf("[%s] Error adding 'Announce' activity %s to 'shares' of %s",
 			h.ServiceIRI, announce.ID(), anchorEventURL)

--- a/pkg/activitypub/store/ariesstore/ariesstore_test.go
+++ b/pkg/activitypub/store/ariesstore/ariesstore_test.go
@@ -76,18 +76,18 @@ func TestNew(t *testing.T) {
 	})
 	t.Run("Failed to open inbox store", func(t *testing.T) {
 		provider, err := ariesstore.New("ServiceName", &mockStore{
-			openStoreNameToFailOn: string(spi.Inbox),
-		}, false)
+			openStoreNameToFailOn: "activitypub-ref",
+		}, true)
 		require.EqualError(t, err, "failed to open stores: failed to open reference stores: "+
-			"failed to open INBOX store: open store error")
+			"failed to open activitypub-ref store: open store error")
 		require.Nil(t, provider)
 	})
 	t.Run("Failed to set store config on inbox store", func(t *testing.T) {
 		provider, err := ariesstore.New("ServiceName", &mockStore{
-			setStoreConfigNameToFailOn: string(spi.Inbox),
-		}, false)
+			setStoreConfigNameToFailOn: "activitypub-ref",
+		}, true)
 		require.EqualError(t, err, "failed to open stores: failed to open reference stores: "+
-			"failed to set store configuration on INBOX store: set store config error")
+			"failed to set store configuration on activitypub-ref store: set store config error")
 		require.Nil(t, provider)
 	})
 	t.Run("Failed to open actor store", func(t *testing.T) {
@@ -458,16 +458,6 @@ func TestStore_Reference_Failures(t *testing.T) {
 			err = provider.AddReference(spi.Following, actor1, actor2)
 			require.EqualError(t, err, "failed to store reference: put error")
 		})
-		t.Run("No store found for the reference type", func(t *testing.T) {
-			provider, err := ariesstore.New("ServiceName", mem.NewProvider(), false)
-			require.NoError(t, err)
-
-			actor1 := testutil.MustParseURL("https://actor1")
-			actor2 := testutil.MustParseURL("https://actor2")
-
-			err = provider.AddReference("UnknownReferenceType", actor1, actor2)
-			require.EqualError(t, err, "no store found for UnknownReferenceType")
-		})
 	})
 	t.Run("Fail to delete reference", func(t *testing.T) {
 		t.Run("Fail to delete in underlying storage", func(t *testing.T) {
@@ -484,16 +474,6 @@ func TestStore_Reference_Failures(t *testing.T) {
 			err = provider.DeleteReference(spi.Following, actor1, actor2)
 			require.EqualError(t, err, "failed to delete reference: delete error")
 		})
-		t.Run("No store found for the reference type", func(t *testing.T) {
-			provider, err := ariesstore.New("ServiceName", mem.NewProvider(), false)
-			require.NoError(t, err)
-
-			actor1 := testutil.MustParseURL("https://actor1")
-			actor2 := testutil.MustParseURL("https://actor2")
-
-			err = provider.DeleteReference("UnknownReferenceType", actor1, actor2)
-			require.EqualError(t, err, "no store found for UnknownReferenceType")
-		})
 	})
 	t.Run("Fail to query references", func(t *testing.T) {
 		t.Run("Fail to query in underlying storage", func(t *testing.T) {
@@ -501,23 +481,13 @@ func TestStore_Reference_Failures(t *testing.T) {
 				OpenStoreReturn: &mock.Store{
 					ErrQuery: errors.New("query error"),
 				},
-			}, false)
+			}, true)
 			require.NoError(t, err)
 
 			actor1 := testutil.MustParseURL("https://actor1")
 
 			_, err = provider.QueryReferences(spi.Following, spi.NewCriteria(spi.WithObjectIRI(actor1)))
 			require.EqualError(t, err, "failed to query store: query error")
-		})
-		t.Run("No store found for the reference type", func(t *testing.T) {
-			provider, err := ariesstore.New("ServiceName", mem.NewProvider(), false)
-			require.NoError(t, err)
-
-			actor1 := testutil.MustParseURL("https://actor1")
-
-			_, err = provider.QueryReferences("UnknownReferenceType",
-				spi.NewCriteria(spi.WithObjectIRI(actor1)))
-			require.EqualError(t, err, "no store found for UnknownReferenceType")
 		})
 		t.Run("Fail to query with both object IRI and activity type", func(t *testing.T) {
 			provider, err := ariesstore.New("ServiceName", mem.NewProvider(), false)

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/greenpau/go-calculator v1.0.1
 	github.com/hyperledger/aries-framework-go v0.1.8-0.20211217135421-f68d5698237a
 	github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20210909220549-ce3a2ee13e22
-	github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211206201819-d0e0ac91edf1
+	github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211219215001-23cd75276fdc
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/orb v0.1.4-0.20211217190732-bf0dd1b79aba
 	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210910143505-343c246c837c
 	github.com/hyperledger/aries-framework-go/spi v0.0.0-20211206182816-9cdcbcd09dc2

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -938,8 +938,8 @@ github.com/hyperledger/aries-framework-go v0.1.8-0.20211217135421-f68d5698237a/g
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20210909220549-ce3a2ee13e22 h1:dzRPCOUIU/RKlGSGJsqpBh0uHOjMN4LC/c25fs7nnlE=
 github.com/hyperledger/aries-framework-go-ext/component/storage/couchdb v0.0.0-20210909220549-ce3a2ee13e22/go.mod h1:FtlFhPHMyLORgrPpvWSmEQSNhLiwAQ4V6rqNPfuDj0o=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20210909220549-ce3a2ee13e22/go.mod h1:aiO9mXZBykIEwmgp9sSdpMuTw0P7b+ZFUltcIB9ZccY=
-github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211206201819-d0e0ac91edf1 h1:uHoQbb1CV2XoK9sZDx/8JyCfhNbSgOLyYg+m+yZYUdc=
-github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211206201819-d0e0ac91edf1/go.mod h1:Yzjzj3YfU3A5NdDeAkymVOqtlWfR32dEt8BYWlAcgcA=
+github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211219215001-23cd75276fdc h1:VI3JX0ymIkI5amU2sKP+25EuopLjkDvUHfmJ/jsPFK0=
+github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211219215001-23cd75276fdc/go.mod h1:Yzjzj3YfU3A5NdDeAkymVOqtlWfR32dEt8BYWlAcgcA=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mysql v0.0.0-20210909220549-ce3a2ee13e22/go.mod h1:bShq2cEzJcCEFkYIlQATTVldlOfyYvmnVPAdUSfCDm4=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/orb v0.1.4-0.20211217190732-bf0dd1b79aba h1:/JKwVZxuuoltl/dZ7l1qIkSGdZNV9BG6f5ccPL2o62o=
 github.com/hyperledger/aries-framework-go-ext/component/vdr/orb v0.1.4-0.20211217190732-bf0dd1b79aba/go.mod h1:g0y1uWqnlfB7DdiAeQ34qNTE4Z5F99XccFIlTEKUMik=


### PR DESCRIPTION
Create a new, "activitypub-ref" database that contains all of the references that were previously in 11 separate databases.

closes #872
closes #873

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>