### PR TITLE
fix: Recovery of anchors from anchor origin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,10 +84,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Setup Go 1.16
+      - name: Setup Go 1.17
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
 
       - uses: actions/checkout@v2
         with: { fetch-depth: 0 }
@@ -135,7 +135,7 @@ jobs:
           file: ./images/orb/Dockerfile
           platforms: linux/amd64,linux/arm64
           build-args: |
-            ALPINE_VER=3.13
+            ALPINE_VER=3.15
             GO_VER=1.17
           push: true
           tags: |
@@ -149,7 +149,7 @@ jobs:
           file: ./images/orb-driver/Dockerfile
           platforms: linux/amd64,linux/arm64
           build-args: |
-            ALPINE_VER=3.13
+            ALPINE_VER=3.15
             GO_VER=1.17
           push: true
           tags: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -49,7 +49,7 @@ jobs:
           file: ./images/orb/Dockerfile
           platforms: linux/amd64,linux/arm64
           build-args: |
-            ALPINE_VER=3.13
+            ALPINE_VER=3.15
             GO_VER=1.17
           push: true
           tags: |
@@ -63,7 +63,7 @@ jobs:
           file: ./images/orb-driver/Dockerfile
           platforms: linux/amd64,linux/arm64
           build-args: |
-            ALPINE_VER=3.13
+            ALPINE_VER=3.15
             GO_VER=1.17
           push: true
           tags: |

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 CONTAINER_IDS      = $(shell type docker >/dev/null 2>&1 && docker ps -a -q)
 DEV_IMAGES         = $(shell type docker >/dev/null 2>&1 && docker images dev-* -q)
 ARCH               = $(shell go env GOARCH)
-GO_VER             = 1.16
+GO_VER             = 1.17
 
 # defined in github.com/trustbloc/orb/pkg/nodeinfo/metadata.go
 METADATA_VAR = OrbVersion=0.1.2
@@ -37,7 +37,7 @@ ORB_DRIVER_REST_PATH=cmd/orb-driver
 # Tool commands (overridable)
 DOCKER_CMD ?= docker
 GO_CMD     ?= go
-ALPINE_VER ?= 3.13
+ALPINE_VER ?= 3.15
 GO_TAGS    ?=
 
 export GO111MODULE=on

--- a/cmd/orb-cli/go.mod
+++ b/cmd/orb-cli/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/square/go-jose/v3 v3.0.0-20200630053402-0a67ce9b0693 // indirect
 	github.com/teserakt-io/golang-ed25519 v0.0.0-20210104091850-3888c087a4c8 // indirect
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220124195951-717ab301acb0 // indirect
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220125222405-838eba904ae4 // indirect
 	github.com/trustbloc/vct v0.1.3 // indirect
 	github.com/whyrusleeping/tar-utils v0.0.0-20180509141711-8c6c8ba81d5c // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/cmd/orb-cli/go.sum
+++ b/cmd/orb-cli/go.sum
@@ -1291,8 +1291,8 @@ github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/sidetree-core-go v0.7.1-0.20211229172717-b542d0074b38/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220124195951-717ab301acb0 h1:6TFHPLzUX+EFOXut3AGQ6zMWaXqiJgLXLKq3C0gtKrw=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220124195951-717ab301acb0/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220125222405-838eba904ae4 h1:Emc7bLbZfCGBddxgmZn1KDOD9PeXcp3YCA/RcJiLwLo=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220125222405-838eba904ae4/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/cmd/orb-driver/go.mod
+++ b/cmd/orb-driver/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7
 	github.com/trustbloc/orb v0.1.3-0.20210914173654-dab098ce4e32
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220124195951-717ab301acb0
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220125222405-838eba904ae4
 )
 
 require (

--- a/cmd/orb-driver/go.sum
+++ b/cmd/orb-driver/go.sum
@@ -1283,8 +1283,8 @@ github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7j
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220124195951-717ab301acb0 h1:6TFHPLzUX+EFOXut3AGQ6zMWaXqiJgLXLKq3C0gtKrw=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220124195951-717ab301acb0/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220125222405-838eba904ae4 h1:Emc7bLbZfCGBddxgmZn1KDOD9PeXcp3YCA/RcJiLwLo=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220125222405-838eba904ae4/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/cmd/orb-server/go.mod
+++ b/cmd/orb-server/go.mod
@@ -19,8 +19,8 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7
-	github.com/trustbloc/orb v0.0.0
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220124195951-717ab301acb0
+	github.com/trustbloc/orb v0.1.3
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220125222405-838eba904ae4
 )
 
 require (

--- a/cmd/orb-server/go.sum
+++ b/cmd/orb-server/go.sum
@@ -749,7 +749,6 @@ github.com/huaweicloud/golangsdk v0.0.0-20200304081349-45ec0797f2a4/go.mod h1:WQ
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/hyperledger/aries-framework-go v0.1.7-0.20210421203733-b5dfd703a8fc/go.mod h1:tBgxVOKcNero3QI21iNf3oxxHkgRMDOby937cqHEvW4=
 github.com/hyperledger/aries-framework-go v0.1.7-0.20210603210127-e57b8c94e3cf/go.mod h1:h6L+YoXtw90OZrH2IequxukIGwzfSpz8pUueQ9T5KqI=
-github.com/hyperledger/aries-framework-go v0.1.7-0.20210816113201-26c0665ef2b9/go.mod h1:VmoqKNXXyYN3R0ObcGA8ZBdbcmKZJFCakuZGDezi+GQ=
 github.com/hyperledger/aries-framework-go v0.1.7/go.mod h1:uve8/q23AUnq4EM0vBkEr1lKZRC67q5RcaHXh0ZOt0Y=
 github.com/hyperledger/aries-framework-go v0.1.8-0.20211203093644-b7d189cc06f4 h1:UpRmhnvnqMZql8e2bS3HFah7bEUN5h318CLuQiQ7PYs=
 github.com/hyperledger/aries-framework-go v0.1.8-0.20211203093644-b7d189cc06f4/go.mod h1:uve8/q23AUnq4EM0vBkEr1lKZRC67q5RcaHXh0ZOt0Y=
@@ -760,12 +759,10 @@ github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-2
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211219215001-23cd75276fdc/go.mod h1:Yzjzj3YfU3A5NdDeAkymVOqtlWfR32dEt8BYWlAcgcA=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mysql v0.0.0-20210909220549-ce3a2ee13e22/go.mod h1:bShq2cEzJcCEFkYIlQATTVldlOfyYvmnVPAdUSfCDm4=
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20210520055214-ae429bb89bf7/go.mod h1:7D+Y5J9cIsUrMGFAsIED+3bAPNjxp6ggXo0/kT5N6BI=
-github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20210807121559-b41545a4f1e8/go.mod h1:00tdiDIlEdmcLuN/5zSr3NI8AycnvRMMt4M07VSqiqw=
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20210820175050-dcc7a225178d/go.mod h1:i40JkMHCh9cHHxSc1SYznO3xDH6ly5CE0B3vPYZVeWI=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210409151411-eeeb8508bd87/go.mod h1:kJT7bcaKsvk1lMp2jqS8srF+ZUie2H4MoPbL2V29dgA=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210421203733-b5dfd703a8fc/go.mod h1:uGc7F3tXQIY6xjs8VEI6/oxp4ZDXDfGjPMCTgax5Zhc=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210520055214-ae429bb89bf7/go.mod h1:aP6VnxeSbmD1OcV2f8y0dRV9fkIZp/+mzmgKxxmSJG4=
-github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210603210127-e57b8c94e3cf/go.mod h1:k8CjDLBLxygTEj3D077OeH4SJsVE3mK60AyeO/C9sxs=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210807121559-b41545a4f1e8/go.mod h1:k8CjDLBLxygTEj3D077OeH4SJsVE3mK60AyeO/C9sxs=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210820175050-dcc7a225178d/go.mod h1:wdgGPwXzih+QD2Q4nvMnGO0dm0D0rxmzQcSNLcW6fcg=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210910143505-343c246c837c h1:DmoZcntsSUqjqARYVmgSZiulfUzbC76JXK0Y1a/lga0=
@@ -779,7 +776,6 @@ github.com/hyperledger/aries-framework-go/spi v0.0.0-20210421203733-b5dfd703a8fc
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210520055214-ae429bb89bf7/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210603134946-53276bbf0c28/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210603182844-353ecb34cf4d/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20210603210127-e57b8c94e3cf/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210806210220-65863dbe349a/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210807121559-b41545a4f1e8/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210818133831-4e22573c126d/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
@@ -794,7 +790,6 @@ github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210324232048-3
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210409151411-eeeb8508bd87/go.mod h1:JHzDtgJLd0134iLFXLxGBjJF+Z+TgiElA/5oVgMazts=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210421203733-b5dfd703a8fc/go.mod h1:asiCVCtH/nocWKhZRMz12aFgdUh8lRHqKis0M8Ei/4I=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210603182844-353ecb34cf4d/go.mod h1:J0SlvlnETEdYojUW4om/UINH0Uobmbtw46cH4DGXv5g=
-github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210603210127-e57b8c94e3cf/go.mod h1:EbPcC3Up7Ygrv+Tf9PMHrl5Qol4Mvux7ghSFBIVntIU=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210807121559-b41545a4f1e8/go.mod h1:3idbNcBl2wdRaETayzpY95KK5SfSzwXb5uqLW/Ldh0g=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210820153043-8b6f36d10ab9/go.mod h1:7jEZdg455syX4f+ozLgwhYfIuiEQ/TgdIoOyALMwPG0=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210909135806-a1c268dfb633/go.mod h1:XtAqwhIKA5tWOiWX/wZEFeANNGnRyQL6CNIIeE3lAVc=
@@ -1297,11 +1292,10 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
-github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7jjHQo2gMGNPIRfhvn4aXQ0FYMrG9lRgQcvZKTviCGc=
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220124195951-717ab301acb0 h1:6TFHPLzUX+EFOXut3AGQ6zMWaXqiJgLXLKq3C0gtKrw=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220124195951-717ab301acb0/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220125222405-838eba904ae4 h1:Emc7bLbZfCGBddxgmZn1KDOD9PeXcp3YCA/RcJiLwLo=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220125222405-838eba904ae4/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/rs/cors v1.7.0
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220124195951-717ab301acb0
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220125222405-838eba904ae4
 	github.com/trustbloc/vct v0.1.3
 	go.mongodb.org/mongo-driver v1.8.0
 	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2

--- a/go.sum
+++ b/go.sum
@@ -746,7 +746,6 @@ github.com/huaweicloud/golangsdk v0.0.0-20200304081349-45ec0797f2a4/go.mod h1:WQ
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/hyperledger/aries-framework-go v0.1.7-0.20210421203733-b5dfd703a8fc/go.mod h1:tBgxVOKcNero3QI21iNf3oxxHkgRMDOby937cqHEvW4=
 github.com/hyperledger/aries-framework-go v0.1.7-0.20210603210127-e57b8c94e3cf/go.mod h1:h6L+YoXtw90OZrH2IequxukIGwzfSpz8pUueQ9T5KqI=
-github.com/hyperledger/aries-framework-go v0.1.7-0.20210816113201-26c0665ef2b9/go.mod h1:VmoqKNXXyYN3R0ObcGA8ZBdbcmKZJFCakuZGDezi+GQ=
 github.com/hyperledger/aries-framework-go v0.1.7/go.mod h1:uve8/q23AUnq4EM0vBkEr1lKZRC67q5RcaHXh0ZOt0Y=
 github.com/hyperledger/aries-framework-go v0.1.8-0.20211203093644-b7d189cc06f4 h1:UpRmhnvnqMZql8e2bS3HFah7bEUN5h318CLuQiQ7PYs=
 github.com/hyperledger/aries-framework-go v0.1.8-0.20211203093644-b7d189cc06f4/go.mod h1:uve8/q23AUnq4EM0vBkEr1lKZRC67q5RcaHXh0ZOt0Y=
@@ -756,12 +755,10 @@ github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-2
 github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20211219215001-23cd75276fdc/go.mod h1:Yzjzj3YfU3A5NdDeAkymVOqtlWfR32dEt8BYWlAcgcA=
 github.com/hyperledger/aries-framework-go-ext/component/storage/mysql v0.0.0-20210909220549-ce3a2ee13e22/go.mod h1:bShq2cEzJcCEFkYIlQATTVldlOfyYvmnVPAdUSfCDm4=
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20210520055214-ae429bb89bf7/go.mod h1:7D+Y5J9cIsUrMGFAsIED+3bAPNjxp6ggXo0/kT5N6BI=
-github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20210807121559-b41545a4f1e8/go.mod h1:00tdiDIlEdmcLuN/5zSr3NI8AycnvRMMt4M07VSqiqw=
 github.com/hyperledger/aries-framework-go/component/storage/edv v0.0.0-20210820175050-dcc7a225178d/go.mod h1:i40JkMHCh9cHHxSc1SYznO3xDH6ly5CE0B3vPYZVeWI=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210409151411-eeeb8508bd87/go.mod h1:kJT7bcaKsvk1lMp2jqS8srF+ZUie2H4MoPbL2V29dgA=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210421203733-b5dfd703a8fc/go.mod h1:uGc7F3tXQIY6xjs8VEI6/oxp4ZDXDfGjPMCTgax5Zhc=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210520055214-ae429bb89bf7/go.mod h1:aP6VnxeSbmD1OcV2f8y0dRV9fkIZp/+mzmgKxxmSJG4=
-github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210603210127-e57b8c94e3cf/go.mod h1:k8CjDLBLxygTEj3D077OeH4SJsVE3mK60AyeO/C9sxs=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210807121559-b41545a4f1e8/go.mod h1:k8CjDLBLxygTEj3D077OeH4SJsVE3mK60AyeO/C9sxs=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210820175050-dcc7a225178d/go.mod h1:wdgGPwXzih+QD2Q4nvMnGO0dm0D0rxmzQcSNLcW6fcg=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20210910143505-343c246c837c h1:DmoZcntsSUqjqARYVmgSZiulfUzbC76JXK0Y1a/lga0=
@@ -775,7 +772,6 @@ github.com/hyperledger/aries-framework-go/spi v0.0.0-20210421203733-b5dfd703a8fc
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210520055214-ae429bb89bf7/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210603134946-53276bbf0c28/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210603182844-353ecb34cf4d/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20210603210127-e57b8c94e3cf/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210806210220-65863dbe349a/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210807121559-b41545a4f1e8/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210818133831-4e22573c126d/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
@@ -790,7 +786,6 @@ github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210324232048-3
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210409151411-eeeb8508bd87/go.mod h1:JHzDtgJLd0134iLFXLxGBjJF+Z+TgiElA/5oVgMazts=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210421203733-b5dfd703a8fc/go.mod h1:asiCVCtH/nocWKhZRMz12aFgdUh8lRHqKis0M8Ei/4I=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210603182844-353ecb34cf4d/go.mod h1:J0SlvlnETEdYojUW4om/UINH0Uobmbtw46cH4DGXv5g=
-github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210603210127-e57b8c94e3cf/go.mod h1:EbPcC3Up7Ygrv+Tf9PMHrl5Qol4Mvux7ghSFBIVntIU=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210807121559-b41545a4f1e8/go.mod h1:3idbNcBl2wdRaETayzpY95KK5SfSzwXb5uqLW/Ldh0g=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210820153043-8b6f36d10ab9/go.mod h1:7jEZdg455syX4f+ozLgwhYfIuiEQ/TgdIoOyALMwPG0=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210909135806-a1c268dfb633/go.mod h1:XtAqwhIKA5tWOiWX/wZEFeANNGnRyQL6CNIIeE3lAVc=
@@ -1290,11 +1285,10 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
-github.com/trustbloc/edge-core v0.1.7-0.20210816120552-ed93662ac716/go.mod h1:7jjHQo2gMGNPIRfhvn4aXQ0FYMrG9lRgQcvZKTviCGc=
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220124195951-717ab301acb0 h1:6TFHPLzUX+EFOXut3AGQ6zMWaXqiJgLXLKq3C0gtKrw=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220124195951-717ab301acb0/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220125222405-838eba904ae4 h1:Emc7bLbZfCGBddxgmZn1KDOD9PeXcp3YCA/RcJiLwLo=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220125222405-838eba904ae4/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/pkg/activitypub/service/activityhandler/activityhandler_test.go
+++ b/pkg/activitypub/service/activityhandler/activityhandler_test.go
@@ -93,7 +93,7 @@ func TestHandler_HandleUnsupportedActivity(t *testing.T) {
 		activity := &vocab.ActivityType{
 			ObjectType: vocab.NewObject(vocab.WithType(vocab.Type("unsupported_type"))),
 		}
-		err := h.HandleActivity(activity)
+		err := h.HandleActivity(nil, activity)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unsupported activity type")
 	})
