### PR TITLE
fix: Don't announce to the actor in the Create activity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,8 @@ bdd-test: generate-test-keys orb-docker orb-driver-docker build-orb-cli-binaries
 clean:
 	rm -Rf ./.build
 	rm -Rf ./test/bdd/docker-compose.log
-	rm -Rf ./test/bdd/fixtures/keys/tls
-	rm -Rf ./test/bdd/fixtures/data/ipfs
+	rm -Rf ./test/bdd/fixtures/keys
+	rm -Rf ./test/bdd/fixtures/data
 	rm -Rf ./test/bdd/fixtures/mongodbbackup
+	rm -Rf ./test/bdd/fixtures/export
+	rm -Rf ./test/bdd/website

--- a/cmd/orb-server/startcmd/params.go
+++ b/cmd/orb-server/startcmd/params.go
@@ -38,7 +38,7 @@ const (
 	defaultAnchorSyncMinActivityAge         = time.Minute
 	defaultVCTMonitoringInterval            = 10 * time.Second
 	defaultAnchorStatusMonitoringInterval   = 5 * time.Second
-	defaultAnchorStatusInProcessGracePeriod = 10 * time.Second
+	defaultAnchorStatusInProcessGracePeriod = time.Minute
 	mqDefaultMaxConnectionSubscriptions     = 1000
 	mqDefaultPublisherChannelPoolSize       = 25
 	defaultActivityPubClientCacheSize       = 100
@@ -87,7 +87,7 @@ const (
 	anchorStatusInProcessGracePeriodFlagName  = "anchor-status-in-process-grace-period"
 	anchorStatusInProcessGracePeriodEnvKey    = "ANCHOR_STATUS_IN_PROCESS_GRACE_PERIOD"
 	anchorStatusInProcessGracePeriodFlagUsage = "The period in which witnesses will not be re-selected for 'in-process' anchors." +
-		"Defaults to 10s if not set. " +
+		"Defaults to 1m if not set. " +
 		commonEnvVarUsageText + anchorStatusInProcessGracePeriodEnvKey
 
 	kmsStoreEndpointFlagName  = "kms-store-endpoint"
@@ -299,7 +299,7 @@ const (
 	maxWitnessDelayFlagName      = "max-witness-delay"
 	maxWitnessDelayEnvKey        = "MAX_WITNESS_DELAY"
 	maxWitnessDelayFlagShorthand = "w"
-	maxWitnessDelayFlagUsage     = "Maximum witness response time (in seconds). " + commonEnvVarUsageText + maxWitnessDelayEnvKey
+	maxWitnessDelayFlagUsage     = "Maximum witness response time (default 10m). " + commonEnvVarUsageText + maxWitnessDelayEnvKey
 
 	signWithLocalWitnessFlagName      = "sign-with-local-witness"
 	signWithLocalWitnessEnvKey        = "SIGN_WITH_LOCAL_WITNESS"
@@ -739,19 +739,9 @@ func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 		batchWriterTimeout = time.Duration(timeout) * time.Millisecond
 	}
 
-	maxWitnessDelayStr, err := cmdutils.GetUserSetVarFromString(cmd, maxWitnessDelayFlagName, maxWitnessDelayEnvKey, true)
+	maxWitnessDelay, err := getDuration(cmd, maxWitnessDelayFlagName, maxWitnessDelayEnvKey, defaultMaxWitnessDelay)
 	if err != nil {
 		return nil, err
-	}
-
-	maxWitnessDelay := defaultMaxWitnessDelay
-	if maxWitnessDelayStr != "" {
-		delay, parseErr := strconv.ParseUint(maxWitnessDelayStr, 10, 32)
-		if parseErr != nil {
-			return nil, fmt.Errorf("invalid max witness delay format: %s", parseErr.Error())
-		}
-
-		maxWitnessDelay = time.Duration(delay) * time.Second
 	}
 
 	signWithLocalWitnessStr, err := cmdutils.GetUserSetVarFromString(cmd, signWithLocalWitnessFlagName, signWithLocalWitnessEnvKey, true)

--- a/cmd/orb-server/startcmd/params_test.go
+++ b/cmd/orb-server/startcmd/params_test.go
@@ -258,7 +258,7 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 		err := startCmd.Execute()
 
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "invalid max witness delay format")
+		require.Contains(t, err.Error(), "invalid duration")
 	})
 
 	t.Run("test invalid sign with local witness flag", func(t *testing.T) {
@@ -271,7 +271,7 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 			"--" + externalEndpointFlagName, "orb.example.com",
 			"--" + casTypeFlagName, "ipfs",
 			"--" + ipfsURLFlagName, "localhost:8081",
-			"--" + maxWitnessDelayFlagName, "5",
+			"--" + maxWitnessDelayFlagName, "1m",
 			"--" + signWithLocalWitnessFlagName, "abc",
 			"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
 			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption,
@@ -773,7 +773,7 @@ func TestStartCmdWithInvalidCIDVersion(t *testing.T) {
 		"--" + vctURLFlagName, "localhost:8081",
 		"--" + cidVersionFlagName, "-1",
 		"--" + batchWriterTimeoutFlagName, "700",
-		"--" + maxWitnessDelayFlagName, "600",
+		"--" + maxWitnessDelayFlagName, "1m",
 		"--" + signWithLocalWitnessFlagName, "false",
 		"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
 		"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption,
@@ -1420,7 +1420,7 @@ func setEnvVars(t *testing.T, databaseType, casType, replicateLocalCASToIPFS str
 	err = os.Setenv(batchWriterTimeoutEnvKey, "2000")
 	require.NoError(t, err)
 
-	err = os.Setenv(maxWitnessDelayEnvKey, "600")
+	err = os.Setenv(maxWitnessDelayEnvKey, "10m")
 	require.NoError(t, err)
 
 	err = os.Setenv(signWithLocalWitnessEnvKey, "true")
@@ -1516,7 +1516,7 @@ func getTestArgs(ipfsURL, casType, localCASReplicateInIPFSEnabled, databaseType,
 		"--" + ipfsURLFlagName, ipfsURL,
 		"--" + cidVersionFlagName, "0",
 		"--" + batchWriterTimeoutFlagName, "700",
-		"--" + maxWitnessDelayFlagName, "600",
+		"--" + maxWitnessDelayFlagName, "1m",
 		"--" + signWithLocalWitnessFlagName, "false",
 		"--" + casTypeFlagName, casType,
 		"--" + didNamespaceFlagName, "namespace",

--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -139,11 +139,10 @@ import (
 const (
 	masterKeyURI = "local-lock://custom/master/key/"
 
-	defaultMaxWitnessDelay                  = 600 * time.Second // 10 minutes
+	defaultMaxWitnessDelay                  = 10 * time.Minute
 	defaultSyncTimeout                      = 1
 	defaulthttpSignaturesEnabled            = true
 	defaultDidDiscoveryEnabled              = false
-	defaultCreateDocumentStoreEnabled       = false
 	defaultUnpublishedOperationStoreEnabled = false
 	defaultIncludeUnpublishedOperations     = false
 	defaultIncludePublishedOperations       = false
@@ -1401,7 +1400,7 @@ func NewAcceptRejectHandler(targetType string, policy acceptRejectPolicy, config
 }
 
 type activityLogger interface {
-	Infof(msg string, args ...interface{})
+	Debugf(msg string, args ...interface{})
 	Warnf(msg string, args ...interface{})
 }
 
@@ -1415,7 +1414,7 @@ func monitorActivities(activityChan <-chan *vocab.ActivityType, l activityLogger
 			l.Warnf("Received activity [%s] of type %s from [%s]",
 				activity.ID(), activity.Type(), activity.Actor())
 		default:
-			l.Infof("Received activity [%s] of type %s from [%s]",
+			l.Debugf("Received activity [%s] of type %s from [%s]",
 				activity.ID(), activity.Type(), activity.Actor())
 		}
 	}

--- a/cmd/orb-server/startcmd/start_test.go
+++ b/cmd/orb-server/startcmd/start_test.go
@@ -200,7 +200,7 @@ type mockActivityLogger struct {
 	mutex sync.Mutex
 }
 
-func (m *mockActivityLogger) Infof(msg string, args ...interface{}) {
+func (m *mockActivityLogger) Debugf(msg string, args ...interface{}) {
 	m.mutex.Lock()
 	m.infos = append(m.infos, fmt.Sprintf(msg, args...))
 	m.mutex.Unlock()

--- a/pkg/activitypub/resthandler/outboxhandler.go
+++ b/pkg/activitypub/resthandler/outboxhandler.go
@@ -21,7 +21,7 @@ import (
 )
 
 type outbox interface {
-	Post(activity *vocab.ActivityType) (*url.URL, error)
+	Post(activity *vocab.ActivityType, exclude ...*url.URL) (*url.URL, error)
 }
 
 // Outbox implements a REST handler for posts to a service's outbox.

--- a/pkg/activitypub/service/activityhandler/inboxhandler.go
+++ b/pkg/activitypub/service/activityhandler/inboxhandler.go
@@ -751,7 +751,8 @@ func (h *Inbox) announceAnchorEvent(create *vocab.ActivityType) error {
 		vocab.WithPublishedTime(&published),
 	)
 
-	if _, err := h.outbox.Post(announce); err != nil {
+	// Announce the activity to our followers but exclude the actor of the Create.
+	if _, err := h.outbox.Post(announce, create.Actor()); err != nil {
 		return orberrors.NewTransient(err)
 	}
 

--- a/pkg/activitypub/service/mocks/mockoutbox.go
+++ b/pkg/activitypub/service/mocks/mockoutbox.go
@@ -51,7 +51,7 @@ func (m *Outbox) Activities() Activities {
 
 // Post post an activity to the outbox. The activity is simply stored
 // so that it may be retrieved by the Activies function.
-func (m *Outbox) Post(activity *vocab.ActivityType) (*url.URL, error) {
+func (m *Outbox) Post(activity *vocab.ActivityType, _ ...*url.URL) (*url.URL, error) {
 	if m.err != nil {
 		return nil, m.err
 	}

--- a/pkg/activitypub/service/outbox/outbox_test.go
+++ b/pkg/activitypub/service/outbox/outbox_test.go
@@ -551,7 +551,8 @@ func TestDeduplicate(t *testing.T) {
 	service1URL := testutil.MustParseURL("http://localhost:8002/services/service1")
 	service2URL := testutil.MustParseURL("http://localhost:8002/services/service2")
 
-	require.Len(t, deduplicate([]*url.URL{service1URL, service2URL, service1URL, service2URL}), 2)
+	require.Len(t, deduplicateAndFilter([]*url.URL{service1URL, service2URL, service1URL, service2URL}, nil), 2)
+	require.Len(t, deduplicateAndFilter([]*url.URL{service1URL, service2URL, service1URL}, []*url.URL{service2URL}), 1)
 }
 
 func TestResolveInboxes(t *testing.T) {
@@ -577,7 +578,7 @@ func TestResolveInboxes(t *testing.T) {
 
 		activityStore.QueryReferencesReturns(nil, errTransient)
 
-		inboxes, err := ob.resolveInboxes([]*url.URL{testutil.NewMockID(service1URL, resthandler.FollowersPath)})
+		inboxes, err := ob.resolveInboxes([]*url.URL{testutil.NewMockID(service1URL, resthandler.FollowersPath)}, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errTransient.Error())
 		require.Empty(t, inboxes)
@@ -588,7 +589,7 @@ func TestResolveInboxes(t *testing.T) {
 
 		activityStore.QueryReferencesReturns(nil, errTransient)
 
-		inboxes, err := ob.resolveInboxes([]*url.URL{testutil.NewMockID(service1URL, resthandler.FollowersPath)})
+		inboxes, err := ob.resolveInboxes([]*url.URL{testutil.NewMockID(service1URL, resthandler.FollowersPath)}, nil)
 		require.NoError(t, err)
 		require.Empty(t, inboxes)
 	})

--- a/pkg/activitypub/service/spi/spi.go
+++ b/pkg/activitypub/service/spi/spi.go
@@ -30,7 +30,7 @@ type Outbox interface {
 	ServiceLifecycle
 
 	// Post posts an activity to the outbox and returns the ID of the activity.
-	Post(activity *vocab.ActivityType) (*url.URL, error)
+	Post(activity *vocab.ActivityType, exclude ...*url.URL) (*url.URL, error)
 }
 
 // Inbox defines the functions for an ActivityPub inbox.

--- a/pkg/anchor/handler/proof/handler.go
+++ b/pkg/anchor/handler/proof/handler.go
@@ -202,7 +202,7 @@ func (h *WitnessProofHandler) handleWitnessPolicy(anchorEvent *vocab.AnchorEvent
 		return fmt.Errorf("failed to get status for anchor event [%s]: %w", anchorID, err)
 	}
 
-	logger.Debugf("Current status for VC [%s] is [%s]", anchorID)
+	logger.Debugf("Current status for VC [%s] is [%s]", anchorID, status)
 
 	if status == proofapi.AnchorIndexStatusCompleted {
 		logger.Infof("VC status has already been marked as completed for [%s]", anchorID)

--- a/pkg/anchor/witness/policy/inspector/inspector.go
+++ b/pkg/anchor/witness/policy/inspector/inspector.go
@@ -49,7 +49,7 @@ type witnessPolicy interface {
 
 // Outbox defines outbox.
 type Outbox interface {
-	Post(activity *vocab.ActivityType) (*url.URL, error)
+	Post(activity *vocab.ActivityType, exclude ...*url.URL) (*url.URL, error)
 }
 
 type outboxProvider func() Outbox
@@ -110,8 +110,8 @@ func (c *Inspector) postOfferActivity(anchorEvent *vocab.AnchorEventType, witnes
 		return fmt.Errorf("failed to post additional offer for anchor event[%s]: %w", anchorEvent.Index(), err)
 	}
 
-	logger.Debugf("created additional pre-announce activity for anchor event[%s], post id[%s]",
-		anchorEvent.Index(), postID)
+	logger.Infof("created additional pre-announce activity for anchor event[%s], post id[%s], to%s",
+		anchorEvent.Index(), postID, witnessesIRI)
 
 	return nil
 }

--- a/pkg/anchor/witness/policy/inspector/inspector_test.go
+++ b/pkg/anchor/witness/policy/inspector/inspector_test.go
@@ -297,7 +297,7 @@ type mockOutbox struct {
 	Err error
 }
 
-func (m *mockOutbox) Post(activity *vocab.ActivityType) (*url.URL, error) {
+func (m *mockOutbox) Post(activity *vocab.ActivityType, _ ...*url.URL) (*url.URL, error) {
 	if m.Err != nil {
 		return nil, m.Err
 	}

--- a/pkg/anchor/writer/writer.go
+++ b/pkg/anchor/writer/writer.go
@@ -128,7 +128,7 @@ type monitoringSvc interface {
 }
 
 type outbox interface {
-	Post(activity *vocab.ActivityType) (*url.URL, error)
+	Post(activity *vocab.ActivityType, exclude ...*url.URL) (*url.URL, error)
 }
 
 type opProcessor interface {

--- a/pkg/anchor/writer/writer_test.go
+++ b/pkg/anchor/writer/writer_test.go
@@ -1713,7 +1713,7 @@ type mockOutbox struct {
 	Err error
 }
 
-func (m *mockOutbox) Post(activity *vocab.ActivityType) (*url.URL, error) {
+func (m *mockOutbox) Post(activity *vocab.ActivityType, _ ...*url.URL) (*url.URL, error) {
 	if m.Err != nil {
 		return nil, m.Err
 	}

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -80,7 +80,7 @@ type metricsProvider interface {
 
 // Outbox defines an ActivityPub outbox.
 type Outbox interface {
-	Post(activity *vocab.ActivityType) (*url.URL, error)
+	Post(activity *vocab.ActivityType, exclude ...*url.URL) (*url.URL, error)
 }
 
 type resourceResolver interface {


### PR DESCRIPTION
When announcing a Create activity to followers, the actor in the Create activity is excluded
since this results in the actor processing the same anchor twice.

closes #1095

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>