### PR TITLE
feat: Implement subset of Linkset vocabulary

### DIFF
--- a/pkg/activitypub/vocab/collection.go
+++ b/pkg/activitypub/vocab/collection.go
@@ -55,7 +55,7 @@ func (t *CollectionType) Current() *url.URL {
 		return nil
 	}
 
-	return t.coll.Current.u
+	return t.coll.Current.URL()
 }
 
 // First returns a URL that may be used to retrieve the first item in the collection.
@@ -64,7 +64,7 @@ func (t *CollectionType) First() *url.URL {
 		return nil
 	}
 
-	return t.coll.First.u
+	return t.coll.First.URL()
 }
 
 // Last returns a URL that may be used to retrieve the last item in the collection.
@@ -73,7 +73,7 @@ func (t *CollectionType) Last() *url.URL {
 		return nil
 	}
 
-	return t.coll.Last.u
+	return t.coll.Last.URL()
 }
 
 // NewCollection returns a new collection.

--- a/pkg/activitypub/vocab/objectproperty.go
+++ b/pkg/activitypub/vocab/objectproperty.go
@@ -79,7 +79,7 @@ func (p *ObjectProperty) IRI() *url.URL {
 		return nil
 	}
 
-	return p.iri.u
+	return p.iri.URL()
 }
 
 // Object returns the object or nil if the object is not set.

--- a/pkg/activitypub/vocab/objecttype.go
+++ b/pkg/activitypub/vocab/objecttype.go
@@ -112,10 +112,10 @@ func (t *ObjectType) URL() Urls {
 		return nil
 	}
 
-	urls := make([]*url.URL, len(t.object.URL.urls))
+	urls := make([]*url.URL, len(t.object.URL.URLs()))
 
-	for i, u := range t.object.URL.urls {
-		urls[i] = u.u
+	for i, u := range t.object.URL.URLs() {
+		urls[i] = u
 	}
 
 	return urls
@@ -247,10 +247,10 @@ func (t *ObjectType) To() Urls {
 		return nil
 	}
 
-	urls := make([]*url.URL, len(t.object.To.urls))
+	urls := make([]*url.URL, len(t.object.To.URLs()))
 
-	for i, u := range t.object.To.urls {
-		urls[i] = u.u
+	for i, u := range t.object.To.URLs() {
+		urls[i] = u
 	}
 
 	return urls

--- a/pkg/anchor/anchorevent/vocab/datauri.go
+++ b/pkg/anchor/anchorevent/vocab/datauri.go
@@ -1,0 +1,131 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vocab
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"strings"
+)
+
+// MediaType defines a type of encoding for content embedded within a data URI.
+type MediaType = string
+
+const (
+	// MediaTypeDataURIJSON indicates that the contents of the data URL is a plain JSON string.
+	MediaTypeDataURIJSON MediaType = "application/json"
+	// MediaTypeDataURIGzipBase64 indicates that the contents of the data URL is compressed with gzip and base64-encoded.
+	MediaTypeDataURIGzipBase64 MediaType = "application/gzip;base64"
+)
+
+const numDataURISegments = 2
+
+// NewDataURI encodes the given content using the given media type and returns
+// a data URL with the encoded data. For example: 'data:application/gzip;base64,H4sIAAAAAAAA...'.
+func NewDataURI(content []byte, dataType MediaType) (*url.URL, error) {
+	encodedData, err := Encode(content, dataType)
+	if err != nil {
+		return nil, err
+	}
+
+	u, err := url.Parse(fmt.Sprintf("data:%s,%s", dataType, encodedData))
+	if err != nil {
+		return nil, fmt.Errorf("parse data URI: %w", err)
+	}
+
+	return u, nil
+}
+
+// DecodeDataURI decodes the given data URI and returns the decoded bytes.
+func DecodeDataURI(u *url.URL) ([]byte, error) {
+	if u.Scheme != "data" {
+		return nil, errors.New("invalid scheme for data URI")
+	}
+
+	segments := strings.Split(u.Opaque, ",")
+
+	if len(segments) < numDataURISegments {
+		return nil, fmt.Errorf("no content in data URI: %s", u)
+	}
+
+	return Decode(segments[1], segments[0])
+}
+
+// Encode encodes the given content using the given media type and returns
+// a string with the encoded data.
+func Encode(content []byte, mediaType MediaType) (string, error) {
+	switch mediaType {
+	case MediaTypeDataURIGzipBase64:
+		return GzipCompress(content)
+	case MediaTypeDataURIJSON:
+		return url.QueryEscape(string(content)), nil
+	case "":
+		return "", fmt.Errorf("media type not specified")
+	default:
+		return "", fmt.Errorf("unsupported media type [%s]", mediaType)
+	}
+}
+
+// Decode decodes the given string using the given media type and returns the decoded bytes.
+func Decode(content string, mediaType MediaType) ([]byte, error) {
+	switch mediaType {
+	case MediaTypeDataURIGzipBase64:
+		return GzipDecompress(content)
+	case MediaTypeDataURIJSON:
+		c, err := url.QueryUnescape(content)
+		if err != nil {
+			return nil, fmt.Errorf("unescape content: %w", err)
+		}
+
+		return []byte(c), nil
+	case "":
+		return nil, fmt.Errorf("media type not specified")
+	default:
+		return nil, fmt.Errorf("unsupported media type [%s]", mediaType)
+	}
+}
+
+// GzipCompress compresses the given content with gzip and returns a base64-encoded string.
+func GzipCompress(docBytes []byte) (string, error) {
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+
+	if _, err := zw.Write(docBytes); err != nil {
+		return "", fmt.Errorf("gzip compress: %w", err)
+	}
+
+	if err := zw.Close(); err != nil {
+		return "", fmt.Errorf("close gzip writer: %w", err)
+	}
+
+	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
+}
+
+// GzipDecompress decompresses the given base64-encoded string with GZIP.
+func GzipDecompress(content string) ([]byte, error) {
+	compressedBytes, err := base64.StdEncoding.DecodeString(content)
+	if err != nil {
+		return nil, fmt.Errorf("base64 decode content: %w", err)
+	}
+
+	zr, err := gzip.NewReader(bytes.NewBuffer(compressedBytes))
+	if err != nil {
+		return nil, fmt.Errorf("new gzip reader: %w", err)
+	}
+
+	decompressedBytes, err := ioutil.ReadAll(zr)
+	if err != nil {
+		return nil, fmt.Errorf("gzip decompress: %w", err)
+	}
+
+	return decompressedBytes, nil
+}

--- a/pkg/anchor/anchorevent/vocab/datauri_test.go
+++ b/pkg/anchor/anchorevent/vocab/datauri_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vocab
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDataURI(t *testing.T) {
+	const content = `{"field1":"value1"}`
+
+	t.Run("gzip -> success", func(t *testing.T) {
+		u, err := NewDataURI([]byte(content), MediaTypeDataURIGzipBase64)
+		require.NoError(t, err)
+
+		contentBytes, err := DecodeDataURI(u)
+		require.NoError(t, err)
+		require.Equal(t, content, string(contentBytes))
+	})
+
+	t.Run("json -> success", func(t *testing.T) {
+		u, err := NewDataURI([]byte(content), MediaTypeDataURIJSON)
+		require.NoError(t, err)
+
+		contentBytes, err := DecodeDataURI(u)
+		require.NoError(t, err)
+		require.Equal(t, content, string(contentBytes))
+	})
+
+	t.Run("invalid scheme -> error", func(t *testing.T) {
+		u, err := url.Parse("https:application/json,some-data")
+		require.NoError(t, err)
+
+		_, err = DecodeDataURI(u)
+		require.EqualError(t, err, "invalid scheme for data URI")
+	})
+
+	t.Run("no content -> error", func(t *testing.T) {
+		u, err := url.Parse("data:application/json")
+		require.NoError(t, err)
+
+		_, err = DecodeDataURI(u)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no content in data URI")
+	})
+
+	t.Run("no media type -> error", func(t *testing.T) {
+		_, err := NewDataURI([]byte(content), "")
+		require.EqualError(t, err, "media type not specified")
+
+		u, err := url.Parse("data:,some-data")
+		require.NoError(t, err)
+
+		_, err = DecodeDataURI(u)
+		require.EqualError(t, err, "media type not specified")
+	})
+
+	t.Run("unsupported media type -> error", func(t *testing.T) {
+		_, err := NewDataURI([]byte(content), "unsupported")
+		require.EqualError(t, err, "unsupported media type [unsupported]")
+
+		u, err := url.Parse("data:application/unsupported,some-data")
+		require.NoError(t, err)
+
+		_, err = DecodeDataURI(u)
+		require.EqualError(t, err, "unsupported media type [application/unsupported]")
+	})
+
+	t.Run("json -> success", func(t *testing.T) {
+		u, err := NewDataURI([]byte(content), MediaTypeDataURIJSON)
+		require.NoError(t, err)
+
+		contentBytes, err := DecodeDataURI(u)
+		require.NoError(t, err)
+		require.Equal(t, content, string(contentBytes))
+	})
+
+	t.Run("gzip decompress -> error", func(t *testing.T) {
+		_, err := GzipDecompress("sfsdf")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "illegal base64 data")
+	})
+}