@@ -138,7 +138,7 @@ func TestHandler_InboxHandleCreateActivity(t *testing.T) {
 			create := aptestutil.NewMockCreateActivity(service1IRI, service2IRI,
 				vocab.NewObjectProperty(vocab.WithAnchorEvent(anchorEvent)))
 
-			require.NoError(t, h.HandleActivity(create))
+			require.NoError(t, h.HandleActivity(nil, create))
 
 			time.Sleep(50 * time.Millisecond)
 
@@ -168,7 +168,7 @@ func TestHandler_InboxHandleCreateActivity(t *testing.T) {
 			anchorEventHandler.WithError(errExpected)
 			defer func() { anchorEventHandler.WithError(nil) }()
 
-			require.True(t, errors.Is(h.HandleActivity(create), errExpected))
+			require.True(t, errors.Is(h.HandleActivity(nil, create), errExpected))
 		})
 	})
 
@@ -181,7 +181,7 @@ func TestHandler_InboxHandleCreateActivity(t *testing.T) {
 			create := aptestutil.NewMockCreateActivity(service1IRI, service2IRI,
 				vocab.NewObjectProperty(vocab.WithAnchorEvent(anchorEvent)))
 
-			require.NoError(t, h.HandleActivity(create))
+			require.NoError(t, h.HandleActivity(nil, create))
 
 			time.Sleep(50 * time.Millisecond)
 
@@ -216,7 +216,7 @@ func TestHandler_InboxHandleCreateActivity(t *testing.T) {
 			create := aptestutil.NewMockCreateActivity(service1IRI, service2IRI,
 				vocab.NewObjectProperty(vocab.WithAnchorEvent(aptestutil.NewMockAnchorEventRef(t))))
 
-			require.True(t, errors.Is(h.HandleActivity(create), errExpected))
+			require.True(t, errors.Is(h.HandleActivity(nil, create), errExpected))
 		})
 	})
 
@@ -224,7 +224,7 @@ func TestHandler_InboxHandleCreateActivity(t *testing.T) {
 		create := aptestutil.NewMockCreateActivity(service1IRI, service2IRI,
 			vocab.NewObjectProperty(vocab.WithObject(vocab.NewObject(vocab.WithType(vocab.TypeService)))))
 
-		err := h.HandleActivity(create)
+		err := h.HandleActivity(nil, create)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unsupported object type in 'Create' activity")
 	})
@@ -258,7 +258,7 @@ func TestHandler_OutboxHandleCreateActivity(t *testing.T) {
 		)
 
 		t.Run("Success", func(t *testing.T) {
-			require.NoError(t, h.HandleActivity(create))
+			require.NoError(t, h.HandleActivity(nil, create))
 
 			it, err := activityStore.QueryReferences(store.AnchorEvent,
 				store.NewCriteria(store.WithObjectIRI(anchorEvent.URL()[0])))
@@ -280,7 +280,7 @@ func TestHandler_OutboxHandleCreateActivity(t *testing.T) {
 		)
 
 		t.Run("Success", func(t *testing.T) {
-			require.NoError(t, h.HandleActivity(create))
+			require.NoError(t, h.HandleActivity(nil, create))
 
 			it, err := activityStore.QueryReferences(store.AnchorEvent,
 				store.NewCriteria(store.WithObjectIRI(anchorEvent.URL()[0])))
@@ -296,7 +296,7 @@ func TestHandler_OutboxHandleCreateActivity(t *testing.T) {
 		create := aptestutil.NewMockCreateActivity(service1IRI, service2IRI,
 			vocab.NewObjectProperty(vocab.WithObject(vocab.NewObject(vocab.WithType(vocab.TypeService)))))
 
-		err := h.HandleActivity(create)
+		err := h.HandleActivity(nil, create)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unsupported object type in 'Create' activity")
 	})
@@ -317,7 +317,7 @@ func TestHandler_OutboxHandleCreateActivity(t *testing.T) {
 			),
 		)
 
-		err := obHandler.HandleActivity(create)
+		err := obHandler.HandleActivity(nil, create)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errExpected.Error())
 	})
@@ -362,7 +362,7 @@ func TestHandler_HandleFollowActivity(t *testing.T) {
 			vocab.WithTo(service1IRI),
 		)
 
-		require.NoError(t, h.HandleActivity(follow))
+		require.NoError(t, h.HandleActivity(nil, follow))
 
 		time.Sleep(50 * time.Millisecond)
 
@@ -385,7 +385,7 @@ func TestHandler_HandleFollowActivity(t *testing.T) {
 			vocab.WithTo(service1IRI),
 		)
 
-		require.NoError(t, h.HandleActivity(follow))
+		require.NoError(t, h.HandleActivity(nil, follow))
 
 		time.Sleep(50 * time.Millisecond)
 
@@ -405,7 +405,7 @@ func TestHandler_HandleFollowActivity(t *testing.T) {
 		followerAuth.WithReject()
 
 		t.Run("Success", func(t *testing.T) {
-			require.NoError(t, h.HandleActivity(follow))
+			require.NoError(t, h.HandleActivity(nil, follow))
 
 			time.Sleep(50 * time.Millisecond)
 
@@ -428,7 +428,7 @@ func TestHandler_HandleFollowActivity(t *testing.T) {
 			vocab.WithTo(service1IRI),
 		)
 
-		err := h.HandleActivity(follow)
+		err := h.HandleActivity(nil, follow)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no actor specified")
 	})
@@ -441,7 +441,7 @@ func TestHandler_HandleFollowActivity(t *testing.T) {
 			vocab.WithTo(service1IRI),
 		)
 
-		err := h.HandleActivity(follow)
+		err := h.HandleActivity(nil, follow)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no IRI specified")
 	})
@@ -454,7 +454,7 @@ func TestHandler_HandleFollowActivity(t *testing.T) {
 			vocab.WithTo(service1IRI),
 		)
 
-		err := h.HandleActivity(follow)
+		err := h.HandleActivity(nil, follow)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "this service is not the target object for the 'Follow'")
 	})
@@ -470,7 +470,7 @@ func TestHandler_HandleFollowActivity(t *testing.T) {
 			vocab.WithTo(service1IRI),
 		)
 
