### PR TITLE
fix: Add minimum activity age param to anchor sync task

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -725,8 +725,9 @@ func startOrbServices(parameters *orbParameters) error {
 
 	err = anchorsynctask.Register(
 		anchorsynctask.Config{
-			ServiceIRI: apServiceIRI,
-			Interval:   parameters.syncPeriod,
+			ServiceIRI:     apServiceIRI,
+			Interval:       parameters.anchorSyncPeriod,
+			MinActivityAge: parameters.anchorSyncMinActivityAge,
 		},
 		taskMgr, apClient, apStore, storeProviders.provider,
 		func() apspi.InboxHandler {

--- a/pkg/activitypub/service/anchorsynctask/anchorsynctask_test.go
+++ b/pkg/activitypub/service/anchorsynctask/anchorsynctask_test.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/hyperledger/aries-framework-go/pkg/mock/storage"
 	"github.com/stretchr/testify/require"
@@ -105,13 +106,20 @@ func TestRun(t *testing.T) {
 		handler.duplicateAnchors = append(handler.duplicateAnchors, announceActivities[1], createActivities[1])
 
 		task, err := newTask(
-			serviceIRI, apClient, apStore, storage.NewMockStoreProvider(),
+			serviceIRI, apClient, apStore, storage.NewMockStoreProvider(), time.Second,
 			func() spi.InboxHandler {
 				return handler
 			},
 		)
 		require.NoError(t, err)
 		require.NotNil(t, task)
+
+		task.run()
+
+		require.Emptyf(t, len(handler.activities),
+			"Should not have processed any activities since the minimum activity age is one second")
+
+		time.Sleep(time.Second)
 
 		task.run()
 
@@ -127,7 +135,7 @@ func TestRun(t *testing.T) {
 		handler := &mockHandler{}
 
 		task, err := newTask(
-			serviceIRI, apClient, s, storage.NewMockStoreProvider(),
+			serviceIRI, apClient, s, storage.NewMockStoreProvider(), time.Nanosecond,
 			func() spi.InboxHandler {
 				return handler
 			},
@@ -152,7 +160,7 @@ func TestRun(t *testing.T) {
 		handler := &mockHandler{}
 
 		task, err := newTask(
-			serviceIRI, apClient, s, storage.NewMockStoreProvider(),
+			serviceIRI, apClient, s, storage.NewMockStoreProvider(), time.Nanosecond,
 			func() spi.InboxHandler {
 				return handler
 			},
@@ -173,7 +181,7 @@ func TestRun(t *testing.T) {
 		handler := &mockHandler{}
 
 		task, err := newTask(
-			serviceIRI, apClient, apStore, storage.NewMockStoreProvider(),
+			serviceIRI, apClient, apStore, storage.NewMockStoreProvider(), time.Nanosecond,
 			func() spi.InboxHandler {
 				return handler
 			},

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -92,6 +92,10 @@ services:
       # we're following.
       # Default value: 1m.
       - ANCHOR_EVENT_SYNC_INTERVAL=1m
+      # ANCHOR_EVENT_MIN_ACTIVITY_AGE is the minimum age of an activity to be synchronized. The activity will be processed
+      # only if its age is greater than this value.
+      # Default value: 1m
+      - ANCHOR_EVENT_MIN_ACTIVITY_AGE=1m
       # VCT_MONITORING_INTERVAL is the interval (period) in which proofs are monitored from various VCTs that promised
       # to anchor a VC by a certain time.
       # Default value: 10s.
@@ -215,6 +219,10 @@ services:
       # we're following.
       # Default value: 1m.
       - ANCHOR_EVENT_SYNC_INTERVAL=1m
+      # ANCHOR_EVENT_MIN_ACTIVITY_AGE is the minimum age of an activity to be synchronized. The activity will be processed
+      # only if its age is greater than this value.
+      # Default value: 1m
+      - ANCHOR_EVENT_MIN_ACTIVITY_AGE=1m
       # VCT_MONITORING_INTERVAL is the interval (period) in which proofs are monitored from various VCTs that promised
       # to anchor a VC by a certain time.
       # Default value: 10s.
@@ -345,6 +353,10 @@ services:
       # we're following.
       # Default value: 1m.
       - ANCHOR_EVENT_SYNC_INTERVAL=1m
+      # ANCHOR_EVENT_MIN_ACTIVITY_AGE is the minimum age of an activity to be synchronized. The activity will be processed
+      # only if its age is greater than this value.
+      # Default value: 1m
+      - ANCHOR_EVENT_MIN_ACTIVITY_AGE=1m
     ports:
       - 48826:80
       - 48827:48827
@@ -442,6 +454,10 @@ services:
       # we're following.
       # Default value: 1m.
       - ANCHOR_EVENT_SYNC_INTERVAL=1m
+      # ANCHOR_EVENT_MIN_ACTIVITY_AGE is the minimum age of an activity to be synchronized. The activity will be processed
+      # only if its age is greater than this value.
+      # Default value: 1m
+      - ANCHOR_EVENT_MIN_ACTIVITY_AGE=1m
     ports:
       - 48926:80
       - 48927:48927
@@ -555,6 +571,10 @@ services:
       # we're following.
       # Default value: 1m.
       - ANCHOR_EVENT_SYNC_INTERVAL=1m
+      # ANCHOR_EVENT_MIN_ACTIVITY_AGE is the minimum age of an activity to be synchronized. The activity will be processed
+      # only if its age is greater than this value.
+      # Default value: 1m
+      - ANCHOR_EVENT_MIN_ACTIVITY_AGE=1m
     ports:
       - 48626:443
       - 48627:48627
@@ -664,6 +684,10 @@ services:
       # we're following.
       # Default value: 1m.
       - ANCHOR_EVENT_SYNC_INTERVAL=1m
+      # ANCHOR_EVENT_MIN_ACTIVITY_AGE is the minimum age of an activity to be synchronized. The activity will be processed
+      # only if its age is greater than this value.
+      # Default value: 1m
+      - ANCHOR_EVENT_MIN_ACTIVITY_AGE=1m
     ports:
       - 48726:443
       - 48727:48727
@@ -770,6 +794,10 @@ services:
       # we're following.
       # Default value: 1m.
       - ANCHOR_EVENT_SYNC_INTERVAL=10s
+      # ANCHOR_EVENT_MIN_ACTIVITY_AGE is the minimum age of an activity to be synchronized. The activity will be processed
+      # only if its age is greater than this value.
+      # Default value: 1m
+      - ANCHOR_EVENT_MIN_ACTIVITY_AGE=20s
       # WITNESS_POLICY_CACHE_EXPIRATION sets the expiration time of witness policy cache.
       # Default value: 30s. Set the cache expiration very low since we're updating the policy frequently during the test.
       - WITNESS_POLICY_CACHE_EXPIRATION=500ms


### PR DESCRIPTION
A minimum activity age parameter is added to the anchor sync task such that the activity needs to be older than this value before it is processed (according to the "published" time of the activity).

For example, the anchor sync task should not process activities that are younger than 1 minute. The minimum age is configurable via the ANCHOR_EVENT_MIN_ACTIVITY_AGE startup parameter (default 1m).

closes #1085

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>