### PR TITLE
chore: Add configuration for witness policy expiry cache

### DIFF
--- a/cmd/orb-server/startcmd/params.go
+++ b/cmd/orb-server/startcmd/params.go
@@ -47,6 +47,7 @@ const (
 	defaultFollowAuthType                   = acceptAllPolicy
 	defaultInviteWitnessAuthType            = acceptAllPolicy
 	defaultMQOpPoolSize                     = 5
+	defaultWitnessPolicyCacheExpiration     = 30 * time.Second
 
 	commonEnvVarUsageText = "Alternatively, this can be set with the following environment variable: "
 
@@ -482,7 +483,10 @@ const (
 	serverIdleTimeoutFlagUsage = "The timeout for server idle timeout. For example, '30s' for a 30 second timeout. " +
 		commonEnvVarUsageText + serverIdleTimeoutEnvKey
 
-	// TODO: Update verification method
+	witnessPolicyCacheExpirationFlagName  = "witness-policy-cache-expiration"
+	witnessPolicyCacheExpirationEnvKey    = "WITNESS_POLICY_CACHE_EXPIRATION"
+	witnessPolicyCacheExpirationFlagUsage = "The expiration time of witness policy cache. " +
+		commonEnvVarUsageText + witnessPolicyCacheExpirationEnvKey
 )
 
 type acceptRejectPolicy string
@@ -570,6 +574,7 @@ type orbParameters struct {
 	apClientCacheExpiration          time.Duration
 	apIRICacheSize                   int
 	apIRICacheExpiration             time.Duration
+	witnessPolicyCacheExpiration     time.Duration
 }
 
 type anchorCredentialParams struct {
@@ -1031,6 +1036,12 @@ func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 		return nil, fmt.Errorf("%s: %w", anchorStatusInProcessGracePeriodFlagName, err)
 	}
 
+	witnessPolicyCacheExpiration, err := getDuration(cmd, witnessPolicyCacheExpirationFlagName,
+		witnessPolicyCacheExpirationEnvKey, defaultWitnessPolicyCacheExpiration)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", witnessPolicyCacheExpirationFlagName, err)
+	}
+
 	apClientCacheSize, apClientCacheExpiration, err := getActivityPubClientParameters(cmd)
 	if err != nil {
 		return nil, err
@@ -1104,6 +1115,7 @@ func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 		vctMonitoringInterval:            vctMonitoringInterval,
 		anchorStatusMonitoringInterval:   anchorStatusMonitoringInterval,
 		anchorStatusInProcessGracePeriod: anchorStatusInProcessGracePeriod,
+		witnessPolicyCacheExpiration:     witnessPolicyCacheExpiration,
 		apClientCacheSize:                apClientCacheSize,
 		apClientCacheExpiration:          apClientCacheExpiration,
 		apIRICacheSize:                   apIRICacheSize,
@@ -1583,6 +1595,7 @@ func createFlags(startCmd *cobra.Command) {
 	startCmd.Flags().StringP(vctMonitoringIntervalFlagName, "", "", vctMonitoringIntervalFlagUsage)
 	startCmd.Flags().StringP(anchorStatusMonitoringIntervalFlagName, "", "", anchorStatusMonitoringIntervalFlagUsage)
 	startCmd.Flags().StringP(anchorStatusInProcessGracePeriodFlagName, "", "", anchorStatusInProcessGracePeriodFlagUsage)
+	startCmd.Flags().StringP(witnessPolicyCacheExpirationFlagName, "", "", witnessPolicyCacheExpirationFlagUsage)
 	startCmd.Flags().StringP(activityPubClientCacheSizeFlagName, "", "", activityPubClientCacheSizeFlagUsage)
 	startCmd.Flags().StringP(activityPubIRICacheSizeFlagName, "", "", activityPubIRICacheSizeFlagUsage)
 	startCmd.Flags().StringP(activityPubIRICacheExpirationFlagName, "", "", activityPubIRICacheExpirationFlagUsage)

--- a/cmd/orb-server/startcmd/params_test.go
+++ b/cmd/orb-server/startcmd/params_test.go
@@ -710,6 +710,19 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 		require.Contains(t, err.Error(), "anchor-status-in-process-grace-period: invalid value [xxx]")
 	})
 
+	t.Run("witness policy cache expiration", func(t *testing.T) {
+		restoreEnv := setEnv(t, witnessPolicyCacheExpirationEnvKey, "xxx")
+		defer restoreEnv()
+
+		startCmd := GetStartCmd()
+
+		startCmd.SetArgs(getTestArgs("localhost:8081", "local", "false", databaseTypeMemOption, ""))
+
+		err := startCmd.Execute()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "witness-policy-cache-expiration: invalid value [xxx]")
+	})
+
 	t.Run("ActivityPub client parameters", func(t *testing.T) {
 		restoreEnv := setEnv(t, activityPubClientCacheSizeEnvKey, "xxx")
 		defer restoreEnv()

--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -152,7 +152,6 @@ const (
 	defaultVerifyLatestFromAnchorOrigin   = false
 	defaultLocalCASReplicateInIPFSEnabled = false
 	defaultDevModeEnabled                 = false
-	defaultPolicyCacheExpiry              = 30 * time.Second
 	defaultCasCacheSize                   = 1000
 
 	unpublishedDIDLabel = "uAAA"
@@ -636,7 +635,7 @@ func startOrbServices(parameters *orbParameters) error {
 		return fmt.Errorf("new VCT monitoring service: %w", err)
 	}
 
-	witnessPolicy, err := policy.New(configStore, defaultPolicyCacheExpiry)
+	witnessPolicy, err := policy.New(configStore, parameters.witnessPolicyCacheExpiration)
 	if err != nil {
 		return fmt.Errorf("failed to create witness policy: %s", err.Error())
 	}

--- a/pkg/anchor/witness/policy/policy.go
+++ b/pkg/anchor/witness/policy/policy.go
@@ -51,7 +51,7 @@ type selector interface {
 	Select(witnesses []*proof.Witness, n int) ([]*proof.Witness, error)
 }
 
-// New parses witness policy from policy string.
+// New will create new witness policy evaluator.
 func New(configStore storage.Store, policyCacheExpiry time.Duration) (*WitnessPolicy, error) {
 	wp := &WitnessPolicy{
 		configStore: configStore,
@@ -70,6 +70,9 @@ func New(configStore storage.Store, policyCacheExpiry time.Duration) (*WitnessPo
 	if err != nil {
 		return nil, fmt.Errorf("failed to set expiry entry in policy cache: %w", err)
 	}
+
+	logger.Debugf("created new witness policy evaluator with policy: %s "+
+		"and witness policy cache expiry period set to: %s", policy, policyCacheExpiry)
 
 	return wp, nil
 }

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -108,6 +108,9 @@ services:
       # ACTIVITYPUB_IRI_CACHE_EXPIRATION sets the expiration time of an ActivityPub actor IRI cache.
       # Default value: 1h (one hour)
       - ACTIVITYPUB_IRI_CACHE_EXPIRATION=90s
+      # WITNESS_POLICY_CACHE_EXPIRATION sets the expiration time of witness policy cache.
+      # Default value: 30s
+      - WITNESS_POLICY_CACHE_EXPIRATION=10s
     ports:
       - 48326:443
       - 48327:48327


### PR DESCRIPTION
Add configuration for witness policy expiry cache. Currently it is defaulted to 30s.

Closes #1028

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>