--- a/pkg/anchor/anchorevent/vocab/linkset.go
+++ b/pkg/anchor/anchorevent/vocab/linkset.go
@@ -1,0 +1,488 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vocab
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+	"github.com/trustbloc/orb/pkg/hashlink"
+)
+
+// LinkType defines the type of the link.
+type LinkType = string
+
+const (
+	// TypeLinkset indicates that the content type is a linkset in JSON format.
+	TypeLinkset LinkType = "application/linkset+json"
+	// TypeJSONLD indicates that the content type is JSON LD.
+	TypeJSONLD LinkType = "application/ld+json"
+)
+
+// AnchorLinkset contains a linkset of AnchorLink objects.
+type AnchorLinkset struct {
+	Linkset []*AnchorLink `json:"linkset"`
+}
+
+// NewAnchorLinkset returns a new AnchorLinkset.
+func NewAnchorLinkset(linkset ...*AnchorLink) *AnchorLinkset {
+	return &AnchorLinkset{
+		Linkset: linkset,
+	}
+}
+
+// AnchorLink is a link to an anchor object which contains items, parent items, and other metadata.
+type AnchorLink struct {
+	link *anchorLink
+}
+
+type anchorLink struct {
+	Anchor  *vocab.URLProperty     `json:"anchor"`
+	Author  *vocab.URLProperty     `json:"author"`
+	Profile *vocab.URLProperty     `json:"profile"`
+	Item    []*Item                `json:"item"`
+	Up      *urlCollectionProperty `json:"up"`
+}
+
+// NewAnchorLink returns a new AnchorLink.
+func NewAnchorLink(anchor, author, profile *url.URL, item []*Item, up []*url.URL) *AnchorLink {
+	return &AnchorLink{
+		link: &anchorLink{
+			Anchor:  vocab.NewURLProperty(anchor),
+			Author:  vocab.NewURLProperty(author),
+			Item:    item,
+			Up:      newURLCollectionProperty(up...),
+			Profile: vocab.NewURLProperty(profile),
+		},
+	}
+}
+
+// Anchor returns the anchor URI.
+func (l *AnchorLink) Anchor() *url.URL {
+	if l == nil {
+		return nil
+	}
+
+	return l.link.Anchor.URL()
+}
+
+// Author returns the originator of the anchor.
+func (l *AnchorLink) Author() *url.URL {
+	if l == nil || l.link == nil {
+		return nil
+	}
+
+	return l.link.Author.URL()
+}
+
+// Items returns the items contained within the link.
+func (l *AnchorLink) Items() []*Item {
+	if l == nil {
+		return nil
+	}
+
+	return l.link.Item
+}
+
+// Up returns the parent items.
+func (l *AnchorLink) Up() []*url.URL {
+	if l == nil {
+		return nil
+	}
+
+	return l.link.Up.URLs()
+}
+
+// Profile returns the profile used to generate the link.
+func (l *AnchorLink) Profile() *url.URL {
+	if l == nil {
+		return nil
+	}
+
+	return l.link.Profile.URL()
+}
+
+// Validate validates the AnchorLink.
+func (l *AnchorLink) Validate() error {
+	if l == nil || l.link == nil {
+		return errors.New("nil link")
+	}
+
+	if l.Anchor() == nil {
+		return errors.New("anchor URI is required")
+	}
+
+	if l.Author() == nil {
+		return errors.New("author URI is required")
+	}
+
+	if l.Profile() == nil {
+		return errors.New("profile URI is required")
+	}
+
+	if len(l.Items()) == 0 {
+		return errors.New("at least one item is required")
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals the object to JSON.
+func (l *AnchorLink) MarshalJSON() ([]byte, error) {
+	return json.Marshal(l.link)
+}
+
+// UnmarshalJSON umarshals the object from JSON.
+func (l *AnchorLink) UnmarshalJSON(b []byte) error {
+	l.link = &anchorLink{}
+
+	return json.Unmarshal(b, l.link)
+}
+
+// AnchorLinksetWithReplies contains the original anchor linkset along with replies.
+// TODO: Think of a better name.
+type AnchorLinksetWithReplies struct {
+	Linkset []*AnchorLinkWithReplies `json:"linkset"`
+}
+
+// NewAnchorLinksetWithReplies returns a new AnchorLinksetWithReplies.
+// TODO: Think of a better name.
+func NewAnchorLinksetWithReplies(linkset ...*AnchorLinkWithReplies) *AnchorLinksetWithReplies {
+	return &AnchorLinksetWithReplies{
+		Linkset: linkset,
+	}
+}
+
+// AnchorLinkWithReplies contains the original anchor link along with replies.
+// TODO: Think of a better name.
+type AnchorLinkWithReplies struct {
+	link *anchorLinkWithReplies
+}
+
+type anchorLinkWithReplies struct {
+	Anchor   *vocab.URLProperty `json:"anchor"`
+	Original *Reference         `json:"original"`
+	Profile  *vocab.URLProperty `json:"profile"`
+	Replies  []*Reference       `json:"replies,omitempty"`
+}
+
+// LinksetOptions holds the options for a linkset.
+type LinksetOptions struct {
+	Replies []*Reference
+}
+
+// WithReply sets the 'Replies' property.
+func WithReply(replies ...*Reference) Opt {
+	return func(opts *Options) {
+		opts.Replies = replies
+	}
+}
+
+// Options holds the options for building a linkset.
+type Options struct {
+	Replies []*Reference
+}
+
+// Opt is an option for an object.
+type Opt func(opts *Options)
+
+// NewOptions returns an Options struct which is populated with the provided options.
+func NewOptions(opts ...Opt) *Options {
+	options := &Options{}
+
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	return options
+}
+
+// NewAnchorLinkWithReplies returns a new AnchorLinkWithReplies.
+// TODO: Think of a better name.
+func NewAnchorLinkWithReplies(anchor, profile *url.URL, original *Reference, opts ...Opt) *AnchorLinkWithReplies {
+	options := NewOptions(opts...)
+
+	return &AnchorLinkWithReplies{
+		link: &anchorLinkWithReplies{
+			Anchor:   vocab.NewURLProperty(anchor),
+			Original: original,
+			Replies:  options.Replies,
+			Profile:  vocab.NewURLProperty(profile),
+		},
+	}
+}
+
+// NewAnchorRef creates a data URI Reference of the given content type and returns the anchor URI
+// (which is a hashlink of the data).
+func NewAnchorRef(data []byte, uriMediaType MediaType, contentType LinkType) (*url.URL, *Reference, error) {
+	anchorHL, err := hashlink.New().CreateHashLink(data, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create hashlink of data: %w", err)
+	}
+
+	anchorURI, err := url.Parse(anchorHL)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse anchorURI hashlink: %w", err)
+	}
+
+	dataURI, err := NewDataURI(data, uriMediaType)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create data URI: %w", err)
+	}
+
+	return anchorURI, NewReference(dataURI, contentType), nil
+}
+
+// Anchor returns the URI of the anchor, which is a hashlink of the uncompressed/unencoded
+// Original content.
+func (l *AnchorLinkWithReplies) Anchor() *url.URL {
+	if l == nil || l.link == nil {
+		return nil
+	}
+
+	return l.link.Anchor.URL()
+}
+
+// Original returns the contents of the anchor that was published as a data URI.
+func (l *AnchorLinkWithReplies) Original() *Reference {
+	if l == nil || l.link == nil {
+		return nil
+	}
+
+	return l.link.Original
+}
+
+// Replies returns a collection of replies to the original resource. (For example, verifiable credentials.)
+func (l *AnchorLinkWithReplies) Replies() []*Reference {
+	if l == nil || l.link == nil {
+		return nil
+	}
+
+	return l.link.Replies
+}
+
+// Profile returns the profile used to generate the link.
+func (l *AnchorLinkWithReplies) Profile() *url.URL {
+	if l == nil || l.link == nil {
+		return nil
+	}
+
+	return l.link.Profile.URL()
+}
+
+// Validate validates the link.
+func (l *AnchorLinkWithReplies) Validate() error {
+	if l == nil || l.link == nil {
+		return errors.New("nil link")
+	}
+
+	anchorHL := l.Anchor()
+	if anchorHL == nil {
+		return errors.New("anchor URI is required")
+	}
+
+	if anchorHL.Scheme != "hl" {
+		return fmt.Errorf("anchor URI is not a valid hashlink: %s", anchorHL)
+	}
+
+	if l.Profile() == nil {
+		return errors.New("profile URI is required")
+	}
+
+	content, err := l.Original().Content()
+	if err != nil {
+		return fmt.Errorf("invalid original content: %w", err)
+	}
+
+	hashOfOriginal, err := hashlink.New().CreateResourceHash(content)
+	if err != nil {
+		return fmt.Errorf("create hashlink from original content: %w", err)
+	}
+
+	if hashOfOriginal != anchorHL.Opaque {
+		return errors.New("hash of the original content does not match the anchor hash")
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals the object to JSON.
+func (l *AnchorLinkWithReplies) MarshalJSON() ([]byte, error) {
+	return json.Marshal(l.link)
+}
+
+// UnmarshalJSON umarshals the object from JSON.
+func (l *AnchorLinkWithReplies) UnmarshalJSON(b []byte) error {
+	l.link = &anchorLinkWithReplies{}
+
+	return json.Unmarshal(b, l.link)
+}
+
+// Reference contains a URI and the content type of the data at that URI.
+type Reference struct {
+	ref *reference
+}
+
+type reference struct {
+	HRef *vocab.URLProperty `json:"href"`
+	Type string             `json:"type"`
+}
+
+// NewReference returns a new reference.
+func NewReference(ref *url.URL, hrefType string) *Reference {
+	return &Reference{
+		&reference{
+			HRef: vocab.NewURLProperty(ref),
+			Type: hrefType,
+		},
+	}
+}
+
+// HRef returns the reference.
+func (r *Reference) HRef() *url.URL {
+	if r == nil {
+		return nil
+	}
+
+	return r.ref.HRef.URL()
+}
+
+// Type returns the content-type of the reference.
+func (r *Reference) Type() string {
+	if r == nil {
+		return ""
+	}
+
+	return r.ref.Type
+}
+
+// Content returns the decoded content of a data URI reference. If the reference
+// is not a data URI then an error is returned.
+func (r *Reference) Content() ([]byte, error) {
+	switch {
+	case strings.HasPrefix(r.HRef().String(), "data:"):
+		return DecodeDataURI(r.HRef())
+	default:
+		return nil, fmt.Errorf("unsupported protocol for %s", r.HRef())
+	}
+}
+
+// MarshalJSON marshals the object to JSON.
+func (r *Reference) MarshalJSON() ([]byte, error) {
+	return json.Marshal(r.ref)
+}
+
+// UnmarshalJSON umarshals the object from JSON.
+func (r *Reference) UnmarshalJSON(b []byte) error {
+	r.ref = &reference{}
+
+	return json.Unmarshal(b, r.ref)
+}
+
+// Item contains a DID (in the HRef) and the previous anchor of the DID.
+type Item struct {
+	item *item
+}
+
+type item struct {
+	HRef     *vocab.URLProperty `json:"href"`
+	Previous *vocab.URLProperty `json:"previous,omitempty"`
+}
+
+// NewItem returns a new Item.
+func NewItem(href, previous *url.URL) *Item {
+	return &Item{
+		item: &item{
+			HRef:     vocab.NewURLProperty(href),
+			Previous: vocab.NewURLProperty(previous),
+		},
+	}
+}
+
+// HRef returns the DID (as a URI).
+func (i *Item) HRef() *url.URL {
+	if i == nil {
+		return nil
+	}
+
+	return i.item.HRef.URL()
+}
+
+// Previous returns the previous anchor or nil (for create operations).
+func (i *Item) Previous() *url.URL {
+	if i == nil {
+		return nil
+	}
+
+	return i.item.Previous.URL()
+}
+
+// MarshalJSON marshals the object to JSON.
+func (i *Item) MarshalJSON() ([]byte, error) {
+	return json.Marshal(i.item)
+}
+
+// UnmarshalJSON umarshals the object from JSON.
+func (i *Item) UnmarshalJSON(b []byte) error {
+	i.item = &item{}
+
+	return json.Unmarshal(b, i.item)
+}
+
+type urlCollectionProperty struct {
+	urls []*vocab.URLProperty
+}
+
+func newURLCollectionProperty(urls ...*url.URL) *urlCollectionProperty {
+	if len(urls) == 0 {
+		return nil
+	}
+
+	p := &urlCollectionProperty{}
+
+	for _, u := range urls {
+		p.urls = append(p.urls, vocab.NewURLProperty(u))
+	}
+
+	return p
+}
+
+func (p *urlCollectionProperty) URLs() []*url.URL {
+	if p == nil || len(p.urls) == 0 {
+		return nil
+	}
+
+	urls := make([]*url.URL, len(p.urls))
+
+	for i, p := range p.urls {
+		urls[i] = p.URL()
+	}
+
+	return urls
+}
+
+// MarshalJSON marshals the URL collection.
+func (p *urlCollectionProperty) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.urls)
+}
+
+// UnmarshalJSON unmarshals the URL collection.
+func (p *urlCollectionProperty) UnmarshalJSON(bytes []byte) error {
+	var iris []*vocab.URLProperty
+
+	if err := json.Unmarshal(bytes, &iris); err != nil {
+		return err
+	}
+
+	p.urls = iris
+
+	return nil
+}

