### PR TITLE
feat: Configure Witness Store Expiry Period

### DIFF
--- a/cmd/orb-server/startcmd/params.go
+++ b/cmd/orb-server/startcmd/params.go
@@ -359,6 +359,11 @@ const (
 	maxWitnessDelayFlagShorthand = "w"
 	maxWitnessDelayFlagUsage     = "Maximum witness response time (default 10m). " + commonEnvVarUsageText + maxWitnessDelayEnvKey
 
+	witnessStoreExpiryPeriodFlagName  = "witness-store-expiry-period"
+	witnessStoreExpiryPeriodEnvKey    = "WITNESS_STORE_EXPIRY_PERIOD"
+	witnessStoreExpiryPeriodFlagUsage = "Witness store expiry period has to be greater than maximum witness response time" +
+		"(default 12m). " + commonEnvVarUsageText + witnessStoreExpiryPeriodEnvKey
+
 	signWithLocalWitnessFlagName      = "sign-with-local-witness"
 	signWithLocalWitnessEnvKey        = "SIGN_WITH_LOCAL_WITNESS"
 	signWithLocalWitnessFlagShorthand = "f"
@@ -621,6 +626,7 @@ type orbParameters struct {
 	discoveryVctDomains                     []string
 	discoveryMinimumResolvers               int
 	maxWitnessDelay                         time.Duration
+	witnessStoreExpiryPeriod                time.Duration
 	syncTimeout                             uint64
 	signWithLocalWitness                    bool
 	httpSignaturesEnabled                   bool
@@ -823,6 +829,15 @@ func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 	maxWitnessDelay, err := getDuration(cmd, maxWitnessDelayFlagName, maxWitnessDelayEnvKey, defaultMaxWitnessDelay)
 	if err != nil {
 		return nil, err
+	}
+
+	witnessStoreExpiryPeriod, err := getDuration(cmd, witnessStoreExpiryPeriodFlagName, witnessStoreExpiryPeriodEnvKey, defaultWitnessStoreExpiryDelta)
+	if err != nil {
+		return nil, err
+	}
+
+	if witnessStoreExpiryPeriod <= maxWitnessDelay {
+		return nil, fmt.Errorf("witness store expiry period must me greater than maximum witness delay")
 	}
 
 	signWithLocalWitnessStr, err := cmdutils.GetUserSetVarFromString(cmd, signWithLocalWitnessFlagName, signWithLocalWitnessEnvKey, true)
@@ -1203,6 +1218,7 @@ func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 		discoveryVctDomains:                     discoveryVctDomains,
 		discoveryMinimumResolvers:               discoveryMinimumResolvers,
 		maxWitnessDelay:                         maxWitnessDelay,
+		witnessStoreExpiryPeriod:                witnessStoreExpiryPeriod,
 		syncTimeout:                             syncTimeout,
 		signWithLocalWitness:                    signWithLocalWitness,
 		httpSignaturesEnabled:                   httpSignaturesEnabled,
@@ -1785,6 +1801,7 @@ func createFlags(startCmd *cobra.Command) {
 	startCmd.Flags().StringArrayP(tlsCACertsFlagName, "", []string{}, tlsCACertsFlagUsage)
 	startCmd.Flags().StringP(batchWriterTimeoutFlagName, batchWriterTimeoutFlagShorthand, "", batchWriterTimeoutFlagUsage)
 	startCmd.Flags().StringP(maxWitnessDelayFlagName, maxWitnessDelayFlagShorthand, "", maxWitnessDelayFlagUsage)
+	startCmd.Flags().StringP(witnessStoreExpiryPeriodFlagName, "", "", witnessStoreExpiryPeriodFlagUsage)
 	startCmd.Flags().StringP(signWithLocalWitnessFlagName, signWithLocalWitnessFlagShorthand, "", signWithLocalWitnessFlagUsage)
 	startCmd.Flags().StringP(httpSignaturesEnabledFlagName, httpSignaturesEnabledShorthand, "", httpSignaturesEnabledUsage)
 	startCmd.Flags().String(enableDidDiscoveryFlagName, "", enableDidDiscoveryUsage)

--- a/cmd/orb-server/startcmd/params_test.go
+++ b/cmd/orb-server/startcmd/params_test.go
@@ -261,6 +261,64 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 		require.Contains(t, err.Error(), "invalid duration")
 	})
 
+	t.Run("test invalid witness store duration", func(t *testing.T) {
+		startCmd := GetStartCmd()
+
+		args := []string{
+			"--" + hostURLFlagName, "localhost:8247",
+			"--" + hostMetricsURLFlagName, "localhost:8248",
+			"--" + vctURLFlagName, "localhost:8081",
+			"--" + externalEndpointFlagName, "orb.example.com",
+			"--" + casTypeFlagName, "ipfs",
+			"--" + ipfsURLFlagName, "localhost:8081",
+			"--" + maxWitnessDelayFlagName, "10s",
+			"--" + witnessStoreExpiryPeriodFlagName, "abc",
+			"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
+			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption,
+			"--" + anchorCredentialSignatureSuiteFlagName, "suite",
+			"--" + anchorCredentialDomainFlagName, "domain.com",
+			"--" + anchorCredentialIssuerFlagName, "issuer.com",
+			"--" + anchorCredentialURLFlagName, "peer.com",
+			"--" + LogLevelFlagName, log.ParseString(log.ERROR),
+		}
+
+		startCmd.SetArgs(args)
+
+		err := startCmd.Execute()
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid duration")
+	})
+
+	t.Run("test invalid witness store duration - less than maximum witness delay", func(t *testing.T) {
+		startCmd := GetStartCmd()
+
+		args := []string{
+			"--" + hostURLFlagName, "localhost:8247",
+			"--" + hostMetricsURLFlagName, "localhost:8248",
+			"--" + vctURLFlagName, "localhost:8081",
+			"--" + externalEndpointFlagName, "orb.example.com",
+			"--" + casTypeFlagName, "ipfs",
+			"--" + ipfsURLFlagName, "localhost:8081",
+			"--" + maxWitnessDelayFlagName, "10s",
+			"--" + witnessStoreExpiryPeriodFlagName, "5s",
+			"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
+			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption,
+			"--" + anchorCredentialSignatureSuiteFlagName, "suite",
+			"--" + anchorCredentialDomainFlagName, "domain.com",
+			"--" + anchorCredentialIssuerFlagName, "issuer.com",
+			"--" + anchorCredentialURLFlagName, "peer.com",
+			"--" + LogLevelFlagName, log.ParseString(log.ERROR),
+		}
+
+		startCmd.SetArgs(args)
+
+		err := startCmd.Execute()
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "witness store expiry period must me greater than maximum witness delay")
+	})
+
 	t.Run("test invalid sign with local witness flag", func(t *testing.T) {
 		startCmd := GetStartCmd()
 
@@ -1516,6 +1574,9 @@ func setEnvVars(t *testing.T, databaseType, casType, replicateLocalCASToIPFS str
 	err = os.Setenv(maxWitnessDelayEnvKey, "10m")
 	require.NoError(t, err)
 
+	err = os.Setenv(witnessStoreExpiryPeriodEnvKey, "12m")
+	require.NoError(t, err)
+
 	err = os.Setenv(signWithLocalWitnessEnvKey, "true")
 	require.NoError(t, err)
 
@@ -1616,6 +1677,7 @@ func getTestArgs(ipfsURL, casType, localCASReplicateInIPFSEnabled, databaseType,
 		"--" + cidVersionFlagName, "0",
 		"--" + batchWriterTimeoutFlagName, "700",
 		"--" + maxWitnessDelayFlagName, "1m",
+		"--" + witnessStoreExpiryPeriodFlagName, "2m",
 		"--" + signWithLocalWitnessFlagName, "false",
 		"--" + casTypeFlagName, casType,
 		"--" + didNamespaceFlagName, "namespace",

--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -140,6 +140,7 @@ const (
 	masterKeyURI = "local-lock://custom/master/key/"
 
 	defaultMaxWitnessDelay                  = 10 * time.Minute
+	defaultWitnessStoreExpiryDelta          = 12 * time.Minute
 	defaultSyncTimeout                      = 1
 	defaulthttpSignaturesEnabled            = true
 	defaultDidDiscoveryEnabled              = false
@@ -562,7 +563,7 @@ func startOrbServices(parameters *orbParameters) error {
 		return fmt.Errorf("failed to create anchor event store: %s", err.Error())
 	}
 
-	witnessProofStore, err := proofstore.New(storeProviders.provider, expiryService, parameters.maxWitnessDelay)
+	witnessProofStore, err := proofstore.New(storeProviders.provider, expiryService, parameters.witnessStoreExpiryPeriod)
 	if err != nil {
 		return fmt.Errorf("failed to create proof store: %s", err.Error())
 	}

--- a/pkg/store/witness/witness_test.go
+++ b/pkg/store/witness/witness_test.go
@@ -679,8 +679,6 @@ func TestStore_HandleExpiryKeys(t *testing.T) {
 		s, err := New(mongoDBProvider, expiryService, time.Second)
 		require.NoError(t, err)
 
-		s.delta = time.Second
-
 		taskMgr.Start()
 
 		err = s.Put(anchorID, []*proof.Witness{getTestWitness(testWitnessURL)})

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -670,6 +670,8 @@ services:
       - DATA_EXPIRY_CHECK_INTERVAL=15s # This is set to a somewhat low value in order to speed up one of the BDD tests which relies on it
       - ANCHOR_STATUS_IN_PROCESS_GRACE_PERIOD=3s
       - ANCHOR_STATUS_MONITORING_INTERVAL=2s
+      - MAX_WITNESS_DELAY=30s
+      - WITNESS_STORE_EXPIRY_PERIOD=32s
 
       # ORB_AUTH_TOKENS_DEF contains the authorization definition for each of the REST endpoints. Format:
       #


### PR DESCRIPTION
Currently witness store expiry period is calculated as max witness delay + hard-coded delta. Modify this functionality to use configured parameter.

Closes # 1132

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>