### PR TITLE
feat: Change AnchorEvent attachments to use encoded content

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -792,6 +792,7 @@ func startOrbServices(parameters *orbParameters) error {
 
 	anchorWriter, err := writer.New(parameters.didNamespace,
 		apServiceIRI, casIRI,
+		parameters.anchorAttachmentMediaType,
 		anchorWriterProviders,
 		o.Publisher(), pubSub,
 		parameters.maxWitnessDelay,

--- a/pkg/activitypub/vocab/options_test.go
+++ b/pkg/activitypub/vocab/options_test.go
@@ -67,7 +67,7 @@ func TestNewOptions(t *testing.T) {
 
 	anchorObj, err := NewAnchorObject(
 		sampleGenerator,
-		MustMarshalToDoc(&sampleContentObj{Field1: "value1", Field2: "value2"}),
+		MustMarshalToDoc(&sampleContentObj{Field1: "value1", Field2: "value2"}), JSONMediaType,
 	)
 	require.NoError(t, err)
 	require.Len(t, anchorObj.URL(), 1)

--- a/pkg/activitypub/vocab/util.go
+++ b/pkg/activitypub/vocab/util.go
@@ -8,9 +8,15 @@ package vocab
 
 import (
 	"bytes"
+	"compress/gzip"
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"net/url"
 	"strings"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
 )
 
 // MarshalToDoc marshals the given object to a Document.
@@ -136,4 +142,99 @@ func MustParseURL(raw string) *url.URL {
 	}
 
 	return u
+}
+
+// EncodeDocument encodes the given document using the given media type and returns
+// a string with the encoded data.
+func EncodeDocument(doc Document, mediaType MediaType) (string, error) {
+	docBytes, err := canonicalizer.MarshalCanonical(doc)
+	if err != nil {
+		return "", fmt.Errorf("marshal canonical: %w", err)
+	}
+
+	return Encode(docBytes, mediaType)
+}
+
+// DecodeToDocument decodes the given string using the given media type and returns the decoded document.
+func DecodeToDocument(content string, mediaType MediaType) (Document, error) {
+	docBytes, err := Decode(content, mediaType)
+	if err != nil {
+		return nil, err
+	}
+
+	doc := make(Document)
+
+	err = json.Unmarshal(docBytes, &doc)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal json: %w", err)
+	}
+
+	return doc, nil
+}
+
+// Encode encodes the given content using the given media type and returns
+// a string with the encoded data.
+func Encode(content []byte, mediaType MediaType) (string, error) {
+	switch mediaType {
+	case GzipMediaType:
+		return GzipCompress(content)
+	case JSONMediaType:
+		return string(content), nil
+	case "":
+		return "", fmt.Errorf("media type not specified")
+	default:
+		return "", fmt.Errorf("unsupported media type [%s]", mediaType)
+	}
+}
+
+// Decode decodes the given string using the given media type and returns the decoded bytes.
+func Decode(content string, mediaType MediaType) ([]byte, error) {
+	switch mediaType {
+	case GzipMediaType:
+		return GzipDecompress(content)
+	case JSONMediaType:
+		return []byte(content), nil
+	case "":
+		return nil, fmt.Errorf("media type not specified")
+	default:
+		return nil, fmt.Errorf("unsupported media type [%s]", mediaType)
+	}
+}
+
+// GzipCompress compresses the given content with gzip and returns a base64-encoded string.
+func GzipCompress(docBytes []byte) (string, error) {
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+
+	if _, err := zw.Write(docBytes); err != nil {
+		return "", fmt.Errorf("gzip compress: %w", err)
+	}
+
+	if err := zw.Close(); err != nil {
+		return "", fmt.Errorf("close gzip writer: %w", err)
+	}
+
+	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
+}
+
+// GzipDecompress decompresses the given base64-encoded string with GZIP.
+func GzipDecompress(content string) ([]byte, error) {
+	compressedBytes, err := base64.StdEncoding.DecodeString(content)
+	if err != nil {
+		return nil, fmt.Errorf("base64 decode content: %w", err)
+	}
+
+	buf := bytes.NewBuffer(compressedBytes)
+
+	zr, err := gzip.NewReader(buf)
+	if err != nil {
+		return nil, fmt.Errorf("new gzip reader: %w", err)
+	}
+
+	decompressedBytes, err := ioutil.ReadAll(zr)
+	if err != nil {
+		return nil, fmt.Errorf("gzip decompress: %w", err)
+	}
+
+	return decompressedBytes, nil
 }

--- a/pkg/activitypub/vocab/util_test.go
+++ b/pkg/activitypub/vocab/util_test.go
@@ -105,6 +105,46 @@ func TestMarshal(t *testing.T) {
 	})
 }
 