-		require.True(t, errors.Is(h.HandleActivity(follow), client.ErrNotFound))
+		require.True(t, errors.Is(h.HandleActivity(nil, follow), client.ErrNotFound))
 	})
 
 	t.Run("AuthorizeActor error", func(t *testing.T) {
@@ -489,7 +489,7 @@ func TestHandler_HandleFollowActivity(t *testing.T) {
 			vocab.WithTo(service1IRI),
 		)
 
-		err := h.HandleActivity(follow)
+		err := h.HandleActivity(nil, follow)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errExpected.Error())
 	})
@@ -537,7 +537,7 @@ func TestHandler_HandleInviteWitnessActivity(t *testing.T) {
 			vocab.WithTarget(vocab.NewObjectProperty(vocab.WithIRI(service1IRI))),
 		)
 
-		require.NoError(t, h.HandleActivity(invite))
+		require.NoError(t, h.HandleActivity(nil, invite))
 
 		time.Sleep(50 * time.Millisecond)
 
@@ -561,7 +561,7 @@ func TestHandler_HandleInviteWitnessActivity(t *testing.T) {
 			vocab.WithTarget(vocab.NewObjectProperty(vocab.WithIRI(service1IRI))),
 		)
 
-		require.NoError(t, h.HandleActivity(invite))
+		require.NoError(t, h.HandleActivity(nil, invite))
 
 		time.Sleep(50 * time.Millisecond)
 
@@ -582,7 +582,7 @@ func TestHandler_HandleInviteWitnessActivity(t *testing.T) {
 		witnessInvitationAuth.WithReject()
 
 		t.Run("Success", func(t *testing.T) {
-			require.NoError(t, h.HandleActivity(invite))
+			require.NoError(t, h.HandleActivity(nil, invite))
 
 			time.Sleep(50 * time.Millisecond)
 
@@ -606,7 +606,7 @@ func TestHandler_HandleInviteWitnessActivity(t *testing.T) {
 			vocab.WithTarget(vocab.NewObjectProperty(vocab.WithIRI(service1IRI))),
 		)
 
-		err := h.HandleActivity(invite)
+		err := h.HandleActivity(nil, invite)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no actor specified")
 	})
@@ -620,7 +620,7 @@ func TestHandler_HandleInviteWitnessActivity(t *testing.T) {
 			vocab.WithTarget(vocab.NewObjectProperty(vocab.WithIRI(service1IRI))),
 		)
 
-		err := h.HandleActivity(invite)
+		err := h.HandleActivity(nil, invite)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no object specified in 'Invite' activity")
 	})
@@ -634,7 +634,7 @@ func TestHandler_HandleInviteWitnessActivity(t *testing.T) {
 			vocab.WithTarget(vocab.NewObjectProperty(vocab.WithIRI(service3IRI))),
 		)
 
-		err := h.HandleActivity(invite)
+		err := h.HandleActivity(nil, invite)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "this service is not the target object for the 'Invite'")
 	})
@@ -651,7 +651,7 @@ func TestHandler_HandleInviteWitnessActivity(t *testing.T) {
 			vocab.WithTarget(vocab.NewObjectProperty(vocab.WithIRI(service1IRI))),
 		)
 
-		require.True(t, errors.Is(h.HandleActivity(invite), client.ErrNotFound))
+		require.True(t, errors.Is(h.HandleActivity(nil, invite), client.ErrNotFound))
 	})
 
 	t.Run("AuthorizeWitness error", func(t *testing.T) {
@@ -671,7 +671,7 @@ func TestHandler_HandleInviteWitnessActivity(t *testing.T) {
 			vocab.WithTarget(vocab.NewObjectProperty(vocab.WithIRI(service1IRI))),
 		)
 
-		err := h.HandleActivity(invite)
+		err := h.HandleActivity(nil, invite)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errExpected.Error())
 	})
@@ -717,7 +717,7 @@ func TestHandler_HandleAcceptActivity(t *testing.T) {
 			vocab.WithTo(service2IRI),
 		)
 
-		require.NoError(t, h.HandleActivity(accept))
+		require.NoError(t, h.HandleActivity(nil, accept))
 
 		time.Sleep(50 * time.Millisecond)
 
@@ -732,7 +732,7 @@ func TestHandler_HandleAcceptActivity(t *testing.T) {
 		require.True(t, containsIRI(following, service1IRI))
 
 		// Post another accept activity with the same actor.
-		err = h.HandleActivity(accept)
+		err = h.HandleActivity(nil, accept)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "already in the 'FOLLOWING' collection")
 	})
@@ -757,7 +757,7 @@ func TestHandler_HandleAcceptActivity(t *testing.T) {
 			vocab.WithTo(service2IRI),
 		)
 
-		require.NoError(t, h.HandleActivity(accept))
+		require.NoError(t, h.HandleActivity(nil, accept))
 
 		time.Sleep(50 * time.Millisecond)
 
@@ -772,7 +772,7 @@ func TestHandler_HandleAcceptActivity(t *testing.T) {
 		require.True(t, containsIRI(witnesses, service1IRI))
 
 		// Post another accept activity with the same actor.
-		err = h.HandleActivity(accept)
+		err = h.HandleActivity(nil, accept)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "already in the 'WITNESS' collection")
 	})
@@ -791,7 +791,7 @@ func TestHandler_HandleAcceptActivity(t *testing.T) {
 			vocab.WithTo(service2IRI),
 		)
 
-		require.EqualError(t, h.HandleActivity(accept), "no actor specified in 'Accept' activity")
+		require.EqualError(t, h.HandleActivity(nil, accept), "no actor specified in 'Accept' activity")
 	})
 
 	t.Run("No activity specified in 'object' field", func(t *testing.T) {
@@ -802,7 +802,7 @@ func TestHandler_HandleAcceptActivity(t *testing.T) {
 			vocab.WithTo(service2IRI),
 		)
 
-		require.EqualError(t, h.HandleActivity(accept),
+		require.EqualError(t, h.HandleActivity(nil, accept),
 			"no activity specified in the 'object' field of the 'Accept' activity")
 	})
 
@@ -821,7 +821,7 @@ func TestHandler_HandleAcceptActivity(t *testing.T) {
 			vocab.WithTo(service2IRI),
 		)
 
-		require.EqualError(t, h.HandleActivity(accept),
+		require.EqualError(t, h.HandleActivity(nil, accept),
 			"unsupported activity type [Announce] in the 'object' field of the 'Accept' activity")
 	})
 
@@ -839,7 +839,7 @@ func TestHandler_HandleAcceptActivity(t *testing.T) {
 			vocab.WithTo(service2IRI),
 		)
 
-		require.EqualError(t, h.HandleActivity(accept),
+		require.EqualError(t, h.HandleActivity(nil, accept),
 			"no actor specified in the object of the 'Accept' activity")
 	})
 
@@ -858,7 +858,7 @@ func TestHandler_HandleAcceptActivity(t *testing.T) {
 			vocab.WithTo(service2IRI),
 		)
 
-		require.EqualError(t, h.HandleActivity(accept),
+		require.EqualError(t, h.HandleActivity(nil, accept),
 			"the actor in the object of the 'Accept' activity is not this service")
 	})
 }
@@ -900,7 +900,7 @@ func TestHandler_HandleAcceptActivityValidationError(t *testing.T) {
 
 		as.QueryActivitiesReturns(nil, errExpected)
 
-		err := h.HandleActivity(accept)
+		err := h.HandleActivity(nil, accept)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errExpected.Error())
 	})
@@ -910,7 +910,7 @@ func TestHandler_HandleAcceptActivityValidationError(t *testing.T) {
 
 		as.QueryActivitiesReturns(it, nil)
 
-		require.True(t, errors.Is(h.HandleActivity(accept), store.ErrNotFound))
+		require.True(t, errors.Is(h.HandleActivity(nil, accept), store.ErrNotFound))
 	})
 
 	t.Run("Actor mismatch", func(t *testing.T) {
@@ -925,7 +925,7 @@ func TestHandler_HandleAcceptActivityValidationError(t *testing.T) {
 
 		as.QueryActivitiesReturns(it, nil)
 
-		err := h.HandleActivity(accept)
+		err := h.HandleActivity(nil, accept)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "actors do not match")
 	})
@@ -943,7 +943,7 @@ func TestHandler_HandleAcceptActivityValidationError(t *testing.T) {
 
 		as.QueryActivitiesReturns(it, nil)
 
-		err := h.HandleActivity(accept)
+		err := h.HandleActivity(nil, accept)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "types do not match")
 	})
@@ -1006,7 +1006,7 @@ func TestHandler_HandleAcceptActivityError(t *testing.T) {
 
 		as.QueryReferencesReturns(nil, errExpected)
 
-		err := h.HandleActivity(acceptFollow)
+		err := h.HandleActivity(nil, acceptFollow)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errExpected.Error())
 	})
@@ -1021,7 +1021,7 @@ func TestHandler_HandleAcceptActivityError(t *testing.T) {
 		as.QueryReferencesReturns(it, nil)
 		as.AddReferenceReturns(errExpected)
 
-		err := h.HandleActivity(acceptFollow)
+		err := h.HandleActivity(nil, acceptFollow)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errExpected.Error())
 	})
@@ -1033,7 +1033,7 @@ func TestHandler_HandleAcceptActivityError(t *testing.T) {
 
 		as.QueryReferencesReturns(nil, errExpected)
 
-		err := h.HandleActivity(acceptInvite)
+		err := h.HandleActivity(nil, acceptInvite)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errExpected.Error())
 	})
@@ -1048,7 +1048,7 @@ func TestHandler_HandleAcceptActivityError(t *testing.T) {
 		as.QueryReferencesReturns(it, nil)
 		as.AddReferenceReturns(errExpected)
 
-		err := h.HandleActivity(acceptInvite)
+		err := h.HandleActivity(nil, acceptInvite)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errExpected.Error())
 	})
@@ -1090,7 +1090,7 @@ func TestHandler_HandleRejectActivity(t *testing.T) {
 			vocab.WithTo(service2IRI),
 		)
 
-		require.NoError(t, h.HandleActivity(reject))
+		require.NoError(t, h.HandleActivity(nil, reject))
 
 		time.Sleep(50 * time.Millisecond)
 
@@ -1120,7 +1120,7 @@ func TestHandler_HandleRejectActivity(t *testing.T) {
 			vocab.WithTo(service2IRI),
 		)
 
-		require.NoError(t, h.HandleActivity(reject))
+		require.NoError(t, h.HandleActivity(nil, reject))
 
 		time.Sleep(50 * time.Millisecond)
 
@@ -1148,7 +1148,7 @@ func TestHandler_HandleRejectActivity(t *testing.T) {
 			vocab.WithTo(service2IRI),
 		)
 
-		require.EqualError(t, h.HandleActivity(reject), "no actor specified in 'Reject' activity")
+		require.EqualError(t, h.HandleActivity(nil, reject), "no actor specified in 'Reject' activity")
 	})
 
 	t.Run("No Follow activity specified in 'object' field", func(t *testing.T) {
@@ -1159,7 +1159,7 @@ func TestHandler_HandleRejectActivity(t *testing.T) {
 			vocab.WithTo(service2IRI),
 		)
 
-		require.EqualError(t, h.HandleActivity(reject),
+		require.EqualError(t, h.HandleActivity(nil, reject),
 			"no activity specified in the 'object' field of the 'Reject' activity")
 	})
 
@@ -1178,7 +1178,7 @@ func TestHandler_HandleRejectActivity(t *testing.T) {
 			vocab.WithTo(service2IRI),
 		)
 
-		require.EqualError(t, h.HandleActivity(reject),
+		require.EqualError(t, h.HandleActivity(nil, reject),
 			"unsupported activity type [Announce] in the 'object' field of the 'Accept' activity")
 	})
 
