### PR TITLE
test: Add env vars to BDD step create_dids_to_file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ test/bdd/fixtures/export
 test/bdd/website
 test/bdd/OrbBDDTestKey.key
 /test/bdd/fixtures/mongodbbackup/
+/test/bdd/fixtures/dids.txt

--- a/test/bdd/did_orb_steps.go
+++ b/test/bdd/did_orb_steps.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1271,9 +1272,19 @@ func (d *DIDOrbSteps) createDIDDocumentsAtURLs(urls []string, num int, concurren
 	return nil
 }
 
-func (d *DIDOrbSteps) createDIDDocumentsAndStoreDIDsToFile(strURLs string, num int, concurrency int, file string) error {
-	if err := d.state.resolveVarsInExpression(&strURLs, &file); err != nil {
+func (d *DIDOrbSteps) createDIDDocumentsAndStoreDIDsToFile(strURLs, strNum, strConcurrency string, file string) error {
+	if err := d.state.resolveVarsInExpression(&strURLs, &file, &strNum, &strConcurrency); err != nil {
 		return err
+	}
+
+	num, err := strconv.Atoi(strNum)
+	if err != nil {
+		return fmt.Errorf("invalid value for number of DIDs: %w", err)
+	}
+
+	concurrency, err := strconv.Atoi(strConcurrency)
+	if err != nil {
+		return fmt.Errorf("invalid value for concurrency: %w", err)
 	}
 
 	urls := strings.Split(strURLs, ",")
@@ -1289,7 +1300,7 @@ func (d *DIDOrbSteps) createDIDDocumentsAndStoreDIDsToFile(strURLs string, num i
 		localUrls[i] = fmt.Sprintf("%s/sidetree/v1/operations", localURL)
 	}
 
-	err := d.createDIDDocumentsAtURLs(localUrls, num, concurrency)
+	err = d.createDIDDocumentsAtURLs(localUrls, num, concurrency)
 	if err != nil {
 		return err
 	}
@@ -1869,7 +1880,7 @@ func (d *DIDOrbSteps) RegisterSteps(s *godog.Suite) {
 	s.Step(`^client sends request to "([^"]*)" to resolve DID document with initial state$`, d.resolveDIDDocumentWithInitialValue)
 	s.Step(`^check for request success`, d.checkResponseIsSuccess)
 	s.Step(`^client sends request to "([^"]*)" to create (\d+) DID documents using (\d+) concurrent requests$`, d.createDIDDocuments)
-	s.Step(`^client sends request to domains "([^"]*)" to create (\d+) DID documents using (\d+) concurrent requests storing the dids to file "([^"]*)"$`, d.createDIDDocumentsAndStoreDIDsToFile)
+	s.Step(`^client sends request to domains "([^"]*)" to create "([^"]*)" DID documents using "([^"]*)" concurrent requests storing the dids to file "([^"]*)"$`, d.createDIDDocumentsAndStoreDIDsToFile)
 	s.Step(`^client sends request to "([^"]*)" to verify the DID documents that were created$`, d.verifyDIDDocuments)
 	s.Step(`^client sends request to domains "([^"]*)" to verify the DID documents that were created from file "([^"]*)"$`, d.verifyDIDDocumentsFromFile)
 	s.Step(`^client sends request to "([^"]*)" to update the DID documents that were created with public key ID "([^"]*)" using (\d+) concurrent requests$`, d.updateDIDDocuments)

--- a/test/bdd/features/create-dids-to-file.feature
+++ b/test/bdd/features/create-dids-to-file.feature
@@ -10,7 +10,7 @@ Feature:
     Given the authorization bearer token for "GET" requests to path "/sidetree/v1/identifiers" is set to "${ORB_BACKUP_READ_TOKEN}"
     And the authorization bearer token for "POST" requests to path "/sidetree/v1/operations" is set to "${ORB_BACKUP_WRITE_TOKEN}"
 
-    When client sends request to domains "${ORB_BACKUP_DID_DOMAINS}" to create 50 DID documents using 5 concurrent requests storing the dids to file "${ORB_BACKUP_CREATED_DIDS_FILE}"
+    When client sends request to domains "${ORB_BACKUP_DID_DOMAINS}" to create "${ORB_BACKUP_NUM_DIDS}" DID documents using "${ORB_BACKUP_CONCURRENCY}" concurrent requests storing the dids to file "${ORB_BACKUP_CREATED_DIDS_FILE}"
     Then client sends request to domains "${ORB_BACKUP_DID_DOMAINS}" to verify the DID documents that were created from file "${ORB_BACKUP_CREATED_DIDS_FILE}"
 
   @verify_created_dids_from_file
@@ -40,5 +40,5 @@ Feature:
     And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain1IRI}","to":"${domain2IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain2IRI}"}'
     When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
-    Then client sends request to domains "https://orb.domain1.com" to create 50 DID documents using 5 concurrent requests storing the dids to file "./fixtures/dids.txt"
+    Then client sends request to domains "https://orb.domain1.com" to create "50" DID documents using "5" concurrent requests storing the dids to file "./fixtures/dids.txt"
     And client sends request to domains "https://orb.domain1.com" to verify the DID documents that were created from file "./fixtures/dids.txt"


### PR DESCRIPTION
The number of DIDs to create and the concurrency are now configurable using the environment variables ORB_BACKUP_NUM_DIDS and ORB_BACKUP_CONCURRENCY.

closes #1093

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>