### PR TITLE
fix: Outbox retries forever if target domain is down

### DIFF
--- a/pkg/anchor/handler/credential/handler.go
+++ b/pkg/anchor/handler/credential/handler.go
@@ -197,7 +197,10 @@ func (h *AnchorEventHandler) processAnchorEvent(anchorInfo *anchorInfo) error {
 
 		err = h.monitoringSvc.Watch(vc, time.Now().Add(h.maxDelay), domain, createdTime)
 		if err != nil {
-			return fmt.Errorf("failed to setup monitoring for anchor credential[%s]: %w", vc.ID, err)
+			// This shouldn't be a fatal error since the anchor being processed may have multiple
+			// witness proofs and, if one of the witness domains is down, it should not prevent the
+			// anchor from being processed.
+			logger.Errorf("Failed to setup monitoring for anchor credential[%s]: %w", vc.ID, err)
 		}
 	}
 

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -68,7 +68,6 @@ type Publisher interface {
 }
 
 type pubSub interface {
-	Subscribe(ctx context.Context, topic string) (<-chan *message.Message, error)
 	SubscribeWithOpts(ctx context.Context, topic string, opts ...spi.Option) (<-chan *message.Message, error)
 	Publish(topic string, messages ...*message.Message) error
 	Close() error


### PR DESCRIPTION
The ActivityPub Outbox now uses the AMQP Pub/Sub subsystem for retrying an unreachable domain. When a destination URL is unreachable, the AMQP message is NACK'ed and the operation is retried with a backoff and maximum number of attempts so as not to retry forever.

closes #1242

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>