### PR TITLE
feat: Add log monitor store

### DIFF
--- a/pkg/store/logmonitor/store.go
+++ b/pkg/store/logmonitor/store.go
@@ -1,0 +1,240 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package logmonitor
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/hyperledger/aries-framework-go/spi/storage"
+	"github.com/trustbloc/edge-core/pkg/log"
+	"github.com/trustbloc/vct/pkg/controller/command"
+
+	orberrors "github.com/trustbloc/orb/pkg/errors"
+)
+
+const (
+	namespace = "log-monitor"
+
+	activeIndex = "active"
+)
+
+var logger = log.New("log-monitor-store")
+
+// New returns new instance of log monitor store.
+func New(provider storage.Provider) (*Store, error) {
+	store, err := provider.OpenStore(namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open log monitor store: %w", err)
+	}
+
+	err = provider.SetStoreConfig(namespace, storage.StoreConfiguration{TagNames: []string{activeIndex}})
+	if err != nil {
+		return nil, fmt.Errorf("failed to set store configuration: %w", err)
+	}
+
+	return &Store{
+		store:     store,
+		marshal:   json.Marshal,
+		unmarshal: json.Unmarshal,
+	}, nil
+}
+
+// Store implements storage for log monitors.
+type Store struct {
+	store     storage.Store
+	marshal   func(v interface{}) ([]byte, error)
+	unmarshal func(data []byte, v interface{}) error
+}
+
+// LogMonitor provides information about log monitor.
+type LogMonitor struct {
+	Log        string
+	Active     bool
+	Processing bool
+	STH        *command.GetSTHResponse
+}
+
+// Activate stores a log to be monitored. If it already exists active flag will be set to true.
+func (s *Store) Activate(logURL string) error {
+	if logURL == "" {
+		return fmt.Errorf("failed to activate log monitor: log URL is empty")
+	}
+
+	rec, err := s.Get(logURL)
+	if err != nil {
+		if errors.Is(err, orberrors.ErrContentNotFound) {
+			// create new log monitor
+			rec = &LogMonitor{
+				Log:        logURL,
+				Active:     true,
+				Processing: false,
+			}
+		} else {
+			return fmt.Errorf("failed to get log monitor record: %w", err)
+		}
+	}
+
+	rec.Active = true
+
+	recBytes, err := s.marshal(rec)
+	if err != nil {
+		return fmt.Errorf("failed to marshal log monitor record: %w", err)
+	}
+
+	logger.Debugf("storing log monitor: %s", string(recBytes))
+
+	indexTag := storage.Tag{
+		Name:  activeIndex,
+		Value: "true",
+	}
+
+	if e := s.store.Put(logURL, recBytes, indexTag); e != nil {
+		return fmt.Errorf("failed to put log monitor: %w", e)
+	}
+
+	return nil
+}
+
+// Deactivate flags log monitor as inactive.
+func (s *Store) Deactivate(logURL string) error {
+	if logURL == "" {
+		return fmt.Errorf("failed to deactivate log monitor: log URL is empty")
+	}
+
+	rec, err := s.Get(logURL)
+	if err != nil {
+		return fmt.Errorf("failed to deactivate log[%s] monitor: %w", logURL, err)
+	}
+
+	rec.Active = false
+
+	recBytes, err := s.marshal(rec)
+	if err != nil {
+		return fmt.Errorf("failed to deactivate log[%s] monitor: marshall error: %w", logURL, err)
+	}
+
+	logger.Debugf("deactivating log monitor: %s", logURL)
+
+	indexTag := storage.Tag{
+		Name:  activeIndex,
+		Value: "false",
+	}
+
+	if e := s.store.Put(logURL, recBytes, indexTag); e != nil {
+		return fmt.Errorf("failed to deactivate log[%s] monitor: %w", logURL, e)
+	}
+
+	return nil
+}
+
+// Get retrieves log monitor.
+func (s *Store) Get(logURL string) (*LogMonitor, error) {
+	recBytes, err := s.store.Get(logURL)
+	if err != nil {
+		if errors.Is(err, storage.ErrDataNotFound) {
+			return nil, orberrors.ErrContentNotFound
+		}
+
+		return nil, fmt.Errorf("failed to get log monitor: %w", err)
+	}
+
+	var rec LogMonitor
+
+	err = s.unmarshal(recBytes, &rec)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal log monitor: %w", err)
+	}
+
+	return &rec, nil
+}
+
+// Update updates a log monitor.
+func (s *Store) Update(logMonitor *LogMonitor) error {
+	if logMonitor == nil {
+		return fmt.Errorf("log monitor is empty")
+	}
+
+	recBytes, err := s.marshal(logMonitor)
+	if err != nil {
+		return fmt.Errorf("failed to marshal log monitor record: %w", err)
+	}
+
+	logger.Debugf("updating log monitor: %s", string(recBytes))
+
+	indexTag := storage.Tag{
+		Name:  activeIndex,
+		Value: strconv.FormatBool(logMonitor.Active),
+	}
+
+	if e := s.store.Put(logMonitor.Log, recBytes, indexTag); e != nil {
+		return fmt.Errorf("failed to store log monitor: %w", e)
+	}
+
+	return nil
+}
+
+// Delete deletes log monitor.
+func (s *Store) Delete(logURL string) error {
+	if err := s.store.Delete(logURL); err != nil {
+		return fmt.Errorf("failed to delete log[%s] monitor: %w", logURL, err)
+	}
+
+	logger.Debugf("deleted log monitor: %s", logURL)
+
+	return nil
+}
+
+// GetActiveLogs retrieves all active log monitors.
+func (s *Store) GetActiveLogs() ([]*LogMonitor, error) {
+	var err error
+
+	query := fmt.Sprintf("%s:%t", activeIndex, true)
+
+	iter, err := s.store.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get active log monitors, query[%s]: %w", query, err)
+	}
+
+	ok, err := iter.Next()
+	if err != nil {
+		return nil, fmt.Errorf("iterator error for get active log monitors: %w", err)
+	}
+
+	if !ok {
+		return nil, orberrors.ErrContentNotFound
+	}
+
+	var logMonitors []*LogMonitor
+
+	for ok {
+		value, err := iter.Value()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get iterator value for active log monitors: %w", err)
+		}
+
+		var logMonitor LogMonitor
+
+		err = s.unmarshal(value, &logMonitor)
+		if err != nil {
+			return nil, fmt.Errorf("unmarshal log monitor: %w", err)
+		}
+
+		logMonitors = append(logMonitors, &logMonitor)
+
+		ok, err = iter.Next()
+		if err != nil {
+			return nil, fmt.Errorf("iterator error for active log monitors: %w", err)
+		}
+	}
+
+	logger.Debugf("get active log monitors: %s", logMonitors)
+
+	return logMonitors, nil
+}

