### PR TITLE
fix: Process anchor event immediately if witness policy does not require witnesses

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -771,6 +771,7 @@ func startOrbServices(parameters *orbParameters) error {
 		AnchorEventStatusStore: anchorEventStatusStore,
 		OpProcessor:            opProcessor,
 		Outbox:                 activityPubService.Outbox(),
+		ProofHandler:           proofHandler,
 		Witness:                witness,
 		Signer:                 vcSigner,
 		MonitoringSvc:          monitoringSvc,

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -17,6 +17,7 @@ Feature:
     And domain "orb.domain2.com" is mapped to "localhost:48426"
     And domain "orb.domain3.com" is mapped to "localhost:48626"
     And domain "orb.domain4.com" is mapped to "localhost:48726"
+    And domain "orb.domain5.com" is mapped to "localhost:49026"
 
     Given the authorization bearer token for "POST" requests to path "/services/orb/outbox" is set to "ADMIN_TOKEN"
     And the authorization bearer token for "POST" requests to path "/services/orb/acceptlist" is set to "ADMIN_TOKEN"
@@ -427,6 +428,16 @@ Feature:
     Then check success response does NOT contain "unpublishedOperations"
     Then check success response contains "createKey"
     Then check success response contains "firstKey"
+
+  @all
+  @standalone_domain
+  Scenario: Standalone domain
+    # Set the witness policy to require no external proofs since this is a stand-alone domain where
+    # no witnesses or followers are configured.
+    When an HTTP POST is sent to "https://orb.domain5.com/policy" with content "OutOf(0,system)" of type "text/plain"
+
+    When client sends request to "https://orb.domain5.com/sidetree/v1/operations" to create 50 DID documents using 10 concurrent requests
+    Then client sends request to "https://orb.domain5.com/sidetree/v1/identifiers" to verify the DID documents that were created
 
   @local_cas
   @create_followed_by_immediate_update

--- a/test/bdd/features/onboard-recovery.feature
+++ b/test/bdd/features/onboard-recovery.feature
@@ -68,6 +68,7 @@ Feature:
     # Don't wait for the updates to finish. On-board domain5 immediately and then verify them on domain5.
 
     # Onboard domain5 by asking to follow domain1 and domain2:
+    When an HTTP POST is sent to "https://orb.domain5.com/policy" with content "MinPercent(100,batch) AND MinPercent(50,system)" of type "text/plain"
     # --- domain1 and domain2 add domain5 to the 'follow' and 'invite-witness' accept lists.
     Given variable "acceptList" is assigned the JSON value '[{"type":"follow","add":["${domain5IRI}"]},{"type":"invite-witness","add":["${domain5IRI}"]}]'
     Then an HTTP POST is sent to "${domain1IRI}/acceptlist" with content "${acceptList}" of type "application/json"
@@ -126,6 +127,7 @@ Feature:
   @orb_domain_backup_and_restore
   Scenario: Backup and restore a domain
     # Onboard domain5 by asking to follow domain1 and domain2:
+    When an HTTP POST is sent to "https://orb.domain5.com/policy" with content "MinPercent(100,batch) AND MinPercent(50,system)" of type "text/plain"
     # --- domain1 and domain2 add domain5 to the 'follow' and 'invite-witness' accept lists.
     Given variable "acceptList" is assigned the JSON value '[{"type":"follow","add":["${domain5IRI}"]},{"type":"invite-witness","add":["${domain5IRI}"]}]'
     Then an HTTP POST is sent to "${domain1IRI}/acceptlist" with content "${acceptList}" of type "application/json"

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -770,6 +770,9 @@ services:
       # we're following.
       # Default value: 1m.
       - ANCHOR_EVENT_SYNC_INTERVAL=10s
+      # WITNESS_POLICY_CACHE_EXPIRATION sets the expiration time of witness policy cache.
+      # Default value: 30s. Set the cache expiration very low since we're updating the policy frequently during the test.
+      - WITNESS_POLICY_CACHE_EXPIRATION=500ms
     ports:
       - 49026:443
       - 49027:49027


### PR DESCRIPTION
For a standalone domain, where no witnesses are configured and the witness policy states that I don't need witnesses, the anchor event is processed immediately using only the proof of the local domain.

closes #1064

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>