@@ -1196,7 +1196,7 @@ func TestHandler_HandleRejectActivity(t *testing.T) {
 			vocab.WithTo(service2IRI),
 		)
 
-		require.EqualError(t, h.HandleActivity(reject),
+		require.EqualError(t, h.HandleActivity(nil, reject),
 			"no actor specified in the object of the 'Reject' activity")
 	})
 
@@ -1216,7 +1216,7 @@ func TestHandler_HandleRejectActivity(t *testing.T) {
 			vocab.WithTo(service2IRI),
 		)
 
-		require.EqualError(t, h.HandleActivity(reject),
+		require.EqualError(t, h.HandleActivity(nil, reject),
 			"the actor in the object of the 'Reject' activity is not this service")
 	})
 }
@@ -1275,7 +1275,7 @@ func TestHandler_HandleAnnounceActivity(t *testing.T) {
 			vocab.WithPublishedTime(&published),
 		)
 
-		require.NoError(t, h.HandleActivity(announce))
+		require.NoError(t, h.HandleActivity(nil, announce))
 
 		time.Sleep(50 * time.Millisecond)
 
@@ -1320,7 +1320,7 @@ func TestHandler_HandleAnnounceActivity(t *testing.T) {
 			vocab.WithPublishedTime(&published),
 		)
 
-		require.NoError(t, h.HandleActivity(announce))
+		require.NoError(t, h.HandleActivity(nil, announce))
 
 		time.Sleep(50 * time.Millisecond)
 
@@ -1357,7 +1357,7 @@ func TestHandler_HandleAnnounceActivity(t *testing.T) {
 			vocab.WithPublishedTime(&published),
 		)
 
-		require.NoError(t, h.HandleActivity(announce))
+		require.NoError(t, h.HandleActivity(nil, announce))
 
 		time.Sleep(50 * time.Millisecond)
 
@@ -1392,7 +1392,7 @@ func TestHandler_HandleAnnounceActivity(t *testing.T) {
 			vocab.WithPublishedTime(&published),
 		)
 
-		err := h.HandleActivity(announce)
+		err := h.HandleActivity(nil, announce)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "expecting 'Info' type")
 	})
@@ -1418,7 +1418,7 @@ func TestHandler_HandleAnnounceActivity(t *testing.T) {
 			vocab.WithPublishedTime(&published),
 		)
 
-		err := h.HandleActivity(announce)
+		err := h.HandleActivity(nil, announce)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "expecting 'Info' type")
 	})
@@ -1436,7 +1436,7 @@ func TestHandler_HandleAnnounceActivity(t *testing.T) {
 			vocab.WithPublishedTime(&published),
 		)
 
-		err := h.HandleActivity(announce)
+		err := h.HandleActivity(nil, announce)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unsupported object type for 'Announce'")
 	})
@@ -1473,7 +1473,7 @@ func TestHandler_HandleAnnounceActivity(t *testing.T) {
 		ib.Start()
 		defer ib.Stop()
 
-		require.NoError(t, ib.HandleActivity(announce))
+		require.NoError(t, ib.HandleActivity(nil, announce))
 
 		time.Sleep(50 * time.Millisecond)
 
@@ -1526,7 +1526,7 @@ func TestHandler_HandleOfferActivity(t *testing.T) {
 			vocab.WithTarget(vocab.NewObjectProperty(vocab.WithIRI(vocab.AnchorWitnessTargetIRI))),
 		)
 
-		require.NoError(t, h.HandleActivity(offer))
+		require.NoError(t, h.HandleActivity(nil, offer))
 
 		time.Sleep(50 * time.Millisecond)
 
@@ -1550,7 +1550,7 @@ func TestHandler_HandleOfferActivity(t *testing.T) {
 			vocab.WithTarget(vocab.NewObjectProperty(vocab.WithIRI(vocab.AnchorWitnessTargetIRI))),
 		)
 
-		err := h.HandleActivity(offer)
+		err := h.HandleActivity(nil, offer)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unable to unmarshal proof")
 	})
@@ -1573,7 +1573,7 @@ func TestHandler_HandleOfferActivity(t *testing.T) {
 			vocab.WithTarget(vocab.NewObjectProperty(vocab.WithIRI(vocab.AnchorWitnessTargetIRI))),
 		)
 
-		require.True(t, errors.Is(h.HandleActivity(offer), errExpected))
+		require.True(t, errors.Is(h.HandleActivity(nil, offer), errExpected))
 	})
 
 	t.Run("No start time", func(t *testing.T) {
@@ -1588,7 +1588,7 @@ func TestHandler_HandleOfferActivity(t *testing.T) {
 			vocab.WithTarget(vocab.NewObjectProperty(vocab.WithIRI(vocab.AnchorWitnessTargetIRI))),
 		)
 
-		err := h.HandleActivity(offer)
+		err := h.HandleActivity(nil, offer)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "startTime is required")
 	})
@@ -1604,7 +1604,7 @@ func TestHandler_HandleOfferActivity(t *testing.T) {
 			vocab.WithTarget(vocab.NewObjectProperty(vocab.WithIRI(vocab.AnchorWitnessTargetIRI))),
 		)
 
-		err := h.HandleActivity(offer)
+		err := h.HandleActivity(nil, offer)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "endTime is required")
 	})
@@ -1623,7 +1623,7 @@ func TestHandler_HandleOfferActivity(t *testing.T) {
 			vocab.WithTarget(vocab.NewObjectProperty(vocab.WithIRI(vocab.AnchorWitnessTargetIRI))),
 		)
 
-		err := h.HandleActivity(offer)
+		err := h.HandleActivity(nil, offer)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "anchor event is required")
 	})
@@ -1642,7 +1642,7 @@ func TestHandler_HandleOfferActivity(t *testing.T) {
 			vocab.WithTarget(vocab.NewObjectProperty(vocab.WithIRI(vocab.AnchorWitnessTargetIRI))),
 		)
 
-		err := h.HandleActivity(offer)
+		err := h.HandleActivity(nil, offer)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "anchor event is required")
 	})
@@ -1663,7 +1663,7 @@ func TestHandler_HandleOfferActivity(t *testing.T) {
 			vocab.WithTarget(vocab.NewObjectProperty(vocab.WithIRI(vocab.AnchorWitnessTargetIRI))),
 		)
 
-		err := h.HandleActivity(offer)
+		err := h.HandleActivity(nil, offer)
 		require.NoError(t, err)
 	})
 
@@ -1682,7 +1682,7 @@ func TestHandler_HandleOfferActivity(t *testing.T) {
 			vocab.WithEndTime(&endTime),
 		)
 
-		err := h.HandleActivity(offer)
+		err := h.HandleActivity(nil, offer)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "object target IRI must be set to https://w3id.org/activityanchors#AnchorWitness")
 	})
@@ -1763,7 +1763,7 @@ func TestHandler_HandleAcceptOfferActivity(t *testing.T) {
 	t.Log(string(bytes))
 
 	t.Run("Success", func(t *testing.T) {
-		require.NoError(t, h.HandleActivity(acceptOffer))
+		require.NoError(t, h.HandleActivity(nil, acceptOffer))
 
 		time.Sleep(50 * time.Millisecond)
 
@@ -1778,7 +1778,7 @@ func TestHandler_HandleAcceptOfferActivity(t *testing.T) {
 		proofHandler.WithError(errExpected)
 		defer proofHandler.WithError(nil)
 
-		require.True(t, errors.Is(h.HandleActivity(acceptOffer), errExpected))
+		require.True(t, errors.Is(h.HandleActivity(nil, acceptOffer), errExpected))
 	})
 
 	t.Run("inReplyTo does not match object IRI in offer activity", func(t *testing.T) {
@@ -2048,7 +2048,7 @@ func TestHandler_HandleUndoFollowActivity(t *testing.T) {
 			vocab.WithTo(service1IRI),
 		)
 
-		require.EqualError(t, ibHandler.HandleActivity(undo), "no actor specified in 'Undo' activity")
+		require.EqualError(t, ibHandler.HandleActivity(nil, undo), "no actor specified in 'Undo' activity")
 	})
 
 	t.Run("No object in activity", func(t *testing.T) {
@@ -2060,7 +2060,7 @@ func TestHandler_HandleUndoFollowActivity(t *testing.T) {
 			vocab.WithTo(service1IRI),
 		)
 
-		require.EqualError(t, ibHandler.HandleActivity(undo),
+		require.EqualError(t, ibHandler.HandleActivity(nil, undo),
 			"no activity specified in 'object' field of the 'Undo' activity")
 	})
 
@@ -2072,7 +2072,7 @@ func TestHandler_HandleUndoFollowActivity(t *testing.T) {
 			vocab.WithTo(service1IRI),
 		)
 
-		err := ibHandler.HandleActivity(undo)
+		err := ibHandler.HandleActivity(nil, undo)
 		require.Error(t, err)
 		require.True(t, errors.Is(err, store.ErrNotFound))
 	})
@@ -2085,7 +2085,7 @@ func TestHandler_HandleUndoFollowActivity(t *testing.T) {
 			vocab.WithTo(service1IRI),
 		)
 
-		err := ibHandler.HandleActivity(undo)
+		err := ibHandler.HandleActivity(nil, undo)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no actor in stored 'Follow' activity")
 	})
@@ -2097,7 +2097,7 @@ func TestHandler_HandleUndoFollowActivity(t *testing.T) {
 			vocab.WithTo(service1IRI),
 		)
 
-		err := ibHandler.HandleActivity(undo)
+		err := ibHandler.HandleActivity(nil, undo)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "not the same as the actor of the original activity")
 	})
@@ -2110,7 +2110,7 @@ func TestHandler_HandleUndoFollowActivity(t *testing.T) {
 			vocab.WithTo(service1IRI),
 		)
 
-		err := ibHandler.HandleActivity(undo)
+		err := ibHandler.HandleActivity(nil, undo)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "not supported")
 	})
@@ -2138,7 +2138,7 @@ func TestHandler_HandleUndoFollowActivity(t *testing.T) {
 			vocab.WithTo(service1IRI),
 		)
 
-		err := inboxHandler.HandleActivity(undo)
+		err := inboxHandler.HandleActivity(nil, undo)
 		require.True(t, orberrors.IsTransient(err))
 
 		create := aptestutil.NewMockCreateActivity(service1IRI, service2IRI,
@@ -2172,7 +2172,7 @@ func TestHandler_HandleUndoFollowActivity(t *testing.T) {
 				vocab.WithTo(service1IRI),
 			)
 
-			require.NoError(t, ibHandler.HandleActivity(undo))
+			require.NoError(t, ibHandler.HandleActivity(nil, undo))
 
 			time.Sleep(50 * time.Millisecond)
 
@@ -2196,7 +2196,7 @@ func TestHandler_HandleUndoFollowActivity(t *testing.T) {
 				vocab.WithTo(service1IRI),
 			)
 
-			err := ibHandler.HandleActivity(undo)
+			err := ibHandler.HandleActivity(nil, undo)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "nil object IRI")
 		})
@@ -2209,7 +2209,7 @@ func TestHandler_HandleUndoFollowActivity(t *testing.T) {
 				vocab.WithTo(service1IRI),
 			)
 
