### PR TITLE
fix: DID resolver sometimes does not return DID with four parts

### DIFF
--- a/cmd/orb-cli/go.mod
+++ b/cmd/orb-cli/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/square/go-jose/v3 v3.0.0-20200630053402-0a67ce9b0693 // indirect
 	github.com/teserakt-io/golang-ed25519 v0.0.0-20210104091850-3888c087a4c8 // indirect
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220127163805-32a4b54f7dff // indirect
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201200000-75907072b045 // indirect
 	github.com/trustbloc/vct v0.1.3 // indirect
 	github.com/whyrusleeping/tar-utils v0.0.0-20180509141711-8c6c8ba81d5c // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/cmd/orb-cli/go.sum
+++ b/cmd/orb-cli/go.sum
@@ -1291,8 +1291,8 @@ github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/sidetree-core-go v0.7.1-0.20211229172717-b542d0074b38/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220127163805-32a4b54f7dff h1:EWFoF/+Z8Yv5aMLdZO2qbu4w9t809sv2x/dSa8oktvI=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220127163805-32a4b54f7dff/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201200000-75907072b045 h1:IL6rRc7Pr8CCecGyzAbKspQQzjcwp4LmZuG5PPUuX0U=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201200000-75907072b045/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/cmd/orb-driver/go.mod
+++ b/cmd/orb-driver/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7
 	github.com/trustbloc/orb v0.1.4-0.20220114151418-ee519eb3cd25
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220127163805-32a4b54f7dff
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201200000-75907072b045
 )
 
 require (

--- a/cmd/orb-driver/go.sum
+++ b/cmd/orb-driver/go.sum
@@ -1286,8 +1286,8 @@ github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/sidetree-core-go v0.7.1-0.20211229172717-b542d0074b38/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220127163805-32a4b54f7dff h1:EWFoF/+Z8Yv5aMLdZO2qbu4w9t809sv2x/dSa8oktvI=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220127163805-32a4b54f7dff/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201200000-75907072b045 h1:IL6rRc7Pr8CCecGyzAbKspQQzjcwp4LmZuG5PPUuX0U=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201200000-75907072b045/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/cmd/orb-server/go.mod
+++ b/cmd/orb-server/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7
 	github.com/trustbloc/orb v0.1.3
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220127163805-32a4b54f7dff
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201200000-75907072b045
 )
 
 require (

--- a/cmd/orb-server/go.sum
+++ b/cmd/orb-server/go.sum
@@ -1294,8 +1294,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220127163805-32a4b54f7dff h1:EWFoF/+Z8Yv5aMLdZO2qbu4w9t809sv2x/dSa8oktvI=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220127163805-32a4b54f7dff/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201200000-75907072b045 h1:IL6rRc7Pr8CCecGyzAbKspQQzjcwp4LmZuG5PPUuX0U=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201200000-75907072b045/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/rs/cors v1.7.0
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220127163805-32a4b54f7dff
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201200000-75907072b045
 	github.com/trustbloc/vct v0.1.3
 	go.mongodb.org/mongo-driver v1.8.0
 	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2

--- a/go.sum
+++ b/go.sum
@@ -1287,8 +1287,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220127163805-32a4b54f7dff h1:EWFoF/+Z8Yv5aMLdZO2qbu4w9t809sv2x/dSa8oktvI=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220127163805-32a4b54f7dff/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201200000-75907072b045 h1:IL6rRc7Pr8CCecGyzAbKspQQzjcwp4LmZuG5PPUuX0U=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201200000-75907072b045/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/tidwall/gjson v1.7.4
 	github.com/trustbloc/orb v0.1.4-0.20211201141158-15a02b430f04
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220127163805-32a4b54f7dff
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201200000-75907072b045
 )
 
 require (

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -1558,8 +1558,8 @@ github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/sidetree-core-go v0.7.1-0.20211124193658-d5f6ccf1e554/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220127163805-32a4b54f7dff h1:EWFoF/+Z8Yv5aMLdZO2qbu4w9t809sv2x/dSa8oktvI=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220127163805-32a4b54f7dff/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201200000-75907072b045 h1:IL6rRc7Pr8CCecGyzAbKspQQzjcwp4LmZuG5PPUuX0U=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201200000-75907072b045/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=


### PR DESCRIPTION
Should fix the error: invalid number of parts[3] for Orb identifier.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>