### PR TITLE
chore: Do not accept DID operations after successful deactivate operation

### DIFF
--- a/cmd/orb-cli/go.sum
+++ b/cmd/orb-cli/go.sum
@@ -1289,8 +1289,8 @@ github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7j
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211229172717-b542d0074b38 h1:qUR/PKxoiIh0Qgr3Uu/m0/CxjFn0bwz4X4hUM+iH0aA=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211229172717-b542d0074b38/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220119231708-bceddd36ff3e h1:eNthqsCTusCa1htZBhibx3s3LHq8J8QGYafx3yOFJrw=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220119231708-bceddd36ff3e/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/cmd/orb-driver/go.mod
+++ b/cmd/orb-driver/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7
 	github.com/trustbloc/orb v0.1.3-0.20210914173654-dab098ce4e32
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211229172717-b542d0074b38
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220119231708-bceddd36ff3e
 )
 
 replace github.com/trustbloc/orb => ../..

--- a/cmd/orb-driver/go.sum
+++ b/cmd/orb-driver/go.sum
@@ -1283,8 +1283,8 @@ github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7j
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211229172717-b542d0074b38 h1:qUR/PKxoiIh0Qgr3Uu/m0/CxjFn0bwz4X4hUM+iH0aA=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211229172717-b542d0074b38/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220119231708-bceddd36ff3e h1:eNthqsCTusCa1htZBhibx3s3LHq8J8QGYafx3yOFJrw=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220119231708-bceddd36ff3e/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/cmd/orb-server/go.mod
+++ b/cmd/orb-server/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7
 	github.com/trustbloc/orb v0.0.0
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211229172717-b542d0074b38
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220119231708-bceddd36ff3e
 )
 
 replace github.com/trustbloc/orb => ../..

