### PR TITLE
chore: Change log level for 'no witnesses' error

### DIFF
--- a/cmd/orb-server/startcmd/params.go
+++ b/cmd/orb-server/startcmd/params.go
@@ -40,7 +40,7 @@ const (
 	defaultAnchorSyncMinActivityAge         = time.Minute
 	defaultVCTMonitoringInterval            = 10 * time.Second
 	defaultAnchorStatusMonitoringInterval   = 5 * time.Second
-	defaultAnchorStatusInProcessGracePeriod = time.Minute
+	defaultAnchorStatusInProcessGracePeriod = 30 * time.Second
 	mqDefaultMaxConnectionSubscriptions     = 1000
 	mqDefaultPublisherChannelPoolSize       = 25
 	mqDefaultObserverPoolSize               = 5

--- a/pkg/anchor/witness/policy/inspector/inspector.go
+++ b/pkg/anchor/witness/policy/inspector/inspector.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
 	"github.com/trustbloc/orb/pkg/anchor/witness/proof"
+	orberrors "github.com/trustbloc/orb/pkg/errors"
 )
 
 var logger = log.New("policy-inspector")
@@ -169,9 +170,9 @@ func (c *Inspector) getAdditionalWitnesses(anchorID string) ([]*url.URL, error) 
 	additionalWitnessesIRI := difference(newlySelectedWitnessesIRI, selectedWitnessesIRI)
 
 	if len(additionalWitnessesIRI) == 0 {
-		return nil, fmt.Errorf("unable to select additional witnesses[%s] from newly selected witnesses[%s] "+
-			"and previously selected witnesses[%s] with exclude witnesses[%s]",
-			additionalWitnessesIRI, newlySelectedWitnessesIRI, selectedWitnessesIRI, excludeWitnesses)
+		return nil, fmt.Errorf("unable to select additional witnesses from newly selected witnesses[%s] "+
+			"and previously selected witnesses[%s] with exclude witnesses[%s]: %w",
+			newlySelectedWitnessesIRI, selectedWitnessesIRI, excludeWitnesses, orberrors.ErrWitnessesNotFound)
 	}
 
 	// update selected flag for additional witnesses

--- a/pkg/anchor/witness/policy/inspector/inspector_test.go
+++ b/pkg/anchor/witness/policy/inspector/inspector_test.go
@@ -203,7 +203,7 @@ func TestInspector_CheckPolicy(t *testing.T) {
 
 		err = c.CheckPolicy(anchorEvent.Index().String())
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to get additional witnesses: unable to select additional witnesses[[]] "+
+		require.Contains(t, err.Error(), "failed to get additional witnesses: unable to select additional witnesses "+
 			"from newly selected witnesses[[http://domain.com/service]] "+
 			"and previously selected witnesses[[http://domain.com/service]]")
 	})

--- a/pkg/context/opqueue/opqueue.go
+++ b/pkg/context/opqueue/opqueue.go
@@ -29,7 +29,7 @@ var logger = log.New("sidetree_context")
 
 const (
 	topic          = "orb.operation"
-	taskID         = "op-queue-monitorOtherServers"
+	taskID         = "op-queue-monitor"
 	storeName      = "op-queue"
 	tagOpExpiry    = "ExpiryTime"
 	tagOpQueueTask = "Task"

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -18,6 +18,9 @@ var (
 
 	// ErrContentNotFound is used to indicate that content at a given address could not be found.
 	ErrContentNotFound = errors.New("content not found")
+
+	// ErrWitnessesNotFound is used to indicate that no witnesses could not be found.
+	ErrWitnessesNotFound = errors.New("witnesses not found")
 )
 
 // NewTransient returns a transient error that wraps the given error in order to indicate to the caller that a retry may

--- a/pkg/store/anchoreventstatus/store.go
+++ b/pkg/store/anchoreventstatus/store.go
@@ -9,6 +9,7 @@ package anchoreventstatus
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -318,7 +319,12 @@ func (s *Store) CheckInProcessAnchors() {
 			if tag.Name == index {
 				err := s.processIndex(tag.Value)
 				if err != nil {
-					logger.Errorf("failed to process anchor event index: %s", err.Error())
+					if errors.Is(err, orberrors.ErrWitnessesNotFound) {
+						// This is not a critical error. Log it as info.
+						logger.Infof("failed to process anchor event index: %s", err.Error())
+					} else {
+						logger.Errorf("failed to process anchor event index: %s", err.Error())
+					}
 				}
 
 				break


### PR DESCRIPTION
Currently an error is logged when no additional witnesses are found. This is changed to Info since it's not critical.

Also, renamed the operation queue monitor task and changed the default anchor status grace period to 30s from 1m.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>