+func TestEncodeDecodeDocument(t *testing.T) {
+	t.Run("JSON media type", func(t *testing.T) {
+		content, err := EncodeDocument(Document{"field1": "value1", "field2": "value2"}, JSONMediaType)
+		require.NoError(t, err)
+		require.Equal(t, `{"field1":"value1","field2":"value2"}`, content)
+
+		doc, err := DecodeToDocument(content, JSONMediaType)
+		require.NoError(t, err)
+		require.Equal(t, "value1", doc["field1"])
+		require.Equal(t, "value2", doc["field2"])
+	})
+
+	t.Run("GZIP media type", func(t *testing.T) {
+		content, err := EncodeDocument(Document{"field1": "value1", "field2": "value2"}, GzipMediaType)
+		require.NoError(t, err)
+		require.Equal(t, `H4sIAAAAAAAA/6pWSstMzUkxVLJSKkvMKU01VNKBiBjBRIyUagEBAAD//+dwtrYlAAAA`, content)
+
+		doc, err := DecodeToDocument(content, GzipMediaType)
+		require.NoError(t, err)
+		require.Equal(t, "value1", doc["field1"])
+		require.Equal(t, "value2", doc["field2"])
+	})
+
+	t.Run("No media type", func(t *testing.T) {
+		_, err := EncodeDocument(Document{"field1": "value1", "field2": "value2"}, "")
+		require.EqualError(t, err, "media type not specified")
+
+		_, err = DecodeToDocument("xxx", "")
+		require.EqualError(t, err, "media type not specified")
+	})
+
+	t.Run("Unsupported media type", func(t *testing.T) {
+		_, err := EncodeDocument(Document{"field1": "value1", "field2": "value2"}, "invalid")
+		require.EqualError(t, err, "unsupported media type [invalid]")
+
+		_, err = DecodeToDocument("xxx", "invalid")
+		require.EqualError(t, err, "unsupported media type [invalid]")
+	})
+}
+
 type mockObject1 struct {
 	Field1 string
 	Field2 int

--- a/pkg/activitypub/vocab/vocab.go
+++ b/pkg/activitypub/vocab/vocab.go
@@ -77,7 +77,9 @@ const (
 	TypeOffer Type = "Offer"
 	// TypeUndo specifies the "Undo" activity type.
 	TypeUndo Type = "Undo"
+)
 
+const (
 	// RelationshipWitness defines the 'witness' relationship of a Link.
 	RelationshipWitness = "witness"
 )
@@ -105,6 +107,16 @@ const (
 	propertyAttachment   = "attachment"
 	propertyIndex        = "index"
 	propertyParent       = "parent"
+)
+
+// MediaType defines a type of encoding for content embedded within a document.
+type MediaType = string
+
+const (
+	// JSONMediaType indicates that the content is plain JSON string.
+	JSONMediaType MediaType = "application/json"
+	// GzipMediaType indicates that the content is compressed with gzip and base64-encoded.
+	GzipMediaType MediaType = "application/gzip"
 )
 
 func reservedProperties() []string {

--- a/pkg/anchor/anchorevent/anchorevent.go
+++ b/pkg/anchor/anchorevent/anchorevent.go
@@ -29,19 +29,19 @@ type ContentObject struct {
 }
 
 // BuildAnchorEvent builds an anchor event from the given payload, content object, and verifiable credential.
-func BuildAnchorEvent(payload *subject.Payload, gen string,
-	indexContentObj, witnessContentObj vocab.Document) (*vocab.AnchorEventType, error) {
+func BuildAnchorEvent(payload *subject.Payload, gen string, indexContentObj,
+	witnessContentObj vocab.Document, attachmentMediaType vocab.MediaType) (*vocab.AnchorEventType, error) {
 	attributedTo, err := url.Parse(payload.AnchorOrigin)
 	if err != nil {
 		return nil, fmt.Errorf("parse attributed to URL [%s]: %w", payload.AnchorOrigin, err)
 	}
 
-	witnessAnchorObj, err := vocab.NewAnchorObject(gen, witnessContentObj)
+	witnessAnchorObj, err := vocab.NewAnchorObject(gen, witnessContentObj, attachmentMediaType)
 	if err != nil {
 		return nil, fmt.Errorf("create new witness anchor object: %w", err)
 	}
 
-	indexAnchorObj, err := vocab.NewAnchorObject(gen, indexContentObj,
+	indexAnchorObj, err := vocab.NewAnchorObject(gen, indexContentObj, attachmentMediaType,
 		vocab.WithLink(vocab.NewLink(witnessAnchorObj.URL()[0], vocab.RelationshipWitness)))
 	if err != nil {
 		return nil, fmt.Errorf("create new index anchor object: %w", err)

--- a/pkg/anchor/anchorevent/anchorevent_test.go
+++ b/pkg/anchor/anchorevent/anchorevent_test.go
@@ -56,7 +56,7 @@ func TestBuildAnchorEvent(t *testing.T) {
 		require.NoError(t, err)
 
 		anchorEvent, err := BuildAnchorEvent(payload, contentObj.GeneratorID, contentObj.Payload,
-			vocab.MustMarshalToDoc(&verifiable.Credential{}))
+			vocab.MustMarshalToDoc(&verifiable.Credential{}), vocab.GzipMediaType)
 		require.NoError(t, err)
 
 		require.Equal(t, anchorOrigin, anchorEvent.AttributedTo().String())
@@ -80,7 +80,7 @@ func TestBuildAnchorEvent(t *testing.T) {
 		contentObjBytes, err := canonicalizer.MarshalCanonical(anchorObject.ContentObject())
 		require.NoError(t, err)
 
-		t.Logf("ContentObject: %s", contentObjBytes)
+		t.Logf("Content: %s", contentObjBytes)
 
 		require.Equal(t, testutil.GetCanonical(t, jsonContentObj), string(contentObjBytes))
 	})
@@ -108,7 +108,7 @@ func TestBuildAnchorEvent(t *testing.T) {
 		require.NotNil(t, anchorEvent.Published)
 
 		// check previous (two items - no create)
-		require.Equal(t, 2, len(anchorEvent.Parent()))
+		require.Equal(t, 4, len(anchorEvent.Parent()))
 
 		anchorObject, err := anchorEvent.AnchorObject(anchorEvent.Index())
 		require.NoError(t, err)
@@ -119,7 +119,7 @@ func TestBuildAnchorEvent(t *testing.T) {
 		contentObjBytes, err := canonicalizer.MarshalCanonical(anchorObject.ContentObject())
 		require.NoError(t, err)
 
-		t.Logf("ContentObject: %s", contentObjBytes)
+		t.Logf("Content: %s", contentObjBytes)
 
 		require.Equal(t, testutil.GetCanonical(t, jsonContentObj2), string(contentObjBytes))
 	})
@@ -165,7 +165,7 @@ func TestGetPayloadFromActivity(t *testing.T) {
 		require.NoError(t, err)
 
 		anchorEvent, err := BuildAnchorEvent(inPayload, contentObj.GeneratorID, contentObj.Payload,
-			vocab.MustMarshalToDoc(&verifiable.Credential{}))
+			vocab.MustMarshalToDoc(&verifiable.Credential{}), vocab.GzipMediaType)
 		require.NoError(t, err)
 
 		activityBytes, err := json.Marshal(anchorEvent)
@@ -220,163 +220,114 @@ func TestGetPayloadFromActivity(t *testing.T) {
 const (
 	//nolint:lll
 	exampleAnchorEvent = `{
-  "@context": [
-    "https://www.w3.org/ns/activitystreams",
-    "https://w3id.org/activityanchors/v1"
-  ],
-  "index": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
+  "@context": "https://w3id.org/activityanchors/v1",
   "attachment": [
     {
-      "contentObject": {
-        "properties": {
-          "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v0",
-          "https://w3id.org/activityanchors#resources": [
-            {
-              "id": "did:orb:uAAA:EiAqm7CXVPxriNZv_A6GVCrqlmCmrUSGJ1YaheTzFxa_Fw"
-            }
-          ]
-        },
-        "subject": "hl:uEiDYMTm9nJ5B0gwpNtflwrcZCT9uT6BFiEs5sYWB45piXg:uoQ-BeEJpcGZzOi8vYmFma3JlaWd5Z2U0MzNoZTZpaGpheWtqdzI3czRmbnl6YmU3dzR0NWFpd2Vld29ucnF3YTZoZ3RjbHk"
-      },
+      "content": "{\"properties\":{\"https://w3id.org/activityanchors#generator\":\"https://w3id.org/orb#v0\",\"https://w3id.org/activityanchors#resources\":[{\"id\":\"did:orb:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw:EiBu_uYz6DWjy65dYQB4w7sr1LYP5K9-HCEDb74bHJq6aQ\",\"previousAnchor\":\"hl:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw\"},{\"id\":\"did:orb:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw:EiCskiP5FXgmaq-cQUlsMMTRZgFLS6CQ-yZRTWDHPQk-SQ\",\"previousAnchor\":\"hl:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw\"},{\"id\":\"did:orb:uEiAQMO-h5_xOy0ig0lOTxuq2uWxPBcQVrkp0EJcp69krcQ:EiBZ0gLKITQe2IYaCLJPjOzzszejFbzOtaNFzJF29uOL4A\",\"previousAnchor\":\"hl:uEiAQMO-h5_xOy0ig0lOTxuq2uWxPBcQVrkp0EJcp69krcQ\"},{\"id\":\"did:orb:uEiCv7I4kHcMy-I6bwbRIffOJ19Sloi-3vl4q93Pb0RwJMw:EiAz8obk2MCsdqLq1trO4ubTYIsg3vlYaJdHKVR3wo3sGw\",\"previousAnchor\":\"hl:uEiCv7I4kHcMy-I6bwbRIffOJ19Sloi-3vl4q93Pb0RwJMw\"},{\"id\":\"did:orb:uEiDrl5KxiTe_EGov5dHetmO2uJOTtIfcKA9PMNgmdGTYiw:EiAADCcZOeu_sgtkF2JSWuwvc7LEw4u24Pfi1d5_0APl3Q\",\"previousAnchor\":\"hl:uEiDrl5KxiTe_EGov5dHetmO2uJOTtIfcKA9PMNgmdGTYiw\"},{\"id\":\"did:orb:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw:EiA6WSQ_2y2vcyakXW24vZk3Q45KMGIE4AL_2S2Hyz9VXw\",\"previousAnchor\":\"hl:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw\"},{\"id\":\"did:orb:uEiDrl5KxiTe_EGov5dHetmO2uJOTtIfcKA9PMNgmdGTYiw:EiAOaoQzphgwqX_PNBDSYDhwgu_3Q63hPZqEYio9tmfFCg\",\"previousAnchor\":\"hl:uEiDrl5KxiTe_EGov5dHetmO2uJOTtIfcKA9PMNgmdGTYiw\"},{\"id\":\"did:orb:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw:EiDMQfIzZFztRMNzTanIY5VoDcRr_zGA5SV0pNuDIDF47w\",\"previousAnchor\":\"hl:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw\"}]},\"subject\":\"hl:uEiAjb4i-wvE5w-pdE-WdX-aecG_Vd30HIvArHVdjjeqVUw:uoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpQWpiNGktd3ZFNXctcGRFLVdkWC1hZWNHX1ZkMzBISXZBckhWZGpqZXFWVXc\"}",
       "generator": "https://w3id.org/orb#v0",
+      "mediaType": "application/json",
       "tag": [
         {
-          "type": "Link",
-          "href": "hl:uEiDzOEQi2wRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
+          "href": "hl:uEiD6H3nMnJDB6WJ2evunRbjyb6R9t2yGwGB7p3g3RUUHRg",
           "rel": [
             "witness"
-          ]
+          ],
+          "type": "Link"
         }
       ],
       "type": "AnchorObject",
-      "url": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw"
+      "url": "hl:uEiBwvdpyXrDOZzEyVNnfaw793ditWQtG_4U72dkReHe4fQ"
     },
     {
-      "contentObject": {
-        "@context": [
-          "https://www.w3.org/2018/credentials/v1",
-          "https://w3id.org/security/jws/v1"
-        ],
-        "credentialSubject": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
-        "id": "http://orb2.domain1.com/vc/3994cc26-555c-47f1-9890-058148c154f1",
-        "issuanceDate": "2021-10-14T18:32:17.894314751Z",
-        "issuer": "http://orb2.domain1.com",
-        "proof": [
-          {
-            "created": "2021-10-14T18:32:17.91Z",
-            "domain": "http://orb.vct:8077/maple2020",
-            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..h3-0HC3L87TM0j0o3Nd0VLlalcVVphwOPsfdkCLZ4q-uL4z8eO2vQ4sobbtOtFpNNZlpIOQnaWJMX3Ch5Wh-AQ",
-            "proofPurpose": "assertionMethod",
-            "type": "Ed25519Signature2018",
-            "verificationMethod": "did:web:orb.domain1.com#orb1key"
-          },
-          {
-            "created": "2021-10-14T18:32:18.09110265Z",
-            "domain": "https://orb.domain2.com",
-            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..DSL3zsltnh9dbSn3VNPb1C-6pKt6VOy-H1WadO5ZV2QZd3xZq3uRRhaShi9K1SzX-VaGPxs3gfbazJ-fpHVxBg",
-            "proofPurpose": "assertionMethod",
-            "type": "Ed25519Signature2018",
-            "verificationMethod": "did:web:orb.domain2.com#orb2key"
-          }
-        ],
-        "type": "VerifiableCredential"
-      },
+      "content": "{\"@context\":[\"https://www.w3.org/2018/credentials/v1\"],\"credentialSubject\":\"hl:uEiBwvdpyXrDOZzEyVNnfaw793ditWQtG_4U72dkReHe4fQ\",\"id\":\"https://orb.domain2.com/vc/204c06b0-89d9-496d-9148-233e138ed745\",\"issuanceDate\":\"2022-02-10T18:02:13.530381545Z\",\"issuer\":\"https://orb.domain2.com\",\"proof\":{\"created\":\"2022-02-10T18:02:13.530557527Z\",\"domain\":\"https://orb.domain2.com\",\"jws\":\"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..w6zwingj2NvResa6elVbYxLv6c_jMTo_9zPY0T9po0MekuWRJCBDlYIR3ESYUdAEpnH1iYQ3_gYT-VMioNZtCw\",\"proofPurpose\":\"assertionMethod\",\"type\":\"Ed25519Signature2018\",\"verificationMethod\":\"did:web:orb.domain2.com#orb2key\"},\"type\":\"VerifiableCredential\"}",
       "generator": "https://w3id.org/orb#v0",
+      "mediaType": "application/json",
       "type": "AnchorObject",
-      "url": "hl:uEiDzOEQi2wRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw"
+      "url": "hl:uEiD6H3nMnJDB6WJ2evunRbjyb6R9t2yGwGB7p3g3RUUHRg"
     }
   ],
-  "attributedTo": "https://orb.domain1.com/services/orb",
+  "attributedTo": "https://orb.domain2.com/services/orb",
+  "index": "hl:uEiBwvdpyXrDOZzEyVNnfaw793ditWQtG_4U72dkReHe4fQ",
   "parent": [
-    "hl:uEiAsiwjaXOYDmOHxmvDl3Mx0TfJ0uCar5YXqumjFJUNIBg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBc2l3amFYT1lEbU9IeG12RGwzTXgwVGZKMHVDYXI1WVhxdW1qRkpVTklCZ3hCaXBmczovL2JhZmtyZWlibXJtZW51eGhnYW9tb2Q0bTI2ZHM1enRkdWp4emhqb2JndnBzeWwydjJuZGNza3EyaWF5",
-    "hl:uEiAn3Y7USoP_lNVX-f0EEu1ajLymnqBJItiMARhKBzAKWg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBbjNZN1VTb1BfbE5WWC1mMEVFdTFhakx5bW5xQkpJdGlNQVJoS0J6QUtXZ3hCaXBmczovL2JhZmtyZWliaDN3aG5pc3VkNzZrbmt2N3o3dWNiZjNrMnJzNmtuaHZhamVybnJkYWJkYmZhb21ha2xp"
+    "hl:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw:uoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpRG56MUZIbzhmRHN5ZE1lU18tYnFkNVQwNXRHRXNueXRHUUVpaF9kMVJRT3d4QmlwZnM6Ly9iYWZrcmVpaGh6NWl1cGk2aHlvenNvdGR6Zjc3ZzVqM3pqNWhnMmdjbGU3Zm5kZWFzZmI3eG92Y3FobQ",
+    "hl:uEiAQMO-h5_xOy0ig0lOTxuq2uWxPBcQVrkp0EJcp69krcQ:uoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQVFNTy1oNV94T3kwaWcwbE9UeHVxMnVXeFBCY1FWcmtwMEVKY3A2OWtyY1F4QmlwZnM6Ly9iYWZrcmVpYXFnZHgyZHo3NGozZnVyaWdza29qNG4ydnd4ZndlNmJvZWN3eGV1NWFxczR1Nnh3amxvZQ",
+    "hl:uEiCv7I4kHcMy-I6bwbRIffOJ19Sloi-3vl4q93Pb0RwJMw:uoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpQ3Y3STRrSGNNeS1JNmJ3YlJJZmZPSjE5U2xvaS0zdmw0cTkzUGIwUndKTXc",
+    "hl:uEiDrl5KxiTe_EGov5dHetmO2uJOTtIfcKA9PMNgmdGTYiw:uoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpRHJsNUt4aVRlX0VHb3Y1ZEhldG1PMnVKT1R0SWZjS0E5UE1OZ21kR1RZaXc"
   ],
-  "published": "2021-10-14T18:32:17.888176489Z",
-  "type": "AnchorEvent",
-  "url": "hl:uEiDhdDIS_-_SWKoh5Y3KJ_sWpIoXZUPBeTBMCSBUKXpe5w:uoQ-BeEJpcGZzOi8vYmFma3JlaWhib3F6YmY3N3Ayam1rdWlwZnJ4ZmNwNnl3dXNmYm96a2R5ZjR0YXRhamVia2NzNnM2NDQ"
+  "published": "2022-02-10T18:02:13.515820672Z",
+  "type": "AnchorEvent"
 }`
 
 	//nolint:lll
 	invalidAnchorEventNoURN = `{
   "@context": "https://w3id.org/activityanchors/v1",
-  "index": "hl:uEiBL1RVIr2DdyRE5h6b8bPys-PuVs5mMPPC778OtklPa-w",
   "attachment": [
     {
-      "contentObject": {
-        "properties": {
-          "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v1",
-          "https://w3id.org/activityanchors#resources": [
-            {
-              "id": "EiD6mH7iCLGjm9mhBr2TP_5_vRz6nyLYZ5E74xbZzrlmLg"
-            }
-          ]
-        },
-        "subject": "hl:uEiB1miJeUsG7PiLvFel8DKoluzDVl3OnpjKgAGZS588PXQ:uoQ-BeEJpcGZzOi8vYmFma3JlaWR2dGlyZjR1d2J4bTdjZjN5djVmNmF6a3JmeG15bmxmM3R1NnRkZmlhYW16am9wdHlwbHU"
-      },
-      "type": "AnchorObject",
+      "content": "{\"properties\":{\"https://w3id.org/activityanchors#generator\":\"https://w3id.org/orb#v0\",\"https://w3id.org/activityanchors#resources\":[{\"id\":\"did:orb:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw:EiBu_uYz6DWjy65dYQB4w7sr1LYP5K9-HCEDb74bHJq6aQ\",\"previousAnchor\":\"hl:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw\"},{\"id\":\"did:orb:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw:EiCskiP5FXgmaq-cQUlsMMTRZgFLS6CQ-yZRTWDHPQk-SQ\",\"previousAnchor\":\"hl:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw\"},{\"id\":\"did:orb:uEiAQMO-h5_xOy0ig0lOTxuq2uWxPBcQVrkp0EJcp69krcQ:EiBZ0gLKITQe2IYaCLJPjOzzszejFbzOtaNFzJF29uOL4A\",\"previousAnchor\":\"hl:uEiAQMO-h5_xOy0ig0lOTxuq2uWxPBcQVrkp0EJcp69krcQ\"},{\"id\":\"did:orb:uEiCv7I4kHcMy-I6bwbRIffOJ19Sloi-3vl4q93Pb0RwJMw:EiAz8obk2MCsdqLq1trO4ubTYIsg3vlYaJdHKVR3wo3sGw\",\"previousAnchor\":\"hl:uEiCv7I4kHcMy-I6bwbRIffOJ19Sloi-3vl4q93Pb0RwJMw\"},{\"id\":\"did:orb:uEiDrl5KxiTe_EGov5dHetmO2uJOTtIfcKA9PMNgmdGTYiw:EiAADCcZOeu_sgtkF2JSWuwvc7LEw4u24Pfi1d5_0APl3Q\",\"previousAnchor\":\"hl:uEiDrl5KxiTe_EGov5dHetmO2uJOTtIfcKA9PMNgmdGTYiw\"},{\"id\":\"did:orb:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw:EiA6WSQ_2y2vcyakXW24vZk3Q45KMGIE4AL_2S2Hyz9VXw\",\"previousAnchor\":\"hl:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw\"},{\"id\":\"did:orb:uEiDrl5KxiTe_EGov5dHetmO2uJOTtIfcKA9PMNgmdGTYiw:EiAOaoQzphgwqX_PNBDSYDhwgu_3Q63hPZqEYio9tmfFCg\",\"previousAnchor\":\"hl:uEiDrl5KxiTe_EGov5dHetmO2uJOTtIfcKA9PMNgmdGTYiw\"},{\"id\":\"did:orb:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw:EiDMQfIzZFztRMNzTanIY5VoDcRr_zGA5SV0pNuDIDF47w\",\"previousAnchor\":\"hl:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw\"}]},\"subject\":\"hl:uEiAjb4i-wvE5w-pdE-WdX-aecG_Vd30HIvArHVdjjeqVUw:uoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpQWpiNGktd3ZFNXctcGRFLVdkWC1hZWNHX1ZkMzBISXZBckhWZGpqZXFWVXc\"}",
       "generator": "https://w3id.org/orb#v0",
-      "url": "hl:uEiBL1RVIr2DdyRE5h6b8bPys-PuVs5mMPPC778OtklPa-w",
-      "witness": {
-        "@context": "https://www.w3.org/2018/credentials/v1",
-        "credentialSubject": {
-          "id": "hl:uEiBy8pPgN9eS3hpQAwpSwJJvm6Awpsnc8kR_fkbUPotehg"
-        },
-        "issuanceDate": "2021-01-27T09:30:10Z",
-        "issuer": "https://sally.example.com/services/anchor",
-        "type": "VerifiableCredential"
-      }
+      "mediaType": "application/json",
+      "tag": [
+        {
+          "href": "hl:uEiD6H3nMnJDB6WJ2evunRbjyb6R9t2yGwGB7p3g3RUUHRg",
+          "rel": [
+            "witness"
+          ],
+          "type": "Link"
+        }
+      ],
+      "type": "AnchorObject",
+      "url": "hl:uEiBwvdpyXrDOZzEyVNnfaw793ditWQtG_4U72dkReHe4fQ"
+    },
+    {
+      "content": "{\"@context\":[\"https://www.w3.org/2018/credentials/v1\"],\"credentialSubject\":\"hl:uEiBwvdpyXrDOZzEyVNnfaw793ditWQtG_4U72dkReHe4fQ\",\"id\":\"https://orb.domain2.com/vc/204c06b0-89d9-496d-9148-233e138ed745\",\"issuanceDate\":\"2022-02-10T18:02:13.530381545Z\",\"issuer\":\"https://orb.domain2.com\",\"proof\":{\"created\":\"2022-02-10T18:02:13.530557527Z\",\"domain\":\"https://orb.domain2.com\",\"jws\":\"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..w6zwingj2NvResa6elVbYxLv6c_jMTo_9zPY0T9po0MekuWRJCBDlYIR3ESYUdAEpnH1iYQ3_gYT-VMioNZtCw\",\"proofPurpose\":\"assertionMethod\",\"type\":\"Ed25519Signature2018\",\"verificationMethod\":\"did:web:orb.domain2.com#orb2key\"},\"type\":\"VerifiableCredential\"}",
+      "generator": "https://w3id.org/orb#v0",
+      "mediaType": "application/json",
+      "type": "AnchorObject",
+      "url": "hl:uEiD6H3nMnJDB6WJ2evunRbjyb6R9t2yGwGB7p3g3RUUHRg"
     }
   ],
-  "attributedTo": "https://orb.domain1.com/services/orb",
-  "parent": [
-    "hl:uEiAsiwjaXOYDmOHxmvDl3Mx0TfJ0uCar5YXqumjFJUNIBg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBc2l3amFYT1lEbU9IeG12RGwzTXgwVGZKMHVDYXI1WVhxdW1qRkpVTklCZ3hCaXBmczovL2JhZmtyZWlibXJtZW51eGhnYW9tb2Q0bTI2ZHM1enRkdWp4emhqb2JndnBzeWwydjJuZGNza3EyaWF5",
-    "hl:uEiAn3Y7USoP_lNVX-f0EEu1ajLymnqBJItiMARhKBzAKWg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBbjNZN1VTb1BfbE5WWC1mMEVFdTFhakx5bW5xQkpJdGlNQVJoS0J6QUtXZ3hCaXBmczovL2JhZmtyZWliaDN3aG5pc3VkNzZrbmt2N3o3dWNiZjNrMnJzNmtuaHZhamVybnJkYWJkYmZhb21ha2xp"
-  ],
-  "published": "2021-01-27T09:30:10Z",
-  "type": "AnchorEvent",
-  "url": "hl:uEiCJWrCq8ttsWob5UVueRQiQ_QUrocJY6ZA8BDgzgakuhg:uoQ-BeEJpcGZzOi8vYmFma3JlaWVqbGt5a3Y0dzNucm5pbjZrcmxvcGVrY2VxN3Vjc3hpb2NsZHV6YXBhZWhhenlka2pvcXk"
+  "attributedTo": "https://orb.domain2.com/services/orb",
+  "index": "hl:uEiBwvdpyXrDOZzEyVNnfaw793ditWQtG_4U72dkReHe4fQ",
+  "published": "2022-02-10T18:02:13.515820672Z",
+  "type": "AnchorEvent"
 }`
 
 	//nolint:lll
 	invalidAnchorEventGenerator = `{
   "@context": "https://w3id.org/activityanchors/v1",
-  "index": "hl:uEiBL1RVIr2DdyRE5h6b8bPys-PuVs5mMPPC778OtklPa-w",
   "attachment": [
     {
-      "contentObject": {
-        "properties": {
-          "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v1",
-          "https://w3id.org/activityanchors#resources": [
-            {
-              "id": "did:orb:uAAA:uEiARIc_M1ZE_CmP-xApv_UTqZPncE1xmY0ugAdELz0MCogo",
-              "previousAnchor": "hl:uEiAs3Y7USoP_lNVX-f0EEu1ajLymnqBJItiMARhKBzAKWg"
-            }
-          ]
-        },
-        "subject": "hl:uEiB1miJeUsG7PiLvFel8DKoluzDVl3OnpjKgAGZS588PXQ:uoQ-BeEJpcGZzOi8vYmFma3JlaWR2dGlyZjR1d2J4bTdjZjN5djVmNmF6a3JmeG15bmxmM3R1NnRkZmlhYW16am9wdHlwbHU"
-      },
+      "content": "{\"properties\":{\"https://w3id.org/activityanchors#generator\":\"https://w3id.org/orb#v0\",\"https://w3id.org/activityanchors#resources\":[{\"id\":\"did:orb:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw:EiBu_uYz6DWjy65dYQB4w7sr1LYP5K9-HCEDb74bHJq6aQ\",\"previousAnchor\":\"hl:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw\"},{\"id\":\"did:orb:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw:EiCskiP5FXgmaq-cQUlsMMTRZgFLS6CQ-yZRTWDHPQk-SQ\",\"previousAnchor\":\"hl:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw\"},{\"id\":\"did:orb:uEiAQMO-h5_xOy0ig0lOTxuq2uWxPBcQVrkp0EJcp69krcQ:EiBZ0gLKITQe2IYaCLJPjOzzszejFbzOtaNFzJF29uOL4A\",\"previousAnchor\":\"hl:uEiAQMO-h5_xOy0ig0lOTxuq2uWxPBcQVrkp0EJcp69krcQ\"},{\"id\":\"did:orb:uEiCv7I4kHcMy-I6bwbRIffOJ19Sloi-3vl4q93Pb0RwJMw:EiAz8obk2MCsdqLq1trO4ubTYIsg3vlYaJdHKVR3wo3sGw\",\"previousAnchor\":\"hl:uEiCv7I4kHcMy-I6bwbRIffOJ19Sloi-3vl4q93Pb0RwJMw\"},{\"id\":\"did:orb:uEiDrl5KxiTe_EGov5dHetmO2uJOTtIfcKA9PMNgmdGTYiw:EiAADCcZOeu_sgtkF2JSWuwvc7LEw4u24Pfi1d5_0APl3Q\",\"previousAnchor\":\"hl:uEiDrl5KxiTe_EGov5dHetmO2uJOTtIfcKA9PMNgmdGTYiw\"},{\"id\":\"did:orb:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw:EiA6WSQ_2y2vcyakXW24vZk3Q45KMGIE4AL_2S2Hyz9VXw\",\"previousAnchor\":\"hl:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw\"},{\"id\":\"did:orb:uEiDrl5KxiTe_EGov5dHetmO2uJOTtIfcKA9PMNgmdGTYiw:EiAOaoQzphgwqX_PNBDSYDhwgu_3Q63hPZqEYio9tmfFCg\",\"previousAnchor\":\"hl:uEiDrl5KxiTe_EGov5dHetmO2uJOTtIfcKA9PMNgmdGTYiw\"},{\"id\":\"did:orb:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw:EiDMQfIzZFztRMNzTanIY5VoDcRr_zGA5SV0pNuDIDF47w\",\"previousAnchor\":\"hl:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw\"}]},\"subject\":\"hl:uEiAjb4i-wvE5w-pdE-WdX-aecG_Vd30HIvArHVdjjeqVUw:uoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpQWpiNGktd3ZFNXctcGRFLVdkWC1hZWNHX1ZkMzBISXZBckhWZGpqZXFWVXc\"}",
+      "mediaType": "application/json",
+      "tag": [
+        {
+          "href": "hl:uEiD6H3nMnJDB6WJ2evunRbjyb6R9t2yGwGB7p3g3RUUHRg",
+          "rel": [
+            "witness"
+          ],
+          "type": "Link"
+        }
+      ],
       "type": "AnchorObject",
-      "generator": "https://invalid#v0",
-      "url": "hl:uEiBL1RVIr2DdyRE5h6b8bPys-PuVs5mMPPC778OtklPa-w",
-      "witness": {
-        "@context": "https://www.w3.org/2018/credentials/v1",
-        "credentialSubject": {
-          "id": "hl:uEiBy8pPgN9eS3hpQAwpSwJJvm6Awpsnc8kR_fkbUPotehg"
-        },
-        "issuanceDate": "2021-01-27T09:30:10Z",
-        "issuer": "https://sally.example.com/services/anchor",
-        "type": "VerifiableCredential"
-      }
+      "url": "hl:uEiBwvdpyXrDOZzEyVNnfaw793ditWQtG_4U72dkReHe4fQ"
+    },
+    {
+      "content": "{\"@context\":[\"https://www.w3.org/2018/credentials/v1\"],\"credentialSubject\":\"hl:uEiBwvdpyXrDOZzEyVNnfaw793ditWQtG_4U72dkReHe4fQ\",\"id\":\"https://orb.domain2.com/vc/204c06b0-89d9-496d-9148-233e138ed745\",\"issuanceDate\":\"2022-02-10T18:02:13.530381545Z\",\"issuer\":\"https://orb.domain2.com\",\"proof\":{\"created\":\"2022-02-10T18:02:13.530557527Z\",\"domain\":\"https://orb.domain2.com\",\"jws\":\"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..w6zwingj2NvResa6elVbYxLv6c_jMTo_9zPY0T9po0MekuWRJCBDlYIR3ESYUdAEpnH1iYQ3_gYT-VMioNZtCw\",\"proofPurpose\":\"assertionMethod\",\"type\":\"Ed25519Signature2018\",\"verificationMethod\":\"did:web:orb.domain2.com#orb2key\"},\"type\":\"VerifiableCredential\"}",
+      "mediaType": "application/json",
+      "type": "AnchorObject",
+      "url": "hl:uEiD6H3nMnJDB6WJ2evunRbjyb6R9t2yGwGB7p3g3RUUHRg"
     }
   ],
-  "attributedTo": "https://orb.domain1.com/services/orb",
+  "attributedTo": "https://orb.domain2.com/services/orb",
+  "index": "hl:uEiBwvdpyXrDOZzEyVNnfaw793ditWQtG_4U72dkReHe4fQ",
   "parent": [
-    "hl:uEiAsiwjaXOYDmOHxmvDl3Mx0TfJ0uCar5YXqumjFJUNIBg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBc2l3amFYT1lEbU9IeG12RGwzTXgwVGZKMHVDYXI1WVhxdW1qRkpVTklCZ3hCaXBmczovL2JhZmtyZWlibXJtZW51eGhnYW9tb2Q0bTI2ZHM1enRkdWp4emhqb2JndnBzeWwydjJuZGNza3EyaWF5",
-    "hl:uEiAn3Y7USoP_lNVX-f0EEu1ajLymnqBJItiMARhKBzAKWg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBbjNZN1VTb1BfbE5WWC1mMEVFdTFhakx5bW5xQkpJdGlNQVJoS0J6QUtXZ3hCaXBmczovL2JhZmtyZWliaDN3aG5pc3VkNzZrbmt2N3o3dWNiZjNrMnJzNmtuaHZhamVybnJkYWJkYmZhb21ha2xp"
+    "hl:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw:uoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpRG56MUZIbzhmRHN5ZE1lU18tYnFkNVQwNXRHRXNueXRHUUVpaF9kMVJRT3d4QmlwZnM6Ly9iYWZrcmVpaGh6NWl1cGk2aHlvenNvdGR6Zjc3ZzVqM3pqNWhnMmdjbGU3Zm5kZWFzZmI3eG92Y3FobQ",
+    "hl:uEiAQMO-h5_xOy0ig0lOTxuq2uWxPBcQVrkp0EJcp69krcQ:uoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQVFNTy1oNV94T3kwaWcwbE9UeHVxMnVXeFBCY1FWcmtwMEVKY3A2OWtyY1F4QmlwZnM6Ly9iYWZrcmVpYXFnZHgyZHo3NGozZnVyaWdza29qNG4ydnd4ZndlNmJvZWN3eGV1NWFxczR1Nnh3amxvZQ",
+    "hl:uEiCv7I4kHcMy-I6bwbRIffOJ19Sloi-3vl4q93Pb0RwJMw:uoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpQ3Y3STRrSGNNeS1JNmJ3YlJJZmZPSjE5U2xvaS0zdmw0cTkzUGIwUndKTXc",
+    "hl:uEiDrl5KxiTe_EGov5dHetmO2uJOTtIfcKA9PMNgmdGTYiw:uoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpRHJsNUt4aVRlX0VHb3Y1ZEhldG1PMnVKT1R0SWZjS0E5UE1OZ21kR1RZaXc"
   ],
-  "published": "2021-01-27T09:30:10Z",
-  "type": "AnchorEvent",
-  "url": "hl:uEiCJWrCq8ttsWob5UVueRQiQ_QUrocJY6ZA8BDgzgakuhg:uoQ-BeEJpcGZzOi8vYmFma3JlaWVqbGt5a3Y0dzNucm5pbjZrcmxvcGVrY2VxN3Vjc3hpb2NsZHV6YXBhZWhhenlka2pvcXk"
+  "published": "2022-02-10T18:02:13.515820672Z",
+  "type": "AnchorEvent"
 }`
 
 	//nolint:lll
@@ -402,10 +353,39 @@ const (
     "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v0",
     "https://w3id.org/activityanchors#resources": [
       {
-        "id": "did:orb:uAAA:EiAqm7CXVPxriNZv_A6GVCrqlmCmrUSGJ1YaheTzFxa_Fw"
+        "id": "did:orb:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw:EiBu_uYz6DWjy65dYQB4w7sr1LYP5K9-HCEDb74bHJq6aQ",
+        "previousAnchor": "hl:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw"
+      },
+      {
+        "id": "did:orb:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw:EiCskiP5FXgmaq-cQUlsMMTRZgFLS6CQ-yZRTWDHPQk-SQ",
+        "previousAnchor": "hl:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw"
+      },
+      {
+        "id": "did:orb:uEiAQMO-h5_xOy0ig0lOTxuq2uWxPBcQVrkp0EJcp69krcQ:EiBZ0gLKITQe2IYaCLJPjOzzszejFbzOtaNFzJF29uOL4A",
+        "previousAnchor": "hl:uEiAQMO-h5_xOy0ig0lOTxuq2uWxPBcQVrkp0EJcp69krcQ"
+      },
+      {
+        "id": "did:orb:uEiCv7I4kHcMy-I6bwbRIffOJ19Sloi-3vl4q93Pb0RwJMw:EiAz8obk2MCsdqLq1trO4ubTYIsg3vlYaJdHKVR3wo3sGw",
+        "previousAnchor": "hl:uEiCv7I4kHcMy-I6bwbRIffOJ19Sloi-3vl4q93Pb0RwJMw"
+      },
+      {
+        "id": "did:orb:uEiDrl5KxiTe_EGov5dHetmO2uJOTtIfcKA9PMNgmdGTYiw:EiAADCcZOeu_sgtkF2JSWuwvc7LEw4u24Pfi1d5_0APl3Q",
+        "previousAnchor": "hl:uEiDrl5KxiTe_EGov5dHetmO2uJOTtIfcKA9PMNgmdGTYiw"
+      },
+      {
+        "id": "did:orb:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw:EiA6WSQ_2y2vcyakXW24vZk3Q45KMGIE4AL_2S2Hyz9VXw",
+        "previousAnchor": "hl:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw"
+      },
+      {
+        "id": "did:orb:uEiDrl5KxiTe_EGov5dHetmO2uJOTtIfcKA9PMNgmdGTYiw:EiAOaoQzphgwqX_PNBDSYDhwgu_3Q63hPZqEYio9tmfFCg",
+        "previousAnchor": "hl:uEiDrl5KxiTe_EGov5dHetmO2uJOTtIfcKA9PMNgmdGTYiw"
+      },
+      {
+        "id": "did:orb:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw:EiDMQfIzZFztRMNzTanIY5VoDcRr_zGA5SV0pNuDIDF47w",
+        "previousAnchor": "hl:uEiDnz1FHo8fDsydMeS_-bqd5T05tGEsnytGQEih_d1RQOw"
       }
     ]
   },
-  "subject": "hl:uEiDYMTm9nJ5B0gwpNtflwrcZCT9uT6BFiEs5sYWB45piXg:uoQ-BeEJpcGZzOi8vYmFma3JlaWd5Z2U0MzNoZTZpaGpheWtqdzI3czRmbnl6YmU3dzR0NWFpd2Vld29ucnF3YTZoZ3RjbHk"
+  "subject": "hl:uEiAjb4i-wvE5w-pdE-WdX-aecG_Vd30HIvArHVdjjeqVUw:uoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpQWpiNGktd3ZFNXctcGRFLVdkWC1hZWNHX1ZkMzBISXZBckhWZGpqZXFWVXc"
 }`
 )

--- a/pkg/anchor/anchorevent/generator/didorbgenerator/didorbgenerator_test.go
+++ b/pkg/anchor/anchorevent/generator/didorbgenerator/didorbgenerator_test.go
@@ -145,11 +145,12 @@ func TestGenerator_GetPayloadFromAnchorEvent(t *testing.T) {
 		},
 	}
 
-	witnessAnchorObj, err := vocab.NewAnchorObject(ID, vocab.MustUnmarshalToDoc([]byte(verifiableCred)))
+	witnessAnchorObj, err := vocab.NewAnchorObject(ID, vocab.MustUnmarshalToDoc([]byte(verifiableCred)),
+		vocab.GzipMediaType)
 	require.NoError(t, err)
 	require.Len(t, witnessAnchorObj.URL(), 1)
 
-	indexAnchorObj, err := vocab.NewAnchorObject(ID, vocab.MustMarshalToDoc(contentObj),
+	indexAnchorObj, err := vocab.NewAnchorObject(ID, vocab.MustMarshalToDoc(contentObj), vocab.GzipMediaType,
 		vocab.WithLink(vocab.NewLink(witnessAnchorObj.URL()[0], vocab.RelationshipWitness)))
 	require.NoError(t, err)
 	require.Len(t, indexAnchorObj.URL(), 1)
@@ -197,7 +198,7 @@ func TestGenerator_GetPayloadFromAnchorEvent(t *testing.T) {
 	})
 
 	t.Run("No subject in content object", func(t *testing.T) {
-		anchorObj, err := vocab.NewAnchorObject(ID, vocab.MustMarshalToDoc(&contentObject{}))
+		anchorObj, err := vocab.NewAnchorObject(ID, vocab.MustMarshalToDoc(&contentObject{}), vocab.GzipMediaType)
 		require.NoError(t, err)
 		require.Len(t, anchorObj.URL(), 1)
 

--- a/pkg/anchor/graph/graph_test.go
+++ b/pkg/anchor/graph/graph_test.go
@@ -291,7 +291,7 @@ func newMockAnchorEvent(t *testing.T, payload *subject.Payload) *vocab.AnchorEve
 	}
 
 	act, err := anchorevent.BuildAnchorEvent(payload, contentObj.GeneratorID, contentObj.Payload,
-		vocab.MustMarshalToDoc(vc))
+		vocab.MustMarshalToDoc(vc), vocab.GzipMediaType)
 	require.NoError(t, err)
 
 	return act

--- a/pkg/anchor/handler/credential/handler_test.go
+++ b/pkg/anchor/handler/credential/handler_test.go
@@ -78,7 +78,7 @@ func TestAnchorCredentialHandler(t *testing.T) {
 	})
 
 	t.Run("Parse created time (error)", func(t *testing.T) {
-		cred := strings.Replace(sampleAnchorEvent, "2021-11-29T15:21:03.074Z", "2021-27T09:30:00Z", 1)
+		cred := strings.Replace(sampleAnchorEvent, "2022-02-10T18:50:48.682348236Z", "2021-27T09:30:00Z", 1)
 
 		anchorEvent := &vocab.AnchorEventType{}
 		require.NoError(t, json.Unmarshal([]byte(cred), anchorEvent))
@@ -328,26 +328,12 @@ const sampleAnchorEvent = `{
   "@context": "https://w3id.org/activityanchors/v1",
   "attachment": [
     {
-      "contentObject": {
-        "properties": {
-          "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v0",
-          "https://w3id.org/activityanchors#resources": [
-            {
-              "id": "did:orb:uEiCPBh27UFpxQq1Sdw-YoyH9n7yPD7AktxAlBGWlMFfGMQ:EiCQNQ4L1bBFtgaFk4FS4kzLyO3gIO15tXn2j0T5EEu2UQ",
-              "previousAnchor": "hl:uEiCPBh27UFpxQq1Sdw-YoyH9n7yPD7AktxAlBGWlMFfGMQ"
-            },
-            {
-              "id": "did:orb:uEiCPBh27UFpxQq1Sdw-YoyH9n7yPD7AktxAlBGWlMFfGMQ:EiAN8R3Na3wa_jkqWRHa3GCXlTrVKlXn4UTecMMkjcdAMQ",
-              "previousAnchor": "hl:uEiCPBh27UFpxQq1Sdw-YoyH9n7yPD7AktxAlBGWlMFfGMQ"
-            }
-          ]
-        },
-        "subject": "hl:uEiB4iWYoR-AfG2-GysgPxs7djSc4zIU08GZu8Y1eEQQDrg:uoQ-BeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQjRpV1lvUi1BZkcyLUd5c2dQeHM3ZGpTYzR6SVUwOEdadThZMWVFUVFEcmc"
-      },
+      "content": "{\"properties\":{\"https://w3id.org/activityanchors#generator\":\"https://w3id.org/orb#v0\",\"https://w3id.org/activityanchors#resources\":[{\"id\":\"did:orb:uEiAk0CUuIIVOxlalYH6JU7gsIwvo5zGNcM_zYo2jXwzBzw:EiCIZ19PGWe_65JLcIp_bmOu_ZrPOerFPXAoXAcdWW7iCg\",\"previousAnchor\":\"hl:uEiAk0CUuIIVOxlalYH6JU7gsIwvo5zGNcM_zYo2jXwzBzw\"}]},\"subject\":\"hl:uEiC0arCOQrIDw2F2Zca10gEutIrHWgIUaC1jPDRRBLADUQ:uoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpQzBhckNPUXJJRHcyRjJaY2ExMGdFdXRJckhXZ0lVYUMxalBEUlJCTEFEVVE\"}",
       "generator": "https://w3id.org/orb#v0",
+      "mediaType": "application/json",
       "tag": [
         {
-          "href": "hl:uEiDqa7j0CTWIUIsndfR1jJwzYdO-31CcUS08e9APyot_-Q",
+          "href": "hl:uEiB_22mkkq3lIOkoZXayxavsGnJ2HP8xR0ke_fGCKqQpyA",
           "rel": [
             "witness"
           ],
@@ -355,47 +341,20 @@ const sampleAnchorEvent = `{
         }
       ],
       "type": "AnchorObject",
-      "url": "hl:uEiBZijGgA16VhYUjoZFUO2ALWjJeuNP1ylWbG1iEQ6ggiQ"
+      "url": "hl:uEiB5sZH1-ZEY0QDRbFgOrGQZqb95A95q5VWNVBBzxAJMCA"
     },
     {
-      "contentObject": {
-        "@context": [
-          "https://www.w3.org/2018/credentials/v1",
-          "https://w3id.org/security/suites/jws-2020/v1"
-        ],
-        "credentialSubject": "hl:uEiBZijGgA16VhYUjoZFUO2ALWjJeuNP1ylWbG1iEQ6ggiQ",
-        "id": "https://orb.domain1.com/vc/9c070be5-e08e-4ade-b210-40ea7eb6b3c8",
-        "issuanceDate": "2021-11-29T15:21:03.0624724Z",
-        "issuer": "https://orb.domain1.com",
-        "proof": [
-          {
-            "created": "2021-11-29T15:21:03.074Z",
-            "domain": "http://orb.vct:8077/maple2020",
-            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..q6Qmujh7C6wJFIL0-hajFTpszGOzvd4GasFwXawdUwMa-emLuoVM8qaEBw0C-3GqNWsS0EzgfMTcL-djPte9Dg",
-            "proofPurpose": "assertionMethod",
-            "type": "Ed25519Signature2018",
-            "verificationMethod": "did:web:orb.domain1.com#orb1key"
-          },
-          {
-            "created": "2021-11-29T15:21:03.1786462Z",
-            "domain": "https://orb.domain2.com",
-            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..q10AkIUmg39QbfiIllvWFVhPVvJeFuCiQzWDdifQ7AdFDmQjchffmTX1MugTYbO5J_dpnZLTfPjXf4XZWIU2AQ",
-            "proofPurpose": "assertionMethod",
-            "type": "Ed25519Signature2018",
-            "verificationMethod": "did:web:orb.domain2.com#orb2key"
-          }
-        ],
-        "type": "VerifiableCredential"
-      },
+      "content": "{\"@context\":[\"https://www.w3.org/2018/credentials/v1\"],\"credentialSubject\":\"hl:uEiB5sZH1-ZEY0QDRbFgOrGQZqb95A95q5VWNVBBzxAJMCA\",\"id\":\"https://orb.domain2.com/vc/1636951e-9117-4134-904a-e0cd177517a1\",\"issuanceDate\":\"2022-02-10T18:50:48.682168399Z\",\"issuer\":\"https://orb.domain2.com\",\"proof\":[{\"created\":\"2022-02-10T18:50:48.682348236Z\",\"domain\":\"https://orb.domain2.com\",\"jws\":\"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..fqgLBKohg962_3GNbH-QXklA89KBMHev95-Pk1XcGa47jq0TbFUeZi3DBGLgc-pDBisqkh0U3bUSvKY_edBAAw\",\"proofPurpose\":\"assertionMethod\",\"type\":\"Ed25519Signature2018\",\"verificationMethod\":\"did:web:orb.domain2.com#orb2key\"},{\"created\":\"2022-02-10T18:50:48.729Z\",\"domain\":\"http://orb.vct:8077/maple2020\",\"jws\":\"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..xlI19T5KT-Sy1CJuCQLIhgGHdlaK0dIjoctRwzJUz6-TpiluluGEa69aCuDjx426TgHvGXJDn8jHi5aDqGuTDA\",\"proofPurpose\":\"assertionMethod\",\"type\":\"Ed25519Signature2018\",\"verificationMethod\":\"did:web:orb.domain1.com#orb1key2\"}],\"type\":\"VerifiableCredential\"}",
       "generator": "https://w3id.org/orb#v0",
+      "mediaType": "application/json",
       "type": "AnchorObject",
-      "url": "hl:uEiDqa7j0CTWIUIsndfR1jJwzYdO-31CcUS08e9APyot_-Q"
+      "url": "hl:uEiB_22mkkq3lIOkoZXayxavsGnJ2HP8xR0ke_fGCKqQpyA"
     }
   ],
-  "attributedTo": "https://orb.domain1.com/services/orb",
-  "index": "hl:uEiBZijGgA16VhYUjoZFUO2ALWjJeuNP1ylWbG1iEQ6ggiQ",
-  "parent": "hl:uEiCPBh27UFpxQq1Sdw-YoyH9n7yPD7AktxAlBGWlMFfGMQ:uoQ-BeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQ1BCaDI3VUZweFFxMVNkdy1Zb3lIOW43eVBEN0FrdHhBbEJHV2xNRmZHTVE",
-  "published": "2021-11-29T15:21:03.0620444Z",
+  "attributedTo": "https://orb.domain2.com/services/orb",
+  "index": "hl:uEiB5sZH1-ZEY0QDRbFgOrGQZqb95A95q5VWNVBBzxAJMCA",
+  "parent": "hl:uEiAk0CUuIIVOxlalYH6JU7gsIwvo5zGNcM_zYo2jXwzBzw:uoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpQWswQ1V1SUlWT3hsYWxZSDZKVTdnc0l3dm81ekdOY01fellvMmpYd3pCenc",
+  "published": "2022-02-10T18:50:48.681998572Z",
   "type": "AnchorEvent"
 }`
 
@@ -404,26 +363,12 @@ const sampleParentAnchorEvent = `{
   "@context": "https://w3id.org/activityanchors/v1",
   "attachment": [
     {
-      "contentObject": {
-        "properties": {
-          "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v0",
-          "https://w3id.org/activityanchors#resources": [
-            {
-              "id": "did:orb:uEiCQhpLcjhOV_tDVibUfPbkhjJM_FUYwQ9AuAHahoAGxyg:EiAN8R3Na3wa_jkqWRHa3GCXlTrVKlXn4UTecMMkjcdAMQ",
-              "previousAnchor": "hl:uEiCQhpLcjhOV_tDVibUfPbkhjJM_FUYwQ9AuAHahoAGxyg"
-            },
-            {
-              "id": "did:orb:uEiCQhpLcjhOV_tDVibUfPbkhjJM_FUYwQ9AuAHahoAGxyg:EiCQNQ4L1bBFtgaFk4FS4kzLyO3gIO15tXn2j0T5EEu2UQ",
-              "previousAnchor": "hl:uEiCQhpLcjhOV_tDVibUfPbkhjJM_FUYwQ9AuAHahoAGxyg"
-            }
-          ]
-        },
-        "subject": "hl:uEiDSfb9B3JJzjHj61vSfM7pYPsl1tKTSTIB9kjEKdQCBWw:uoQ-BeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpRFNmYjlCM0pKempIajYxdlNmTTdwWVBzbDF0S1RTVElCOWtqRUtkUUNCV3c"
-      },
+      "content": "{\"properties\":{\"https://w3id.org/activityanchors#generator\":\"https://w3id.org/orb#v0\",\"https://w3id.org/activityanchors#resources\":[{\"id\":\"did:orb:uEiAk0CUuIIVOxlalYH6JU7gsIwvo5zGNcM_zYo2jXwzBzw:EiCIZ19PGWe_65JLcIp_bmOu_ZrPOerFPXAoXAcdWW7iCg\",\"previousAnchor\":\"hl:uEiAk0CUuIIVOxlalYH6JU7gsIwvo5zGNcM_zYo2jXwzBzw\"}]},\"subject\":\"hl:uEiC0arCOQrIDw2F2Zca10gEutIrHWgIUaC1jPDRRBLADUQ:uoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpQzBhckNPUXJJRHcyRjJaY2ExMGdFdXRJckhXZ0lVYUMxalBEUlJCTEFEVVE\"}",
       "generator": "https://w3id.org/orb#v0",
+      "mediaType": "application/json",
       "tag": [
         {
-          "href": "hl:uEiAQZHVlPe0To_t9Mz-K__W6Bf2owOASxjZMdz3EM1akrA",
+          "href": "hl:uEiB_22mkkq3lIOkoZXayxavsGnJ2HP8xR0ke_fGCKqQpyA",
           "rel": [
             "witness"
           ],
@@ -431,47 +376,20 @@ const sampleParentAnchorEvent = `{
         }
       ],
       "type": "AnchorObject",
-      "url": "hl:uEiDvP1yOfMsF5JYqFH_F4QX12_IOwp9tNRjsRl4fZrofSQ"
+      "url": "hl:uEiB5sZH1-ZEY0QDRbFgOrGQZqb95A95q5VWNVBBzxAJMCA"
     },
     {
-      "contentObject": {
-        "@context": [
-          "https://www.w3.org/2018/credentials/v1",
-          "https://w3id.org/security/suites/jws-2020/v1"
-        ],
-        "credentialSubject": "hl:uEiDvP1yOfMsF5JYqFH_F4QX12_IOwp9tNRjsRl4fZrofSQ",
-        "id": "https://orb.domain1.com/vc/ec1c7fc7-7941-4178-ab58-7f0f8e18b8dc",
-        "issuanceDate": "2021-11-29T15:20:57.9755326Z",
-        "issuer": "https://orb.domain1.com",
-        "proof": [
-          {
-            "created": "2021-11-29T15:20:57.983Z",
-            "domain": "http://orb.vct:8077/maple2020",
-            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..2Hgmb6c6r8RCnJ1Wf7EmhUBoZ73oEoqrb1kETEyNcox27OP1R3fzpq-DoyELbk7fO8to8L241D0bbx9nyzZNAA",
-            "proofPurpose": "assertionMethod",
-            "type": "Ed25519Signature2018",
-            "verificationMethod": "did:web:orb.domain1.com#orb1key"
-          },
-          {
-            "created": "2021-11-29T15:20:58.0907253Z",
-            "domain": "https://orb.domain2.com",
-            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..D5gxR0LGQIsltpKvm4Fwm63xy47ThBP-eJROqxXoEPAwTgMM5_zhGxTK1n_XdEpXg3jtd6VGzzsh86HU50dfBw",
-            "proofPurpose": "assertionMethod",
-            "type": "Ed25519Signature2018",
-            "verificationMethod": "did:web:orb.domain2.com#orb2key"
-          }
-        ],
-        "type": "VerifiableCredential"
-      },
+      "content": "{\"@context\":[\"https://www.w3.org/2018/credentials/v1\"],\"credentialSubject\":\"hl:uEiB5sZH1-ZEY0QDRbFgOrGQZqb95A95q5VWNVBBzxAJMCA\",\"id\":\"https://orb.domain2.com/vc/1636951e-9117-4134-904a-e0cd177517a1\",\"issuanceDate\":\"2022-02-10T18:50:48.682168399Z\",\"issuer\":\"https://orb.domain2.com\",\"proof\":[{\"created\":\"2022-02-10T18:50:48.682348236Z\",\"domain\":\"https://orb.domain2.com\",\"jws\":\"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..fqgLBKohg962_3GNbH-QXklA89KBMHev95-Pk1XcGa47jq0TbFUeZi3DBGLgc-pDBisqkh0U3bUSvKY_edBAAw\",\"proofPurpose\":\"assertionMethod\",\"type\":\"Ed25519Signature2018\",\"verificationMethod\":\"did:web:orb.domain2.com#orb2key\"},{\"created\":\"2022-02-10T18:50:48.729Z\",\"domain\":\"http://orb.vct:8077/maple2020\",\"jws\":\"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..xlI19T5KT-Sy1CJuCQLIhgGHdlaK0dIjoctRwzJUz6-TpiluluGEa69aCuDjx426TgHvGXJDn8jHi5aDqGuTDA\",\"proofPurpose\":\"assertionMethod\",\"type\":\"Ed25519Signature2018\",\"verificationMethod\":\"did:web:orb.domain1.com#orb1key2\"}],\"type\":\"VerifiableCredential\"}",
       "generator": "https://w3id.org/orb#v0",
+      "mediaType": "application/json",
       "type": "AnchorObject",
-      "url": "hl:uEiAQZHVlPe0To_t9Mz-K__W6Bf2owOASxjZMdz3EM1akrA"
+      "url": "hl:uEiB_22mkkq3lIOkoZXayxavsGnJ2HP8xR0ke_fGCKqQpyA"
     }
   ],
-  "attributedTo": "https://orb.domain1.com/services/orb",
-  "index": "hl:uEiDvP1yOfMsF5JYqFH_F4QX12_IOwp9tNRjsRl4fZrofSQ",
-  "parent": "hl:uEiCQhpLcjhOV_tDVibUfPbkhjJM_FUYwQ9AuAHahoAGxyg:uoQ-BeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQ1FocExjamhPVl90RFZpYlVmUGJraGpKTV9GVVl3UTlBdUFIYWhvQUd4eWc",
-  "published": "2021-11-29T15:20:57.975214Z",
+  "attributedTo": "https://orb.domain2.com/services/orb",
+  "index": "hl:uEiB5sZH1-ZEY0QDRbFgOrGQZqb95A95q5VWNVBBzxAJMCA",
+  "parent": "hl:uEiAk0CUuIIVOxlalYH6JU7gsIwvo5zGNcM_zYo2jXwzBzw:uoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpQWswQ1V1SUlWT3hsYWxZSDZKVTdnc0l3dm81ekdOY01fellvMmpYd3pCenc",
+  "published": "2022-02-10T18:50:48.681998572Z",
   "type": "AnchorEvent"
 }`
 
@@ -480,24 +398,12 @@ const sampleGrandparentAnchorEvent = `{
   "@context": "https://w3id.org/activityanchors/v1",
   "attachment": [
     {
-      "contentObject": {
-        "properties": {
-          "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v0",
-          "https://w3id.org/activityanchors#resources": [
-            {
-              "id": "did:orb:uAAA:EiAN8R3Na3wa_jkqWRHa3GCXlTrVKlXn4UTecMMkjcdAMQ"
-            },
-            {
-              "id": "did:orb:uAAA:EiCQNQ4L1bBFtgaFk4FS4kzLyO3gIO15tXn2j0T5EEu2UQ"
-            }
-          ]
-        },
-        "subject": "hl:uEiCH0q3MEo8iI-tpO-oPYKpAxt_J0CPGZCknwobkmM2d3A:uoQ-BeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQ0gwcTNNRW84aUktdHBPLW9QWUtwQXh0X0owQ1BHWkNrbndvYmttTTJkM0E"
-      },
+      "content": "{\"properties\":{\"https://w3id.org/activityanchors#generator\":\"https://w3id.org/orb#v0\",\"https://w3id.org/activityanchors#resources\":[{\"id\":\"did:orb:uAAA:EiCIZ19PGWe_65JLcIp_bmOu_ZrPOerFPXAoXAcdWW7iCg\"}]},\"subject\":\"hl:uEiB_EO3wonWIqC-2qzI730l3IQhYCzNxWtdNynBJi_O-uw:uoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpQl9FTzN3b25XSXFDLTJxekk3MzBsM0lRaFlDek54V3RkTnluQkppX08tdXc\"}",
       "generator": "https://w3id.org/orb#v0",
+      "mediaType": "application/json",
       "tag": [
         {
-          "href": "hl:uEiAK350M8UQQlUS6f4hKeWzi5iYvw6n3c96doONIAZe0pQ",
+          "href": "hl:uEiB-dxzjTbnnyxGyLYFqZof9YahIFO-JHR-u6pZIcbFiAg",
           "rel": [
             "witness"
           ],
@@ -505,45 +411,18 @@ const sampleGrandparentAnchorEvent = `{
         }
       ],
       "type": "AnchorObject",
-      "url": "hl:uEiDvX0mmtBDXE9AswkkfEMOXniSQ_SIbN57Kz8XfV03lUA"
+      "url": "hl:uEiBOxwW4jVeoEXk-D2GK1rVfLDxqiKBNK1aPxhtDq-4WUw"
     },
     {
-      "contentObject": {
-        "@context": [
-          "https://www.w3.org/2018/credentials/v1",
-          "https://w3id.org/security/suites/jws-2020/v1"
-        ],
-        "credentialSubject": "hl:uEiDvX0mmtBDXE9AswkkfEMOXniSQ_SIbN57Kz8XfV03lUA",
-        "id": "https://orb.domain1.com/vc/433284e4-9891-4bf8-ad01-85de12a15ed8",
-        "issuanceDate": "2021-11-29T15:20:55.9382235Z",
-        "issuer": "https://orb.domain1.com",
-        "proof": [
-          {
-            "created": "2021-11-29T15:20:55.947Z",
-            "domain": "http://orb.vct:8077/maple2020",
-            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..qILZ-0Dk__TbxKYNQJmictTDlCQvPMZK-g9ONCSEz58NYQI3tS4qbyvRrtTWeT84x8Rm4vpb2EDqxQv2pi6cAA",
-            "proofPurpose": "assertionMethod",
-            "type": "Ed25519Signature2018",
-            "verificationMethod": "did:web:orb.domain1.com#orb1key"
-          },
-          {
-            "created": "2021-11-29T15:20:56.0750857Z",
-            "domain": "https://orb.domain2.com",
-            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..H_OTWQxSx7pypRjGd9q9IOBiDueQO9oJGq0GFZMUQBLLCZYsx5fp1B54yoKHg6_AmwgJOAKgfUIiHuEekcA3BA",
-            "proofPurpose": "assertionMethod",
-            "type": "Ed25519Signature2018",
-            "verificationMethod": "did:web:orb.domain2.com#orb2key"
-          }
-        ],
-        "type": "VerifiableCredential"
-      },
+      "content": "{\"@context\":[\"https://www.w3.org/2018/credentials/v1\"],\"credentialSubject\":\"hl:uEiBOxwW4jVeoEXk-D2GK1rVfLDxqiKBNK1aPxhtDq-4WUw\",\"id\":\"https://orb.domain2.com/vc/525b6a6d-b288-47ed-bf5f-1cc7a5c161f1\",\"issuanceDate\":\"2022-02-10T18:50:45.695225137Z\",\"issuer\":\"https://orb.domain2.com\",\"proof\":[{\"created\":\"2022-02-10T18:50:45.695532436Z\",\"domain\":\"https://orb.domain2.com\",\"jws\":\"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..uWopymt6qTIyXFAN3cETf7XXkTCcqSNA7Cqw9GALcq-Ax19tjAMpcAT_VPoM3Kf-RUb8s5lDgsozMCwWXakZBg\",\"proofPurpose\":\"assertionMethod\",\"type\":\"Ed25519Signature2018\",\"verificationMethod\":\"did:web:orb.domain2.com#orb2key\"},{\"created\":\"2022-02-10T18:50:45.784Z\",\"domain\":\"http://orb.vct:8077/maple2020\",\"jws\":\"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..61LDooN6Lg71-YX3R371O9z7m15M2iG30QBDxNDWG3psg50HXiA7JJOn245nBaV9_pee_lzB0kjBD1CYg7Y_BQ\",\"proofPurpose\":\"assertionMethod\",\"type\":\"Ed25519Signature2018\",\"verificationMethod\":\"did:web:orb.domain1.com#orb1key2\"}],\"type\":\"VerifiableCredential\"}",
       "generator": "https://w3id.org/orb#v0",
+      "mediaType": "application/json",
       "type": "AnchorObject",
-      "url": "hl:uEiAK350M8UQQlUS6f4hKeWzi5iYvw6n3c96doONIAZe0pQ"
+      "url": "hl:uEiB-dxzjTbnnyxGyLYFqZof9YahIFO-JHR-u6pZIcbFiAg"
     }
   ],
-  "attributedTo": "https://orb.domain1.com/services/orb",
-  "index": "hl:uEiDvX0mmtBDXE9AswkkfEMOXniSQ_SIbN57Kz8XfV03lUA",
-  "published": "2021-11-29T15:20:55.9326576Z",
+  "attributedTo": "https://orb.domain2.com/services/orb",
+  "index": "hl:uEiBOxwW4jVeoEXk-D2GK1rVfLDxqiKBNK1aPxhtDq-4WUw",
+  "published": "2022-02-10T18:50:45.692283508Z",
   "type": "AnchorEvent"
 }`

--- a/pkg/anchor/handler/proof/handler.go
+++ b/pkg/anchor/handler/proof/handler.go
@@ -227,7 +227,7 @@ func (h *WitnessProofHandler) handleWitnessPolicy(anchorEvent *vocab.AnchorEvent
 		return fmt.Errorf("create new object with document: %w", err)
 	}
 
-	witnessAnchorObj, err := vocab.NewAnchorObject(anchorObj.Generator(), witness)
+	witnessAnchorObj, err := vocab.NewAnchorObject(anchorObj.Generator(), witness, anchorObj.MediaType())
 	if err != nil {
 		return fmt.Errorf("create new anchor object: %w", err)
 	}
@@ -235,6 +235,7 @@ func (h *WitnessProofHandler) handleWitnessPolicy(anchorEvent *vocab.AnchorEvent
 	witnessedAnchorObj, err := vocab.NewAnchorObject(
 		anchorObj.Generator(),
 		anchorObj.ContentObject(),
+		anchorObj.MediaType(),
 		vocab.WithLink(vocab.NewLink(witnessAnchorObj.URL()[0], vocab.RelationshipWitness)),
 	)
 	if err != nil {

--- a/pkg/anchor/handler/proof/handler_test.go
+++ b/pkg/anchor/handler/proof/handler_test.go
@@ -707,150 +707,71 @@ func (wp *mockWitnessPolicy) Evaluate(_ []*proofapi.WitnessProof) (bool, error) 
 
 //nolint:lll
 const anchorEvent = `{
-  "@context": [
-    "https://www.w3.org/ns/activitystreams",
-    "https://w3id.org/activityanchors/v1"
-  ],
-  "index": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
+  "@context": "https://w3id.org/activityanchors/v1",
   "attachment": [
     {
-      "contentObject": {
-        "properties": {
-          "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v0",
-          "https://w3id.org/activityanchors#resources": [
-            {
-              "ID": "did:orb:uAAA:EiAqm7CXVPxriNZv_A6GVCrqlmCmrUSGJ1YaheTzFxa_Fw"
-            }
-          ]
-        },
-        "subject": "hl:uEiDYMTm9nJ5B0gwpNtflwrcZCT9uT6BFiEs5sYWB45piXg:uoQ-BeEJpcGZzOi8vYmFma3JlaWd5Z2U0MzNoZTZpaGpheWtqdzI3czRmbnl6YmU3dzR0NWFpd2Vld29ucnF3YTZoZ3RjbHk"
-      },
+      "content": "{\"properties\":{\"https://w3id.org/activityanchors#generator\":\"https://w3id.org/orb#v0\",\"https://w3id.org/activityanchors#resources\":[{\"id\":\"did:orb:uEiAk0CUuIIVOxlalYH6JU7gsIwvo5zGNcM_zYo2jXwzBzw:EiCIZ19PGWe_65JLcIp_bmOu_ZrPOerFPXAoXAcdWW7iCg\",\"previousAnchor\":\"hl:uEiAk0CUuIIVOxlalYH6JU7gsIwvo5zGNcM_zYo2jXwzBzw\"}]},\"subject\":\"hl:uEiC0arCOQrIDw2F2Zca10gEutIrHWgIUaC1jPDRRBLADUQ:uoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpQzBhckNPUXJJRHcyRjJaY2ExMGdFdXRJckhXZ0lVYUMxalBEUlJCTEFEVVE\"}",
       "generator": "https://w3id.org/orb#v0",
+      "mediaType": "application/json",
       "tag": [
         {
-          "type": "Link",
-          "href": "hl:uEiDzOEQi2wRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
+          "href": "hl:uEiB_22mkkq3lIOkoZXayxavsGnJ2HP8xR0ke_fGCKqQpyA",
           "rel": [
             "witness"
-          ]
+          ],
+          "type": "Link"
         }
       ],
       "type": "AnchorObject",
-      "url": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw"
+      "url": "hl:uEiB5sZH1-ZEY0QDRbFgOrGQZqb95A95q5VWNVBBzxAJMCA"
     },
     {
-      "contentObject": {
-        "@context": [
-          "https://www.w3.org/2018/credentials/v1",
-          "https://w3id.org/security/jws/v1"
-        ],
-        "credentialSubject": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
-        "id": "http://orb2.domain1.com/vc/3994cc26-555c-47f1-9890-058148c154f1",
-        "issuanceDate": "2021-10-14T18:32:17.894314751Z",
-        "issuer": "http://orb2.domain1.com",
-        "proof": [
-          {
-            "created": "2021-10-14T18:32:18.09110265Z",
-            "domain": "https://orb.domain2.com",
-            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..DSL3zsltnh9dbSn3VNPb1C-6pKt6VOy-H1WadO5ZV2QZd3xZq3uRRhaShi9K1SzX-VaGPxs3gfbazJ-fpHVxBg",
-            "proofPurpose": "assertionMethod",
-            "type": "Ed25519Signature2018",
-            "verificationMethod": "did:web:orb.domain2.com#orb2key"
-          }
-        ],
-        "type": "VerifiableCredential"
-      },
+      "content": "{\"@context\":[\"https://www.w3.org/2018/credentials/v1\"],\"credentialSubject\":\"hl:uEiB5sZH1-ZEY0QDRbFgOrGQZqb95A95q5VWNVBBzxAJMCA\",\"id\":\"https://orb.domain2.com/vc/1636951e-9117-4134-904a-e0cd177517a1\",\"issuanceDate\":\"2022-02-10T18:50:48.682168399Z\",\"issuer\":\"https://orb.domain2.com\",\"proof\":[{\"created\":\"2022-02-10T18:50:48.682348236Z\",\"domain\":\"https://orb.domain2.com\",\"jws\":\"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..fqgLBKohg962_3GNbH-QXklA89KBMHev95-Pk1XcGa47jq0TbFUeZi3DBGLgc-pDBisqkh0U3bUSvKY_edBAAw\",\"proofPurpose\":\"assertionMethod\",\"type\":\"Ed25519Signature2018\",\"verificationMethod\":\"did:web:orb.domain2.com#orb2key\"},{\"created\":\"2022-02-10T18:50:48.729Z\",\"domain\":\"http://orb.vct:8077/maple2020\",\"jws\":\"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..xlI19T5KT-Sy1CJuCQLIhgGHdlaK0dIjoctRwzJUz6-TpiluluGEa69aCuDjx426TgHvGXJDn8jHi5aDqGuTDA\",\"proofPurpose\":\"assertionMethod\",\"type\":\"Ed25519Signature2018\",\"verificationMethod\":\"did:web:orb.domain1.com#orb1key2\"}],\"type\":\"VerifiableCredential\"}",
       "generator": "https://w3id.org/orb#v0",
+      "mediaType": "application/json",
       "type": "AnchorObject",
-      "url": "hl:uEiDzOEQi2wRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw"
+      "url": "hl:uEiB_22mkkq3lIOkoZXayxavsGnJ2HP8xR0ke_fGCKqQpyA"
     }
   ],
-  "attributedTo": "https://orb.domain1.com/services/orb",
-  "parent": [
-    "hl:uEiAsiwjaXOYDmOHxmvDl3Mx0TfJ0uCar5YXqumjFJUNIBg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBc2l3amFYT1lEbU9IeG12RGwzTXgwVGZKMHVDYXI1WVhxdW1qRkpVTklCZ3hCaXBmczovL2JhZmtyZWlibXJtZW51eGhnYW9tb2Q0bTI2ZHM1enRkdWp4emhqb2JndnBzeWwydjJuZGNza3EyaWF5",
-    "hl:uEiAn3Y7USoP_lNVX-f0EEu1ajLymnqBJItiMARhKBzAKWg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBbjNZN1VTb1BfbE5WWC1mMEVFdTFhakx5bW5xQkpJdGlNQVJoS0J6QUtXZ3hCaXBmczovL2JhZmtyZWliaDN3aG5pc3VkNzZrbmt2N3o3dWNiZjNrMnJzNmtuaHZhamVybnJkYWJkYmZhb21ha2xp"
-  ],
-  "published": "2021-10-14T18:32:17.888176489Z",
-  "type": "AnchorEvent",
-  "url": "hl:uEiDhdDIS_-_SWKoh5Y3KJ_sWpIoXZUPBeTBMCSBUKXpe5w:uoQ-BeEJpcGZzOi8vYmFma3JlaWhib3F6YmY3N3Ayam1rdWlwZnJ4ZmNwNnl3dXNmYm96a2R5ZjR0YXRhamVia2NzNnM2NDQ"
+  "attributedTo": "https://orb.domain2.com/services/orb",
+  "index": "hl:uEiB5sZH1-ZEY0QDRbFgOrGQZqb95A95q5VWNVBBzxAJMCA",
+  "parent": "hl:uEiAk0CUuIIVOxlalYH6JU7gsIwvo5zGNcM_zYo2jXwzBzw:uoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpQWswQ1V1SUlWT3hsYWxZSDZKVTdnc0l3dm81ekdOY01fellvMmpYd3pCenc",
+  "published": "2022-02-10T18:50:48.681998572Z",
+  "type": "AnchorEvent"
 }`
 
 //nolint:lll
 const anchorEventTwoProofs = `{
-  "@context": [
-    "https://www.w3.org/ns/activitystreams",
-    "https://w3id.org/activityanchors/v1"
-  ],
-  "index": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
+  "@context": "https://w3id.org/activityanchors/v1",
   "attachment": [
     {
-      "contentObject": {
-        "properties": {
-          "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v0",
-          "https://w3id.org/activityanchors#resources": [
-            {
-              "ID": "did:orb:uAAA:EiAqm7CXVPxriNZv_A6GVCrqlmCmrUSGJ1YaheTzFxa_Fw"
-            }
-          ]
-        },
-        "subject": "hl:uEiDYMTm9nJ5B0gwpNtflwrcZCT9uT6BFiEs5sYWB45piXg:uoQ-BeEJpcGZzOi8vYmFma3JlaWd5Z2U0MzNoZTZpaGpheWtqdzI3czRmbnl6YmU3dzR0NWFpd2Vld29ucnF3YTZoZ3RjbHk"
-      },
+      "content": "{\"properties\":{\"https://w3id.org/activityanchors#generator\":\"https://w3id.org/orb#v0\",\"https://w3id.org/activityanchors#resources\":[{\"id\":\"did:orb:uAAA:EiCjNbfvKWZDsa59BcLw0TE9t6JrY6D8N9T_8GKnuI8oxw\"},{\"id\":\"did:orb:uAAA:EiBlxzs4KPQ0H4zJHFVwY7x3UGuJe4Lro9HMr2SXz0LUDw\"},{\"id\":\"did:orb:uAAA:EiDhm7PZtsT6V9kwr5Uxcr_CJgobAVqQlGNG4_3r4TQQFA\"},{\"id\":\"did:orb:uAAA:EiAFi_-TaUuSa4C991o0BhFoJwxkEtRiQDSb3x_H76XyGQ\"},{\"id\":\"did:orb:uAAA:EiDoYvqwqqo9YSkqBB0LEM0oxkn1ouRfnMlHN1mlCoJKxw\"},{\"id\":\"did:orb:uAAA:EiCDzGTIVFUr3YCyWiyzExvOAMwogn29XOM01Y6v9kKKiA\"}]},\"subject\":\"hl:uEiBuyLBSjEYws4_MZyoD9Bt7rXsnVNKkM1eX0rB5SDQeGA:uoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpQnV5TEJTakVZd3M0X01aeW9EOUJ0N3JYc25WTktrTTFlWDByQjVTRFFlR0E\"}",
       "generator": "https://w3id.org/orb#v0",
+      "mediaType": "application/json",
       "tag": [
         {
-          "type": "Link",
-          "href": "hl:uEiDzOEQi2wRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
+          "href": "hl:uEiDM_cyudC07RwQF0hrtk_J7_l0jg9S01slXwz6f9aI_2A",
           "rel": [
             "witness"
-          ]
+          ],
+          "type": "Link"
         }
       ],
       "type": "AnchorObject",
-      "url": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw"
+      "url": "hl:uEiB4mpKUX0qR40jurnRBlNb2iXRb5-AqgBskZOMC1nA2QA"
     },
     {
-      "contentObject": {
-        "@context": [
-          "https://www.w3.org/2018/credentials/v1",
-          "https://w3id.org/security/jws/v1"
-        ],
-        "credentialSubject": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
-        "id": "http://orb2.domain1.com/vc/3994cc26-555c-47f1-9890-058148c154f1",
-        "issuanceDate": "2021-10-14T18:32:17.894314751Z",
-        "issuer": "http://orb2.domain1.com",
-        "proof": [
-          {
-            "created": "2021-10-14T18:32:17.91Z",
-            "domain": "http://orb.vct:8077/maple2020",
-            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..h3-0HC3L87TM0j0o3Nd0VLlalcVVphwOPsfdkCLZ4q-uL4z8eO2vQ4sobbtOtFpNNZlpIOQnaWJMX3Ch5Wh-AQ",
-            "proofPurpose": "assertionMethod",
-            "type": "Ed25519Signature2018",
-            "verificationMethod": "did:web:orb.domain1.com#orb1key"
-          },
-          {
-            "created": "2021-10-14T18:32:18.09110265Z",
-            "domain": "https://orb.domain2.com",
-            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..DSL3zsltnh9dbSn3VNPb1C-6pKt6VOy-H1WadO5ZV2QZd3xZq3uRRhaShi9K1SzX-VaGPxs3gfbazJ-fpHVxBg",
-            "proofPurpose": "assertionMethod",
-            "type": "Ed25519Signature2018",
-            "verificationMethod": "did:web:orb.domain2.com#orb2key"
-          }
-        ],
-        "type": "VerifiableCredential"
-      },
+      "content": "{\"@context\":[\"https://www.w3.org/2018/credentials/v1\"],\"credentialSubject\":\"hl:uEiB4mpKUX0qR40jurnRBlNb2iXRb5-AqgBskZOMC1nA2QA\",\"id\":\"https://orb.domain2.com/vc/1588d22b-2461-4347-a150-afee8e7cf5c7\",\"issuanceDate\":\"2022-02-10T19:27:32.200199824Z\",\"issuer\":\"https://orb.domain2.com\",\"proof\":[{\"created\":\"2022-02-10T19:27:32.200372694Z\",\"domain\":\"https://orb.domain2.com\",\"jws\":\"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..CjOYK7XH7zyH3-Gtg54rFkuOaIt9W4Ov8uYksHPJeBNmTHBdwmyyJ6yExguDQ2yak6KvgeIou70_za4QHWIBCw\",\"proofPurpose\":\"assertionMethod\",\"type\":\"Ed25519Signature2018\",\"verificationMethod\":\"did:web:orb.domain2.com#orb2key\"},{\"created\":\"2022-02-10T19:27:32.306Z\",\"domain\":\"http://orb.vct:8077/maple2020\",\"jws\":\"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..bRPBmMYeBTjO01M4QHXmsfZNSL8gmPTdhac7yQkTpWiDgpykXs_KyVdBtuA5rvUBsfsfCzDSgvp15SmufDXaDQ\",\"proofPurpose\":\"assertionMethod\",\"type\":\"Ed25519Signature2018\",\"verificationMethod\":\"did:web:orb.domain1.com#orb1key2\"}],\"type\":\"VerifiableCredential\"}",
       "generator": "https://w3id.org/orb#v0",
+      "mediaType": "application/json",
       "type": "AnchorObject",
-      "url": "hl:uEiDzOEQi2wRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw"
+      "url": "hl:uEiDM_cyudC07RwQF0hrtk_J7_l0jg9S01slXwz6f9aI_2A"
     }
   ],
-  "attributedTo": "https://orb.domain1.com/services/orb",
-  "parent": [
-    "hl:uEiAsiwjaXOYDmOHxmvDl3Mx0TfJ0uCar5YXqumjFJUNIBg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBc2l3amFYT1lEbU9IeG12RGwzTXgwVGZKMHVDYXI1WVhxdW1qRkpVTklCZ3hCaXBmczovL2JhZmtyZWlibXJtZW51eGhnYW9tb2Q0bTI2ZHM1enRkdWp4emhqb2JndnBzeWwydjJuZGNza3EyaWF5",
-    "hl:uEiAn3Y7USoP_lNVX-f0EEu1ajLymnqBJItiMARhKBzAKWg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBbjNZN1VTb1BfbE5WWC1mMEVFdTFhakx5bW5xQkpJdGlNQVJoS0J6QUtXZ3hCaXBmczovL2JhZmtyZWliaDN3aG5pc3VkNzZrbmt2N3o3dWNiZjNrMnJzNmtuaHZhamVybnJkYWJkYmZhb21ha2xp"
-  ],
-  "published": "2021-10-14T18:32:17.888176489Z",
-  "type": "AnchorEvent",
-  "url": "hl:uEiDhdDIS_-_SWKoh5Y3KJ_sWpIoXZUPBeTBMCSBUKXpe5w:uoQ-BeEJpcGZzOi8vYmFma3JlaWhib3F6YmY3N3Ayam1rdWlwZnJ4ZmNwNnl3dXNmYm96a2R5ZjR0YXRhamVia2NzNnM2NDQ"
+  "attributedTo": "https://orb.domain2.com/services/orb",
+  "index": "hl:uEiB4mpKUX0qR40jurnRBlNb2iXRb5-AqgBskZOMC1nA2QA",
+  "published": "2022-02-10T19:27:32.198982074Z",
+  "type": "AnchorEvent"
 }`
 
 //nolint:lll

--- a/pkg/anchor/util/util_test.go
+++ b/pkg/anchor/util/util_test.go
@@ -62,7 +62,8 @@ func TestVerifiableCredentialFromAnchorEvent(t *testing.T) {
 		vcDoc, err := vocab.MarshalToDoc(vc)
 		require.NoError(t, err)
 
-		act, err := anchorevent.BuildAnchorEvent(payload, contentObj.GeneratorID, contentObj.Payload, vcDoc)
+		act, err := anchorevent.BuildAnchorEvent(payload, contentObj.GeneratorID, contentObj.Payload,
+			vcDoc, vocab.GzipMediaType)
 		require.NoError(t, err)
 
 		vcBytes, err := vc.MarshalJSON()
@@ -90,7 +91,7 @@ func TestVerifiableCredentialFromAnchorEvent(t *testing.T) {
 		doc, err := vocab.UnmarshalToDoc([]byte(`{}`))
 		require.NoError(t, err)
 
-		indexAnchorObj, err := vocab.NewAnchorObject("some-generator", doc)
+		indexAnchorObj, err := vocab.NewAnchorObject("some-generator", doc, vocab.GzipMediaType)
 		require.NoError(t, err)
 
 		act := vocab.NewAnchorEvent(
@@ -140,7 +141,8 @@ func TestGetWitnessDoc(t *testing.T) {
 		vcDoc, err := vocab.MarshalToDoc(vc)
 		require.NoError(t, err)
 
-		act, err := anchorevent.BuildAnchorEvent(payload, contentObj.GeneratorID, contentObj.Payload, vcDoc)
+		act, err := anchorevent.BuildAnchorEvent(payload, contentObj.GeneratorID, contentObj.Payload,
+			vcDoc, vocab.GzipMediaType)
 		require.NoError(t, err)
 
 		vcDoc, err = GetWitnessDoc(act)
@@ -159,7 +161,7 @@ func TestGetWitnessDoc(t *testing.T) {
 		doc, err := vocab.UnmarshalToDoc([]byte(`{}`))
 		require.NoError(t, err)
 
-		indexAnchorObj, err := vocab.NewAnchorObject("some-generator", doc)
+		indexAnchorObj, err := vocab.NewAnchorObject("some-generator", doc, vocab.GzipMediaType)
 		require.NoError(t, err)
 
 		ae := vocab.NewAnchorEvent(
@@ -176,7 +178,7 @@ func TestGetWitnessDoc(t *testing.T) {
 		doc, err := vocab.UnmarshalToDoc([]byte(`{}`))
 		require.NoError(t, err)
 
-		indexAnchorObj, err := vocab.NewAnchorObject("some-generator", doc,
+		indexAnchorObj, err := vocab.NewAnchorObject("some-generator", doc, vocab.GzipMediaType,
 			vocab.WithLink(vocab.NewLink(testutil.MustParseURL("hl:uEiCYs2XYno8FGuqzbiQ6gBrg_hqpELV9pJaUA75Y0mATRw"),
 				"some-relationship")))
 		require.NoError(t, err)
@@ -195,7 +197,7 @@ func TestGetWitnessDoc(t *testing.T) {
 		doc, err := vocab.UnmarshalToDoc([]byte(`{}`))
 		require.NoError(t, err)
 
-		indexAnchorObj, err := vocab.NewAnchorObject("some-generator", doc,
+		indexAnchorObj, err := vocab.NewAnchorObject("some-generator", doc, vocab.GzipMediaType,
 			vocab.WithLink(vocab.NewLink(testutil.MustParseURL("hl:uEiCYs2XYno8FGuqzbiQ6gBrg_hqpELV9pJaUA75Y0mATRw"),
 				vocab.RelationshipWitness)))
 		require.NoError(t, err)
@@ -214,7 +216,7 @@ func TestGetWitnessDoc(t *testing.T) {
 		doc, err := vocab.UnmarshalToDoc([]byte(`{}`))
 		require.NoError(t, err)
 
-		indexAnchorObj, err := vocab.NewAnchorObject("some-generator", doc,
+		indexAnchorObj, err := vocab.NewAnchorObject("some-generator", doc, vocab.GzipMediaType,
 			vocab.WithLink(vocab.NewLink(testutil.MustParseURL("hl:uEiCYs2XYno8FGuqzbiQ6gBrg_hqpELV9pJaUA75Y0mATRw"),
 				vocab.RelationshipWitness)))
 		require.NoError(t, err)

--- a/pkg/anchor/witness/policy/inspector/inspector_test.go
+++ b/pkg/anchor/witness/policy/inspector/inspector_test.go
@@ -345,78 +345,35 @@ func (wp *mockWitnessPolicy) Select(witnesses []*proof.Witness, _ ...*proof.Witn
 
 //nolint: lll
 const jsonAnchorEvent = `{
-  "@context": [
-    "https://www.w3.org/ns/activitystreams",
-    "https://w3id.org/activityanchors/v1"
-  ],
-  "index": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
+  "@context": "https://w3id.org/activityanchors/v1",
   "attachment": [
     {
-      "contentObject": {
-        "properties": {
-          "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v0",
-          "https://w3id.org/activityanchors#resources": [
-            {
-              "ID": "did:orb:uAAA:EiAqm7CXVPxriNZv_A6GVCrqlmCmrUSGJ1YaheTzFxa_Fw"
-            }
-          ]
-        },
-        "subject": "hl:uEiDYMTm9nJ5B0gwpNtflwrcZCT9uT6BFiEs5sYWB45piXg:uoQ-BeEJpcGZzOi8vYmFma3JlaWd5Z2U0MzNoZTZpaGpheWtqdzI3czRmbnl6YmU3dzR0NWFpd2Vld29ucnF3YTZoZ3RjbHk"
-      },
+      "content": "{\"properties\":{\"https://w3id.org/activityanchors#generator\":\"https://w3id.org/orb#v0\",\"https://w3id.org/activityanchors#resources\":[{\"id\":\"did:orb:uEiAk0CUuIIVOxlalYH6JU7gsIwvo5zGNcM_zYo2jXwzBzw:EiCIZ19PGWe_65JLcIp_bmOu_ZrPOerFPXAoXAcdWW7iCg\",\"previousAnchor\":\"hl:uEiAk0CUuIIVOxlalYH6JU7gsIwvo5zGNcM_zYo2jXwzBzw\"}]},\"subject\":\"hl:uEiC0arCOQrIDw2F2Zca10gEutIrHWgIUaC1jPDRRBLADUQ:uoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpQzBhckNPUXJJRHcyRjJaY2ExMGdFdXRJckhXZ0lVYUMxalBEUlJCTEFEVVE\"}",
       "generator": "https://w3id.org/orb#v0",
+      "mediaType": "application/json",
       "tag": [
         {
-          "type": "Link",
-          "href": "hl:uEiDzOEQi2wRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
+          "href": "hl:uEiB_22mkkq3lIOkoZXayxavsGnJ2HP8xR0ke_fGCKqQpyA",
           "rel": [
             "witness"
-          ]
+          ],
+          "type": "Link"
         }
       ],
       "type": "AnchorObject",
-      "url": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw"
+      "url": "hl:uEiB5sZH1-ZEY0QDRbFgOrGQZqb95A95q5VWNVBBzxAJMCA"
     },
     {
-      "contentObject": {
-        "@context": [
-          "https://www.w3.org/2018/credentials/v1",
-          "https://w3id.org/security/jws/v1"
-        ],
-        "credentialSubject": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
-        "id": "http://orb2.domain1.com/vc/3994cc26-555c-47f1-9890-058148c154f1",
-        "issuanceDate": "2021-10-14T18:32:17.894314751Z",
-        "issuer": "http://orb2.domain1.com",
-        "proof": [
-          {
-            "created": "2021-10-14T18:32:17.91Z",
-            "domain": "http://orb.vct:8077/maple2020",
-            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..h3-0HC3L87TM0j0o3Nd0VLlalcVVphwOPsfdkCLZ4q-uL4z8eO2vQ4sobbtOtFpNNZlpIOQnaWJMX3Ch5Wh-AQ",
-            "proofPurpose": "assertionMethod",
-            "type": "Ed25519Signature2018",
-            "verificationMethod": "did:web:orb.domain1.com#orb1key"
-          },
-          {
-            "created": "2021-10-14T18:32:18.09110265Z",
-            "domain": "https://orb.domain2.com",
-            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..DSL3zsltnh9dbSn3VNPb1C-6pKt6VOy-H1WadO5ZV2QZd3xZq3uRRhaShi9K1SzX-VaGPxs3gfbazJ-fpHVxBg",
-            "proofPurpose": "assertionMethod",
-            "type": "Ed25519Signature2018",
-            "verificationMethod": "did:web:orb.domain2.com#orb2key"
-          }
-        ],
-        "type": "VerifiableCredential"
-      },
+      "content": "{\"@context\":[\"https://www.w3.org/2018/credentials/v1\"],\"credentialSubject\":\"hl:uEiB5sZH1-ZEY0QDRbFgOrGQZqb95A95q5VWNVBBzxAJMCA\",\"id\":\"https://orb.domain2.com/vc/1636951e-9117-4134-904a-e0cd177517a1\",\"issuanceDate\":\"2022-02-10T18:50:48.682168399Z\",\"issuer\":\"https://orb.domain2.com\",\"proof\":[{\"created\":\"2022-02-10T18:50:48.682348236Z\",\"domain\":\"https://orb.domain2.com\",\"jws\":\"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..fqgLBKohg962_3GNbH-QXklA89KBMHev95-Pk1XcGa47jq0TbFUeZi3DBGLgc-pDBisqkh0U3bUSvKY_edBAAw\",\"proofPurpose\":\"assertionMethod\",\"type\":\"Ed25519Signature2018\",\"verificationMethod\":\"did:web:orb.domain2.com#orb2key\"},{\"created\":\"2022-02-10T18:50:48.729Z\",\"domain\":\"http://orb.vct:8077/maple2020\",\"jws\":\"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..xlI19T5KT-Sy1CJuCQLIhgGHdlaK0dIjoctRwzJUz6-TpiluluGEa69aCuDjx426TgHvGXJDn8jHi5aDqGuTDA\",\"proofPurpose\":\"assertionMethod\",\"type\":\"Ed25519Signature2018\",\"verificationMethod\":\"did:web:orb.domain1.com#orb1key2\"}],\"type\":\"VerifiableCredential\"}",
       "generator": "https://w3id.org/orb#v0",
+      "mediaType": "application/json",
       "type": "AnchorObject",
-      "url": "hl:uEiDzOEQi2wRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw"
+      "url": "hl:uEiB_22mkkq3lIOkoZXayxavsGnJ2HP8xR0ke_fGCKqQpyA"
     }
   ],
-  "attributedTo": "https://orb.domain1.com/services/orb",
-  "parent": [
-    "hl:uEiAsiwjaXOYDmOHxmvDl3Mx0TfJ0uCar5YXqumjFJUNIBg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBc2l3amFYT1lEbU9IeG12RGwzTXgwVGZKMHVDYXI1WVhxdW1qRkpVTklCZ3hCaXBmczovL2JhZmtyZWlibXJtZW51eGhnYW9tb2Q0bTI2ZHM1enRkdWp4emhqb2JndnBzeWwydjJuZGNza3EyaWF5",
-    "hl:uEiAn3Y7USoP_lNVX-f0EEu1ajLymnqBJItiMARhKBzAKWg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBbjNZN1VTb1BfbE5WWC1mMEVFdTFhakx5bW5xQkpJdGlNQVJoS0J6QUtXZ3hCaXBmczovL2JhZmtyZWliaDN3aG5pc3VkNzZrbmt2N3o3dWNiZjNrMnJzNmtuaHZhamVybnJkYWJkYmZhb21ha2xp"
-  ],
-  "published": "2021-10-14T18:32:17.888176489Z",
-  "type": "AnchorEvent",
-  "url": "hl:uEiDhdDIS_-_SWKoh5Y3KJ_sWpIoXZUPBeTBMCSBUKXpe5w:uoQ-BeEJpcGZzOi8vYmFma3JlaWhib3F6YmY3N3Ayam1rdWlwZnJ4ZmNwNnl3dXNmYm96a2R5ZjR0YXRhamVia2NzNnM2NDQ"
+  "attributedTo": "https://orb.domain2.com/services/orb",
+  "index": "hl:uEiB5sZH1-ZEY0QDRbFgOrGQZqb95A95q5VWNVBBzxAJMCA",
+  "parent": "hl:uEiAk0CUuIIVOxlalYH6JU7gsIwvo5zGNcM_zYo2jXwzBzw:uoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpQWswQ1V1SUlWT3hsYWxZSDZKVTdnc0l3dm81ekdOY01fellvMmpYd3pCenc",
+  "published": "2022-02-10T18:50:48.681998572Z",
+  "type": "AnchorEvent"
 }`

--- a/pkg/anchor/writer/writer_test.go
+++ b/pkg/anchor/writer/writer_test.go
@@ -86,8 +86,9 @@ func TestNew(t *testing.T) {
 	}
 
 	t.Run("Success", func(t *testing.T) {
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, &mocks.PubSub{},
-			testMaxWitnessDelay, signWithLocalWitness, nil, &mocks.MetricsProvider{})
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers,
+			&anchormocks.AnchorPublisher{}, &mocks.PubSub{}, testMaxWitnessDelay,
+			signWithLocalWitness, nil, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 		require.NotNil(t, c)
 	})
@@ -98,8 +99,9 @@ func TestNew(t *testing.T) {
 		ps := &mocks.PubSub{}
 		ps.SubscribeReturns(nil, errExpected)
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
-			testMaxWitnessDelay, signWithLocalWitness, nil, &mocks.MetricsProvider{})
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers,
+			&anchormocks.AnchorPublisher{}, ps, testMaxWitnessDelay, signWithLocalWitness,
+			nil, &mocks.MetricsProvider{})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errExpected.Error())
 		require.Nil(t, c)
@@ -164,8 +166,9 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			WFClient:               wfClient,
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
-			testMaxWitnessDelay, false, resourceresolver.New(http.DefaultClient,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers,
+			&anchormocks.AnchorPublisher{}, ps, testMaxWitnessDelay, false,
+			resourceresolver.New(http.DefaultClient,
 				nil), &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -226,8 +229,8 @@ func TestWriter_WriteAnchor(t *testing.T) {
 
 		testServerURL = testServer.URL
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
-			testMaxWitnessDelay, false,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers,
+			&anchormocks.AnchorPublisher{}, ps, testMaxWitnessDelay, false,
 			resourceresolver.New(http.DefaultClient,
 				ipfs.New(testServer.URL, 5*time.Second, 0, &mocks.MetricsProvider{}),
 			), &mocks.MetricsProvider{})
@@ -269,8 +272,8 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			WFClient:               wfClient,
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
-			testMaxWitnessDelay, false,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers,
+			&anchormocks.AnchorPublisher{}, ps, testMaxWitnessDelay, false,
 			resourceresolver.New(http.DefaultClient, nil), &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -323,8 +326,8 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			WFClient:               wfClient,
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
-			testMaxWitnessDelay, signWithLocalWitness,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers,
+			&anchormocks.AnchorPublisher{}, ps, testMaxWitnessDelay, signWithLocalWitness,
 			resourceresolver.New(http.DefaultClient, nil), &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -374,8 +377,8 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			WFClient:               wfClient,
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
-			testMaxWitnessDelay, signWithLocalWitness,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers,
+			&anchormocks.AnchorPublisher{}, ps, testMaxWitnessDelay, signWithLocalWitness,
 			resourceresolver.New(http.DefaultClient, nil), &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -424,8 +427,8 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			WFClient:         wfClient,
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, nil, ps,
-			testMaxWitnessDelay, signWithLocalWitness,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers,
+			nil, ps, testMaxWitnessDelay, signWithLocalWitness,
 			resourceresolver.New(http.DefaultClient, nil), &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -471,8 +474,9 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			WFClient:         wfClient,
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
-			testMaxWitnessDelay, signWithLocalWitness, nil, &mocks.MetricsProvider{})
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers,
+			&anchormocks.AnchorPublisher{}, ps, testMaxWitnessDelay, signWithLocalWitness,
+			nil, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
 		opRefs := []*operation.Reference{
@@ -510,8 +514,8 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			WFClient:               wfClient,
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
-			testMaxWitnessDelay, false,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers,
+			&anchormocks.AnchorPublisher{}, ps, testMaxWitnessDelay, false,
 			resourceresolver.New(http.DefaultClient, nil), &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -548,8 +552,8 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			Signer:        &mockSigner{Err: fmt.Errorf("signer error")},
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providersWithErr, &anchormocks.AnchorPublisher{}, ps,
-			testMaxWitnessDelay, signWithLocalWitness,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providersWithErr,
+			&anchormocks.AnchorPublisher{}, ps, testMaxWitnessDelay, signWithLocalWitness,
 			resourceresolver.New(http.DefaultClient, nil), &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -591,8 +595,8 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			AnchorEventStore:       anchorEventStore,
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providersWithErr, &anchormocks.AnchorPublisher{}, ps,
-			testMaxWitnessDelay, signWithLocalWitness,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providersWithErr,
+			&anchormocks.AnchorPublisher{}, ps, testMaxWitnessDelay, signWithLocalWitness,
 			resourceresolver.New(http.DefaultClient, nil), &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -624,8 +628,8 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			Witness:       &mockWitness{Err: fmt.Errorf("witness error")},
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providersWithErr, &anchormocks.AnchorPublisher{}, ps,
-			testMaxWitnessDelay, signWithLocalWitness,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providersWithErr,
+			&anchormocks.AnchorPublisher{}, ps, testMaxWitnessDelay, signWithLocalWitness,
 			resourceresolver.New(http.DefaultClient, nil), &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -663,8 +667,8 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			AnchorEventStore: anchorEventStoreWithErr,
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providersWithErr, &anchormocks.AnchorPublisher{}, ps,
-			testMaxWitnessDelay, signWithLocalWitness,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providersWithErr,
+			&anchormocks.AnchorPublisher{}, ps, testMaxWitnessDelay, signWithLocalWitness,
 			resourceresolver.New(http.DefaultClient, nil), &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -704,8 +708,8 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			AnchorEventStore: anchorEventStoreWithErr,
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providersWithErr, &anchormocks.AnchorPublisher{}, ps,
-			testMaxWitnessDelay, signWithLocalWitness,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providersWithErr,
+			&anchormocks.AnchorPublisher{}, ps, testMaxWitnessDelay, signWithLocalWitness,
 			resourceresolver.New(http.DefaultClient, nil), &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -739,8 +743,9 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			AnchorEventStore: anchorEventStore,
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
-			testMaxWitnessDelay, signWithLocalWitness, nil, &mocks.MetricsProvider{})
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers,
+			&anchormocks.AnchorPublisher{}, ps, testMaxWitnessDelay, signWithLocalWitness,
+			nil, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
 		err = c.WriteAnchor("anchor", nil, []*operation.Reference{{UniqueSuffix: testDID, Type: operation.TypeUpdate}}, 0)
@@ -774,7 +779,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 		publisher := &anchormocks.AnchorPublisher{}
 		publisher.PublishAnchorReturns(errors.New("injected publisher error"))
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, publisher, ps,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers, publisher, ps,
 			testMaxWitnessDelay, false,
 			resourceresolver.New(http.DefaultClient, nil), &mocks.MetricsProvider{})
 		require.NoError(t, err)
@@ -823,8 +828,8 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			AnchorEventStatusStore: statusStore,
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
-			testMaxWitnessDelay, false,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers,
+			&anchormocks.AnchorPublisher{}, ps, testMaxWitnessDelay, false,
 			resourceresolver.New(nil, ipfs.New("SomeIPFSNodeURL", time.Second, 0, &mocks.MetricsProvider{})),
 			&mocks.MetricsProvider{})
 		require.NoError(t, err)
@@ -874,8 +879,9 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			ProofHandler:           servicemocks.NewProofHandler(),
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
-			testMaxWitnessDelay, false, resourceresolver.New(http.DefaultClient,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers,
+			&anchormocks.AnchorPublisher{}, ps, testMaxWitnessDelay,
+			false, resourceresolver.New(http.DefaultClient,
 				nil), &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -940,7 +946,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			ProofHandler:           servicemocks.NewProofHandler(),
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers, &anchormocks.AnchorPublisher{}, ps,
 			testMaxWitnessDelay, false, resourceresolver.New(http.DefaultClient,
 				nil), &mocks.MetricsProvider{})
 		require.NoError(t, err)
@@ -1023,7 +1029,7 @@ func TestWriter_handle(t *testing.T) {
 			DocumentLoader:   testutil.GetLoader(t),
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers, &anchormocks.AnchorPublisher{}, ps,
 			testMaxWitnessDelay, signWithLocalWitness, nil, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -1051,8 +1057,9 @@ func TestWriter_handle(t *testing.T) {
 			DocumentLoader:   testutil.GetLoader(t),
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providersWithErr, &anchormocks.AnchorPublisher{}, ps,
-			testMaxWitnessDelay, signWithLocalWitness, nil, &mocks.MetricsProvider{})
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providersWithErr,
+			&anchormocks.AnchorPublisher{}, ps, testMaxWitnessDelay, signWithLocalWitness,
+			nil, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
 		anchorEvent := &vocab.AnchorEventType{}
@@ -1087,7 +1094,7 @@ func TestWriter_handle(t *testing.T) {
 		anchorPublisher := &anchormocks.AnchorPublisher{}
 		anchorPublisher.PublishAnchorReturns(errExpected)
 
-		c, err := New(namespace, apServiceIRI, casIRI, providersWithErr, anchorPublisher, ps,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providersWithErr, anchorPublisher, ps,
 			testMaxWitnessDelay, signWithLocalWitness, nil, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -1117,7 +1124,7 @@ func TestWriter_handle(t *testing.T) {
 			WitnessStore:     &mockWitnessStore{},
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers, &anchormocks.AnchorPublisher{}, ps,
 			testMaxWitnessDelay, signWithLocalWitness, nil, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -1149,7 +1156,7 @@ func TestWriter_handle(t *testing.T) {
 			DocumentLoader:   testutil.GetLoader(t),
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers, &anchormocks.AnchorPublisher{}, ps,
 			testMaxWitnessDelay, signWithLocalWitness, nil, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -1182,8 +1189,9 @@ func TestWriter_handle(t *testing.T) {
 			DocumentLoader:   testutil.GetLoader(t),
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providersWithErr, &anchormocks.AnchorPublisher{}, ps,
-			testMaxWitnessDelay, signWithLocalWitness, nil, &mocks.MetricsProvider{})
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providersWithErr,
+			&anchormocks.AnchorPublisher{}, ps, testMaxWitnessDelay, signWithLocalWitness,
+			nil, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
 		anchorEvent := &vocab.AnchorEventType{}
@@ -1211,7 +1219,7 @@ func TestWriter_handle(t *testing.T) {
 			DocumentLoader:   testutil.GetLoader(t),
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers, &anchormocks.AnchorPublisher{}, ps,
 			testMaxWitnessDelay, signWithLocalWitness, nil, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -1243,7 +1251,7 @@ func TestWriter_handle(t *testing.T) {
 			DocumentLoader:   testutil.GetLoader(t),
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers, &anchormocks.AnchorPublisher{}, ps,
 			testMaxWitnessDelay, signWithLocalWitness, nil, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -1292,7 +1300,7 @@ func TestWriter_postOfferActivity(t *testing.T) {
 			WFClient:               wfClient,
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers, &anchormocks.AnchorPublisher{}, ps,
 			testMaxWitnessDelay, signWithLocalWitness, nil, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -1305,7 +1313,7 @@ func TestWriter_postOfferActivity(t *testing.T) {
 			Outbox: &mockOutbox{},
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers, &anchormocks.AnchorPublisher{}, ps,
 			testMaxWitnessDelay, signWithLocalWitness, nil, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -1323,7 +1331,7 @@ func TestWriter_postOfferActivity(t *testing.T) {
 			WFClient:      wfClient,
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers, &anchormocks.AnchorPublisher{}, ps,
 			testMaxWitnessDelay, signWithLocalWitness, nil, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -1348,7 +1356,7 @@ func TestWriter_postOfferActivity(t *testing.T) {
 			WFClient:      wfClientWithErr,
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers, &anchormocks.AnchorPublisher{}, ps,
 			testMaxWitnessDelay, signWithLocalWitness, nil, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -1373,7 +1381,7 @@ func TestWriter_postOfferActivity(t *testing.T) {
 			WFClient:      wfClient,
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers, &anchormocks.AnchorPublisher{}, ps,
 			testMaxWitnessDelay, signWithLocalWitness, nil, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -1393,7 +1401,7 @@ func TestWriter_postOfferActivity(t *testing.T) {
 			WFClient:               wfClient,
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers, &anchormocks.AnchorPublisher{}, ps,
 			testMaxWitnessDelay, signWithLocalWitness, nil, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -1412,7 +1420,7 @@ func TestWriter_postOfferActivity(t *testing.T) {
 			WFClient:               wfClient,
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers, &anchormocks.AnchorPublisher{}, ps,
 			testMaxWitnessDelay, signWithLocalWitness, nil, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -1467,7 +1475,7 @@ func TestWriter_getWitnesses(t *testing.T) {
 			OpProcessor: &mockOpProcessor{Map: opMap},
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers, &anchormocks.AnchorPublisher{}, ps,
 			testMaxWitnessDelay, signWithLocalWitness,
 			resourceresolver.New(http.DefaultClient, nil, resourceresolver.WithCacheLifetime(0)),
 			&mocks.MetricsProvider{})
@@ -1531,7 +1539,7 @@ func TestWriter_getWitnesses(t *testing.T) {
 			OpProcessor: &mockOpProcessor{Map: opMap},
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers, &anchormocks.AnchorPublisher{}, ps,
 			testMaxWitnessDelay, signWithLocalWitness, nil, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -1557,7 +1565,7 @@ func TestWriter_getWitnesses(t *testing.T) {
 			OpProcessor: &mockOpProcessor{Map: opMap},
 		}
 
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers, &anchormocks.AnchorPublisher{}, ps,
 			testMaxWitnessDelay, signWithLocalWitness, nil, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -1592,8 +1600,9 @@ func TestWriter_getBatchWitnessesIRI(t *testing.T) {
 
 	wfClient := wfclient.New(wfclient.WithHTTPClient(wfHTTPClient))
 
-	c, err := New(namespace, apServiceIRI, nil, &Providers{WFClient: wfClient}, &anchormocks.AnchorPublisher{}, ps,
-		testMaxWitnessDelay, true, nil, &mocks.MetricsProvider{})
+	c, err := New(namespace, apServiceIRI, nil, vocab.JSONMediaType, &Providers{WFClient: wfClient},
+		&anchormocks.AnchorPublisher{}, ps, testMaxWitnessDelay, true, nil,
+		&mocks.MetricsProvider{})
 	require.NoError(t, err)
 
 	t.Run("success", func(t *testing.T) {
@@ -1654,7 +1663,7 @@ func TestWriter_Read(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("success", func(t *testing.T) {
-		c, err := New(namespace, apServiceIRI, casIRI, providers, &anchormocks.AnchorPublisher{}, ps,
+		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers, &anchormocks.AnchorPublisher{}, ps,
 			testMaxWitnessDelay, signWithLocalWitness, nil, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 
@@ -1876,135 +1885,70 @@ func (wp *mockWitnessPolicy) Select(witnesses []*proof.Witness, _ ...*proof.Witn
 
 //nolint: lll
 const jsonAnchorEvent = `{
-  "@context": [
-    "https://www.w3.org/ns/activitystreams",
-    "https://w3id.org/activityanchors/v1"
-  ],
-  "index": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
+  "@context": "https://w3id.org/activityanchors/v1",
   "attachment": [
     {
-      "contentObject": {
-        "properties": {
-          "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v0",
-          "https://w3id.org/activityanchors#resources": [
-            {
-              "ID": "did:orb:uAAA:EiAqm7CXVPxriNZv_A6GVCrqlmCmrUSGJ1YaheTzFxa_Fw"
-            }
-          ]
-        },
-        "subject": "hl:uEiDYMTm9nJ5B0gwpNtflwrcZCT9uT6BFiEs5sYWB45piXg:uoQ-BeEJpcGZzOi8vYmFma3JlaWd5Z2U0MzNoZTZpaGpheWtqdzI3czRmbnl6YmU3dzR0NWFpd2Vld29ucnF3YTZoZ3RjbHk"
-      },
+      "content": "{\"properties\":{\"https://w3id.org/activityanchors#generator\":\"https://w3id.org/orb#v0\",\"https://w3id.org/activityanchors#resources\":[{\"id\":\"did:orb:uEiAk0CUuIIVOxlalYH6JU7gsIwvo5zGNcM_zYo2jXwzBzw:EiCIZ19PGWe_65JLcIp_bmOu_ZrPOerFPXAoXAcdWW7iCg\",\"previousAnchor\":\"hl:uEiAk0CUuIIVOxlalYH6JU7gsIwvo5zGNcM_zYo2jXwzBzw\"}]},\"subject\":\"hl:uEiC0arCOQrIDw2F2Zca10gEutIrHWgIUaC1jPDRRBLADUQ:uoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpQzBhckNPUXJJRHcyRjJaY2ExMGdFdXRJckhXZ0lVYUMxalBEUlJCTEFEVVE\"}",
       "generator": "https://w3id.org/orb#v0",
+      "mediaType": "application/json",
       "tag": [
         {
-          "type": "Link",
-          "href": "hl:uEiDzOEQi2wRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
+          "href": "hl:uEiB_22mkkq3lIOkoZXayxavsGnJ2HP8xR0ke_fGCKqQpyA",
           "rel": [
             "witness"
-          ]
+          ],
+          "type": "Link"
         }
       ],
       "type": "AnchorObject",
-      "url": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw"
+      "url": "hl:uEiB5sZH1-ZEY0QDRbFgOrGQZqb95A95q5VWNVBBzxAJMCA"
     },
     {
-      "contentObject": {
-        "@context": [
-          "https://www.w3.org/2018/credentials/v1",
-          "https://w3id.org/security/jws/v1"
-        ],
-        "credentialSubject": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
-        "id": "http://orb2.domain1.com/vc/3994cc26-555c-47f1-9890-058148c154f1",
-        "issuanceDate": "2021-10-14T18:32:17.894314751Z",
-        "issuer": "http://orb2.domain1.com",
-        "proof": [
-          {
-            "created": "2021-10-14T18:32:17.91Z",
-            "domain": "http://orb.vct:8077/maple2020",
-            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..h3-0HC3L87TM0j0o3Nd0VLlalcVVphwOPsfdkCLZ4q-uL4z8eO2vQ4sobbtOtFpNNZlpIOQnaWJMX3Ch5Wh-AQ",
-            "proofPurpose": "assertionMethod",
-            "type": "Ed25519Signature2018",
-            "verificationMethod": "did:web:orb.domain1.com#orb1key"
-          },
-          {
-            "created": "2021-10-14T18:32:18.09110265Z",
-            "domain": "https://orb.domain2.com",
-            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..DSL3zsltnh9dbSn3VNPb1C-6pKt6VOy-H1WadO5ZV2QZd3xZq3uRRhaShi9K1SzX-VaGPxs3gfbazJ-fpHVxBg",
-            "proofPurpose": "assertionMethod",
-            "type": "Ed25519Signature2018",
-            "verificationMethod": "did:web:orb.domain2.com#orb2key"
-          }
-        ],
-        "type": "VerifiableCredential"
-      },
+      "content": "{\"@context\":[\"https://www.w3.org/2018/credentials/v1\"],\"credentialSubject\":\"hl:uEiB5sZH1-ZEY0QDRbFgOrGQZqb95A95q5VWNVBBzxAJMCA\",\"id\":\"https://orb.domain2.com/vc/1636951e-9117-4134-904a-e0cd177517a1\",\"issuanceDate\":\"2022-02-10T18:50:48.682168399Z\",\"issuer\":\"https://orb.domain2.com\",\"proof\":[{\"created\":\"2022-02-10T18:50:48.682348236Z\",\"domain\":\"https://orb.domain2.com\",\"jws\":\"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..fqgLBKohg962_3GNbH-QXklA89KBMHev95-Pk1XcGa47jq0TbFUeZi3DBGLgc-pDBisqkh0U3bUSvKY_edBAAw\",\"proofPurpose\":\"assertionMethod\",\"type\":\"Ed25519Signature2018\",\"verificationMethod\":\"did:web:orb.domain2.com#orb2key\"},{\"created\":\"2022-02-10T18:50:48.729Z\",\"domain\":\"http://orb.vct:8077/maple2020\",\"jws\":\"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..xlI19T5KT-Sy1CJuCQLIhgGHdlaK0dIjoctRwzJUz6-TpiluluGEa69aCuDjx426TgHvGXJDn8jHi5aDqGuTDA\",\"proofPurpose\":\"assertionMethod\",\"type\":\"Ed25519Signature2018\",\"verificationMethod\":\"did:web:orb.domain1.com#orb1key2\"}],\"type\":\"VerifiableCredential\"}",
       "generator": "https://w3id.org/orb#v0",
+      "mediaType": "application/json",
       "type": "AnchorObject",
-      "url": "hl:uEiDzOEQi2wRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw"
+      "url": "hl:uEiB_22mkkq3lIOkoZXayxavsGnJ2HP8xR0ke_fGCKqQpyA"
     }
   ],
-  "attributedTo": "https://orb.domain1.com/services/orb",
-  "parent": [
-    "hl:uEiAsiwjaXOYDmOHxmvDl3Mx0TfJ0uCar5YXqumjFJUNIBg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBc2l3amFYT1lEbU9IeG12RGwzTXgwVGZKMHVDYXI1WVhxdW1qRkpVTklCZ3hCaXBmczovL2JhZmtyZWlibXJtZW51eGhnYW9tb2Q0bTI2ZHM1enRkdWp4emhqb2JndnBzeWwydjJuZGNza3EyaWF5",
-    "hl:uEiAn3Y7USoP_lNVX-f0EEu1ajLymnqBJItiMARhKBzAKWg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBbjNZN1VTb1BfbE5WWC1mMEVFdTFhakx5bW5xQkpJdGlNQVJoS0J6QUtXZ3hCaXBmczovL2JhZmtyZWliaDN3aG5pc3VkNzZrbmt2N3o3dWNiZjNrMnJzNmtuaHZhamVybnJkYWJkYmZhb21ha2xp"
-  ],
-  "published": "2021-10-14T18:32:17.888176489Z",
-  "type": "AnchorEvent",
-  "url": "hl:uEiDhdDIS_-_SWKoh5Y3KJ_sWpIoXZUPBeTBMCSBUKXpe5w:uoQ-BeEJpcGZzOi8vYmFma3JlaWhib3F6YmY3N3Ayam1rdWlwZnJ4ZmNwNnl3dXNmYm96a2R5ZjR0YXRhamVia2NzNnM2NDQ"
+  "attributedTo": "https://orb.domain2.com/services/orb",
+  "index": "hl:uEiB5sZH1-ZEY0QDRbFgOrGQZqb95A95q5VWNVBBzxAJMCA",
+  "parent": "hl:uEiAk0CUuIIVOxlalYH6JU7gsIwvo5zGNcM_zYo2jXwzBzw:uoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpQWswQ1V1SUlWT3hsYWxZSDZKVTdnc0l3dm81ekdOY01fellvMmpYd3pCenc",
+  "published": "2022-02-10T18:50:48.681998572Z",
+  "type": "AnchorEvent"
 }`
 
 //nolint: lll
 const jsonAnchorEventInvalidWitness = `{
-  "@context": [
-    "https://www.w3.org/ns/activitystreams",
-    "https://w3id.org/activityanchors/v1"
-  ],
-  "index": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
+  "@context": "https://w3id.org/activityanchors/v1",
   "attachment": [
     {
-      "contentObject": {
-        "properties": {
-          "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v0",
-          "https://w3id.org/activityanchors#resources": [
-            {
-              "ID": "did:orb:uAAA:EiAqm7CXVPxriNZv_A6GVCrqlmCmrUSGJ1YaheTzFxa_Fw"
-            }
-          ]
-        },
-        "subject": "hl:uEiDYMTm9nJ5B0gwpNtflwrcZCT9uT6BFiEs5sYWB45piXg:uoQ-BeEJpcGZzOi8vYmFma3JlaWd5Z2U0MzNoZTZpaGpheWtqdzI3czRmbnl6YmU3dzR0NWFpd2Vld29ucnF3YTZoZ3RjbHk"
-      },
+      "content": "{\"properties\":{\"https://w3id.org/activityanchors#generator\":\"https://w3id.org/orb#v0\",\"https://w3id.org/activityanchors#resources\":[{\"id\":\"did:orb:uEiAk0CUuIIVOxlalYH6JU7gsIwvo5zGNcM_zYo2jXwzBzw:EiCIZ19PGWe_65JLcIp_bmOu_ZrPOerFPXAoXAcdWW7iCg\",\"previousAnchor\":\"hl:uEiAk0CUuIIVOxlalYH6JU7gsIwvo5zGNcM_zYo2jXwzBzw\"}]},\"subject\":\"hl:uEiC0arCOQrIDw2F2Zca10gEutIrHWgIUaC1jPDRRBLADUQ:uoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpQzBhckNPUXJJRHcyRjJaY2ExMGdFdXRJckhXZ0lVYUMxalBEUlJCTEFEVVE\"}",
       "generator": "https://w3id.org/orb#v0",
+      "mediaType": "application/json",
       "tag": [
         {
-          "type": "Link",
-          "href": "hl:uEiDzOEQi2wRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
+          "href": "hl:uEiB_22mkkq3lIOkoZXayxavsGnJ2HP8xR0ke_fGCKqQpyA",
           "rel": [
             "witness"
-          ]
+          ],
+          "type": "Link"
         }
       ],
       "type": "AnchorObject",
-      "url": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw"
+      "url": "hl:uEiB5sZH1-ZEY0QDRbFgOrGQZqb95A95q5VWNVBBzxAJMCA"
     },
     {
-      "contentObject": {
-        "@context": [
-          "https://www.w3.org/2018/credentials/v1",
-          "https://w3id.org/security/jws/v1"
-        ],
-        "credentialSubject": "hl:uEiDzUEQi2qRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw",
-        "type": "VerifiableCredential"
-      },
+      "content": "{\"@context\":[\"https://www.w3.org/2018/credentials/v1\"],\"credentialSubject\":\"hl:uEiB5sZH1-ZEY0QDRbFgOrGQZqb95A95q5VWNVBBzxAJMCA\",\"id\":\"https://orb.domain2.com/vc/1636951e-9117-4134-904a-e0cd177517a1\",\"issuanceDate\":\"2022-02-10T18:50:48.682168399Z\",\"proof\":[{\"created\":\"2022-02-10T18:50:48.682348236Z\",\"domain\":\"https://orb.domain2.com\",\"jws\":\"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..fqgLBKohg962_3GNbH-QXklA89KBMHev95-Pk1XcGa47jq0TbFUeZi3DBGLgc-pDBisqkh0U3bUSvKY_edBAAw\",\"proofPurpose\":\"assertionMethod\",\"type\":\"Ed25519Signature2018\",\"verificationMethod\":\"did:web:orb.domain2.com#orb2key\"},{\"created\":\"2022-02-10T18:50:48.729Z\",\"domain\":\"http://orb.vct:8077/maple2020\",\"jws\":\"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..xlI19T5KT-Sy1CJuCQLIhgGHdlaK0dIjoctRwzJUz6-TpiluluGEa69aCuDjx426TgHvGXJDn8jHi5aDqGuTDA\",\"proofPurpose\":\"assertionMethod\",\"type\":\"Ed25519Signature2018\",\"verificationMethod\":\"did:web:orb.domain1.com#orb1key2\"}],\"type\":\"VerifiableCredential\"}",
       "generator": "https://w3id.org/orb#v0",
+      "mediaType": "application/json",
       "type": "AnchorObject",
-      "url": "hl:uEiDzOEQi2wRreCTfvp2AKmTaxuqUUZZNhbxe5RTBH59AWw"
+      "url": "hl:uEiB_22mkkq3lIOkoZXayxavsGnJ2HP8xR0ke_fGCKqQpyA"
     }
   ],
-  "attributedTo": "https://orb.domain1.com/services/orb",
-  "parent": [
-    "hl:uEiAsiwjaXOYDmOHxmvDl3Mx0TfJ0uCar5YXqumjFJUNIBg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBc2l3amFYT1lEbU9IeG12RGwzTXgwVGZKMHVDYXI1WVhxdW1qRkpVTklCZ3hCaXBmczovL2JhZmtyZWlibXJtZW51eGhnYW9tb2Q0bTI2ZHM1enRkdWp4emhqb2JndnBzeWwydjJuZGNza3EyaWF5",
-    "hl:uEiAn3Y7USoP_lNVX-f0EEu1ajLymnqBJItiMARhKBzAKWg:uoQ-CeEdodHRwczovL2V4YW1wbGUuY29tL2Nhcy91RWlBbjNZN1VTb1BfbE5WWC1mMEVFdTFhakx5bW5xQkpJdGlNQVJoS0J6QUtXZ3hCaXBmczovL2JhZmtyZWliaDN3aG5pc3VkNzZrbmt2N3o3dWNiZjNrMnJzNmtuaHZhamVybnJkYWJkYmZhb21ha2xp"
-  ],
-  "published": "2021-10-14T18:32:17.888176489Z",
-  "type": "AnchorEvent",
-  "url": "hl:uEiDhdDIS_-_SWKoh5Y3KJ_sWpIoXZUPBeTBMCSBUKXpe5w:uoQ-BeEJpcGZzOi8vYmFma3JlaWhib3F6YmY3N3Ayam1rdWlwZnJ4ZmNwNnl3dXNmYm96a2R5ZjR0YXRhamVia2NzNnM2NDQ"
+  "attributedTo": "https://orb.domain2.com/services/orb",
+  "index": "hl:uEiB5sZH1-ZEY0QDRbFgOrGQZqb95A95q5VWNVBBzxAJMCA",
+  "parent": "hl:uEiAk0CUuIIVOxlalYH6JU7gsIwvo5zGNcM_zYo2jXwzBzw:uoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpQWswQ1V1SUlWT3hsYWxZSDZKVTdnc0l3dm81ekdOY01fellvMmpYd3pCenc",
+  "published": "2022-02-10T18:50:48.681998572Z",
+  "type": "AnchorEvent"
 }`

--- a/pkg/internal/aptestutil/aptestutil.go
+++ b/pkg/internal/aptestutil/aptestutil.go
@@ -222,6 +222,7 @@ func NewMockAnchorEvent(t *testing.T) *vocab.AnchorEventType {
 	witnessAnchorObj, err := vocab.NewAnchorObject(
 		generator,
 		vocab.MustUnmarshalToDoc([]byte(verifiableCred)),
+		vocab.GzipMediaType,
 	)
 	require.NoError(t, err)
 	require.Len(t, witnessAnchorObj.URL(), 1)
@@ -236,6 +237,7 @@ func NewMockAnchorEvent(t *testing.T) *vocab.AnchorEventType {
 				Field2: "value2",
 			},
 		),
+		vocab.GzipMediaType,
 		vocab.WithLink(vocab.NewLink(witnessAnchorObj.URL()[0], vocab.RelationshipWitness)),
 	)
 	require.NoError(t, err)

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -885,7 +885,7 @@ func newMockAnchorEvent(t *testing.T, payload *subject.Payload) *vocab.AnchorEve
 	require.NoError(t, err)
 
 	act, err := anchorevent.BuildAnchorEvent(payload, contentObj.GeneratorID, contentObj.Payload,
-		vocab.MustMarshalToDoc(vc))
+		vocab.MustMarshalToDoc(vc), vocab.GzipMediaType)
 	require.NoError(t, err)
 
 	return act

--- a/pkg/orbclient/aoprovider/anchororiginprovider_test.go
+++ b/pkg/orbclient/aoprovider/anchororiginprovider_test.go
@@ -273,7 +273,7 @@ func newMockAnchorEvent(t *testing.T, payload *subject.Payload) *vocab.AnchorEve
 	}
 
 	act, err := anchorevent.BuildAnchorEvent(payload, contentObj.GeneratorID, contentObj.Payload,
-		vocab.MustMarshalToDoc(vc))
+		vocab.MustMarshalToDoc(vc), vocab.GzipMediaType)
 	require.NoError(t, err)
 
 	return act

--- a/test/bdd/features/activitypub.feature
+++ b/test/bdd/features/activitypub.feature
@@ -186,7 +186,7 @@ Feature:
     # A 'Create' activity should have been posted to domain1's followers (domain2).
     When an HTTP GET is sent to "https://orb.domain2.com/services/orb/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
-    And the JSON path "orderedItems.#.id" of the response contains "${domain1IRI}/activities/5ea84ab1-9ed9-4f84-8241-e7f6b97ecd94"
+    And the JSON path "orderedItems.#.id" of the response contains "${domain1IRI}/activities/55a9f656-7ce1-4d5b-8f38-966cfdcbc155"
 
     # An 'Announce' activity should have been posted to domain2's followers (domain3).
     When an HTTP GET is sent to "https://orb.domain2.com/services/orb/outbox?page=true"
@@ -210,12 +210,12 @@ Feature:
     Then the JSON path "type" of the response equals "CollectionPage"
     And the JSON path "items" of the response does not contain "${domain3IRI}"
 
-    When an HTTP GET is sent to "https://orb.domain3.com/services/orb/shares/hl%3AuEiA-wMFlsv-OGRDiSgxqc_TmJzuRpTRcm7s2FOXkH-oJRg%3AuoQ-BeEJpcGZzOi8vYmFma3JlaWI2eWRhd2xteDdyeW1yYnlza2JydmhoNWhnZTQ1emRqanVsc24zd25xdTR4c2I3MnFqaXk"
+    When an HTTP GET is sent to "https://orb.domain3.com/services/orb/shares/hl%3AuEiDifpBqbQq7laXLKKXIehmXNo1k1sdt1Z1EbHlmdXf2Qw%3AuoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpRGlmcEJxYlFxN2xhWExLS1hJZWhtWE5vMWsxc2R0MVoxRWJIbG1kWGYyUXd4QmlwZnM6Ly9iYWZrcmVpaGNwMmlndTNpa3hvazJsc3ppdXhlaHVnbXhnMmd3anZ3aG54a3oycmRtcGZ0aGs1N3dpbQ"
     Then the JSON path "type" of the response equals "OrderedCollection"
     Then the JSON path "first" of the response is saved to variable "sharesFirstPage"
     When an HTTP GET is sent to "${sharesFirstPage}"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
-    And the JSON path "orderedItems.0.object.items.0.url" of the response equals "hl:uEiA-wMFlsv-OGRDiSgxqc_TmJzuRpTRcm7s2FOXkH-oJRg:uoQ-BeEJpcGZzOi8vYmFma3JlaWI2eWRhd2xteDdyeW1yYnlza2JydmhoNWhnZTQ1emRqanVsc24zd25xdTR4c2I3MnFqaXk"
+    And the JSON path "orderedItems.0.object.items.0.url" of the response equals "hl:uEiDifpBqbQq7laXLKKXIehmXNo1k1sdt1Z1EbHlmdXf2Qw:uoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpRGlmcEJxYlFxN2xhWExLS1hJZWhtWE5vMWsxc2R0MVoxRWJIbG1kWGYyUXd4QmlwZnM6Ly9iYWZrcmVpaGNwMmlndTNpa3hvazJsc3ppdXhlaHVnbXhnMmd3anZ3aG54a3oycmRtcGZ0aGs1N3dpbQ"
 
   @activitypub_invite_witness
   Scenario: invite witness/accept/undo
@@ -305,7 +305,7 @@ Feature:
     # The 'Offer' activity should be in the inbox of domain1.
     When an HTTP GET is sent to "https://orb.domain1.com/services/orb/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
-    And the JSON path "orderedItems.#.id" of the response contains "${domain2IRI}/activities/a9e66de1-2f9c-4822-b321-07d8c36d31a4"
+    And the JSON path "orderedItems.#.id" of the response contains "${domain2IRI}/activities/018c5944-5201-4af4-bce0-ea2cb143ee2b"
 
     And variable "undoInviteWitnessActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain2IRI}","to":"${domain1IRI}","object":{"actor":"${domain2IRI}","id":"${inviteWitnessID}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain1IRI}","type":"Invite"}}'
     When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${undoInviteWitnessActivity}" of type "application/json"

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -324,8 +324,18 @@ Feature:
     And variable "anchorHash" is assigned the value "$hashlink(|${anchorLink}|).ResourceHash"
 
     When an HTTP GET is sent to "https://orb.domain1.com/cas/${anchorHash}"
-    Then the JSON path 'attachment.#(contentObject.type="VerifiableCredential").contentObject.id' of the response is saved to variable "vcID"
+    Then the JSON path "index" of the response is saved to variable "anchorIndex"
 
+    # Get the hashlink of the verifiable credential content from the index
+    Then the JSON path 'attachment.#(url="${anchorIndex}").tag.#(type="Link").href' of the response is saved to variable "vcHL"
+    # Get the verifiable credential encoded content
+    Then the JSON path 'attachment.#(url="${vcHL}").content' of the response is saved to variable "vcEncodedContent"
+    Then the JSON path 'attachment.#(url="${vcHL}").mediaType' of the response is saved to variable "vcContentType"
+    # Decode the verifiable credential content according to the specified media type
+    Then the content "${vcEncodedContent}" of type "${vcContentType}" is decoded and saved to variable "vcContent"
+    Then the JSON path "id" of document '${vcContent}' is saved to variable "vcID"
+
+    # Ensure the verifiable credential can be retrieved by ID
     When an HTTP GET is sent to "${vcID}"
     Then the JSON path "id" of the response equals "${vcID}"
 

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -115,6 +115,7 @@ services:
       # WITNESS_POLICY_CACHE_EXPIRATION sets the expiration time of witness policy cache.
       # Default value: 30s
       - WITNESS_POLICY_CACHE_EXPIRATION=10s
+      - ANCHOR_ATTACHMENT_MEDIA_TYPE=application/gzip
     ports:
       - 48326:443
       - 48327:48327
@@ -239,6 +240,7 @@ services:
       # ACTIVITYPUB_IRI_CACHE_EXPIRATION sets the expiration time of an ActivityPub actor IRI cache.
       # Default value: 1h (one hour)
       - ACTIVITYPUB_IRI_CACHE_EXPIRATION=90s
+      - ANCHOR_ATTACHMENT_MEDIA_TYPE=application/gzip
     ports:
       - 48526:443
       - 48527:48527
@@ -357,6 +359,7 @@ services:
       # only if its age is greater than this value.
       # Default value: 1m
       - ANCHOR_EVENT_SYNC_MIN_ACTIVITY_AGE=1m
+      - ANCHOR_ATTACHMENT_MEDIA_TYPE=application/json
     ports:
       - 48826:80
       - 48827:48827
@@ -458,6 +461,7 @@ services:
       # only if its age is greater than this value.
       # Default value: 1m
       - ANCHOR_EVENT_SYNC_MIN_ACTIVITY_AGE=1m
+      - ANCHOR_ATTACHMENT_MEDIA_TYPE=application/json
     ports:
       - 48926:80
       - 48927:48927

--- a/test/bdd/fixtures/testdata/create_activity.json
+++ b/test/bdd/fixtures/testdata/create_activity.json
@@ -4,26 +4,17 @@
     "https://w3id.org/activityanchors/v1"
   ],
   "actor": "https://orb.domain1.com/services/orb",
-  "id": "https://orb.domain1.com/services/orb/activities/5ea84ab1-9ed9-4f84-8241-e7f6b97ecd94",
+  "id": "https://orb.domain1.com/services/orb/activities/55a9f656-7ce1-4d5b-8f38-966cfdcbc155",
   "object": {
     "@context": "https://w3id.org/activityanchors/v1",
     "attachment": [
       {
-        "contentObject": {
-          "properties": {
-            "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v0",
-            "https://w3id.org/activityanchors#resources": [
-              {
-                "id": "did:orb:uAAA:EiCVLYJdOmoKgq6kXMGe7ZhrHhNGXhjD7cnkfz8JGw_yjw"
-              }
-            ]
-          },
-          "subject": "hl:uEiAGpSCfjDlcs_ztFEyHaqndwAEzUrSars7_rFN-bHbquA:uoQ-BeEJpcGZzOi8vYmFma3JlaWFndXVxajdkYnpsc3o3ejNpdWpzZHd2a281eWFhdGd1dnV0a3htNTc1bWtuN2d5NXhreGE"
-        },
+        "content": "H4sIAAAAAAAA/4SQy3KbMABF/0XZpg0POx2zwzZgXMA2JjzU6XSERCzFgIgQyODJv3e87qL7O/ecOXfQCd5VQrKqB9YdUCm73np5USYj37m4vCAs2cjkhFpMueifLlVbCSS5ANa/Yy7Kp1EDz/+/EVXPB4Ef0F93wAiwAGHE4qK0Btu2LYfZU/N+9JxgJ72+OZiHVx9e/9wKJ2Dl5udbYkN1abNPHIZJeQJfv7+eQT+UHxWWD7HaGhy2PR5oPKrFLvB3SaK91zatAzcuwjHfb6DWdsrt3WtKf6x8ZQ389G1TOZKTXazwzMfAWE0FW15LQ6coW9yCJhrL8+qjyMORvKVd7K6PyN0bZI79xKn91D0p2NzWyLuFcb2HSQ6L8zVCobdURINz3MgMbfHynJPFqakVbMPXYFqxIoMCN2kHzTVHmWwj09GKtpM4o58kgVNkQIoyXScG7Iixn6OW1jiPOWqoHnmuWWVwho3Oq21aP0r8DQAA//+H9xwO0gEAAA==",
         "generator": "https://w3id.org/orb#v0",
+        "mediaType": "application/gzip",
         "tag": [
           {
-            "href": "hl:uEiDTSIyOm4vgLleEOhKqj5i-JhpvqNRtadO9parG2R9W0w",
+            "href": "hl:uEiDitojxPVsciVFkA76-2VUZqxvsfg0Rc587SiKcJRwYVA",
             "rel": [
               "witness"
             ],
@@ -31,50 +22,23 @@
           }
         ],
         "type": "AnchorObject",
-        "url": "hl:uEiCtX8AtV9t1WLezJ8irzzFBaKGGM8kr7e4OQohxa-1wVg"
+        "url": "hl:uEiBIWW6wXXjJyAAeIewft4I9ROWXg6zjAQPPQMna3P07ig"
       },
       {
-        "contentObject": {
-          "@context": [
-            "https://www.w3.org/2018/credentials/v1",
-            "https://w3id.org/security/suites/jws-2020/v1"
-          ],
-          "credentialSubject": "hl:uEiCtX8AtV9t1WLezJ8irzzFBaKGGM8kr7e4OQohxa-1wVg",
-          "id": "https://orb.domain1.com/vc/39ec8eda-42e3-42db-a70a-ea5f3d56244b",
-          "issuanceDate": "2021-10-27T20:20:52.70237546Z",
-          "issuer": "https://orb.domain1.com",
-          "proof": [
-            {
-              "created": "2021-10-27T20:20:52.732Z",
-              "domain": "http://orb.vct:8077/maple2020",
-              "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..cvVgIAtldakYH40gAUnnuajRDOasKnrjYpj1Y0grZQDJb-rOjGQBHI_Yg4U3qLyX3C49P1pzZQKL4wrnt3a8Cg",
-              "proofPurpose": "assertionMethod",
-              "type": "Ed25519Signature2018",
-              "verificationMethod": "did:web:orb.domain1.com#orb1key"
-            },
-            {
-              "created": "2021-10-27T20:20:52.897710856Z",
-              "domain": "https://orb.domain2.com",
-              "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..3Wm9GHzBr-sqHkFV4fSkjv-xyYQJKTHsn86LLe_8WIFOP83aHWMGXolhMxJaQpFb2AULz4tiAsYQISa3XfVwBw",
-              "proofPurpose": "assertionMethod",
-              "type": "Ed25519Signature2018",
-              "verificationMethod": "did:web:orb.domain2.com#orb2key"
-            }
-          ],
-          "type": "VerifiableCredential"
-        },
+        "content": "H4sIAAAAAAAA/7yT23OiPhTH/5f8XuUWLhKeflStC62gRSva6ewECBrkYkkAbaf/+w67tnubzj7szL4m+X7OnM/JeQH/x1XJyYkD6wHsOT8yS5K6rhM7VazqnQRlxZTimiSk5BTnTGoV8DgA30+CJspIzIEF9rnVTOiVs14bXRhm7tm2iUO6lGsOuvPX4c54zuzFfL6YlVidy0O6AwNAkz55qVvVkZhUBaalIsZVIbWxhKCupalsChibWNAiggSEzKFATMPUVBQnSYp6DGMNLmMyxpwAC0AZQkGGgiIvoWKpqqUiUYaabiBDRtvLe1J/XBoMwLGuqhRYDy99s5iT5COuZvTEb+EL8QJsY26Z8nAoFfiYEyhDGQxA1jFgAXJ299E0pj51r7eTu+UicJhTONAbOca2uGYxXDGn8M44XFA/Z3STbWQnV5AoBtNw5KJP5to5sGccCS7MFmP7qdmvF+0BrlhY5dMZnOIlUyJjtpwYicHwsk232e1x1HJ0usN843naVRYOPbhaXwcM291bw/OmPlasd4gZIzWnVTkjfF8lYAD4+dhfTBKo6woK6K7EvKlJ/0XAALSkpimN8Q8RCyQ0sToSWb/o/a+qI+VAzhC8Dv7kV9ENBZqqBn+z/PPc4GVuf+v38wGXCfTnXqzgJ1qeqLtN6Y07DpnQ2SOm4xsko/Z+pD15G46qqCiWflhqs8BHus3DA9vhKG3ICgbcPw1VPua3t/bun/mFb37hgZzB6+M79v5rHkc5Gb0vL3j9EgAA//9u/yEWAQQAAA==",
         "generator": "https://w3id.org/orb#v0",
+        "mediaType": "application/gzip",
         "type": "AnchorObject",
-        "url": "hl:uEiDTSIyOm4vgLleEOhKqj5i-JhpvqNRtadO9parG2R9W0w"
+        "url": "hl:uEiDitojxPVsciVFkA76-2VUZqxvsfg0Rc587SiKcJRwYVA"
       }
     ],
     "attributedTo": "https://orb.domain1.com/services/orb",
-    "index": "hl:uEiCtX8AtV9t1WLezJ8irzzFBaKGGM8kr7e4OQohxa-1wVg",
-    "published": "2021-10-27T20:20:52.694269029Z",
+    "index": "hl:uEiBIWW6wXXjJyAAeIewft4I9ROWXg6zjAQPPQMna3P07ig",
+    "published": "2022-02-10T21:33:39.020661418Z",
     "type": "AnchorEvent",
-    "url": "hl:uEiA-wMFlsv-OGRDiSgxqc_TmJzuRpTRcm7s2FOXkH-oJRg:uoQ-BeEJpcGZzOi8vYmFma3JlaWI2eWRhd2xteDdyeW1yYnlza2JydmhoNWhnZTQ1emRqanVsc24zd25xdTR4c2I3MnFqaXk"
+    "url": "hl:uEiDifpBqbQq7laXLKKXIehmXNo1k1sdt1Z1EbHlmdXf2Qw:uoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpRGlmcEJxYlFxN2xhWExLS1hJZWhtWE5vMWsxc2R0MVoxRWJIbG1kWGYyUXd4QmlwZnM6Ly9iYWZrcmVpaGNwMmlndTNpa3hvazJsc3ppdXhlaHVnbXhnMmd3anZ3aG54a3oycmRtcGZ0aGs1N3dpbQ"
   },
-  "published": "2021-10-27T20:20:53.148242625Z",
+  "published": "2022-02-10T21:33:39.279618592Z",
   "to": [
     "https://orb.domain1.com/services/orb/followers",
     "https://www.w3.org/ns/activitystreams#Public"

--- a/test/bdd/fixtures/testdata/offer_activity.json
+++ b/test/bdd/fixtures/testdata/offer_activity.json
@@ -1,28 +1,18 @@
 {
   "@context": "https://www.w3.org/ns/activitystreams",
   "actor": "https://orb.domain2.com/services/orb",
-  "endTime": "2021-10-27T20:30:54.75836827Z",
-  "id": "https://orb.domain2.com/services/orb/activities/a9e66de1-2f9c-4822-b321-07d8c36d31a4",
+  "endTime": "2022-02-10T22:00:15.7046171Z",
+  "id": "https://orb.domain2.com/services/orb/activities/018c5944-5201-4af4-bce0-ea2cb143ee2b",
   "object": {
     "@context": "https://w3id.org/activityanchors/v1",
     "attachment": [
       {
-        "contentObject": {
-          "properties": {
-            "https://w3id.org/activityanchors#generator": "https://w3id.org/orb#v0",
-            "https://w3id.org/activityanchors#resources": [
-              {
-                "id": "did:orb:uEiA-wMFlsv-OGRDiSgxqc_TmJzuRpTRcm7s2FOXkH-oJRg:EiCVLYJdOmoKgq6kXMGe7ZhrHhNGXhjD7cnkfz8JGw_yjw",
-                "previousAnchor": "hl:uEiA-wMFlsv-OGRDiSgxqc_TmJzuRpTRcm7s2FOXkH-oJRg"
-              }
-            ]
-          },
-          "subject": "hl:uEiBN-H0wxN9_izGjfi8D7WH7DmH8NAawQvL2cnONNGCsVw:uoQ-BeEJpcGZzOi8vYmFma3JlaWNuN2I2dGJyZzdwNmZ0ZGkzNmY0YjYyeXAzYnpxN3luYWd3YmJwZjV0c29vZ3RpeWZtazQ"
-        },
+        "content": "{\"properties\":{\"https://w3id.org/activityanchors#generator\":\"https://w3id.org/orb#v0\",\"https://w3id.org/activityanchors#resources\":[{\"id\":\"did:orb:uAAA:EiAmj6LLkoL5DgmBKI-SRoKKksnVc9OYqfjj08VXe5e9hw\"},{\"id\":\"did:orb:uAAA:EiAH7AOxCsoi-WLjac5FxzGxWyHJVhrtXjwbNwZTYNKo8g\"},{\"id\":\"did:orb:uAAA:EiDKvvUEvfMPvSxPUpF37RQoxkJKxdJJNtgjqEYyx8S9IA\"},{\"id\":\"did:orb:uAAA:EiAP6d5LVlGjwm2z1gDUuieH20lT-Pm-CDbr5WYWn7RPMg\"},{\"id\":\"did:orb:uAAA:EiDu7cQmLhVqcQTouf8YIxtUYtvY-eI-HWYu2BwQUbddng\"},{\"id\":\"did:orb:uAAA:EiAre1hiLvvfBnHj8MktHgJjTE-e1coek3JadAGTO2LWdw\"},{\"id\":\"did:orb:uAAA:EiAcUlv97lHEY3D56dWesas4OUB-KQHL_tckmNaFl7MaGw\"},{\"id\":\"did:orb:uAAA:EiAkAhDukhlrul22BpNhWqewhpN_C0_Ad6Jq6xLd57jOgA\"},{\"id\":\"did:orb:uAAA:EiAfeHIah4UJYTJ7tdgPWPGqVHU0wSuga9q5tmXGMdbYRQ\"},{\"id\":\"did:orb:uAAA:EiBP7qgmpguk4iX7t_eb86FGA02E6Qjf6y2lyPfuf9I0Kw\"},{\"id\":\"did:orb:uAAA:EiB96llulf66DJV-dE8-ESdQefE5yBff7dO53BVVnmXxQw\"},{\"id\":\"did:orb:uAAA:EiBwy1l0ucgzJNNEsJVN8tKddqZocVvHkKefpQoMDazDkg\"},{\"id\":\"did:orb:uAAA:EiAIaz4ZJxQ3_7fOXNpfo7Qo3SvqWppwXn97UCYWT83PEQ\"},{\"id\":\"did:orb:uAAA:EiC6yBURHZ2PVIrtwtj0KneexPvnqfYQBL6GHLkKixxOWA\"},{\"id\":\"did:orb:uAAA:EiCA7I6xO9DDqziAfHmshOPDHwwJdTFXMKy9nLqnaVufKg\"}]},\"subject\":\"hl:uEiDLf0LkQ3TO_mWzoPkxnrmzUOM9T2oZSCMjO56epzU0eg:uoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpRExmMExrUTNUT19tV3pvUGt4bnJtelVPTTlUMm9aU0NNak81NmVwelUwZWc\"}",
         "generator": "https://w3id.org/orb#v0",
+        "mediaType": "application/json",
         "tag": [
           {
-            "href": "hl:uEiDL8iXtM0uL7y85SPNcn-IVUg08Gdhn6EufFvz-uWiwlw",
+            "href": "hl:uEiA5gn0G4xdsC-hIAIE2trPTRjtJlQhZ7cV4dWkcwy_9OA",
             "rel": [
               "witness"
             ],
@@ -30,44 +20,26 @@
           }
         ],
         "type": "AnchorObject",
-        "url": "hl:uEiCDFlNNQ6PvDg0W49WpZP6375hmAN_WlsUdJP2KZ1-9_g"
+        "url": "hl:uEiBAnjeqN2h1BdgJ4uKu0YVHtSQL0IfGo5cKSLuTtgQP_Q"
       },
       {
-        "contentObject": {
-          "@context": [
-            "https://www.w3.org/2018/credentials/v1",
-            "https://w3id.org/security/suites/jws-2020/v1"
-          ],
-          "credentialSubject": "hl:uEiCDFlNNQ6PvDg0W49WpZP6375hmAN_WlsUdJP2KZ1-9_g",
-          "id": "https://orb2.domain1.com/vc/c56ae4d1-7c8d-45a1-bb8b-b596c1454830",
-          "issuanceDate": "2021-10-27T20:20:54.702740385Z",
-          "issuer": "https://orb2.domain1.com",
-          "proof": {
-            "created": "2021-10-27T20:20:54.711Z",
-            "domain": "http://orb.vct:8077/maple2020",
-            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..KzeNdqoM43Vpt7l5_COjLj23Puhxf0SFxkW4QNjUhJQuBLJkeNtBMkoYYhuXUb57L4cZPD21IOVEK2mm46ipAA",
-            "proofPurpose": "assertionMethod",
-            "type": "Ed25519Signature2018",
-            "verificationMethod": "did:web:orb.domain1.com#orb1key"
-          },
-          "type": "VerifiableCredential"
-        },
+        "content": "{\"@context\":[\"https://www.w3.org/2018/credentials/v1\"],\"credentialSubject\":\"hl:uEiBAnjeqN2h1BdgJ4uKu0YVHtSQL0IfGo5cKSLuTtgQP_Q\",\"id\":\"https://orb.domain2.com/vc/ee03f40c-7f67-4ec4-b523-c504e353f66d\",\"issuanceDate\":\"2022-02-10T21:50:15.606028255Z\",\"issuer\":\"https://orb.domain2.com\",\"proof\":{\"created\":\"2022-02-10T21:50:15.61403824Z\",\"domain\":\"https://orb.domain2.com\",\"jws\":\"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..dsYSfh8JATP-LOUch1JLP4ScRZHkh0OohZAwm6g170fkvo-C8uYpeI_88JxO7xgPapq6ejuYR0RPYSa_H-eSCA\",\"proofPurpose\":\"assertionMethod\",\"type\":\"Ed25519Signature2018\",\"verificationMethod\":\"did:web:orb.domain2.com#orb2key\"},\"type\":\"VerifiableCredential\"}",
         "generator": "https://w3id.org/orb#v0",
+        "mediaType": "application/json",
         "type": "AnchorObject",
-        "url": "hl:uEiDL8iXtM0uL7y85SPNcn-IVUg08Gdhn6EufFvz-uWiwlw"
+        "url": "hl:uEiA5gn0G4xdsC-hIAIE2trPTRjtJlQhZ7cV4dWkcwy_9OA"
       }
     ],
-    "attributedTo": "https://orb.domain1.com/services/orb",
-    "index": "hl:uEiCDFlNNQ6PvDg0W49WpZP6375hmAN_WlsUdJP2KZ1-9_g",
-    "parent": "hl:uEiA-wMFlsv-OGRDiSgxqc_TmJzuRpTRcm7s2FOXkH-oJRg:uoQ-BeEJpcGZzOi8vYmFma3JlaWI2eWRhd2xteDdyeW1yYnlza2JydmhoNWhnZTQ1emRqanVsc24zd25xdTR4c2I3MnFqaXk",
-    "published": "2021-10-27T20:20:54.699265538Z",
+    "attributedTo": "https://orb.domain2.com/services/orb",
+    "index": "hl:uEiBAnjeqN2h1BdgJ4uKu0YVHtSQL0IfGo5cKSLuTtgQP_Q",
+    "published": "2022-02-10T21:50:15.592568774Z",
     "type": "AnchorEvent"
   },
-  "startTime": "2021-10-27T20:20:54.75836827Z",
+  "startTime": "2022-02-10T21:50:15.7046171Z",
   "target": "https://w3id.org/activityanchors#AnchorWitness",
   "to": [
-    "https://www.w3.org/ns/activitystreams#Public",
-    "https://orb.domain1.com/services/orb/witnesses"
+    "https://orb.domain1.com/services/orb",
+    "https://www.w3.org/ns/activitystreams#Public"
   ],
   "type": "Offer"
 }


### PR DESCRIPTION
The AnchorEvent model is changed to use the ActivityStreams "content" and "mediaType" fields instead of the "contentObject" field. The content field contains a content object which is encoded according to the "mediaType" field. Two media types are currently supported: "application/json" and "application/gzip".

- The application/json media type escapes the JSON fields and embeds them in the "content" field.
- The application/gzip media type compresses the JSON content and base64-encodes the compressed data

closes #997

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>