### PR TITLE
chore: Adjust task scheduler time for domain4

### DIFF
--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -545,7 +545,7 @@ Feature:
     Then container "orb-domain3" is stopped
 
     # wait for event status monitor process to wake-up and re-select different system witness
-    Then we wait 10 seconds
+    Then we wait 5 seconds
 
     When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did
     Then check success response contains "#canonicalDID"

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -639,7 +639,7 @@ services:
       # TASK_MANAGER_CHECK_INTERVAL is the interval in which to check for scheduled tasks to be run. Note that this value is
       # merely the 'check' interval since each task has its own interval.
       # Default value: 10s.
-      - TASK_MANAGER_CHECK_INTERVAL=10s
+      - TASK_MANAGER_CHECK_INTERVAL=2s
       # ANCHOR_EVENT_SYNC_INTERVAL is the interval in which anchor events are synchronized with other services that
       # we're following.
       # Default value: 1m.


### PR DESCRIPTION
Decrease time scheduler time for domain4 so witness re-selection test can execute faster.

Closes #991

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>