--- a/cmd/orb-server/go.sum
+++ b/cmd/orb-server/go.sum
@@ -1300,8 +1300,8 @@ github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoi
 github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7jjHQo2gMGNPIRfhvn4aXQ0FYMrG9lRgQcvZKTviCGc=
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211229172717-b542d0074b38 h1:qUR/PKxoiIh0Qgr3Uu/m0/CxjFn0bwz4X4hUM+iH0aA=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211229172717-b542d0074b38/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220119231708-bceddd36ff3e h1:eNthqsCTusCa1htZBhibx3s3LHq8J8QGYafx3yOFJrw=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220119231708-bceddd36ff3e/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/go.mod
+++ b/go.mod
@@ -32,97 +32,18 @@ require (
 	github.com/rs/cors v1.7.0
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211229172717-b542d0074b38
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220119231708-bceddd36ff3e
 	github.com/trustbloc/vct v0.1.3
 	go.mongodb.org/mongo-driver v1.8.0
 	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2
 )
 
 require (
-	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
-	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5 // indirect
-	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
-	github.com/VictoriaMetrics/fastcache v1.5.7 // indirect
-	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/btcsuite/btcd v0.22.0-beta // indirect
-	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
-	github.com/cespare/xxhash/v2 v2.1.1 // indirect
-	github.com/containerd/continuity v0.0.0-20200710164510-efbc4488d8fe // indirect
-	github.com/crackcomm/go-gitignore v0.0.0-20170627025303-887ab5e44cc3 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/docker/cli v20.10.7+incompatible // indirect
-	github.com/docker/docker v20.10.7+incompatible // indirect
-	github.com/docker/go-connections v0.4.0 // indirect
-	github.com/docker/go-units v0.4.0 // indirect
-	github.com/evanphx/json-patch v4.1.0+incompatible // indirect
-	github.com/go-chi/chi v4.0.2+incompatible // indirect
-	github.com/go-chi/render v1.0.1 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
-	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
-	github.com/google/certificate-transparency-go v1.1.2-0.20210512142713-bed466244fa6 // indirect
-	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/google/tink/go v1.6.1-0.20210519071714-58be99b3c4d0 // indirect
-	github.com/google/trillian v1.3.14-0.20210520152752-ceda464a95a3 // indirect
-	github.com/hashicorp/errwrap v1.0.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/imdario/mergo v0.3.12 // indirect
-	github.com/ipfs/go-ipfs-files v0.0.8 // indirect
-	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a // indirect
-	github.com/kilic/bls12-381 v0.1.1-0.20210503002446-7b7597926c69 // indirect
-	github.com/klauspost/compress v1.13.6 // indirect
-	github.com/libp2p/go-buffer-pool v0.0.2 // indirect
-	github.com/libp2p/go-flow-metrics v0.0.3 // indirect
-	github.com/libp2p/go-libp2p-core v0.6.1 // indirect
-	github.com/libp2p/go-openssl v0.0.7 // indirect
-	github.com/lithammer/shortuuid/v3 v3.0.7 // indirect
-	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
-	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 // indirect
-	github.com/minio/sha256-simd v0.1.1 // indirect
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/mitchellh/mapstructure v1.4.1 // indirect
-	github.com/moby/term v0.0.0-20201216013528-df9cb8a40635 // indirect
-	github.com/multiformats/go-base32 v0.0.3 // indirect
-	github.com/multiformats/go-base36 v0.1.0 // indirect
-	github.com/multiformats/go-multiaddr v0.3.0 // indirect
-	github.com/multiformats/go-multiaddr-net v0.2.0 // indirect
-	github.com/multiformats/go-varint v0.0.6 // indirect
-	github.com/oklog/ulid v1.3.1 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.0.1 // indirect
-	github.com/opencontainers/runc v1.0.0-rc9 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
-	github.com/prometheus/client_model v0.2.0 // indirect
-	github.com/prometheus/common v0.26.0 // indirect
-	github.com/prometheus/procfs v0.6.0 // indirect
-	github.com/sirupsen/logrus v1.7.0 // indirect
-	github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 // indirect
-	github.com/spaolacci/murmur3 v1.1.0 // indirect
-	github.com/square/go-jose/v3 v3.0.0-20200630053402-0a67ce9b0693 // indirect
-	github.com/teserakt-io/golang-ed25519 v0.0.0-20210104091850-3888c087a4c8 // indirect
-	github.com/whyrusleeping/tar-utils v0.0.0-20180509141711-8c6c8ba81d5c // indirect
-	github.com/x448/float16 v0.8.4 // indirect
-	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
-	github.com/xdg-go/scram v1.0.2 // indirect
-	github.com/xdg-go/stringprep v1.0.2 // indirect
-	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
-	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
-	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a // indirect
-	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/crypto v0.0.0-20211202192323-5770296d904e // indirect
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
-	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
 	golang.org/x/text v0.3.7 // indirect
-	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
-	google.golang.org/grpc v1.39.0 // indirect
-	google.golang.org/protobuf v1.27.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
 go 1.17

--- a/go.sum
+++ b/go.sum
@@ -1293,8 +1293,8 @@ github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoi
 github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7jjHQo2gMGNPIRfhvn4aXQ0FYMrG9lRgQcvZKTviCGc=
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211229172717-b542d0074b38 h1:qUR/PKxoiIh0Qgr3Uu/m0/CxjFn0bwz4X4hUM+iH0aA=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211229172717-b542d0074b38/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220119231708-bceddd36ff3e h1:eNthqsCTusCa1htZBhibx3s3LHq8J8QGYafx3yOFJrw=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220119231708-bceddd36ff3e/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/pkg/document/updatehandler/decorator/decorator.go
+++ b/pkg/document/updatehandler/decorator/decorator.go
@@ -90,6 +90,13 @@ func (d *OperationDecorator) Decorate(op *operation.Operation) (*operation.Opera
 		return nil, err
 	}
 
+	logger.Debugf("processor returned internal result for suffix[%s] for operation type[%s]: %+v",
+		op.UniqueSuffix, op.Type, internalResult)
+
+	if internalResult.Deactivated {
+		return nil, fmt.Errorf("document has been deactivated, no further operations are allowed")
+	}
+
 	d.metrics.ProcessorResolveTime(time.Since(processorResolveStartTime))
 
 	if op.Type == operation.TypeUpdate || op.Type == operation.TypeDeactivate {

--- a/pkg/document/updatehandler/decorator/decorator_test.go
+++ b/pkg/document/updatehandler/decorator/decorator_test.go
@@ -327,6 +327,24 @@ func TestOperationDecorator_Decorate(t *testing.T) {
 		require.Contains(t, err.Error(), "operation processor error")
 	})
 
+	t.Run("error - document has been deactivated, no further operations allowed", func(t *testing.T) {
+		rm := &protocol.ResolutionModel{
+			Deactivated: true,
+		}
+
+		processor := &mocks.OperationProcessor{}
+		processor.ResolveReturns(rm, nil)
+
+		handler := New(namespace, domain, processor, &mocks.EndpointClient{},
+			&mocks.RemoteResolver{}, &orbmocks.MetricsProvider{})
+		require.NotNil(t, handler)
+
+		op, err := handler.Decorate(&operation.Operation{UniqueSuffix: suffix})
+		require.Error(t, err)
+		require.Nil(t, op)
+		require.Contains(t, err.Error(), "document has been deactivated, no further operations are allowed")
+	})
+
 	t.Run("error - anchor origin has additional operations", func(t *testing.T) {
 		processor := &mocks.OperationProcessor{}
 		processor.ResolveReturns(&protocol.ResolutionModel{

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -470,6 +470,16 @@ Feature:
 
     Then client verifies resolved document
 
+    When client sends request to "https://orb.domain4.com/sidetree/v1/operations" to deactivate DID document
+    Then check for request success
+    Then we wait 2 seconds
+
+    When client sends request to "https://orb.domain4.com/sidetree/v1/identifiers" to resolve DID document with canonical did
+    Then check success response contains "deactivated"
+
+    When client sends request to "https://orb.domain4.com/sidetree/v1/operations" to recover DID document
+    Then check error response contains "document has been deactivated, no further operations are allowed"
+
   @local_cas
   @alternate_links_scenario
   Scenario: WebFinger query returns alternate links for "Liked" anchor credentials

--- a/test/bdd/features/did-sidetree.feature
+++ b/test/bdd/features/did-sidetree.feature
@@ -108,6 +108,9 @@ Feature:
     When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with canonical did
     Then check success response contains "deactivated"
 
+    When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to recover DID document
+    Then check error response contains "document has been deactivated, no further operations are allowed"
+
   @create_recover_did_doc
   Scenario: recover did doc
     Given the authorization bearer token for "GET" requests to path "/sidetree/v1/identifiers" is set to "READ_TOKEN"

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/tidwall/gjson v1.7.4
 	github.com/trustbloc/orb v0.1.4-0.20211201141158-15a02b430f04
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20211229172717-b542d0074b38
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220119231708-bceddd36ff3e
 )
 
 replace github.com/trustbloc/orb => ../../

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -1558,8 +1558,8 @@ github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/sidetree-core-go v0.7.1-0.20211124193658-d5f6ccf1e554/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211229172717-b542d0074b38 h1:qUR/PKxoiIh0Qgr3Uu/m0/CxjFn0bwz4X4hUM+iH0aA=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20211229172717-b542d0074b38/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220119231708-bceddd36ff3e h1:eNthqsCTusCa1htZBhibx3s3LHq8J8QGYafx3yOFJrw=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220119231708-bceddd36ff3e/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=


### PR DESCRIPTION
Block DID operations that are issued after successful deactivate operation at REST API.

Updated sidetree-core, added BDD test for issuing operation after deactivate.

Closes #1032

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>