-			err := ibHandler.HandleActivity(undo)
+			err := ibHandler.HandleActivity(nil, undo)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), fmt.Sprintf("object IRI mismatch - expecting %s but got %s",
 				service1IRI, service3IRI))
@@ -2231,7 +2231,7 @@ func TestHandler_HandleUndoFollowActivity(t *testing.T) {
 				vocab.WithTo(service1IRI),
 			)
 
-			require.NoError(t, ibHandler.HandleActivity(undo))
+			require.NoError(t, ibHandler.HandleActivity(nil, undo))
 
 			time.Sleep(50 * time.Millisecond)
 
@@ -2258,7 +2258,7 @@ func TestHandler_HandleUndoFollowActivity(t *testing.T) {
 				vocab.WithTo(service1IRI),
 			)
 
-			require.NoError(t, obHandler.HandleActivity(undo))
+			require.NoError(t, obHandler.HandleActivity(nil, undo))
 
 			time.Sleep(50 * time.Millisecond)
 
@@ -2282,7 +2282,7 @@ func TestHandler_HandleUndoFollowActivity(t *testing.T) {
 				vocab.WithTo(service1IRI),
 			)
 
-			err := obHandler.HandleActivity(undo)
+			err := obHandler.HandleActivity(nil, undo)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "nil object IRI")
 		})
@@ -2294,7 +2294,7 @@ func TestHandler_HandleUndoFollowActivity(t *testing.T) {
 				vocab.WithTo(service1IRI),
 			)
 
-			err := obHandler.HandleActivity(undo)
+			err := obHandler.HandleActivity(nil, undo)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "not the same as the actor of the original activity")
 		})
@@ -2316,7 +2316,7 @@ func TestHandler_HandleUndoFollowActivity(t *testing.T) {
 				vocab.WithTo(service1IRI),
 			)
 
-			require.NoError(t, obHandler.HandleActivity(undo))
+			require.NoError(t, obHandler.HandleActivity(nil, undo))
 
 			time.Sleep(50 * time.Millisecond)
 
@@ -2396,7 +2396,7 @@ func TestHandler_HandleUndoInviteWitnessActivity(t *testing.T) {
 				vocab.WithTo(service1IRI),
 			)
 
-			require.NoError(t, ibHandler.HandleActivity(undo))
+			require.NoError(t, ibHandler.HandleActivity(nil, undo))
 
 			time.Sleep(50 * time.Millisecond)
 
@@ -2420,7 +2420,7 @@ func TestHandler_HandleUndoInviteWitnessActivity(t *testing.T) {
 				vocab.WithTo(service1IRI),
 			)
 
-			err := ibHandler.HandleActivity(undo)
+			err := ibHandler.HandleActivity(nil, undo)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "object IRI mismatch")
 		})
@@ -2433,7 +2433,7 @@ func TestHandler_HandleUndoInviteWitnessActivity(t *testing.T) {
 				vocab.WithTo(service1IRI),
 			)
 
-			err := ibHandler.HandleActivity(undo)
+			err := ibHandler.HandleActivity(nil, undo)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "nil target IRI")
 		})
@@ -2446,7 +2446,7 @@ func TestHandler_HandleUndoInviteWitnessActivity(t *testing.T) {
 				vocab.WithTo(service1IRI),
 			)
 
-			err := ibHandler.HandleActivity(undo)
+			err := ibHandler.HandleActivity(nil, undo)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "target IRI mismatch")
 		})
@@ -2467,7 +2467,7 @@ func TestHandler_HandleUndoInviteWitnessActivity(t *testing.T) {
 				vocab.WithTo(service1IRI),
 			)
 
-			require.NoError(t, ibHandler.HandleActivity(undo))
+			require.NoError(t, ibHandler.HandleActivity(nil, undo))
 
 			time.Sleep(50 * time.Millisecond)
 
@@ -2494,7 +2494,7 @@ func TestHandler_HandleUndoInviteWitnessActivity(t *testing.T) {
 				vocab.WithTo(service1IRI),
 			)
 
-			require.NoError(t, obHandler.HandleActivity(undo))
+			require.NoError(t, obHandler.HandleActivity(nil, undo))
 
 			time.Sleep(50 * time.Millisecond)
 
@@ -2518,7 +2518,7 @@ func TestHandler_HandleUndoInviteWitnessActivity(t *testing.T) {
 				vocab.WithTo(service1IRI),
 			)
 
-			err := obHandler.HandleActivity(undo)
+			err := obHandler.HandleActivity(nil, undo)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "object IRI mismatch")
 		})
@@ -2531,7 +2531,7 @@ func TestHandler_HandleUndoInviteWitnessActivity(t *testing.T) {
 				vocab.WithTo(service1IRI),
 			)
 
-			err := obHandler.HandleActivity(undo)
+			err := obHandler.HandleActivity(nil, undo)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "nil target IRI")
 		})
@@ -2544,7 +2544,7 @@ func TestHandler_HandleUndoInviteWitnessActivity(t *testing.T) {
 				vocab.WithTo(service1IRI),
 			)
 
-			err := obHandler.HandleActivity(undo)
+			err := obHandler.HandleActivity(nil, undo)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "target IRI mismatch")
 		})
@@ -2556,7 +2556,7 @@ func TestHandler_HandleUndoInviteWitnessActivity(t *testing.T) {
 				vocab.WithTo(service1IRI),
 			)
 
-			err := obHandler.HandleActivity(undo)
+			err := obHandler.HandleActivity(nil, undo)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "is not the same as the actor of the original activity")
 		})
@@ -2578,7 +2578,7 @@ func TestHandler_HandleUndoInviteWitnessActivity(t *testing.T) {
 				vocab.WithTo(service1IRI),
 			)
 
-			require.NoError(t, obHandler.HandleActivity(undo))
+			require.NoError(t, obHandler.HandleActivity(nil, undo))
 
 			time.Sleep(50 * time.Millisecond)
 
@@ -2642,7 +2642,7 @@ func TestHandler_HandleUndoLikeActivity(t *testing.T) {
 				vocab.WithTo(service1IRI),
 			)
 
-			require.NoError(t, ibHandler.HandleActivity(undo))
+			require.NoError(t, ibHandler.HandleActivity(nil, undo))
 
 			time.Sleep(50 * time.Millisecond)
 
@@ -2685,7 +2685,7 @@ func TestHandler_HandleUndoLikeActivity(t *testing.T) {
 				vocab.WithTo(service1IRI),
 			)
 
-			err := ibHandler.HandleActivity(undo)
+			err := ibHandler.HandleActivity(nil, undo)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "invalid anchor event URL")
 		})
@@ -2711,7 +2711,7 @@ func TestHandler_HandleUndoLikeActivity(t *testing.T) {
 				vocab.WithTo(service1IRI),
 			)
 
-			require.NoError(t, obHandler.HandleActivity(undo))
+			require.NoError(t, obHandler.HandleActivity(nil, undo))
 
 			time.Sleep(50 * time.Millisecond)
 
@@ -2895,7 +2895,7 @@ func TestHandler_InboxHandleLikeActivity(t *testing.T) {
 	)
 
 	t.Run("Success", func(t *testing.T) {
-		require.NoError(t, h.HandleActivity(like))
+		require.NoError(t, h.HandleActivity(nil, like))
 
 		time.Sleep(50 * time.Millisecond)
 
@@ -2921,7 +2921,7 @@ func TestHandler_InboxHandleLikeActivity(t *testing.T) {
 			vocab.WithPublishedTime(&publishedTime),
 		)
 
-		require.NoError(t, h.HandleActivity(likeNoResult))
+		require.NoError(t, h.HandleActivity(nil, likeNoResult))
 
 		time.Sleep(50 * time.Millisecond)
 
@@ -2952,7 +2952,7 @@ func TestHandler_InboxHandleLikeActivity(t *testing.T) {
 			),
 		)
 
-		err := h.HandleActivity(invalidLike)
+		err := h.HandleActivity(nil, invalidLike)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "anchor reference URL is required")
 	})
@@ -2973,7 +2973,7 @@ func TestHandler_InboxHandleLikeActivity(t *testing.T) {
 		h.Start()
 		defer h.Stop()
 
-		err := h.HandleActivity(like)
+		err := h.HandleActivity(nil, like)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errExpected.Error())
 	})
@@ -2993,7 +2993,7 @@ func TestHandler_InboxHandleLikeActivity(t *testing.T) {
 		h.Start()
 		defer h.Stop()
 
-		err := h.HandleActivity(like)
+		err := h.HandleActivity(nil, like)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errExpected.Error())
 	})
@@ -3041,7 +3041,7 @@ func TestHandler_OutboxHandleLikeActivity(t *testing.T) {
 	)
 
 	t.Run("Success", func(t *testing.T) {
-		require.NoError(t, h.HandleActivity(like))
+		require.NoError(t, h.HandleActivity(nil, like))
 
 		it, err := activityStore.QueryReferences(store.Liked,
 			store.NewCriteria(store.WithObjectIRI(service2IRI)))
@@ -3069,7 +3069,7 @@ func TestHandler_OutboxHandleLikeActivity(t *testing.T) {
 			),
 		)
 
-		require.EqualError(t, h.HandleActivity(invalidLike), "no anchor reference URL in 'Like' activity")
+		require.EqualError(t, h.HandleActivity(nil, invalidLike), "no anchor reference URL in 'Like' activity")
 	})
 
 	t.Run("Store error", func(t *testing.T) {
@@ -3083,7 +3083,7 @@ func TestHandler_OutboxHandleLikeActivity(t *testing.T) {
 		h.Start()
 		defer h.Stop()
 
-		err := h.HandleActivity(like)
+		err := h.HandleActivity(nil, like)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), err.Error())
 	})

--- a/pkg/activitypub/service/activityhandler/outboxhandler.go
+++ b/pkg/activitypub/service/activityhandler/outboxhandler.go
@@ -47,7 +47,7 @@ func NewOutbox(cfg *Config, s store.Store, activityPubClient activityPubClient) 
 }
 
 // HandleActivity handles the ActivityPub activity in the outbox.
