### PR TITLE
feat: Check if anchor exists if 0 operations processed

### DIFF
--- a/cmd/orb-cli/go.mod
+++ b/cmd/orb-cli/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/square/go-jose/v3 v3.0.0-20200630053402-0a67ce9b0693 // indirect
 	github.com/teserakt-io/golang-ed25519 v0.0.0-20210104091850-3888c087a4c8 // indirect
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201223130-9cef7f4cec7f // indirect
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220204221628-a3c5de52192b // indirect
 	github.com/trustbloc/vct v0.1.3 // indirect
 	github.com/whyrusleeping/tar-utils v0.0.0-20180509141711-8c6c8ba81d5c // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/cmd/orb-cli/go.sum
+++ b/cmd/orb-cli/go.sum
@@ -1291,8 +1291,8 @@ github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201200000-75907072b045/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201223130-9cef7f4cec7f h1:7+fwfRC9m2iVN1JbKzOu8QkacU7gdknfYREN8XXdPhw=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201223130-9cef7f4cec7f/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220204221628-a3c5de52192b h1:w7IZk8s/JQ6DEUnrtaM9m9twwEbeeEJZ/ecoZofpeL8=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220204221628-a3c5de52192b/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/cmd/orb-driver/go.mod
+++ b/cmd/orb-driver/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7
 	github.com/trustbloc/orb v0.1.4-0.20220201200943-513f238cd9ed
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201223130-9cef7f4cec7f
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220204221628-a3c5de52192b
 )
 
 require (

--- a/cmd/orb-driver/go.sum
+++ b/cmd/orb-driver/go.sum
@@ -1286,8 +1286,8 @@ github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201200000-75907072b045/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201223130-9cef7f4cec7f h1:7+fwfRC9m2iVN1JbKzOu8QkacU7gdknfYREN8XXdPhw=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201223130-9cef7f4cec7f/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220204221628-a3c5de52192b h1:w7IZk8s/JQ6DEUnrtaM9m9twwEbeeEJZ/ecoZofpeL8=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220204221628-a3c5de52192b/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/cmd/orb-server/go.mod
+++ b/cmd/orb-server/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7
 	github.com/trustbloc/orb v0.1.3
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201223130-9cef7f4cec7f
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220204221628-a3c5de52192b
 )
 
 require (

--- a/cmd/orb-server/go.sum
+++ b/cmd/orb-server/go.sum
@@ -1294,8 +1294,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201223130-9cef7f4cec7f h1:7+fwfRC9m2iVN1JbKzOu8QkacU7gdknfYREN8XXdPhw=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201223130-9cef7f4cec7f/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220204221628-a3c5de52192b h1:w7IZk8s/JQ6DEUnrtaM9m9twwEbeeEJZ/ecoZofpeL8=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220204221628-a3c5de52192b/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/rs/cors v1.7.0
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.7
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201223130-9cef7f4cec7f
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220204221628-a3c5de52192b
 	github.com/trustbloc/vct v0.1.3
 	go.mongodb.org/mongo-driver v1.8.0
 	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2

--- a/go.sum
+++ b/go.sum
@@ -1287,8 +1287,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3O60k=
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201223130-9cef7f4cec7f h1:7+fwfRC9m2iVN1JbKzOu8QkacU7gdknfYREN8XXdPhw=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201223130-9cef7f4cec7f/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220204221628-a3c5de52192b h1:w7IZk8s/JQ6DEUnrtaM9m9twwEbeeEJZ/ecoZofpeL8=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220204221628-a3c5de52192b/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/pkg/activitypub/service/anchorsynctask/activitysynctask_test.go
+++ b/pkg/activitypub/service/anchorsynctask/activitysynctask_test.go
@@ -228,18 +228,18 @@ func (m *mockHandler) HandleCreateActivity(src *url.URL, a *vocab.ActivityType, 
 	return nil
 }
 
-func (m *mockHandler) HandleAnnounceActivity(src *url.URL, a *vocab.ActivityType) error {
+func (m *mockHandler) HandleAnnounceActivity(src *url.URL, a *vocab.ActivityType) (int, error) {
 	if m.err != nil {
-		return m.err
+		return 0, m.err
 	}
 
 	if m.exists(a) {
-		return spi.ErrDuplicateAnchorEvent
+		return 0, spi.ErrDuplicateAnchorEvent
 	}
 
 	m.activities = append(m.activities, a)
 
-	return nil
+	return 1, nil
 }
 
 func (m *mockHandler) exists(activity *vocab.ActivityType) bool {

--- a/pkg/activitypub/service/spi/spi.go
+++ b/pkg/activitypub/service/spi/spi.go
@@ -84,7 +84,7 @@ var ErrDuplicateAnchorEvent = errors.New("anchor event already handled")
 // InboxHandler defines functions for handling Create and Announce activities.
 type InboxHandler interface {
 	HandleCreateActivity(source *url.URL, create *vocab.ActivityType, announce bool) error
-	HandleAnnounceActivity(source *url.URL, create *vocab.ActivityType) error
+	HandleAnnounceActivity(source *url.URL, create *vocab.ActivityType) (numProcessed int, err error)
 }
 
 // UndeliverableActivityHandler handles undeliverable activities.

--- a/pkg/versions/1_0/txnprocessor/txnprocessor_test.go
+++ b/pkg/versions/1_0/txnprocessor/txnprocessor_test.go
@@ -29,7 +29,7 @@ func TestTxnProcessor_Process(t *testing.T) {
 		}
 
 		p := New(providers)
-		err := p.Process(txn.SidetreeTxn{})
+		_, err := p.Process(txn.SidetreeTxn{})
 		require.NoError(t, err)
 	})
 
@@ -40,7 +40,7 @@ func TestTxnProcessor_Process(t *testing.T) {
 		}
 
 		p := New(providers)
-		err := p.Process(txn.SidetreeTxn{AnchorString: anchorString}, suffix)
+		_, err := p.Process(txn.SidetreeTxn{AnchorString: anchorString}, suffix)
 		require.NoError(t, err)
 	})
 
