### PR TITLE
feat: Configure current protocol in Protocol Client

### DIFF
--- a/cmd/orb-server/startcmd/params.go
+++ b/cmd/orb-server/startcmd/params.go
@@ -543,6 +543,12 @@ const (
 	sidetreeProtocolVersionsEnvKey   = "SIDETREE_PROTOCOL_VERSIONS"
 	sidetreeProtocolVersionsUsage    = `Comma-separated list of sidetree protocol versions. ` +
 		commonEnvVarUsageText + sidetreeProtocolVersionsEnvKey
+
+	currentSidetreeProtocolVersionFlagName = "current-sidetree-protocol-version"
+	currentSidetreeProtocolVersionEnvKey   = "CURRENT_SIDETREE_PROTOCOL_VERSION"
+	currentSidetreeProtocolVersionUsage    = `One of available sidetree protocol versions.  ` +
+		`Defaults to latest Sidetree protocol version. ` +
+		commonEnvVarUsageText + currentSidetreeProtocolVersionEnvKey
 )
 
 type acceptRejectPolicy string
@@ -629,6 +635,7 @@ type orbParameters struct {
 	apIRICacheExpiration                    time.Duration
 	witnessPolicyCacheExpiration            time.Duration
 	sidetreeProtocolVersions                []string
+	currentSidetreeProtocolVersion          string
 }
 
 type anchorCredentialParams struct {
@@ -1135,6 +1142,8 @@ func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 		sidetreeProtocolVersions = sidetreeProtocolVersionsArr
 	}
 
+	currentSidetreeProtocolVersion := cmdutils.GetUserSetOptionalVarFromString(cmd, currentSidetreeProtocolVersionFlagName, currentSidetreeProtocolVersionEnvKey)
+
 	return &orbParameters{
 		hostURL:                                 hostURL,
 		hostMetricsURL:                          hostMetricsURL,
@@ -1203,6 +1212,7 @@ func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 		serverIdleTimeout:                       serverIdleTimeout,
 		anchorAttachmentMediaType:               anchorAttachmentMediaType,
 		sidetreeProtocolVersions:                sidetreeProtocolVersions,
+		currentSidetreeProtocolVersion:          currentSidetreeProtocolVersion,
 	}, nil
 }
 
@@ -1786,4 +1796,5 @@ func createFlags(startCmd *cobra.Command) {
 	startCmd.Flags().StringP(serverIdleTimeoutFlagName, "", "", serverIdleTimeoutFlagUsage)
 	startCmd.Flags().StringP(anchorAttachmentMediaTypeFlagName, "", "", anchorAttachmentMediaTypeFlagUsage)
 	startCmd.Flags().String(sidetreeProtocolVersionsFlagName, "", sidetreeProtocolVersionsUsage)
+	startCmd.Flags().String(currentSidetreeProtocolVersionFlagName, "", currentSidetreeProtocolVersionUsage)
 }