-func (h *Outbox) HandleActivity(activity *vocab.ActivityType) error {
+func (h *Outbox) HandleActivity(_ *url.URL, activity *vocab.ActivityType) error {
 	typeProp := activity.Type()
 
 	switch {

--- a/pkg/activitypub/service/anchorsynctask/anchorsynctask_test.go
+++ b/pkg/activitypub/service/anchorsynctask/anchorsynctask_test.go
@@ -12,6 +12,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
+	"net/url"
 	"testing"
 
 	"github.com/hyperledger/aries-framework-go/pkg/mock/storage"
@@ -89,6 +90,7 @@ func TestRun(t *testing.T) {
 	apStore := memstore.New("service1")
 
 	require.NoError(t, apStore.AddReference(spi2.Following, serviceIRI, service2IRI))
+	require.NoError(t, apStore.AddReference(spi2.Follower, serviceIRI, service2IRI))
 	require.NoError(t, apStore.AddActivity(createActivities[0])) // This activity should be ignored.
 
 	apClient := mocks.NewActivitPubClient().
@@ -204,7 +206,7 @@ type mockHandler struct {
 	err              error
 }
 
-func (m *mockHandler) HandleCreateActivity(a *vocab.ActivityType, announce bool) error {
+func (m *mockHandler) HandleCreateActivity(src *url.URL, a *vocab.ActivityType, announce bool) error {
 	if m.err != nil {
 		return m.err
 	}
@@ -218,7 +220,7 @@ func (m *mockHandler) HandleCreateActivity(a *vocab.ActivityType, announce bool)
 	return nil
 }
 
-func (m *mockHandler) HandleAnnounceActivity(a *vocab.ActivityType) error {
+func (m *mockHandler) HandleAnnounceActivity(src *url.URL, a *vocab.ActivityType) error {
 	if m.err != nil {
 		return m.err
 	}

--- a/pkg/activitypub/service/anchorsynctask/syncstore_test.go
+++ b/pkg/activitypub/service/anchorsynctask/syncstore_test.go
@@ -57,18 +57,18 @@ func TestSyncStore_GetAndPut(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, s)
 
-	require.NoError(t, s.PutLastSyncedPage(service1IRI, page0, 3))
+	require.NoError(t, s.PutLastSyncedPage(service1IRI, outbox, page0, 3))
 	require.NoError(t, err)
 
-	require.NoError(t, s.PutLastSyncedPage(service2IRI, page1, 4))
+	require.NoError(t, s.PutLastSyncedPage(service2IRI, outbox, page1, 4))
 	require.NoError(t, err)
 
-	page, index, err := s.GetLastSyncedPage(service1IRI)
+	page, index, err := s.GetLastSyncedPage(service1IRI, outbox)
 	require.NoError(t, err)
 	require.Equal(t, page0.String(), page.String())
 	require.Equal(t, 3, index)
 
-	page, index, err = s.GetLastSyncedPage(service2IRI)
+	page, index, err = s.GetLastSyncedPage(service2IRI, outbox)
 	require.NoError(t, err)
 	require.Equal(t, page1.String(), page.String())
 	require.Equal(t, 4, index)
@@ -94,7 +94,7 @@ func TestSyncStore_Error(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, s)
 
-		_, _, err = s.GetLastSyncedPage(serviceIRI)
+		_, _, err = s.GetLastSyncedPage(serviceIRI, outbox)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errExpected.Error())
 	})
@@ -112,10 +112,10 @@ func TestSyncStore_Error(t *testing.T) {
 
 		s.unmarshal = func(data []byte, v interface{}) error { return errExpected }
 
-		require.NoError(t, s.PutLastSyncedPage(serviceIRI, page, 3))
+		require.NoError(t, s.PutLastSyncedPage(serviceIRI, outbox, page, 3))
 		require.NoError(t, err)
 
-		_, _, err = s.GetLastSyncedPage(serviceIRI)
+		_, _, err = s.GetLastSyncedPage(serviceIRI, outbox)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errExpected.Error())
 	})
@@ -132,13 +132,13 @@ func TestSyncStore_Error(t *testing.T) {
 		infoBytes, err := json.Marshal(info)
 		require.NoError(t, err)
 
-		require.NoError(t, p.Store.Put(serviceIRI.String(), infoBytes))
+		require.NoError(t, p.Store.Put(getKey(serviceIRI, outbox), infoBytes))
 
 		s, err := newSyncStore(p)
 		require.NoError(t, err)
 		require.NotNil(t, s)
 
-		_, _, err = s.GetLastSyncedPage(serviceIRI)
+		_, _, err = s.GetLastSyncedPage(serviceIRI, outbox)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "missing protocol scheme")
 	})
@@ -155,7 +155,7 @@ func TestSyncStore_Error(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, s)
 
-		err = s.PutLastSyncedPage(serviceIRI, page, 3)
+		err = s.PutLastSyncedPage(serviceIRI, outbox, page, 3)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errExpected.Error())
 	})
@@ -173,7 +173,7 @@ func TestSyncStore_Error(t *testing.T) {
 
 		s.marshal = func(v interface{}) ([]byte, error) { return nil, errExpected }
 
-		err = s.PutLastSyncedPage(serviceIRI, page, 3)
+		err = s.PutLastSyncedPage(serviceIRI, outbox, page, 3)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errExpected.Error())
 	})

--- a/pkg/activitypub/service/inbox/inbox.go
+++ b/pkg/activitypub/service/inbox/inbox.go
@@ -228,7 +228,7 @@ func (h *Inbox) handleActivityMsg(msg *message.Message) (*vocab.ActivityType, er
 		return activity, nil
 	}
 
