### PR TITLE
feat: Use an AMQP channel pool for the publisher

### DIFF
--- a/cmd/orb-server/go.mod
+++ b/cmd/orb-server/go.mod
@@ -23,4 +23,6 @@ require (
 
 replace github.com/trustbloc/orb => ../..
 
+replace github.com/ThreeDotsLabs/watermill-amqp => github.com/trustbloc/watermill-amqp v1.1.5-0.20220106223131-ce18ebbcf857
+
 go 1.16

--- a/cmd/orb-server/go.sum
+++ b/cmd/orb-server/go.sum
@@ -129,8 +129,6 @@ github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrU
 github.com/ThreeDotsLabs/watermill v1.1.0/go.mod h1:Qd1xNFxolCAHCzcMrm6RnjW0manbvN+DJVWc1MWRFlI=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.6 h1:wYybtpC+LMQCC8j3/D1BQPobWh0rZ4ZX57i3+zy7t8I=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.6/go.mod h1:QLZSaklpSZ/7yv288LL2DFOgCEi86VYEmQvzmaMlHoA=
-github.com/ThreeDotsLabs/watermill-amqp v1.1.4-0.20211104161030-4f337d77fb1f h1:qp8UJVaMmyVSju15pkJvhdCE5LEaasDnWLAlZpm6R5E=
-github.com/ThreeDotsLabs/watermill-amqp v1.1.4-0.20211104161030-4f337d77fb1f/go.mod h1:5RtpKNTriXCWQZ67YDg1G7qsphZoUue/EWOmQqTZi3Q=
 github.com/ThreeDotsLabs/watermill-http v1.1.3 h1:2jHbbE+gbq7pKWBCtOxeHTWSBNrS44Oh7QOzuAeHH/g=
 github.com/ThreeDotsLabs/watermill-http v1.1.3/go.mod h1:mkQ9CC0pxTZerNwr281rBoOy355vYt/lePkmYSX/BRg=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=
@@ -1304,6 +1302,8 @@ github.com/trustbloc/sidetree-core-go v0.7.1-0.20211229172717-b542d0074b38 h1:qU
 github.com/trustbloc/sidetree-core-go v0.7.1-0.20211229172717-b542d0074b38/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
+github.com/trustbloc/watermill-amqp v1.1.5-0.20220106223131-ce18ebbcf857 h1:3Xm1XZaaXf4DlN/Yeas8qnQLaAfTqCUmsQROiy+n9/0=
+github.com/trustbloc/watermill-amqp v1.1.5-0.20220106223131-ce18ebbcf857/go.mod h1:5RtpKNTriXCWQZ67YDg1G7qsphZoUue/EWOmQqTZi3Q=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -593,6 +593,7 @@ func startOrbServices(parameters *orbParameters) error {
 		pubSub = amqp.New(amqp.Config{
 			URI:                        parameters.mqURL,
 			MaxConnectionSubscriptions: parameters.mqMaxConnectionSubscriptions,
+			PublisherChannelPoolSize:   parameters.mqPublisherChannelPoolSize,
 		})
 	} else {
 		pubSub = mempubsub.New(mempubsub.DefaultConfig())

--- a/go.mod
+++ b/go.mod
@@ -44,3 +44,5 @@ require (
 )
 
 go 1.16
+
+replace github.com/ThreeDotsLabs/watermill-amqp => github.com/trustbloc/watermill-amqp v1.1.5-0.20220106223131-ce18ebbcf857

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,6 @@ github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrU
 github.com/ThreeDotsLabs/watermill v1.1.0/go.mod h1:Qd1xNFxolCAHCzcMrm6RnjW0manbvN+DJVWc1MWRFlI=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.6 h1:wYybtpC+LMQCC8j3/D1BQPobWh0rZ4ZX57i3+zy7t8I=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.6/go.mod h1:QLZSaklpSZ/7yv288LL2DFOgCEi86VYEmQvzmaMlHoA=
-github.com/ThreeDotsLabs/watermill-amqp v1.1.4-0.20211104161030-4f337d77fb1f h1:qp8UJVaMmyVSju15pkJvhdCE5LEaasDnWLAlZpm6R5E=
-github.com/ThreeDotsLabs/watermill-amqp v1.1.4-0.20211104161030-4f337d77fb1f/go.mod h1:5RtpKNTriXCWQZ67YDg1G7qsphZoUue/EWOmQqTZi3Q=
 github.com/ThreeDotsLabs/watermill-http v1.1.3 h1:2jHbbE+gbq7pKWBCtOxeHTWSBNrS44Oh7QOzuAeHH/g=
 github.com/ThreeDotsLabs/watermill-http v1.1.3/go.mod h1:mkQ9CC0pxTZerNwr281rBoOy355vYt/lePkmYSX/BRg=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=
@@ -1297,6 +1295,8 @@ github.com/trustbloc/sidetree-core-go v0.7.1-0.20211229172717-b542d0074b38 h1:qU
 github.com/trustbloc/sidetree-core-go v0.7.1-0.20211229172717-b542d0074b38/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
+github.com/trustbloc/watermill-amqp v1.1.5-0.20220106223131-ce18ebbcf857 h1:3Xm1XZaaXf4DlN/Yeas8qnQLaAfTqCUmsQROiy+n9/0=
+github.com/trustbloc/watermill-amqp v1.1.5-0.20220106223131-ce18ebbcf857/go.mod h1:5RtpKNTriXCWQZ67YDg1G7qsphZoUue/EWOmQqTZi3Q=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/pkg/pubsub/amqp/amqppubsub_test.go
+++ b/pkg/pubsub/amqp/amqppubsub_test.go
@@ -364,7 +364,7 @@ func (m *mockConnectionMgr) close() error {
 	return m.err
 }
 
-func (m *mockConnectionMgr) getConnection() (connection, error) {
+func (m *mockConnectionMgr) getConnection(bool) (connection, error) {
 	if m.err != nil {
 		return nil, m.err
 	}

--- a/pkg/pubsub/wmlogger/wmlogger.go
+++ b/pkg/pubsub/wmlogger/wmlogger.go
@@ -39,7 +39,7 @@ func (l *Logger) Error(msg string, err error, fields watermill.LogFields) {
 // Info logs an informational message.
 func (l *Logger) Info(msg string, fields watermill.LogFields) {
 	// Watermill outputs too many INFO logs, so use the DEBUG log level.
-	if level := log.GetLevel(Module); level < log.DEBUG {
+	if level := log.GetLevel(Module); level < log.INFO {
 		return
 	}
 

--- a/pkg/pubsub/wmlogger/wmlogger_test.go
+++ b/pkg/pubsub/wmlogger/wmlogger_test.go
@@ -65,7 +65,7 @@ func TestWMLogger(t *testing.T) {
 		logger.Trace("message", nil)
 
 		require.Equal(t, 1, l.ErrorfCallCount())
-		require.Equal(t, 0, l.InfofCallCount())
+		require.Equal(t, 1, l.InfofCallCount())
 		require.Equal(t, 0, l.DebugfCallCount())
 	})
 

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     environment:
       - ORB_SYNC_TIMEOUT=3
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
-      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:DEBUG
+      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:watermill=INFO:DEBUG
       - ORB_VCT_URL=http://orb.vct:8077/maple2020
       - ORB_HOST_URL=172.20.0.23:443
       - ORB_HOST_METRICS_URL=172.20.0.23:48327
@@ -43,6 +43,9 @@ services:
       - MQ_OP_POOL=10
       # MQ_OBSERVER_POOL specifies the number of subscribers that concurrently process messages from the observer queue (default 5).
       - MQ_OBSERVER_POOL=5
+      # MQ_PUBLISHER_POOL specifies the size of a channel pool for an AMQP publisher (default 25). If set to 0 then
+      #	a channel pool is not used and a new channel is opened/closed for every publish to a queue.
+      - MQ_PUBLISHER_POOL=50
       - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN1}
       - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain1.com
@@ -129,7 +132,7 @@ services:
     environment:
       - ORB_SYNC_TIMEOUT=3
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
-      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:DEBUG
+      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:watermill=INFO:DEBUG
       - ORB_VCT_URL=http://orb.vct:8077/maple2020
       - ORB_HOST_URL=172.20.0.2:443
       - ORB_HOST_METRICS_URL=172.20.0.2:48527
@@ -160,6 +163,9 @@ services:
       - MQ_OP_POOL=10
       # MQ_OBSERVER_POOL specifies the number of subscribers that concurrently process messages from the observer queue (default 5).
       - MQ_OBSERVER_POOL=5
+      # MQ_PUBLISHER_POOL specifies the size of a channel pool for an AMQP publisher (default 25). If set to 0 then
+      #	a channel pool is not used and a new channel is opened/closed for every publish to a queue.
+      - MQ_PUBLISHER_POOL=50
       - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN1}
       - ANCHOR_CREDENTIAL_ISSUER=https://orb2.domain1.com
@@ -262,7 +268,7 @@ services:
     environment:
       - ORB_SYNC_TIMEOUT=3
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
-      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:DEBUG
+      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:watermill=INFO:DEBUG
       - ORB_HOST_URL=172.20.0.4:80
       - ORB_HOST_METRICS_URL=172.20.0.4:48827
       - ORB_PRIVATE_KEY=9kRTh70Ut0MKPeHY3Gdv/pi8SACx6dFjaEiIHf7JDugPpXBnCHVvRbgdzYbWfCGsXdvh/Zct+AldKG4bExjHXg
@@ -287,6 +293,9 @@ services:
       # - MQ_OP_POOL=5
       # MQ_OBSERVER_POOL specifies the number of subscribers that concurrently process messages from the observer queue (default 5).
       - MQ_OBSERVER_POOL=5
+      # MQ_PUBLISHER_POOL specifies the size of a channel pool for an AMQP publisher (default 25). If set to 0 then
+      #	a channel pool is not used and a new channel is opened/closed for every publish to a queue.
+      - MQ_PUBLISHER_POOL=25
       - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN2}
       - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain2.com
@@ -356,7 +365,7 @@ services:
     environment:
       - ORB_SYNC_TIMEOUT=3
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
-      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:DEBUG
+      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:watermill=INFO:DEBUG
       - ORB_HOST_URL=172.20.0.5:80
       - ORB_HOST_METRICS_URL=172.20.0.5:48927
       - ORB_PRIVATE_KEY=9kRTh70Ut0MKPeHY3Gdv/pi8SACx6dFjaEiIHf7JDugPpXBnCHVvRbgdzYbWfCGsXdvh/Zct+AldKG4bExjHXg
@@ -381,6 +390,9 @@ services:
       # - MQ_OP_POOL=5
       # MQ_OBSERVER_POOL specifies the number of subscribers that concurrently process messages from the observer queue (default 5).
       - MQ_OBSERVER_POOL=5
+      # MQ_PUBLISHER_POOL specifies the size of a channel pool for an AMQP publisher (default 25). If set to 0 then
+      #	a channel pool is not used and a new channel is opened/closed for every publish to a queue.
+      - MQ_PUBLISHER_POOL=25
       - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN2}
       - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain2.com
@@ -450,7 +462,7 @@ services:
     environment:
       - ORB_SYNC_TIMEOUT=3
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
-      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:DEBUG
+      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:watermill=INFO:DEBUG
       - ORB_PRIVATE_KEY=9kRTh70Ut0MKPeHY3Gdv/pi8SACx6dFjaEiIHf7JDugPpXBnCHVvRbgdzYbWfCGsXdvh/Zct+AldKG4bExjHXg
       - ORB_KEY_ID=orb3key
       - ORB_HOST_URL=172.20.0.6:443
@@ -478,6 +490,9 @@ services:
       # - MQ_OP_POOL=5
       # MQ_OBSERVER_POOL specifies the number of subscribers that concurrently process messages from the observer queue (default 5).
       - MQ_OBSERVER_POOL=5
+      # MQ_PUBLISHER_POOL specifies the size of a channel pool for an AMQP publisher (default 25). If set to 0 then
+      #	a channel pool is not used and a new channel is opened/closed for every publish to a queue.
+      - MQ_PUBLISHER_POOL=25
       - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN3}
       - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain3.com
@@ -560,7 +575,7 @@ services:
     environment:
       - ORB_SYNC_TIMEOUT=3
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
-      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:DEBUG
+      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:watermill=INFO:DEBUG
       - ORB_HOST_URL=172.20.0.7:443
       - ORB_HOST_METRICS_URL=172.20.0.7:48727
       - ORB_PRIVATE_KEY=9kRTh70Ut0MKPeHY3Gdv/pi8SACx6dFjaEiIHf7JDugPpXBnCHVvRbgdzYbWfCGsXdvh/Zct+AldKG4bExjHXg
@@ -588,6 +603,9 @@ services:
       # - MQ_OP_POOL=5
       # MQ_OBSERVER_POOL specifies the number of subscribers that concurrently process messages from the observer queue (default 5).
       - MQ_OBSERVER_POOL=3
+      # MQ_PUBLISHER_POOL specifies the size of a channel pool for an AMQP publisher (default 25). If set to 0 then
+      #	a channel pool is not used and a new channel is opened/closed for every publish to a queue.
+      - MQ_PUBLISHER_POOL=25
       - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN4}
       - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain4.com