--- a/cmd/orb-server/startcmd/params_test.go
+++ b/cmd/orb-server/startcmd/params_test.go
@@ -1466,6 +1466,12 @@ func setEnvVars(t *testing.T, databaseType, casType, replicateLocalCASToIPFS str
 
 	err = os.Setenv(enableUnpublishedOperationStoreEnvKey, "true")
 	require.NoError(t, err)
+
+	err = os.Setenv(sidetreeProtocolVersionsEnvKey, "1.0")
+	require.NoError(t, err)
+
+	err = os.Setenv(currentSidetreeProtocolVersionEnvKey, "1.0")
+	require.NoError(t, err)
 }
 
 func unsetEnvVars(t *testing.T) {
@@ -1551,6 +1557,8 @@ func getTestArgs(ipfsURL, casType, localCASReplicateInIPFSEnabled, databaseType,
 		"--" + includeUnpublishedOperationsFlagName, "true",
 		"--" + resolveFromAnchorOriginFlagName, "true",
 		"--" + verifyLatestFromAnchorOriginFlagName, "true",
+		"--" + sidetreeProtocolVersionsFlagName, "1.0",
+		"--" + currentSidetreeProtocolVersionFlagName, "1.0",
 	}
 
 	if databaseURL != "" {

--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -1077,7 +1077,18 @@ func getProtocolClientProvider(parameters *orbParameters, casClient casapi.Clien
 	}
 
 	pcp := orbpcp.New()
-	pcp.Add(parameters.didNamespace, orbpc.New(protocolVersions))
+
+	var pcOpts []orbpc.Option
+	if parameters.currentSidetreeProtocolVersion != "" {
+		pcOpts = append(pcOpts, orbpc.WithCurrentProtocolVersion(parameters.currentSidetreeProtocolVersion))
+	}
+
+	pc, err := orbpc.New(protocolVersions, pcOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	pcp.Add(parameters.didNamespace, pc)
 
 	return pcp, nil
 }

--- a/pkg/context/protocol/client/client_test.go
+++ b/pkg/context/protocol/client/client_test.go
@@ -15,12 +15,31 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	client := New(nil)
-	require.NotNil(t, client)
+	t.Run("success", func(t *testing.T) {
+		v1_0 := &coremocks.ProtocolVersion{}
+		v1_0.ProtocolReturns(protocol.Protocol{
+			GenesisTime:         1,
+			MultihashAlgorithms: []uint{18},
+			MaxOperationSize:    2000,
+			MaxOperationCount:   10000,
+		})
+
+		client, err := New([]protocol.Version{v1_0})
+		require.NotNil(t, client)
+		require.NoError(t, err)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		client, err := New(nil)
+		require.Nil(t, client)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "must provide at least one protocol version")
+	})
 }
 
 func TestClient_Current(t *testing.T) {
 	v1_0 := &coremocks.ProtocolVersion{}
+	v1_0.VersionReturns("1.0")
 	v1_0.ProtocolReturns(protocol.Protocol{
 		GenesisTime:         1,
 		MultihashAlgorithms: []uint{18},
@@ -29,6 +48,7 @@ func TestClient_Current(t *testing.T) {
 	})
 
 	v0_1 := &coremocks.ProtocolVersion{}
+	v0_1.VersionReturns("0.1")
 	v0_1.ProtocolReturns(protocol.Protocol{
 		GenesisTime:         0,
 		MultihashAlgorithms: []uint{18},
@@ -36,14 +56,29 @@ func TestClient_Current(t *testing.T) {
 		MaxOperationCount:   100,
 	})
 
-	versions := []protocol.Version{v1_0, v0_1}
+	t.Run("success - default", func(t *testing.T) {
+		versions := []protocol.Version{v1_0, v0_1}
 
-	client := New(versions)
-	require.NotNil(t, client)
+		client, err := New(versions)
+		require.NotNil(t, client)
+		require.NoError(t, err)
 
-	p, err := client.Current()
-	require.NoError(t, err)
-	require.Equal(t, uint(10000), p.Protocol().MaxOperationCount)
+		p, err := client.Current()
+		require.NoError(t, err)
+		require.Equal(t, uint(10000), p.Protocol().MaxOperationCount)
+	})
+
+	t.Run("success - with current protocol version", func(t *testing.T) {
+		versions := []protocol.Version{v0_1, v1_0}
+
+		client, err := New(versions, WithCurrentProtocolVersion("0.1"))
+		require.NotNil(t, client)
+		require.NoError(t, err)
+
+		p, err := client.Current()
+		require.NoError(t, err)
+		require.Equal(t, uint(100), p.Protocol().MaxOperationCount)
+	})
 }
 
 func TestClient_Get(t *testing.T) {
@@ -67,8 +102,9 @@ func TestClient_Get(t *testing.T) {
 
 	versions := []protocol.Version{v1_0, v0_1}
 
-	client := New(versions)
+	client, err := New(versions)
 	require.NotNil(t, client)
+	require.NoError(t, err)
 
 	p, err := client.Get(0)
 	require.NoError(t, err)

--- a/pkg/context/protocol/provider/provider_test.go
+++ b/pkg/context/protocol/provider/provider_test.go
@@ -32,8 +32,9 @@ func TestClientProvider_ForNamespace(t *testing.T) {
 
 	versions := []protocol.Version{v1_0}
 
-	pc := client.New(versions)
+	pc, err := client.New(versions)
 	require.NotNil(t, pc)
+	require.NoError(t, err)
 
 	p := New()
 	require.NotNil(t, p)

--- a/test/bdd/fixtures/docker-compose-testver.yml
+++ b/test/bdd/fixtures/docker-compose-testver.yml
@@ -32,6 +32,7 @@ services:
       - ORB_DISCOVERY_DOMAIN=shared.domain.com
       - DID_NAMESPACE=did:orb
       - SIDETREE_PROTOCOL_VERSIONS=${SIDETREE_VERSIONS}
+      - CURRENT_SIDETREE_PROTOCOL_VERSION=${CURRENT_SIDETREE_VERSION}
       - ALLOWED_ORIGINS=https://orb.domain1.com,https://orb.domain2.com,ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
       - BATCH_WRITER_TIMEOUT=1000
@@ -162,6 +163,7 @@ services:
       - ORB_DISCOVERY_DOMAIN=shared.domain.com
       - DID_NAMESPACE=did:orb
       - SIDETREE_PROTOCOL_VERSIONS=${SIDETREE_VERSIONS}
+      - CURRENT_SIDETREE_PROTOCOL_VERSION=${CURRENT_SIDETREE_VERSION}
       - ALLOWED_ORIGINS=https://orb.domain1.com,https://orb.domain2.com,ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
       - BATCH_WRITER_TIMEOUT=1000
@@ -299,6 +301,7 @@ services:
       - ORB_DISCOVERY_DOMAIN=shared.domain.com
       - DID_NAMESPACE=did:orb
       - SIDETREE_PROTOCOL_VERSIONS=${SIDETREE_VERSIONS}
+      - CURRENT_SIDETREE_PROTOCOL_VERSION=${CURRENT_SIDETREE_VERSION}
       - ALLOWED_ORIGINS=https://orb.domain1.com,https://orb.domain2.com,ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
       - BATCH_WRITER_TIMEOUT=1000
@@ -402,6 +405,7 @@ services:
       - ORB_DISCOVERY_DOMAIN=shared.domain.com
       - DID_NAMESPACE=did:orb
       - SIDETREE_PROTOCOL_VERSIONS=${SIDETREE_VERSIONS}
+      - CURRENT_SIDETREE_PROTOCOL_VERSION=${CURRENT_SIDETREE_VERSION}
       - ALLOWED_ORIGINS=https://orb.domain1.com,https://orb.domain2.com,ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
       - BATCH_WRITER_TIMEOUT=1000
@@ -508,6 +512,7 @@ services:
       - ORB_DISCOVERY_DOMAIN=shared.domain.com
       - DID_NAMESPACE=did:orb
       - SIDETREE_PROTOCOL_VERSIONS=${SIDETREE_VERSIONS}
+      - CURRENT_SIDETREE_PROTOCOL_VERSION=${CURRENT_SIDETREE_VERSION}
       - ALLOWED_ORIGINS=https://orb.domain1.com,https://orb.domain2.com,https://orb.domain3.com,ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
       - BATCH_WRITER_TIMEOUT=2000


### PR DESCRIPTION
Add ability to set current protocol version (used for accepting operations and rendering did document). This will allow us to deploy new code and keep processing requests as per previous version. Also, observer will be able to process anchors with advanced protocol version.

Close #1126

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>