### PR TITLE
test: Modify create-dids-to-file BDD test

### DIFF
--- a/test/bdd/features/create-dids-to-file.feature
+++ b/test/bdd/features/create-dids-to-file.feature
@@ -6,18 +6,17 @@
 
 Feature:
   @create_dids_to_file
-  Scenario: Create DIDs, store them in a file and verify the DIDs from the file. (Uses environment variables.)
+  Scenario: Create DIDs and store them in a file. (Uses environment variables.)
     Given the authorization bearer token for "GET" requests to path "/sidetree/v1/identifiers" is set to "${ORB_BACKUP_READ_TOKEN}"
     And the authorization bearer token for "POST" requests to path "/sidetree/v1/operations" is set to "${ORB_BACKUP_WRITE_TOKEN}"
 
-    When client sends request to domains "${ORB_BACKUP_DID_DOMAINS}" to create "${ORB_BACKUP_NUM_DIDS}" DID documents using "${ORB_BACKUP_CONCURRENCY}" concurrent requests storing the dids to file "${ORB_BACKUP_CREATED_DIDS_FILE}"
-    Then client sends request to domains "${ORB_BACKUP_DID_DOMAINS}" to verify the DID documents that were created from file "${ORB_BACKUP_CREATED_DIDS_FILE}"
+    Then client sends request to domains "${ORB_BACKUP_DID_DOMAINS}" to create "${ORB_BACKUP_NUM_DIDS}" DID documents using "${ORB_BACKUP_CONCURRENCY}" concurrent requests storing the dids to file "${ORB_BACKUP_CREATED_DIDS_FILE}"
 
   @verify_created_dids_from_file
   Scenario: Verify the DIDs in the given file. (Uses environment variables.)
     Given the authorization bearer token for "GET" requests to path "/sidetree/v1/identifiers" is set to "${ORB_BACKUP_READ_TOKEN}"
 
-    Then client sends request to domains "${ORB_BACKUP_DID_DOMAINS}" to verify the DID documents that were created from file "${ORB_BACKUP_CREATED_DIDS_FILE}"
+    Then client sends request to domains "${ORB_BACKUP_DID_DOMAINS}" to verify the DID documents that were created from file "${ORB_BACKUP_CREATED_DIDS_FILE}" with a maximum of "${ORB_BACKUP_VERIFY_ATTEMPTS}" attempts
 
   @all
   @create_and_verify_dids_from_file
@@ -41,4 +40,4 @@ Feature:
     When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     Then client sends request to domains "https://orb.domain1.com" to create "50" DID documents using "5" concurrent requests storing the dids to file "./fixtures/dids.txt"
-    And client sends request to domains "https://orb.domain1.com" to verify the DID documents that were created from file "./fixtures/dids.txt"
+    And client sends request to domains "https://orb.domain1.com" to verify the DID documents that were created from file "./fixtures/dids.txt" with a maximum of "25" attempts

--- a/test/bdd/httpclient.go
+++ b/test/bdd/httpclient.go
@@ -120,7 +120,7 @@ func (c *httpClient) GetWithSignature(url, domain string) (*httpResponse, error)
 	}, nil
 }
 
-func (c *httpClient) GetWithRetry(url string, attempts uint8, retryableCode int, retryableCodes ...int) (*httpResponse, error) {
+func (c *httpClient) GetWithRetry(url string, attempts int, retryableCode int, retryableCodes ...int) (*httpResponse, error) {
 	codes := append(retryableCodes, retryableCode)
 
 	return c.GetWithRetryFunc(url, attempts, func(resp *httpResponse) bool {
@@ -128,7 +128,7 @@ func (c *httpClient) GetWithRetry(url string, attempts uint8, retryableCode int,
 	})
 }
 
-func (c *httpClient) GetWithRetryFunc(url string, attempts uint8, shouldRetry func(resp *httpResponse) bool) (*httpResponse, error) {
+func (c *httpClient) GetWithRetryFunc(url string, attempts int, shouldRetry func(resp *httpResponse) bool) (*httpResponse, error) {
 	var err error
 	var resp *httpResponse
 


### PR DESCRIPTION
- Modify the step, create_dids_to_file, so that the DIDs are not verified. This allows other steps to immediatley run withouthout waiting for the DIDs to be anchored.
- Modify step, verify_created_dids_from_file, to add the env parameter ORB_BACKUP_VERIFY_ATTEMPTS to specifiy the maximum number of attempts to verify that a DID has been anchored.

closes #1122

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>