### PR TITLE
chore: Add 0 or positive check for minimum number of witnesses required.

### DIFF
--- a/pkg/anchor/witness/policy/config/parser.go
+++ b/pkg/anchor/witness/policy/config/parser.go
@@ -115,6 +115,10 @@ func (wp *WitnessPolicyConfig) processOutOf(token string) error {
 		return fmt.Errorf("first argument for OutOf policy must be an integer: %w", err)
 	}
 
+	if minNo < 0 {
+		return fmt.Errorf("first argument[%d] for OutOf policy rule must be 0 or positive integer", minNo)
+	}
+
 	switch outOfArgs[1] {
 	case RoleSystem:
 		wp.MinNumberSystem = minNo

--- a/pkg/anchor/witness/policy/config/parser_test.go
+++ b/pkg/anchor/witness/policy/config/parser_test.go
@@ -80,6 +80,13 @@ func TestParse_OutOf(t *testing.T) {
 		require.Contains(t, err.Error(), "first argument for OutOf policy must be an integer")
 	})
 
+	t.Run("error - first argument for OutOf policy must be 0 or positive integer", func(t *testing.T) {
+		wp, err := Parse("OutOf(-1,system)")
+		require.Error(t, err)
+		require.Nil(t, wp)
+		require.Contains(t, err.Error(), "first argument[-1] for OutOf policy rule must be 0 or positive integer")
+	})
+
 	t.Run("error - role 'invalid' not supported for OutOf policy", func(t *testing.T) {
 		wp, err := Parse("OutOf(2,invalid)")
 		require.Error(t, err)


### PR DESCRIPTION
Currently for minimum number of witnesses in witness policy rule OutOf() we only check for integer for first parameter. It should be 0 or positive integer since it denotes minimum number of witnesses required to satisfy policy.

Percent rule MinPercent() is already enforcing integer that is between 0 and 100 which is correct for percent.

Closes #1025

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>