--- a/pkg/store/logmonitor/store_test.go
+++ b/pkg/store/logmonitor/store_test.go
@@ -1,0 +1,473 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package logmonitor
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb"
+	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
+	mockstore "github.com/hyperledger/aries-framework-go/component/storageutil/mock"
+	"github.com/hyperledger/aries-framework-go/spi/storage"
+	"github.com/stretchr/testify/require"
+
+	orberrors "github.com/trustbloc/orb/pkg/errors"
+	"github.com/trustbloc/orb/pkg/internal/testutil/mongodbtestutil"
+)
+
+const testLog = "http://vct.com/log"
+
+func TestNew(t *testing.T) {
+	t.Run("test new store", func(t *testing.T) {
+		s, err := New(mem.NewProvider())
+		require.NoError(t, err)
+		require.NotNil(t, s)
+	})
+
+	t.Run("test error from open store", func(t *testing.T) {
+		s, err := New(&mockstore.Provider{
+			ErrOpenStore: fmt.Errorf("failed to open store"),
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to open store")
+		require.Nil(t, s)
+	})
+}
+
+func TestStore_Activate(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		s, err := New(mem.NewProvider())
+		require.NoError(t, err)
+
+		err = s.Activate(testLog)
+		require.NoError(t, err)
+
+		rec, err := s.Get(testLog)
+		require.NoError(t, err)
+		require.Equal(t, testLog, rec.Log)
+		require.Equal(t, true, rec.Active)
+		require.Equal(t, false, rec.Processing)
+		require.Nil(t, rec.STH)
+	})
+
+	t.Run("success - activate, deactivate, activate", func(t *testing.T) {
+		s, err := New(mem.NewProvider())
+		require.NoError(t, err)
+
+		err = s.Activate(testLog)
+		require.NoError(t, err)
+
+		rec, err := s.Get(testLog)
+		require.NoError(t, err)
+		require.Equal(t, true, rec.Active)
+
+		err = s.Deactivate(testLog)
+		require.NoError(t, err)
+
+		rec, err = s.Get(testLog)
+		require.NoError(t, err)
+		require.Equal(t, false, rec.Active)
+
+		err = s.Activate(testLog)
+		require.NoError(t, err)
+
+		rec, err = s.Get(testLog)
+		require.NoError(t, err)
+		require.Equal(t, true, rec.Active)
+	})
+
+	t.Run("error - empty log URL", func(t *testing.T) {
+		s, err := New(mem.NewProvider())
+		require.NoError(t, err)
+
+		err = s.Activate("")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to activate log monitor: log URL is empty")
+	})
+
+	t.Run("error - error from store put", func(t *testing.T) {
+		storeProvider := &mockstore.Provider{OpenStoreReturn: &mockstore.Store{
+			GetReturn: []byte("{}"),
+			ErrPut:    fmt.Errorf("error put"),
+		}}
+
+		s, err := New(storeProvider)
+		require.NoError(t, err)
+
+		err = s.Activate(testLog)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error put")
+	})
+
+	t.Run("error - error from store get", func(t *testing.T) {
+		storeProvider := &mockstore.Provider{OpenStoreReturn: &mockstore.Store{
+			ErrGet: fmt.Errorf("error get"),
+		}}
+
+		s, err := New(storeProvider)
+		require.NoError(t, err)
+
+		err = s.Activate(testLog)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error get")
+	})
+
+	t.Run("error - error from store put", func(t *testing.T) {
+		recBytes, err := json.Marshal(&LogMonitor{Log: testLog})
+		require.NoError(t, err)
+
+		storeProvider := &mockstore.Provider{OpenStoreReturn: &mockstore.Store{
+			GetReturn: recBytes,
+			ErrPut:    fmt.Errorf("error put"),
+		}}
+
+		s, err := New(storeProvider)
+		require.NoError(t, err)
+
+		err = s.Deactivate(testLog)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error put")
+	})
+}
+
+func TestStore_Deactivate(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		s, err := New(mem.NewProvider())
+		require.NoError(t, err)
+
+		err = s.Activate(testLog)
+		require.NoError(t, err)
+
+		rec, err := s.Get(testLog)
+		require.NoError(t, err)
+		require.Equal(t, true, rec.Active)
+
+		err = s.Deactivate(testLog)
+		require.NoError(t, err)
+
+		rec, err = s.Get(testLog)
+		require.NoError(t, err)
+		require.Equal(t, false, rec.Active)
+	})
+
+	t.Run("error - empty log URL", func(t *testing.T) {
+		s, err := New(mem.NewProvider())
+		require.NoError(t, err)
+
+		err = s.Deactivate("")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to deactivate log monitor: log URL is empty")
+	})
+
+	t.Run("error - from store get", func(t *testing.T) {
+		storeProvider := &mockstore.Provider{OpenStoreReturn: &mockstore.Store{
+			ErrGet: fmt.Errorf("error get"),
+		}}
+
+		s, err := New(storeProvider)
+		require.NoError(t, err)
+
+		err = s.Deactivate(testLog)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error get")
+	})
+
+	t.Run("error - marshal error", func(t *testing.T) {
+		s, err := New(mem.NewProvider())
+		require.NoError(t, err)
+
+		err = s.Activate(testLog)
+		require.NoError(t, err)
+
+		errExpected := errors.New("injected marshal error")
+
+		s.marshal = func(v interface{}) ([]byte, error) {
+			return nil, errExpected
+		}
+
+		err = s.Deactivate(testLog)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+	})
+
+	t.Run("error - error from store put", func(t *testing.T) {
+		recBytes, err := json.Marshal(&LogMonitor{Log: testLog})
+		require.NoError(t, err)
+
+		storeProvider := &mockstore.Provider{OpenStoreReturn: &mockstore.Store{
+			GetReturn: recBytes,
+			ErrPut:    fmt.Errorf("error put"),
+		}}
+
+		s, err := New(storeProvider)
+		require.NoError(t, err)
+
+		err = s.Activate(testLog)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error put")
+	})
+}
+
+func TestStore_Get(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		s, err := New(mem.NewProvider())
+		require.NoError(t, err)
+
+		err = s.Activate(testLog)
+		require.NoError(t, err)
+
+		rec, err := s.Get(testLog)
+		require.NoError(t, err)
+		require.Equal(t, rec.Active, true)
+		require.Equal(t, rec.Processing, false)
+		require.Nil(t, rec.STH)
+	})
+
+	t.Run("error - from store get", func(t *testing.T) {
+		storeProvider := &mockstore.Provider{OpenStoreReturn: &mockstore.Store{
+			ErrGet: fmt.Errorf("error get"),
+		}}
+
+		s, err := New(storeProvider)
+		require.NoError(t, err)
+
+		vc, err := s.Get(testLog)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error get")
+		require.Nil(t, vc)
+	})
+
+	t.Run("error - ErrDataNotFound from store get", func(t *testing.T) {
+		storeProvider := &mockstore.Provider{OpenStoreReturn: &mockstore.Store{
+			ErrGet: storage.ErrDataNotFound,
+		}}
+
+		s, err := New(storeProvider)
+		require.NoError(t, err)
+
+		vc, err := s.Get(testLog)
+		require.True(t, errors.Is(err, orberrors.ErrContentNotFound))
+		require.Nil(t, vc)
+	})
+
+	t.Run("error - marshal error", func(t *testing.T) {
+		s, err := New(mem.NewProvider())
+		require.NoError(t, err)
+
+		errExpected := errors.New("injected marshal error")
+
+		s.marshal = func(v interface{}) ([]byte, error) {
+			return nil, errExpected
+		}
+
+		err = s.Activate(testLog)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+	})
+
+	t.Run("error - unmarshal error", func(t *testing.T) {
+		s, err := New(mem.NewProvider())
+		require.NoError(t, err)
+
+		errExpected := errors.New("injected unmarshal error")
+
+		s.unmarshal = func(data []byte, v interface{}) error {
+			return errExpected
+		}
+
+		err = s.Activate(testLog)
+		require.NoError(t, err)
+
+		rec, err := s.Get(testLog)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+		require.Nil(t, rec)
+	})
+}
+
+func TestStore_Update(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		s, err := New(mem.NewProvider())
+		require.NoError(t, err)
+
+		err = s.Activate(testLog)
+		require.NoError(t, err)
+
+		rec, err := s.Get(testLog)
+		require.NoError(t, err)
+		require.Equal(t, true, rec.Active)
+		require.Equal(t, false, rec.Processing)
+		require.Nil(t, rec.STH)
+
+		rec.Processing = true
+
+		err = s.Update(rec)
+		require.NoError(t, err)
+		require.Equal(t, true, rec.Active)
+		require.Equal(t, true, rec.Processing)
+		require.Nil(t, rec.STH)
+	})
+
+	t.Run("error - marshal error", func(t *testing.T) {
+		s, err := New(mem.NewProvider())
+		require.NoError(t, err)
+
+		errExpected := errors.New("injected marshal error")
+
+		s.marshal = func(v interface{}) ([]byte, error) {
+			return nil, errExpected
+		}
+
+		rec := &LogMonitor{Log: testLog, Active: true, Processing: false}
+
+		err = s.Update(rec)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+	})
+
+	t.Run("error - error from store put", func(t *testing.T) {
+		storeProvider := &mockstore.Provider{OpenStoreReturn: &mockstore.Store{
+			ErrPut: fmt.Errorf("error put"),
+		}}
+
+		s, err := New(storeProvider)
+		require.NoError(t, err)
+
+		rec := &LogMonitor{Log: testLog, Active: true, Processing: false}
+
+		err = s.Update(rec)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error put")
+	})
+
+	t.Run("error - log is nil", func(t *testing.T) {
+		s, err := New(mem.NewProvider())
+		require.NoError(t, err)
+
+		err = s.Update(nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "log monitor is empty")
+	})
+}
+
+func TestStore_Delete(t *testing.T) {
+	t.Run("test success", func(t *testing.T) {
+		s, err := New(mem.NewProvider())
+		require.NoError(t, err)
+
+		err = s.Activate(testLog)
+		require.NoError(t, err)
+
+		rec, err := s.Get(testLog)
+		require.NoError(t, err)
+		require.NotNil(t, rec)
+
+		err = s.Delete(testLog)
+		require.NoError(t, err)
+
+		rec, err = s.Get(testLog)
+		require.Error(t, err)
+		require.Equal(t, err.Error(), "content not found")
+		require.Nil(t, rec)
+	})
+
+	t.Run("test error from store delete", func(t *testing.T) {
+		storeProvider := &mockstore.Provider{OpenStoreReturn: &mockstore.Store{
+			ErrDelete: fmt.Errorf("error delete"),
+		}}
+
+		s, err := New(storeProvider)
+		require.NoError(t, err)
+
+		err = s.Delete(testLog)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error delete")
+	})
+}
+
+func TestStore_GetActiveLogs(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mongoDBConnString, stopMongo := mongodbtestutil.StartMongoDB(t)
+		defer stopMongo()
+
+		mongoDBProvider, err := mongodb.NewProvider(mongoDBConnString)
+		require.NoError(t, err)
+
+		s, err := New(mongoDBProvider)
+		require.NoError(t, err)
+
+		err = s.Activate(testLog)
+		require.NoError(t, err)
+
+		logs, err := s.GetActiveLogs()
+		require.NoError(t, err)
+		require.NotEmpty(t, logs)
+	})
+	t.Run("error - query error", func(t *testing.T) {
+		mongoDBConnString, stopMongo := mongodbtestutil.StartMongoDB(t)
+
+		mongoDBProvider, err := mongodb.NewProvider(mongoDBConnString)
+		require.NoError(t, err)
+
+		s, err := New(mongoDBProvider)
+		require.NoError(t, err)
+
+		err = s.Activate(testLog)
+		require.NoError(t, err)
+
+		stopMongo()
+
+		logs, err := s.GetActiveLogs()
+		require.Error(t, err)
+		require.Nil(t, logs)
+	})
+	t.Run("error - no active logs", func(t *testing.T) {
+		mongoDBConnString, stopMongo := mongodbtestutil.StartMongoDB(t)
+		defer stopMongo()
+
+		mongoDBProvider, err := mongodb.NewProvider(mongoDBConnString)
+		require.NoError(t, err)
+
+		s, err := New(mongoDBProvider)
+		require.NoError(t, err)
+
+		logs, err := s.GetActiveLogs()
+		require.Error(t, err)
+		require.Nil(t, logs)
+		require.Equal(t, err.Error(), orberrors.ErrContentNotFound.Error())
+	})
+
+	t.Run("error - unmarshall error", func(t *testing.T) {
+		mongoDBConnString, stopMongo := mongodbtestutil.StartMongoDB(t)
+		defer stopMongo()
+
+		mongoDBProvider, err := mongodb.NewProvider(mongoDBConnString)
+		require.NoError(t, err)
+
+		s, err := New(mongoDBProvider)
+		require.NoError(t, err)
+
+		store, err := mongoDBProvider.OpenStore(namespace)
+		require.NoError(t, err)
+
+		indexTag := storage.Tag{
+			Name:  activeIndex,
+			Value: "true",
+		}
+
+		err = store.Put(testLog, []byte("not-json"), indexTag)
+		require.NoError(t, err)
+
+		logs, err := s.GetActiveLogs()
+		require.Error(t, err)
+		require.Nil(t, logs)
+		require.Contains(t, err.Error(), "unmarshal log monitor: invalid character")
+	})
+}


### PR DESCRIPTION
Store will be used for tracking logs that will be monitored by Orb server. It will be used by log monitoring service (get active logs, update STH for log) and orb-cli (activate, deactivate, delete)

Store operations:
- activate log
- deactivate log
- update log
- delete log
- get active logs

Closes #1194

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>