### PR TITLE
test: Support for reading compressed DID file

### DIFF
--- a/test/bdd/utils.go
+++ b/test/bdd/utils.go
@@ -7,8 +7,12 @@ SPDX-License-Identifier: Apache-2.0
 package bdd
 
 import (
+	"archive/zip"
 	"bytes"
+	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"os/exec"
 )
 
@@ -33,4 +37,34 @@ func executeCMD(path string, args ...string) (string, error) {
 	}
 
 	return out.String(), nil
+}
+
+func readZip(b []byte) (io.Reader, error) {
+	zipReader, e := zip.NewReader(bytes.NewReader(b), int64(len(b)))
+	if e != nil {
+		return nil, e
+	}
+
+	// Read all the files from zip archive
+	for _, zipFile := range zipReader.File {
+		logger.Infof("Reading file from ZIP: [%s]", zipFile.Name)
+
+		unzippedFileBytes, e := readZipFile(zipFile)
+		if e != nil {
+			return nil, e
+		}
+
+		return bytes.NewReader(unzippedFileBytes), nil
+	}
+
+	return nil, errors.New("no files found in ZIP")
+}
+
+func readZipFile(zf *zip.File) ([]byte, error) {
+	f, err := zf.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return ioutil.ReadAll(f)
 }


### PR DESCRIPTION
The BDD step verify_created_dids_from_file now supports ZIP files as well as plain text files.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>