--- a/pkg/anchor/anchorevent/vocab/linkset_test.go
+++ b/pkg/anchor/anchorevent/vocab/linkset_test.go
@@ -1,0 +1,487 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vocab
+
+import (
+	"encoding/json"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/pkg/internal/testutil"
+)
+
+func TestNilAnchorEventLink(t *testing.T) {
+	var l *AnchorLinkWithReplies
+
+	require.Nil(t, l.Anchor())
+	require.Nil(t, l.Profile())
+	require.Nil(t, l.Original())
+	require.Empty(t, l.Original().Type())
+	require.Nil(t, l.Original().HRef())
+	require.Nil(t, l.Replies())
+}
+
+func TestNilAnchorLink(t *testing.T) {
+	var l *AnchorLink
+
+	require.Nil(t, l.Anchor())
+	require.Nil(t, l.Profile())
+	require.Nil(t, l.Up())
+	require.Nil(t, l.Items())
+	require.Nil(t, l.Author())
+}
+
+//nolint:lll
+func TestLinksetMarshalUnmarshal(t *testing.T) {
+	profile := testutil.MustParseURL("https://w3id.org/orb#v0")
+
+	sidetreeIndexHL := testutil.MustParseURL("hl:uEiCVVS-n0wx0OfeEXBM9jcGNOcMEArYYWPIxk5D_l96ySg")
+
+	itemHRef1 := testutil.MustParseURL("did:orb:uAAA:EiBfWqeAJfENeHLABsYIYmsIqtk-bsmvJmoR6IgISd6ZcA")
+	prevHRef1 := testutil.MustParseURL("hl:uEiAVAPhjewMUvawD0gl-MYMzvTPVuUA1DpO1SmBqcGbhvw")
+	upHRef1 := testutil.MustParseURL("hl:uEiAVAPhjewMUvawD0gl-MYMzvTPVuUA1DpO1SmBqcGbhvw:uoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpQVZBUGhqZXdNVXZhd0QwZ2wtTVlNenZUUFZ1VUExRHBPMVNtQnFjR2Jodnc")
+
+	itemHRef2 := testutil.MustParseURL("did:orb:uAAA:EiBfWqeAJfENeHLABsYIYmsIqtk-bsmvJmoR6IgISd6AdB")
+
+	author := testutil.MustParseURL("https://orb.domain2.com/services/orb")
+
+	originalLinkset := NewAnchorLinkset(
+		NewAnchorLink(sidetreeIndexHL, author, profile,
+			[]*Item{
+				NewItem(itemHRef1, prevHRef1),
+				NewItem(itemHRef2, nil),
+			},
+			[]*url.URL{upHRef1},
+		),
+	)
+
+	originalLSBytes := testutil.MarshalCanonical(t, originalLinkset)
+
+	t.Logf("Original: %s", originalLSBytes)
+
+	require.Equal(t, testutil.GetCanonical(t, originalLinksetJSON), string(originalLSBytes))
+
+	t.Run("application/gzip;base64 encoding -> success", func(t *testing.T) {
+		t.Run("marshal -> success", func(t *testing.T) {
+			anchor, originalRef, err := NewAnchorRef(originalLSBytes, MediaTypeDataURIGzipBase64, TypeLinkset)
+			require.NoError(t, err)
+
+			reply1DataURI, err := NewDataURI([]byte(testutil.GetCanonical(t, replyJSONData)), MediaTypeDataURIGzipBase64)
+			require.NoError(t, err)
+
+			reply2DataURI, err := NewDataURI([]byte(testutil.GetCanonical(t, replyJSONData)), MediaTypeDataURIGzipBase64)
+			require.NoError(t, err)
+
+			ls := NewAnchorLinksetWithReplies(
+				NewAnchorLinkWithReplies(anchor, profile, originalRef,
+					WithReply(
+						NewReference(reply1DataURI, TypeJSONLD),
+						NewReference(reply2DataURI, TypeJSONLD),
+					),
+				),
+			)
+
+			lsBytes := testutil.MarshalCanonical(t, ls)
+
+			t.Logf("AnchorLinksetWithReplies: %s", lsBytes)
+
+			require.Equal(t, testutil.GetCanonical(t, linksetGZIPBase64JSON), string(lsBytes))
+		})
+
+		t.Run("unmarshal -> success", func(t *testing.T) {
+			ls := &AnchorLinksetWithReplies{}
+			require.NoError(t, json.Unmarshal([]byte(linksetGZIPBase64JSON), ls))
+
+			require.Len(t, ls.Linkset, 1)
+
+			link := ls.Linkset[0]
+			require.NotNil(t, link)
+
+			require.NoError(t, link.Validate())
+
+			originalBytes, err := link.Original().Content()
+			require.NoError(t, err)
+
+			require.Equal(t, testutil.GetCanonical(t, originalLinksetJSON), string(originalBytes))
+
+			anchorLS := &AnchorLinkset{}
+			require.NoError(t, json.Unmarshal(originalBytes, anchorLS))
+
+			require.Len(t, anchorLS.Linkset, 1)
+
+			anchorLink := anchorLS.Linkset[0]
+
+			require.NoError(t, anchorLink.Validate())
+
+			require.Equal(t, sidetreeIndexHL.String(), anchorLink.Anchor().String())
+		})
+	})
+
+	t.Run("application/json encoding -> success", func(t *testing.T) {
+		t.Run("marshal -> success", func(t *testing.T) {
+			anchor, originalRef, err := NewAnchorRef(originalLSBytes, MediaTypeDataURIJSON, TypeLinkset)
+			require.NoError(t, err)
+
+			reply1DataURI, err := NewDataURI([]byte(testutil.GetCanonical(t, replyJSONData)), MediaTypeDataURIJSON)
+			require.NoError(t, err)
+
+			reply2DataURI, err := NewDataURI([]byte(testutil.GetCanonical(t, replyJSONData)), MediaTypeDataURIJSON)
+			require.NoError(t, err)
+
+			ls := NewAnchorLinksetWithReplies(
+				NewAnchorLinkWithReplies(anchor, profile, originalRef,
+					WithReply(
+						NewReference(reply1DataURI, TypeJSONLD),
+						NewReference(reply2DataURI, TypeJSONLD),
+					),
+				),
+			)
+
+			lsBytes := testutil.MarshalCanonical(t, ls)
+
+			t.Logf("AnchorLinksetWithReplies: %s", lsBytes)
+
+			require.Equal(t, testutil.GetCanonical(t, linksetURLEncodedJSON), string(lsBytes))
+		})
+
+		t.Run("unmarshal -> success", func(t *testing.T) {
+			ls := &AnchorLinksetWithReplies{}
+			require.NoError(t, json.Unmarshal([]byte(linksetURLEncodedJSON), ls))
+
+			require.Len(t, ls.Linkset, 1)
+
+			link := ls.Linkset[0]
+			require.NotNil(t, link)
+
+			require.NoError(t, link.Validate())
+
+			require.NotNil(t, link.Profile())
+			require.Equal(t, profile.String(), link.Profile().String())
+
+			require.Len(t, link.Replies(), 2)
+
+			require.NotNil(t, link.Original())
+
+			originalLSBytes, err := link.Original().Content()
+			require.NoError(t, err)
+
+			require.Equal(t, testutil.GetCanonical(t, originalLinksetJSON), string(originalLSBytes))
+
+			originalLS := &AnchorLinkset{}
+			require.NoError(t, json.Unmarshal(originalLSBytes, originalLS))
+			require.Len(t, originalLS.Linkset, 1)
+
+			anchorLink := originalLS.Linkset[0]
+
+			require.NotNil(t, anchorLink.Anchor())
+			require.Equal(t, sidetreeIndexHL.String(), anchorLink.Anchor().String())
+
+			require.NotNil(t, anchorLink.Author())
+			require.Equal(t, author.String(), anchorLink.Author().String())
+
+			require.Len(t, anchorLink.Items(), 2)
+			require.Equal(t, itemHRef1.String(), anchorLink.Items()[0].HRef().String())
+			require.Equal(t, prevHRef1.String(), anchorLink.Items()[0].Previous().String())
+			require.Equal(t, itemHRef2.String(), anchorLink.Items()[1].HRef().String())
+
+			require.Len(t, anchorLink.Up(), 1)
+			require.Equal(t, upHRef1.String(), anchorLink.Up()[0].String())
+
+			require.Equal(t, profile.String(), anchorLink.Profile().String())
+		})
+	})
+
+	t.Run("Unmarshal -> error", func(t *testing.T) {
+		t.Run("AnchorLinkWithReplies", func(t *testing.T) {
+			l := &AnchorLinkWithReplies{}
+			require.Error(t, l.UnmarshalJSON([]byte("}")))
+		})
+
+		t.Run("AnchorLink", func(t *testing.T) {
+			l := &AnchorLink{}
+			require.Error(t, l.UnmarshalJSON([]byte("}")))
+		})
+
+		t.Run("Reference", func(t *testing.T) {
+			r := &Reference{}
+			require.Error(t, r.UnmarshalJSON([]byte("}")))
+		})
+
+		t.Run("Item", func(t *testing.T) {
+			i := &Item{}
+			require.Error(t, i.UnmarshalJSON([]byte("}")))
+		})
+	})
+}
+
+func TestAnchorLink_Validate(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		l := NewAnchorLink(
+			testutil.MustParseURL("hl:uEiCVVS-n0wx0OfeEXBM9jcGNOcMEArYYWPIxk5D_l96ySg"),
+			testutil.MustParseURL("https://orb.domain2.com/services/orb"),
+			testutil.MustParseURL("https://w3id.org/orb#v0"),
+			[]*Item{
+				NewItem(
+					testutil.MustParseURL("did:orb:uAAA:EiBfWqeAJfENeHLABsYIYmsIqtk-bsmvJmoR6IgISd6ZcA"),
+					nil,
+				),
+			},
+			nil,
+		)
+		require.NoError(t, l.Validate())
+	})
+
+	t.Run("nil link -> error", func(t *testing.T) {
+		var l *AnchorLink
+		require.EqualError(t, l.Validate(), "nil link")
+	})
+
+	t.Run("nil anchor URI -> error", func(t *testing.T) {
+		l := NewAnchorLink(
+			nil,
+			testutil.MustParseURL("https://orb.domain2.com/services/orb"),
+			testutil.MustParseURL("https://w3id.org/orb#v0"),
+			[]*Item{
+				NewItem(
+					testutil.MustParseURL("did:orb:uAAA:EiBfWqeAJfENeHLABsYIYmsIqtk-bsmvJmoR6IgISd6ZcA"),
+					nil,
+				),
+			},
+			nil,
+		)
+		require.EqualError(t, l.Validate(), "anchor URI is required")
+	})
+
+	t.Run("nil author URI -> error", func(t *testing.T) {
+		l := NewAnchorLink(
+			testutil.MustParseURL("hl:uEiCVVS-n0wx0OfeEXBM9jcGNOcMEArYYWPIxk5D_l96ySg"),
+			nil,
+			testutil.MustParseURL("https://w3id.org/orb#v0"),
+			[]*Item{
+				NewItem(
+					testutil.MustParseURL("did:orb:uAAA:EiBfWqeAJfENeHLABsYIYmsIqtk-bsmvJmoR6IgISd6ZcA"),
+					nil,
+				),
+			},
+			nil,
+		)
+		require.EqualError(t, l.Validate(), "author URI is required")
+	})
+
+	t.Run("nil profile URI -> error", func(t *testing.T) {
+		l := NewAnchorLink(
+			testutil.MustParseURL("hl:uEiCVVS-n0wx0OfeEXBM9jcGNOcMEArYYWPIxk5D_l96ySg"),
+			testutil.MustParseURL("https://orb.domain2.com/services/orb"),
+			nil,
+			[]*Item{
+				NewItem(
+					testutil.MustParseURL("did:orb:uAAA:EiBfWqeAJfENeHLABsYIYmsIqtk-bsmvJmoR6IgISd6ZcA"),
+					nil,
+				),
+			},
+			nil,
+		)
+		require.EqualError(t, l.Validate(), "profile URI is required")
+	})
+
+	t.Run("no items -> error", func(t *testing.T) {
+		l := NewAnchorLink(
+			testutil.MustParseURL("hl:uEiCVVS-n0wx0OfeEXBM9jcGNOcMEArYYWPIxk5D_l96ySg"),
+			testutil.MustParseURL("https://orb.domain2.com/services/orb"),
+			testutil.MustParseURL("https://w3id.org/orb#v0"),
+			nil, nil,
+		)
+		require.EqualError(t, l.Validate(), "at least one item is required")
+	})
+}
+
+//nolint:lll
+func TestAnchorLinkWithReplies_Validate(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		l := NewAnchorLinkWithReplies(
+			testutil.MustParseURL("hl:uEiDhwm4mNgdS5AqYulZitFOski8JXZgw5uBrTYsDKoHvjg"),
+			testutil.MustParseURL("https://w3id.org/orb#v0"),
+			NewReference(
+				testutil.MustParseURL("data:application/gzip;base64,H4sIAAAAAAAA/5zOzZKaMAAA4HdJr1IBXXfkFlZWcQSVnwh0dnaEhH8IQkhwd3z3jj301ktf4JvvG9RFWw2EAe3XN7i2SU57oIG81kajeEPIlVpZTPIxJUagW+sy2drHxDJgH4aXkzlVL5vPer26uxmYgYKR5g+T9yQFGsAF1mgfayOEUDMKPb3cCNynhk12B6gPoRk2g3ljlRQPDd831FmZmeniVZRAMANdT3hBx+HvBiJ4yksiLJ9fxUbOaskKrS/undDoQ2XTHRW30W/JNs65AI/ZvxoQe461aEXVreqhVVvl9dOT2Gu5nLyluZ/cIEv1N31BpkjNwOPjGaFpUZPng7Fu0OZzsSjwT9pnc9rHP7gMZmDs/qupjfQs6cRgFO8ckXxRflDX97B4qWJVya+X5f3Q2Dx212UYWBz7qDujSPe3+S0KsI2CKMfyWUSqYB6qbdJGvv8eKcg3Jmennyxks3P7XjrqnuI2AY+Px+8AAAD//wAw1xPvAQAA"),
+				TypeLinkset,
+			),
+		)
+		require.NoError(t, l.Validate())
+	})
+
+	t.Run("nil link -> error", func(t *testing.T) {
+		var l *AnchorLinkWithReplies
+		require.EqualError(t, l.Validate(), "nil link")
+	})
+
+	t.Run("nil anchor -> error", func(t *testing.T) {
+		l := NewAnchorLinkWithReplies(
+			nil,
+			testutil.MustParseURL("https://w3id.org/orb#v0"),
+			NewReference(
+				testutil.MustParseURL("data:application/gzip;base64,H4sIAAAAAAAA/5zOzZKaMAAA4HdJr1IBXXfkFlZWcQSVnwh0dnaEhH8IQkhwd3z3jj301ktf4JvvG9RFWw2EAe3XN7i2SU57oIG81kajeEPIlVpZTPIxJUagW+sy2drHxDJgH4aXkzlVL5vPer26uxmYgYKR5g+T9yQFGsAF1mgfayOEUDMKPb3cCNynhk12B6gPoRk2g3ljlRQPDd831FmZmeniVZRAMANdT3hBx+HvBiJ4yksiLJ9fxUbOaskKrS/undDoQ2XTHRW30W/JNs65AI/ZvxoQe461aEXVreqhVVvl9dOT2Gu5nLyluZ/cIEv1N31BpkjNwOPjGaFpUZPng7Fu0OZzsSjwT9pnc9rHP7gMZmDs/qupjfQs6cRgFO8ckXxRflDX97B4qWJVya+X5f3Q2Dx212UYWBz7qDujSPe3+S0KsI2CKMfyWUSqYB6qbdJGvv8eKcg3Jmennyxks3P7XjrqnuI2AY+Px+8AAAD//wAw1xPvAQAA"),
+				TypeLinkset,
+			),
+		)
+		require.EqualError(t, l.Validate(), "anchor URI is required")
+	})
+
+	t.Run("invalid anchor hashlink -> error", func(t *testing.T) {
+		l := NewAnchorLinkWithReplies(
+			testutil.MustParseURL("https://someurl"),
+			testutil.MustParseURL("https://w3id.org/orb#v0"),
+			NewReference(
+				testutil.MustParseURL("data:application/gzip;base64,H4sIAAAAAAAA/5zOzZKaMAAA4HdJr1IBXXfkFlZWcQSVnwh0dnaEhH8IQkhwd3z3jj301ktf4JvvG9RFWw2EAe3XN7i2SU57oIG81kajeEPIlVpZTPIxJUagW+sy2drHxDJgH4aXkzlVL5vPer26uxmYgYKR5g+T9yQFGsAF1mgfayOEUDMKPb3cCNynhk12B6gPoRk2g3ljlRQPDd831FmZmeniVZRAMANdT3hBx+HvBiJ4yksiLJ9fxUbOaskKrS/undDoQ2XTHRW30W/JNs65AI/ZvxoQe461aEXVreqhVVvl9dOT2Gu5nLyluZ/cIEv1N31BpkjNwOPjGaFpUZPng7Fu0OZzsSjwT9pnc9rHP7gMZmDs/qupjfQs6cRgFO8ckXxRflDX97B4qWJVya+X5f3Q2Dx212UYWBz7qDujSPe3+S0KsI2CKMfyWUSqYB6qbdJGvv8eKcg3Jmennyxks3P7XjrqnuI2AY+Px+8AAAD//wAw1xPvAQAA"),
+				TypeLinkset,
+			),
+		)
+		require.EqualError(t, l.Validate(), "anchor URI is not a valid hashlink: https://someurl")
+	})
+
+	t.Run("nil profile -> error", func(t *testing.T) {
+		l := NewAnchorLinkWithReplies(
+			testutil.MustParseURL("hl:uEiDhwm4mNgdS5AqYulZitFOski8JXZgw5uBrTYsDKoHvjg"),
+			nil,
+			NewReference(
+				testutil.MustParseURL("data:application/gzip;base64,H4sIAAAAAAAA/5zOzZKaMAAA4HdJr1IBXXfkFlZWcQSVnwh0dnaEhH8IQkhwd3z3jj301ktf4JvvG9RFWw2EAe3XN7i2SU57oIG81kajeEPIlVpZTPIxJUagW+sy2drHxDJgH4aXkzlVL5vPer26uxmYgYKR5g+T9yQFGsAF1mgfayOEUDMKPb3cCNynhk12B6gPoRk2g3ljlRQPDd831FmZmeniVZRAMANdT3hBx+HvBiJ4yksiLJ9fxUbOaskKrS/undDoQ2XTHRW30W/JNs65AI/ZvxoQe461aEXVreqhVVvl9dOT2Gu5nLyluZ/cIEv1N31BpkjNwOPjGaFpUZPng7Fu0OZzsSjwT9pnc9rHP7gMZmDs/qupjfQs6cRgFO8ckXxRflDX97B4qWJVya+X5f3Q2Dx212UYWBz7qDujSPe3+S0KsI2CKMfyWUSqYB6qbdJGvv8eKcg3Jmennyxks3P7XjrqnuI2AY+Px+8AAAD//wAw1xPvAQAA"),
+				TypeLinkset,
+			),
+		)
+		require.EqualError(t, l.Validate(), "profile URI is required")
+	})
+
+	t.Run("invalid original content -> error", func(t *testing.T) {
+		l := NewAnchorLinkWithReplies(
+			testutil.MustParseURL("hl:uEiDhwm4mNgdS5AqYulZitFOski8JXZgw5uBrTYsDKoHvjg"),
+			testutil.MustParseURL("https://w3id.org/orb#v0"),
+			NewReference(
+				testutil.MustParseURL("data:application/gzip;base64,H4sIAAAAAAAA/5zOzZKsdss"),
+				TypeLinkset,
+			),
+		)
+		err := l.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "illegal base64 data at input byte")
+	})
+
+	t.Run("anchor hash mismatch -> error", func(t *testing.T) {
+		l := NewAnchorLinkWithReplies(
+			testutil.MustParseURL("hl:uEiDhwm4mNgdS5AqYulZitFOski8JXZgw5uBrTYsDKwHvjg"),
+			testutil.MustParseURL("https://w3id.org/orb#v0"),
+			NewReference(
+				testutil.MustParseURL("data:application/gzip;base64,H4sIAAAAAAAA/5zOzZKaMAAA4HdJr1IBXXfkFlZWcQSVnwh0dnaEhH8IQkhwd3z3jj301ktf4JvvG9RFWw2EAe3XN7i2SU57oIG81kajeEPIlVpZTPIxJUagW+sy2drHxDJgH4aXkzlVL5vPer26uxmYgYKR5g+T9yQFGsAF1mgfayOEUDMKPb3cCNynhk12B6gPoRk2g3ljlRQPDd831FmZmeniVZRAMANdT3hBx+HvBiJ4yksiLJ9fxUbOaskKrS/undDoQ2XTHRW30W/JNs65AI/ZvxoQe461aEXVreqhVVvl9dOT2Gu5nLyluZ/cIEv1N31BpkjNwOPjGaFpUZPng7Fu0OZzsSjwT9pnc9rHP7gMZmDs/qupjfQs6cRgFO8ckXxRflDX97B4qWJVya+X5f3Q2Dx212UYWBz7qDujSPe3+S0KsI2CKMfyWUSqYB6qbdJGvv8eKcg3Jmennyxks3P7XjrqnuI2AY+Px+8AAAD//wAw1xPvAQAA"),
+				TypeLinkset,
+			),
+		)
+		require.EqualError(t, l.Validate(), "hash of the original content does not match the anchor hash")
+	})
+}
+
+const (
+	//nolint:lll
+	originalLinksetJSON = `{
+  "linkset": [
+    {
+      "anchor": "hl:uEiCVVS-n0wx0OfeEXBM9jcGNOcMEArYYWPIxk5D_l96ySg",
+      "author": "https://orb.domain2.com/services/orb",
+      "item": [
+        {
+          "href": "did:orb:uAAA:EiBfWqeAJfENeHLABsYIYmsIqtk-bsmvJmoR6IgISd6ZcA",
+          "previous": "hl:uEiAVAPhjewMUvawD0gl-MYMzvTPVuUA1DpO1SmBqcGbhvw"
+        },
+        {
+          "href": "did:orb:uAAA:EiBfWqeAJfENeHLABsYIYmsIqtk-bsmvJmoR6IgISd6AdB"
+        }
+      ],
+      "profile": "https://w3id.org/orb#v0",
+      "up": [
+        "hl:uEiAVAPhjewMUvawD0gl-MYMzvTPVuUA1DpO1SmBqcGbhvw:uoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpQVZBUGhqZXdNVXZhd0QwZ2wtTVlNenZUUFZ1VUExRHBPMVNtQnFjR2Jodnc"
+      ]
+    }
+  ]
+}`
+
+	//nolint:lll
+	replyJSONData = `{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1"
+  ],
+  "credentialSubject": "hl:uEiD96Zjp10atu2DPV1VbSxZmMvk5r5iAvSlnXXAfpkpY9g",
+  "id": "https://orb.domain2.com/vc/afeead95-8507-460b-a73c-cf9b4853b4a9",
+  "issuanceDate": "2022-02-22T15:45:41.6601759Z",
+  "issuer": "https://orb.domain2.com",
+  "proof": [
+    {
+      "created": "2022-02-22T15:45:41.6613096Z",
+      "domain": "https://orb.domain2.com",
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..2Sp1wXzI69pontDt-x26KwEBFhEzif33io9lIEHEEBRHgiLAFr4D6XDDVyjMmSCXWWuYBMZUFWwwHJkpPi08Dg",
+      "proofPurpose": "assertionMethod",
+      "type": "Ed25519Signature2018",
+      "verificationMethod": "did:web:orb.domain2.com#orb2key"
+    },
+    {
+      "created": "2022-02-22T15:45:42.664Z",
+      "domain": "http://orb.vct:8077/maple2020",
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19.._vShdZ5z_YKjWfKPt5zgTJpUoYx1pMfjETiFVHHVsZrUlAM9CXLSjrRAzGicT4uqTVFqurrpsQstPAABpm_DDQ",
+      "proofPurpose": "assertionMethod",
+      "type": "Ed25519Signature2018",
+      "verificationMethod": "did:web:orb.domain1.com#orb1key2"
+    }
+  ],
+  "type": "VerifiableCredential"
+}`
+
+	//nolint:lll
+	linksetGZIPBase64JSON = `{
+  "linkset": [
+    {
+      "anchor": "hl:uEiDMut3ejYHWvds0PajgKg9zy9OqwWZTirAQob6tp42kog",
+      "original": {
+        "href": "data:application/gzip;base64,H4sIAAAAAAAA/6TQX4+aQBQF8O9y+4qKtGvivA2VVYzgH5ZR2JgGZgYZBQZhGHQ3fvfGpmn63D7f3JzfOZ9QiOrScgXo/ROSiuayAQR5gTpHfCckGFRmfzPXGXcOtjc907m/pp6Dmyjab9zb5WX2o5hO7sEJDEg69ftbqbpFo5Fs0iGTZSIqa0hlOWp5owXl7fMABgjFy1+xecMzQMAEQ7JJUYcxRo6ws/2V42Xm+HyxwnYbuVHZuld1GaRtqZel3E3ckxuwSUwxGFA3XAvZtX/0mOBNfua9F+qkn5mnYuBF3od+25AuxONZvR4HpX2l8zTXPTyM/2ZgZsPj+ITITBT8rx36r4INZXN69v6iTTCgqwG9/4MTdXI7sLmjJFvsevoh9cqa3iPxckmtcZ7sv91Xpa/TYHqODp5mIam3JLbDeX6ND8wnhzhn5raPrV69kcLnVRyGr/GYhM5tt7A3HvHVtno976ylZBWF4+P4+BkAAP//kmCCUyECAAA=",
+        "type": "application/linkset+json"
+      },
+      "profile": "https://w3id.org/orb#v0",
+      "replies": [
+        {
+          "href": "data:application/gzip;base64,H4sIAAAAAAAA/7yTXXOiPBiG/0veU+UjAgpHrwpWbG21+Emn0wkQNAgkTYKonf73HXbb7s7utEc7e5rkue65r8nzAv6PaSnxSQLnAeylZMJR1bqulbqjUL5Toab31JjjBJeSoFyoRx08tsDPk6CKMhxL4IB97lQecW0rzJiuIVlBd7bSV1FwCovp8WByk/SPQV5uNv2UHdjW3oEWIEkz+ZZLeaQktECkhEpMC/UYqyjFGCW22e6ZWrdtWFrURt1O3I5TOzJ6ZicykN1ghKhQGWMXSQwcADUI2xpsQ7jQTccwHUNXLEvTu6Ydvr3G/PNg0AKMU5oC5+GlqYokTj6l6h3NthrqD8CX1KwWwAH4PNlHVzG5I5NR6N0v5oEv/MKHt0PfCouRiOFS+MXtGW3m5C4XZJttNT/XbUWBAdPrzcW3bEZL6cr2CVrXtTcY7b0LSTsdQu3c98aeN7gf78hNf8QN19q47uqcTYtguFmvq+1gGi5H67oeTw5sRrSeu3uvO6s4o6Lxh4TAXBJaTrHc0wS0gDyz5sJLoGnqdkB2JZIVx833AC1wxJykJEa/jDggIYlT48j5TcN/lEfwgM/gtfW1XKhYlvGH2Devx1g6Pa3bVQvEcgw1qP0FvU/HYJ+E5uVpe52t0+uZNC+7xYQt6faks2maeQsyWo3HKxHyZd6f2sPNTZDx+/7lisQLo3perEbPFedMzIWc9fsDVjy57vyf6dXf9eoHfIbg9fGDu/oOQFGOhx+LC16/BQAA//8oVea0/QMAAA==",
+          "type": "application/ld+json"
+        },
+        {
+          "href": "data:application/gzip;base64,H4sIAAAAAAAA/7yTXXOiPBiG/0veU+UjAgpHrwpWbG21+Emn0wkQNAgkTYKonf73HXbb7s7utEc7e5rkue65r8nzAv6PaSnxSQLnAeylZMJR1bqulbqjUL5Toab31JjjBJeSoFyoRx08tsDPk6CKMhxL4IB97lQecW0rzJiuIVlBd7bSV1FwCovp8WByk/SPQV5uNv2UHdjW3oEWIEkz+ZZLeaQktECkhEpMC/UYqyjFGCW22e6ZWrdtWFrURt1O3I5TOzJ6ZicykN1ghKhQGWMXSQwcADUI2xpsQ7jQTccwHUNXLEvTu6Ydvr3G/PNg0AKMU5oC5+GlqYokTj6l6h3NthrqD8CX1KwWwAH4PNlHVzG5I5NR6N0v5oEv/MKHt0PfCouRiOFS+MXtGW3m5C4XZJttNT/XbUWBAdPrzcW3bEZL6cr2CVrXtTcY7b0LSTsdQu3c98aeN7gf78hNf8QN19q47uqcTYtguFmvq+1gGi5H67oeTw5sRrSeu3uvO6s4o6Lxh4TAXBJaTrHc0wS0gDyz5sJLoGnqdkB2JZIVx833AC1wxJykJEa/jDggIYlT48j5TcN/lEfwgM/gtfW1XKhYlvGH2Devx1g6Pa3bVQvEcgw1qP0FvU/HYJ+E5uVpe52t0+uZNC+7xYQt6faks2maeQsyWo3HKxHyZd6f2sPNTZDx+/7lisQLo3perEbPFedMzIWc9fsDVjy57vyf6dXf9eoHfIbg9fGDu/oOQFGOhx+LC16/BQAA//8oVea0/QMAAA==",
+          "type": "application/ld+json"
+        }
+      ]
+    }
+  ]
+}`
+
+	//nolint:lll
+	linksetURLEncodedJSON = `{
+  "linkset": [
+    {
+      "anchor": "hl:uEiDMut3ejYHWvds0PajgKg9zy9OqwWZTirAQob6tp42kog",
+      "original": {
+        "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiCVVS-n0wx0OfeEXBM9jcGNOcMEArYYWPIxk5D_l96ySg%22%2C%22author%22%3A%22https%3A%2F%2Forb.domain2.com%2Fservices%2Forb%22%2C%22item%22%3A%5B%7B%22href%22%3A%22did%3Aorb%3AuAAA%3AEiBfWqeAJfENeHLABsYIYmsIqtk-bsmvJmoR6IgISd6ZcA%22%2C%22previous%22%3A%22hl%3AuEiAVAPhjewMUvawD0gl-MYMzvTPVuUA1DpO1SmBqcGbhvw%22%7D%2C%7B%22href%22%3A%22did%3Aorb%3AuAAA%3AEiBfWqeAJfENeHLABsYIYmsIqtk-bsmvJmoR6IgISd6AdB%22%7D%5D%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%2C%22up%22%3A%5B%22hl%3AuEiAVAPhjewMUvawD0gl-MYMzvTPVuUA1DpO1SmBqcGbhvw%3AuoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpQVZBUGhqZXdNVXZhd0QwZ2wtTVlNenZUUFZ1VUExRHBPMVNtQnFjR2Jodnc%22%5D%7D%5D%7D",
+        "type": "application/linkset+json"
+      },
+      "profile": "https://w3id.org/orb#v0",
+      "replies": [
+        {
+          "href": "data:application/json,%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww.w3.org%2F2018%2Fcredentials%2Fv1%22%5D%2C%22credentialSubject%22%3A%22hl%3AuEiD96Zjp10atu2DPV1VbSxZmMvk5r5iAvSlnXXAfpkpY9g%22%2C%22id%22%3A%22https%3A%2F%2Forb.domain2.com%2Fvc%2Fafeead95-8507-460b-a73c-cf9b4853b4a9%22%2C%22issuanceDate%22%3A%222022-02-22T15%3A45%3A41.6601759Z%22%2C%22issuer%22%3A%22https%3A%2F%2Forb.domain2.com%22%2C%22proof%22%3A%5B%7B%22created%22%3A%222022-02-22T15%3A45%3A41.6613096Z%22%2C%22domain%22%3A%22https%3A%2F%2Forb.domain2.com%22%2C%22jws%22%3A%22eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..2Sp1wXzI69pontDt-x26KwEBFhEzif33io9lIEHEEBRHgiLAFr4D6XDDVyjMmSCXWWuYBMZUFWwwHJkpPi08Dg%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22type%22%3A%22Ed25519Signature2018%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain2.com%23orb2key%22%7D%2C%7B%22created%22%3A%222022-02-22T15%3A45%3A42.664Z%22%2C%22domain%22%3A%22http%3A%2F%2Forb.vct%3A8077%2Fmaple2020%22%2C%22jws%22%3A%22eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19.._vShdZ5z_YKjWfKPt5zgTJpUoYx1pMfjETiFVHHVsZrUlAM9CXLSjrRAzGicT4uqTVFqurrpsQstPAABpm_DDQ%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22type%22%3A%22Ed25519Signature2018%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain1.com%23orb1key2%22%7D%5D%2C%22type%22%3A%22VerifiableCredential%22%7D",
+          "type": "application/ld+json"
+        },
+        {
+          "href": "data:application/json,%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww.w3.org%2F2018%2Fcredentials%2Fv1%22%5D%2C%22credentialSubject%22%3A%22hl%3AuEiD96Zjp10atu2DPV1VbSxZmMvk5r5iAvSlnXXAfpkpY9g%22%2C%22id%22%3A%22https%3A%2F%2Forb.domain2.com%2Fvc%2Fafeead95-8507-460b-a73c-cf9b4853b4a9%22%2C%22issuanceDate%22%3A%222022-02-22T15%3A45%3A41.6601759Z%22%2C%22issuer%22%3A%22https%3A%2F%2Forb.domain2.com%22%2C%22proof%22%3A%5B%7B%22created%22%3A%222022-02-22T15%3A45%3A41.6613096Z%22%2C%22domain%22%3A%22https%3A%2F%2Forb.domain2.com%22%2C%22jws%22%3A%22eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..2Sp1wXzI69pontDt-x26KwEBFhEzif33io9lIEHEEBRHgiLAFr4D6XDDVyjMmSCXWWuYBMZUFWwwHJkpPi08Dg%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22type%22%3A%22Ed25519Signature2018%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain2.com%23orb2key%22%7D%2C%7B%22created%22%3A%222022-02-22T15%3A45%3A42.664Z%22%2C%22domain%22%3A%22http%3A%2F%2Forb.vct%3A8077%2Fmaple2020%22%2C%22jws%22%3A%22eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19.._vShdZ5z_YKjWfKPt5zgTJpUoYx1pMfjETiFVHHVsZrUlAM9CXLSjrRAzGicT4uqTVFqurrpsQstPAABpm_DDQ%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22type%22%3A%22Ed25519Signature2018%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain1.com%23orb1key2%22%7D%5D%2C%22type%22%3A%22VerifiableCredential%22%7D",
+          "type": "application/ld+json"
+        }
+      ]
+    }
+  ]
+}`
+)

--- a/pkg/internal/testutil/testutil.go
+++ b/pkg/internal/testutil/testutil.go
@@ -66,6 +66,17 @@ func GetCanonical(t *testing.T, raw string) string {
 	return string(bytes)
 }
 
+// MarshalCanonical marshals the given object to a canonical JSON.
+func MarshalCanonical(t *testing.T, i interface{}) []byte {
+	t.Helper()
+
+	bytes, err := canonicalizer.MarshalCanonical(i)
+
+	require.NoError(t, err)
+
+	return bytes
+}
+
 type provider struct {
 	ContextStore        ldstore.ContextStore
 	RemoteProviderStore ldstore.RemoteProviderStore


### PR DESCRIPTION
Implement a subset of the Linkset vocabulary (https://www.ietf.org/archive/id/draft-ietf-httpapi-linkset-08.html) which will be used as a replacement for AnchorEvent.

closes #1157

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>