@@ -51,7 +51,7 @@ func TestTxnProcessor_Process(t *testing.T) {
 		}
 
 		p := New(providers)
-		err := p.Process(txn.SidetreeTxn{AnchorString: anchorString}, "different")
+		_, err := p.Process(txn.SidetreeTxn{AnchorString: anchorString}, "different")
 		require.NoError(t, err)
 	})
 
@@ -68,7 +68,7 @@ func TestTxnProcessor_Process(t *testing.T) {
 		}
 
 		p := New(providers)
-		err := p.Process(txn.SidetreeTxn{})
+		_, err := p.Process(txn.SidetreeTxn{})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errExpected.Error())
 	})
@@ -83,7 +83,7 @@ func TestProcessTxnOperations(t *testing.T) {
 		}
 
 		p := New(providers)
-		err := p.processTxnOperations([]*operation.AnchoredOperation{{UniqueSuffix: "abc"}},
+		_, err := p.processTxnOperations([]*operation.AnchoredOperation{{UniqueSuffix: "abc"}},
 			&txn.SidetreeTxn{AnchorString: anchorString})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to store operation from anchor string")
@@ -98,7 +98,7 @@ func TestProcessTxnOperations(t *testing.T) {
 		}
 
 		p := New(providers)
-		err := p.processTxnOperations([]*operation.AnchoredOperation{{UniqueSuffix: suffix}},
+		_, err := p.processTxnOperations([]*operation.AnchoredOperation{{UniqueSuffix: suffix}},
 			&txn.SidetreeTxn{AnchorString: anchorString})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "get error")
@@ -114,7 +114,7 @@ func TestProcessTxnOperations(t *testing.T) {
 		batchOps, err := p.OperationProtocolProvider.GetTxnOperations(&txn.SidetreeTxn{AnchorString: anchorString})
 		require.NoError(t, err)
 
-		err = p.processTxnOperations(batchOps, &txn.SidetreeTxn{AnchorString: anchorString})
+		_, err = p.processTxnOperations(batchOps, &txn.SidetreeTxn{AnchorString: anchorString})
 		require.NoError(t, err)
 	})
 