@@ -667,7 +685,7 @@ services:
     environment:
       - ORB_SYNC_TIMEOUT=3
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
-      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:DEBUG
+      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:watermill=INFO:DEBUG
       - ORB_HOST_URL=172.20.0.31:443
       - ORB_HOST_METRICS_URL=172.20.0.31:48727
       - ORB_PRIVATE_KEY=9kRTh70Ut0MKPeHY3Gdv/pi8SACx6dFjaEiIHf7JDugPpXBnCHVvRbgdzYbWfCGsXdvh/Zct+AldKG4bExjHXg
@@ -695,6 +713,9 @@ services:
       # - MQ_OP_POOL=5
       # MQ_OBSERVER_POOL specifies the number of subscribers that concurrently process messages from the observer queue (default 5).
       - MQ_OBSERVER_POOL=5
+      # MQ_PUBLISHER_POOL specifies the size of a channel pool for an AMQP publisher (default 25). If set to 0 then
+      #	a channel pool is not used and a new channel is opened/closed for every publish to a queue.
+      - MQ_PUBLISHER_POOL=25
       - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN4}
       - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain5.com


### PR DESCRIPTION
Use the latest watermill-amqp client library which implements a Publisher channel pool. The channel pool improves performance in high volume systems by not incurring the overhead of opening and closing channels, and the pool also acts as a throttle to prevent the AMQP server from overloading.

Also, use separate AMQP connections for publishers and subscribers since this is recommended for RabbitMQ (https://www.cloudamqp.com/blog/part1-rabbitmq-best-practice.html#separate-connections-for-publisher-and-consumer).

closes #943
closes #985

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>