-	err = h.activityHandler.HandleActivity(activity)
+	err = h.activityHandler.HandleActivity(nil, activity)
 	if err != nil {
 		// If it's a transient error then return it so that the message is Nacked and retried. Otherwise, fall
 		// through in order to store the activity and Ack the message.

--- a/pkg/activitypub/service/mocks/activityhandler.gen.go
+++ b/pkg/activitypub/service/mocks/activityhandler.gen.go
@@ -2,33 +2,19 @@
 package mocks
 
 import (
+	"net/url"
 	"sync"
 
 	"github.com/trustbloc/orb/pkg/activitypub/service/spi"
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
-	"github.com/trustbloc/orb/pkg/lifecycle"
 )
 
 type ActivityHandler struct {
-	StartStub        func()
-	startMutex       sync.RWMutex
-	startArgsForCall []struct{}
-	StopStub         func()
-	stopMutex        sync.RWMutex
-	stopArgsForCall  []struct{}
-	StateStub        func() lifecycle.State
-	stateMutex       sync.RWMutex
-	stateArgsForCall []struct{}
-	stateReturns     struct {
-		result1 lifecycle.State
-	}
-	stateReturnsOnCall map[int]struct {
-		result1 lifecycle.State
-	}
-	HandleActivityStub        func(activity *vocab.ActivityType) error
+	HandleActivityStub        func(*url.URL, *vocab.ActivityType) error
 	handleActivityMutex       sync.RWMutex
 	handleActivityArgsForCall []struct {
-		activity *vocab.ActivityType
+		arg1 *url.URL
+		arg2 *vocab.ActivityType
 	}
 	handleActivityReturns struct {
 		result1 error
@@ -36,10 +22,29 @@ type ActivityHandler struct {
 	handleActivityReturnsOnCall map[int]struct {
 		result1 error
 	}
+	StartStub        func()
+	startMutex       sync.RWMutex
+	startArgsForCall []struct {
+	}
+	StateStub        func() uint32
+	stateMutex       sync.RWMutex
+	stateArgsForCall []struct {
+	}
+	stateReturns struct {
+		result1 uint32
+	}
+	stateReturnsOnCall map[int]struct {
+		result1 uint32
+	}
+	StopStub        func()
+	stopMutex       sync.RWMutex
+	stopArgsForCall []struct {
+	}
 	SubscribeStub        func() <-chan *vocab.ActivityType
 	subscribeMutex       sync.RWMutex
-	subscribeArgsForCall []struct{}
-	subscribeReturns     struct {
+	subscribeArgsForCall []struct {
+	}
+	subscribeReturns struct {
 		result1 <-chan *vocab.ActivityType
 	}
 	subscribeReturnsOnCall map[int]struct {
@@ -49,93 +54,24 @@ type ActivityHandler struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *ActivityHandler) Start() {
-	fake.startMutex.Lock()
-	fake.startArgsForCall = append(fake.startArgsForCall, struct{}{})
-	fake.recordInvocation("Start", []interface{}{})
-	fake.startMutex.Unlock()
-	if fake.StartStub != nil {
-		fake.StartStub()
-	}
-}
-
-func (fake *ActivityHandler) StartCallCount() int {
-	fake.startMutex.RLock()
-	defer fake.startMutex.RUnlock()
-	return len(fake.startArgsForCall)
-}
-
-func (fake *ActivityHandler) Stop() {
-	fake.stopMutex.Lock()
-	fake.stopArgsForCall = append(fake.stopArgsForCall, struct{}{})
-	fake.recordInvocation("Stop", []interface{}{})
-	fake.stopMutex.Unlock()
-	if fake.StopStub != nil {
-		fake.StopStub()
-	}
-}
-
-func (fake *ActivityHandler) StopCallCount() int {
-	fake.stopMutex.RLock()
-	defer fake.stopMutex.RUnlock()
-	return len(fake.stopArgsForCall)
-}
-
-func (fake *ActivityHandler) State() lifecycle.State {
-	fake.stateMutex.Lock()
-	ret, specificReturn := fake.stateReturnsOnCall[len(fake.stateArgsForCall)]
-	fake.stateArgsForCall = append(fake.stateArgsForCall, struct{}{})
-	fake.recordInvocation("State", []interface{}{})
-	fake.stateMutex.Unlock()
-	if fake.StateStub != nil {
-		return fake.StateStub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.stateReturns.result1
-}
-
-func (fake *ActivityHandler) StateCallCount() int {
-	fake.stateMutex.RLock()
-	defer fake.stateMutex.RUnlock()
-	return len(fake.stateArgsForCall)
-}
-
-func (fake *ActivityHandler) StateReturns(result1 lifecycle.State) {
-	fake.StateStub = nil
-	fake.stateReturns = struct {
-		result1 lifecycle.State
-	}{result1}
-}
-
-func (fake *ActivityHandler) StateReturnsOnCall(i int, result1 lifecycle.State) {
-	fake.StateStub = nil
-	if fake.stateReturnsOnCall == nil {
-		fake.stateReturnsOnCall = make(map[int]struct {
-			result1 lifecycle.State
-		})
-	}
-	fake.stateReturnsOnCall[i] = struct {
-		result1 lifecycle.State
-	}{result1}
-}
-
-func (fake *ActivityHandler) HandleActivity(activity *vocab.ActivityType) error {
+func (fake *ActivityHandler) HandleActivity(arg1 *url.URL, arg2 *vocab.ActivityType) error {
 	fake.handleActivityMutex.Lock()
 	ret, specificReturn := fake.handleActivityReturnsOnCall[len(fake.handleActivityArgsForCall)]
 	fake.handleActivityArgsForCall = append(fake.handleActivityArgsForCall, struct {
-		activity *vocab.ActivityType
-	}{activity})
-	fake.recordInvocation("HandleActivity", []interface{}{activity})
+		arg1 *url.URL
+		arg2 *vocab.ActivityType
+	}{arg1, arg2})
+	stub := fake.HandleActivityStub
+	fakeReturns := fake.handleActivityReturns
+	fake.recordInvocation("HandleActivity", []interface{}{arg1, arg2})
 	fake.handleActivityMutex.Unlock()
-	if fake.HandleActivityStub != nil {
-		return fake.HandleActivityStub(activity)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.handleActivityReturns.result1
+	return fakeReturns.result1
 }
 
 func (fake *ActivityHandler) HandleActivityCallCount() int {
@@ -144,13 +80,22 @@ func (fake *ActivityHandler) HandleActivityCallCount() int {
 	return len(fake.handleActivityArgsForCall)
 }
 
-func (fake *ActivityHandler) HandleActivityArgsForCall(i int) *vocab.ActivityType {
+func (fake *ActivityHandler) HandleActivityCalls(stub func(*url.URL, *vocab.ActivityType) error) {
+	fake.handleActivityMutex.Lock()
+	defer fake.handleActivityMutex.Unlock()
+	fake.HandleActivityStub = stub
+}
+
+func (fake *ActivityHandler) HandleActivityArgsForCall(i int) (*url.URL, *vocab.ActivityType) {
 	fake.handleActivityMutex.RLock()
 	defer fake.handleActivityMutex.RUnlock()
-	return fake.handleActivityArgsForCall[i].activity
+	argsForCall := fake.handleActivityArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *ActivityHandler) HandleActivityReturns(result1 error) {
+	fake.handleActivityMutex.Lock()
+	defer fake.handleActivityMutex.Unlock()
 	fake.HandleActivityStub = nil
 	fake.handleActivityReturns = struct {
 		result1 error
@@ -158,6 +103,8 @@ func (fake *ActivityHandler) HandleActivityReturns(result1 error) {
 }
 
 func (fake *ActivityHandler) HandleActivityReturnsOnCall(i int, result1 error) {
+	fake.handleActivityMutex.Lock()
+	defer fake.handleActivityMutex.Unlock()
 	fake.HandleActivityStub = nil
 	if fake.handleActivityReturnsOnCall == nil {
 		fake.handleActivityReturnsOnCall = make(map[int]struct {
@@ -169,19 +116,123 @@ func (fake *ActivityHandler) HandleActivityReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *ActivityHandler) Subscribe() <-chan *vocab.ActivityType {
-	fake.subscribeMutex.Lock()
-	ret, specificReturn := fake.subscribeReturnsOnCall[len(fake.subscribeArgsForCall)]
-	fake.subscribeArgsForCall = append(fake.subscribeArgsForCall, struct{}{})
-	fake.recordInvocation("Subscribe", []interface{}{})
-	fake.subscribeMutex.Unlock()
-	if fake.SubscribeStub != nil {
-		return fake.SubscribeStub()
+func (fake *ActivityHandler) Start() {
+	fake.startMutex.Lock()
+	fake.startArgsForCall = append(fake.startArgsForCall, struct {
+	}{})
+	stub := fake.StartStub
+	fake.recordInvocation("Start", []interface{}{})
+	fake.startMutex.Unlock()
+	if stub != nil {
+		fake.StartStub()
+	}
+}
+
+func (fake *ActivityHandler) StartCallCount() int {
+	fake.startMutex.RLock()
+	defer fake.startMutex.RUnlock()
+	return len(fake.startArgsForCall)
+}
+
+func (fake *ActivityHandler) StartCalls(stub func()) {
+	fake.startMutex.Lock()
+	defer fake.startMutex.Unlock()
+	fake.StartStub = stub
+}
+
+func (fake *ActivityHandler) State() uint32 {
+	fake.stateMutex.Lock()
+	ret, specificReturn := fake.stateReturnsOnCall[len(fake.stateArgsForCall)]
+	fake.stateArgsForCall = append(fake.stateArgsForCall, struct {
+	}{})
+	stub := fake.StateStub
+	fakeReturns := fake.stateReturns
+	fake.recordInvocation("State", []interface{}{})
+	fake.stateMutex.Unlock()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.subscribeReturns.result1
+	return fakeReturns.result1
+}
+
+func (fake *ActivityHandler) StateCallCount() int {
+	fake.stateMutex.RLock()
+	defer fake.stateMutex.RUnlock()
+	return len(fake.stateArgsForCall)
+}
+
+func (fake *ActivityHandler) StateCalls(stub func() uint32) {
+	fake.stateMutex.Lock()
+	defer fake.stateMutex.Unlock()
+	fake.StateStub = stub
+}
+
+func (fake *ActivityHandler) StateReturns(result1 uint32) {
+	fake.stateMutex.Lock()
+	defer fake.stateMutex.Unlock()
+	fake.StateStub = nil
+	fake.stateReturns = struct {
+		result1 uint32
+	}{result1}
+}
+
+func (fake *ActivityHandler) StateReturnsOnCall(i int, result1 uint32) {
+	fake.stateMutex.Lock()
+	defer fake.stateMutex.Unlock()
+	fake.StateStub = nil
+	if fake.stateReturnsOnCall == nil {
+		fake.stateReturnsOnCall = make(map[int]struct {
+			result1 uint32
+		})
+	}
+	fake.stateReturnsOnCall[i] = struct {
+		result1 uint32
+	}{result1}
+}
+
+func (fake *ActivityHandler) Stop() {
+	fake.stopMutex.Lock()
+	fake.stopArgsForCall = append(fake.stopArgsForCall, struct {
+	}{})
+	stub := fake.StopStub
+	fake.recordInvocation("Stop", []interface{}{})
+	fake.stopMutex.Unlock()
+	if stub != nil {
+		fake.StopStub()
+	}
+}
+
+func (fake *ActivityHandler) StopCallCount() int {
+	fake.stopMutex.RLock()
+	defer fake.stopMutex.RUnlock()
+	return len(fake.stopArgsForCall)
+}
+
+func (fake *ActivityHandler) StopCalls(stub func()) {
+	fake.stopMutex.Lock()
+	defer fake.stopMutex.Unlock()
+	fake.StopStub = stub
+}
+
+func (fake *ActivityHandler) Subscribe() <-chan *vocab.ActivityType {
+	fake.subscribeMutex.Lock()
+	ret, specificReturn := fake.subscribeReturnsOnCall[len(fake.subscribeArgsForCall)]
+	fake.subscribeArgsForCall = append(fake.subscribeArgsForCall, struct {
+	}{})
+	stub := fake.SubscribeStub
+	fakeReturns := fake.subscribeReturns
+	fake.recordInvocation("Subscribe", []interface{}{})
+	fake.subscribeMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
 }
 
 func (fake *ActivityHandler) SubscribeCallCount() int {
@@ -190,7 +241,15 @@ func (fake *ActivityHandler) SubscribeCallCount() int {
 	return len(fake.subscribeArgsForCall)
 }
 
+func (fake *ActivityHandler) SubscribeCalls(stub func() <-chan *vocab.ActivityType) {
+	fake.subscribeMutex.Lock()
+	defer fake.subscribeMutex.Unlock()
+	fake.SubscribeStub = stub
+}
+
 func (fake *ActivityHandler) SubscribeReturns(result1 <-chan *vocab.ActivityType) {
+	fake.subscribeMutex.Lock()
+	defer fake.subscribeMutex.Unlock()
 	fake.SubscribeStub = nil
 	fake.subscribeReturns = struct {
 		result1 <-chan *vocab.ActivityType
@@ -198,6 +257,8 @@ func (fake *ActivityHandler) SubscribeReturns(result1 <-chan *vocab.ActivityType
 }
 
 func (fake *ActivityHandler) SubscribeReturnsOnCall(i int, result1 <-chan *vocab.ActivityType) {
+	fake.subscribeMutex.Lock()
+	defer fake.subscribeMutex.Unlock()
 	fake.SubscribeStub = nil
 	if fake.subscribeReturnsOnCall == nil {
 		fake.subscribeReturnsOnCall = make(map[int]struct {
@@ -212,14 +273,14 @@ func (fake *ActivityHandler) SubscribeReturnsOnCall(i int, result1 <-chan *vocab
 func (fake *ActivityHandler) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.startMutex.RLock()
-	defer fake.startMutex.RUnlock()
-	fake.stopMutex.RLock()
-	defer fake.stopMutex.RUnlock()
-	fake.stateMutex.RLock()
-	defer fake.stateMutex.RUnlock()
 	fake.handleActivityMutex.RLock()
 	defer fake.handleActivityMutex.RUnlock()
+	fake.startMutex.RLock()
+	defer fake.startMutex.RUnlock()
+	fake.stateMutex.RLock()
+	defer fake.stateMutex.RUnlock()
+	fake.stopMutex.RLock()
+	defer fake.stopMutex.RUnlock()
 	fake.subscribeMutex.RLock()
 	defer fake.subscribeMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/pkg/activitypub/service/mocks/mockanchoreventhandler.go
+++ b/pkg/activitypub/service/mocks/mockanchoreventhandler.go
@@ -35,7 +35,7 @@ func (m *AnchorEventHandler) WithError(err error) *AnchorEventHandler {
 }
 
 // HandleAnchorEvent stores the anchor event or returns an error if it was set.
-func (m *AnchorEventHandler) HandleAnchorEvent(actor, hl *url.URL, anchorEvent *vocab.AnchorEventType) error {
+func (m *AnchorEventHandler) HandleAnchorEvent(actor, hl, src *url.URL, anchorEvent *vocab.AnchorEventType) error {
 	if m.err != nil {
 		return m.err
 	}

--- a/pkg/activitypub/service/outbox/outbox.go
+++ b/pkg/activitypub/service/outbox/outbox.go
@@ -240,7 +240,7 @@ func (h *Outbox) Post(activity *vocab.ActivityType) (*url.URL, error) {
 		return nil, fmt.Errorf("store activity: %w", err)
 	}
 
-	err = h.activityHandler.HandleActivity(activity)
+	err = h.activityHandler.HandleActivity(nil, activity)
 	if err != nil {
 		return nil, fmt.Errorf("handle activity: %w", err)
 	}

--- a/pkg/activitypub/service/spi/spi.go
+++ b/pkg/activitypub/service/spi/spi.go
@@ -40,7 +40,7 @@ type Inbox interface {
 
 // AnchorEventHandler handles a new, published anchor event.
 type AnchorEventHandler interface {
-	HandleAnchorEvent(actor, anchorEventRef *url.URL, anchorEvent *vocab.AnchorEventType) error
+	HandleAnchorEvent(actor, anchorEventRef, source *url.URL, anchorEvent *vocab.AnchorEventType) error
 }
 
 // AnchorEventAcknowledgementHandler handles notification of a successful anchor event processed from an Orb server,
@@ -70,8 +70,9 @@ type ProofHandler interface {
 type ActivityHandler interface {
 	ServiceLifecycle
 
-	// HandleActivity handles the ActivityPub activity.
-	HandleActivity(activity *vocab.ActivityType) error
+	// HandleActivity handles the ActivityPub activity. An optional source may be added
+	// to indicate where the activity was retrieved from.
+	HandleActivity(source *url.URL, activity *vocab.ActivityType) error
 
 	// Subscribe allows a client to receive published activities.
 	Subscribe() <-chan *vocab.ActivityType
@@ -82,8 +83,8 @@ var ErrDuplicateAnchorEvent = errors.New("anchor event already handled")
 
 // InboxHandler defines functions for handling Create and Announce activities.
 type InboxHandler interface {
-	HandleCreateActivity(create *vocab.ActivityType, announce bool) error
-	HandleAnnounceActivity(create *vocab.ActivityType) error
+	HandleCreateActivity(source *url.URL, create *vocab.ActivityType, announce bool) error
+	HandleAnnounceActivity(source *url.URL, create *vocab.ActivityType) error
 }
 
 // UndeliverableActivityHandler handles undeliverable activities.

--- a/pkg/anchor/handler/credential/handler_test.go
+++ b/pkg/anchor/handler/credential/handler_test.go
@@ -61,7 +61,7 @@ func TestAnchorCredentialHandler(t *testing.T) {
 		hl, err := hashlink.New().CreateHashLink([]byte(testutil.GetCanonical(t, sampleAnchorEvent)), nil)
 		require.NoError(t, err)
 
-		err = handler.HandleAnchorEvent(actor, testutil.MustParseURL(hl), anchorEvent)
+		err = handler.HandleAnchorEvent(actor, testutil.MustParseURL(hl), actor, anchorEvent)
 		require.NoError(t, err)
 	})
 
@@ -73,7 +73,7 @@ func TestAnchorCredentialHandler(t *testing.T) {
 
 		handler := newAnchorEventHandler(t, casStore)
 
-		err = handler.HandleAnchorEvent(actor, testutil.MustParseURL(hl), nil)
+		err = handler.HandleAnchorEvent(actor, testutil.MustParseURL(hl), nil, nil)
 		require.NoError(t, err)
 	})
 
@@ -87,7 +87,7 @@ func TestAnchorCredentialHandler(t *testing.T) {
 		require.NoError(t, err)
 
 		err = newAnchorEventHandler(t, createInMemoryCAS(t)).
-			HandleAnchorEvent(actor, testutil.MustParseURL(hl), anchorEvent)
+			HandleAnchorEvent(actor, testutil.MustParseURL(hl), nil, anchorEvent)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "parse created: parsing time")
 	})
@@ -104,7 +104,7 @@ func TestAnchorCredentialHandler(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NoError(t, newAnchorEventHandler(t, createInMemoryCAS(t)).
-			HandleAnchorEvent(actor, testutil.MustParseURL(hl), anchorEvent))
+			HandleAnchorEvent(actor, testutil.MustParseURL(hl), nil, anchorEvent))
 	})
 
 	t.Run("Neither local nor remote CAS has the anchor credential", func(t *testing.T) {
@@ -127,7 +127,7 @@ func TestAnchorCredentialHandler(t *testing.T) {
 		hl, err := hashlink.New().CreateHashLink([]byte(sampleAnchorEvent), nil)
 		require.NoError(t, err)
 
-		err = anchorCredentialHandler.HandleAnchorEvent(actor, testutil.MustParseURL(hl), nil)
+		err = anchorCredentialHandler.HandleAnchorEvent(actor, testutil.MustParseURL(hl), nil, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "content not found")
 	})

--- a/pkg/anchor/info/info.go
+++ b/pkg/anchor/info/info.go
@@ -8,7 +8,8 @@ package info
 
 // AnchorInfo represents a hashlink that can be used to fetch the anchor.
 type AnchorInfo struct {
-	Hashlink      string `json:"hashLink"`
-	LocalHashlink string `json:"localHashLink"`
-	AttributedTo  string `json:"attributedTo,omitempty"`
+	Hashlink         string   `json:"hashLink"`
+	LocalHashlink    string   `json:"localHashLink"`
+	AttributedTo     string   `json:"attributedTo,omitempty"`
+	AlternateSources []string `json:"alternateSources,omitempty"`
 }

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -324,6 +324,7 @@ func (o *Observer) processAnchor(anchor *anchorinfo.AnchorInfo,
 		ProtocolVersion:      anchorPayload.Version,
 		CanonicalReference:   canonicalID,
 		EquivalentReferences: equivalentRefs,
+		AlternateSources:     anchor.AlternateSources,
 	}
 
 	logger.Debugf("processing anchor[%s], core index[%s]", anchor.Hashlink, anchorPayload.CoreIndex)

--- a/pkg/protocolversion/versions/v1_0/factory/factory.go
+++ b/pkg/protocolversion/versions/v1_0/factory/factory.go
@@ -8,8 +8,10 @@ package factory
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hyperledger/aries-framework-go/spi/storage"
+	"github.com/trustbloc/edge-core/pkg/log"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/cas"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/compression"
@@ -22,6 +24,7 @@ import (
 
 	"github.com/trustbloc/orb/pkg/config"
 	ctxcommon "github.com/trustbloc/orb/pkg/context/common"
+	"github.com/trustbloc/orb/pkg/hashlink"
 	vcommon "github.com/trustbloc/orb/pkg/protocolversion/versions/common"
 	protocolcfg "github.com/trustbloc/orb/pkg/protocolversion/versions/v1_0/config"
 	orboperationparser "github.com/trustbloc/orb/pkg/versions/1_0/operationparser"
@@ -29,6 +32,8 @@ import (
 	"github.com/trustbloc/orb/pkg/versions/1_0/operationparser/validators/anchortime"
 	"github.com/trustbloc/orb/pkg/versions/1_0/txnprocessor"
 )
+
+var logger = log.New("protocol-v1_0")
 
 // Factory implements version 0.1 of the Sidetree protocol.
 type Factory struct{}
@@ -51,7 +56,8 @@ func (v *Factory) Create(version string, casClient cas.Client, casResolver ctxco
 	orbParser := orboperationparser.New(opParser)
 
 	cp := compression.New(compression.WithDefaultAlgorithms())
-	op := txnprovider.NewOperationProvider(p, opParser, &casReader{casResolver}, cp)
+	op := txnprovider.NewOperationProvider(p, opParser, &casReader{casResolver}, cp,
+		txnprovider.WithSourceCASURIFormatter(formatWebCASURI))
 	oh := txnprovider.NewOperationHandler(p, casClient, cp, opParser)
 	dc := doccomposer.New()
 	oa := operationapplier.New(p, opParser, dc)
@@ -104,4 +110,27 @@ func (c *casReader) Read(cid string) ([]byte, error) {
 	}
 
 	return data, nil
+}
+
+func formatWebCASURI(uri, serviceURI string) (string, error) {
+	// A CAS URI can either be a CID or a hashlink.
+	hash, err := hashlink.GetResourceHashFromHashLink(uri)
+	if err != nil {
+		logger.Debugf("CAS URI [%s] is not a hashlink: %s. Assuming that it's a plain hash.", uri, err)
+
+		hash = uri
+	}
+
+	// A serviceURI URI looks like this: https://orb.domain1.com/services/orb.
+	parts := strings.Split(serviceURI, ":")
+
+	scheme := parts[0]
+	host := strings.Split(parts[1][2:], "/")[0]
+
+	// The WebCAS URI will look like this: https:orb.domain1.com:<hash>.
+	casURI := fmt.Sprintf("%s:%s:%s", scheme, host, hash)
+
+	logger.Debugf("Adding alternate CAS URI: %s", casURI)
+
+	return casURI, nil
 }

--- a/pkg/protocolversion/versions/v1_0/factory/factory_test.go
+++ b/pkg/protocolversion/versions/v1_0/factory/factory_test.go
@@ -93,6 +93,20 @@ func TestCasReader_Read(t *testing.T) {
 	})
 }
 
+func TestFormatWebCASURI(t *testing.T) {
+	t.Run("hash", func(t *testing.T) {
+		casURI, err := formatWebCASURI("12345", "https://orb.domain1.com/services/orb")
+		require.NoError(t, err)
+		require.Equal(t, casURI, "https:orb.domain1.com:12345")
+	})
+
+	t.Run("hashlink", func(t *testing.T) {
+		casURI, err := formatWebCASURI("hl:12345", "https://orb.domain1.com/services/orb")
+		require.NoError(t, err)
+		require.Equal(t, casURI, "https:orb.domain1.com:12345")
+	})
+}
+
 func createNewResolver(t *testing.T, casClient extendedcasclient.Client) *casresolver.Resolver {
 	t.Helper()
 

--- a/pkg/store/anchoreventstatus/store.go
+++ b/pkg/store/anchoreventstatus/store.go
@@ -291,7 +291,6 @@ func (s *Store) GetStatus(anchorID string) (proof.AnchorIndexStatus, error) {
 // CheckInProcessAnchors will be invoked to check for in-complete (not processed) anchors.
 func (s *Store) CheckInProcessAnchors() {
 	query := fmt.Sprintf("%s<=%d", statusCheckTimeTagName, time.Now().Unix())
-	logger.Debugf("Checking anchor event status data query: %s", query)
 
 	iterator, err := s.store.Query(query)
 	if err != nil {

--- a/test/bdd/features/onboard-recovery.feature
+++ b/test/bdd/features/onboard-recovery.feature
@@ -70,31 +70,34 @@ Feature:
     # Onboard domain5 by asking to follow domain1 and domain2:
     # --- domain1 and domain2 add domain5 to the 'follow' and 'invite-witness' accept lists.
     Given variable "acceptList" is assigned the JSON value '[{"type":"follow","add":["${domain5IRI}"]},{"type":"invite-witness","add":["${domain5IRI}"]}]'
-    When an HTTP POST is sent to "${domain1IRI}/acceptlist" with content "${acceptList}" of type "application/json"
-    When an HTTP POST is sent to "${domain2IRI}/acceptlist" with content "${acceptList}" of type "application/json"
+    Then an HTTP POST is sent to "${domain1IRI}/acceptlist" with content "${acceptList}" of type "application/json"
+    Then an HTTP POST is sent to "${domain2IRI}/acceptlist" with content "${acceptList}" of type "application/json"
     # --- domain5 server follows domain1 server
     And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain5IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain5.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
+    Then an HTTP POST is sent to "https://orb.domain5.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
     # --- domain5 server follows domain2 server
     And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain5IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain5.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
+    Then an HTTP POST is sent to "https://orb.domain5.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
     # --- domain5 invites domain1 to be a witness
     And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain5IRI}","to":"${domain1IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain5.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    Then an HTTP POST is sent to "https://orb.domain5.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
     # --- domain5 invites domain2 to be a witness
     And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain5IRI}","to":"${domain2IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain5.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    Then an HTTP POST is sent to "https://orb.domain5.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
     # --- domain1 server follows domain5 server
     And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain1IRI}","to":"${domain5IRI}","object":"${domain5IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
+    Then an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
     # --- domain2 server follows domain5 server
     And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain2IRI}","to":"${domain5IRI}","object":"${domain5IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
+    Then an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
 
     # The synchronization process should kick in for domain5, i.e. domain5 will read all missed 'Create' and 'Announce'
     # activities from domain1 and domain2's outbox to figure out which events were missed (which should be all of them)
     # and then process the missed anchor events.
-    Then client sends request to "https://orb.domain5.com/sidetree/v1/identifiers" to verify the DID documents that were updated with key "newkey_1_3"
+    # Create some new DIDs on domain5 while recovery is happening.
+    When client sends request to "https://orb.domain5.com/sidetree/v1/operations" to create 50 DID documents using 5 concurrent requests
+    Then client sends request to "https://orb.domain5.com/sidetree/v1/identifiers" to verify the DID documents that were created
+    And client sends request to "https://orb.domain5.com/sidetree/v1/identifiers" to verify the DID documents that were updated with key "newkey_1_3"
 
     # Now stop domain5 for a while and populate domain1 & domain2 with more creates/updates.
     Then container "orb-domain5" is stopped

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/tidwall/gjson v1.7.4
 	github.com/trustbloc/orb v0.1.4-0.20211201141158-15a02b430f04
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220124195951-717ab301acb0
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220125222405-838eba904ae4
 )
 
 require (

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -1558,8 +1558,8 @@ github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/sidetree-core-go v0.7.1-0.20211124193658-d5f6ccf1e554/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220124195951-717ab301acb0 h1:6TFHPLzUX+EFOXut3AGQ6zMWaXqiJgLXLKq3C0gtKrw=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220124195951-717ab301acb0/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220125222405-838eba904ae4 h1:Emc7bLbZfCGBddxgmZn1KDOD9PeXcp3YCA/RcJiLwLo=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220125222405-838eba904ae4/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=


### PR DESCRIPTION
This commit adds the capability for an anchor origin to recover AnchorEvents and Sidetree files that it had previously published but does not currently have in its database (possibly due to a backup/restore). Logic has been added in the anchor sync process to also process the inboxes of services that are following me. So, an AnchorEvent may be recovered by reading the inbox of a service to which I had previously published a 'Create' activity. All of the Sidetree files are also recovered by supplying an 'alternate source' to the Observer. (The alternate source is the service from which I recovered the 'Create' activity.)

Also upgraded the Go version to 1.17 to all Docker images/builds and updated the Alpine version to 3.15. (This fixes a bug in Go version 1.17.3 where closing an HTTP response body always resulted in an error 'context canceled'. See https://github.com/golang/net/commit/f0573a1506aed9f8168fbd7d5e757448db58b427.)

closes #1030

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>