@@ -136,7 +136,7 @@ func TestProcessTxnOperations(t *testing.T) {
 			})
 		require.NoError(t, err)
 
-		err = p.processTxnOperations(batchOps,
+		_, err = p.processTxnOperations(batchOps,
 			&txn.SidetreeTxn{AnchorString: anchorString, CanonicalReference: canonicalRef})
 		require.NoError(t, err)
 	})
@@ -155,7 +155,7 @@ func TestProcessTxnOperations(t *testing.T) {
 		// only first operation will be processed, subsequent operations will be discarded
 		batchOps = append(batchOps, batchOps...)
 
-		err = p.processTxnOperations(batchOps, &txn.SidetreeTxn{AnchorString: anchorString})
+		_, err = p.processTxnOperations(batchOps, &txn.SidetreeTxn{AnchorString: anchorString})
 		require.NoError(t, err)
 	})
 
@@ -171,7 +171,7 @@ func TestProcessTxnOperations(t *testing.T) {
 		batchOps, err := p.OperationProtocolProvider.GetTxnOperations(&txn.SidetreeTxn{AnchorString: anchorString})
 		require.NoError(t, err)
 
-		err = p.processTxnOperations(batchOps, &txn.SidetreeTxn{AnchorString: anchorString})
+		_, err = p.processTxnOperations(batchOps, &txn.SidetreeTxn{AnchorString: anchorString})
 		require.NoError(t, err)
 	})
 
@@ -189,7 +189,7 @@ func TestProcessTxnOperations(t *testing.T) {
 		batchOps, err := p.OperationProtocolProvider.GetTxnOperations(&txn.SidetreeTxn{AnchorString: anchorString})
 		require.NoError(t, err)
 
-		err = p.processTxnOperations(batchOps, &txn.SidetreeTxn{AnchorString: anchorString})
+		_, err = p.processTxnOperations(batchOps, &txn.SidetreeTxn{AnchorString: anchorString})
 		require.Error(t, err)
 		require.Contains(t, err.Error(),
 			"failed to delete unpublished operations for anchor string[1.coreIndexURI]: delete all error")

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/tidwall/gjson v1.7.4
 	github.com/trustbloc/orb v0.1.4-0.20220201200943-513f238cd9ed
-	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201223130-9cef7f4cec7f
+	github.com/trustbloc/sidetree-core-go v0.7.1-0.20220204221628-a3c5de52192b
 )
 
 require (

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -1558,8 +1558,8 @@ github.com/trustbloc/edge-core v0.1.7 h1:DzFoB3TsBqRWI7GSkrtPQJi/su84GOFFVsDR6V3
 github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9IvY3u0Sr/2XY=
 github.com/trustbloc/sidetree-core-go v0.6.1-0.20210817155948-c3cb7a03f63b/go.mod h1:uv89fJcqz21OrBqZUyXTPp0BBmyi2xh+Eigy5T/dIsc=
 github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201200000-75907072b045/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201223130-9cef7f4cec7f h1:7+fwfRC9m2iVN1JbKzOu8QkacU7gdknfYREN8XXdPhw=
-github.com/trustbloc/sidetree-core-go v0.7.1-0.20220201223130-9cef7f4cec7f/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220204221628-a3c5de52192b h1:w7IZk8s/JQ6DEUnrtaM9m9twwEbeeEJZ/ecoZofpeL8=
+github.com/trustbloc/sidetree-core-go v0.7.1-0.20220204221628-a3c5de52192b/go.mod h1:4HsMCENpBIjuTsWBe8BauH9xAwdJNLUDEzC4UkGVvVE=
 github.com/trustbloc/vct v0.1.3 h1:5QYeF96cGLxq2jBuPlhDPKydaKwMF1vYSn/bssQNBOE=
 github.com/trustbloc/vct v0.1.3/go.mod h1:gbdyUr5zpoMLTUNgq9YKLciPaiYpvTtooqh7E3wa6pY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=


### PR DESCRIPTION
If the transaction processor determines that all of the operations in the batch are already in local storage then a check is made to see if the anchor is also store. If so, the anchor will not be processed again. (This is most likely due do multiple Announce activities announcing the same anchor event.)

closes #1104

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>