### PR TITLE
chore: Add BDD test for verifying new log with tree size > 0

### DIFF
--- a/test/bdd/fixtures/docker-compose-testver.yml
+++ b/test/bdd/fixtures/docker-compose-testver.yml
@@ -344,6 +344,121 @@ services:
       orb_net:
         ipv4_address: 172.20.0.6
 
+  orb-domain4:
+    container_name: orb.domain4.com
+    image: ${ORB_TEST_FIXTURE_IMAGE}:latest
+    restart: always
+    environment:
+      - ORB_SYNC_TIMEOUT=3
+      - ORB_KMS_TYPE=web
+      - ORB_KMS_ENDPOINT=http://orb.kms:7878
+      - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:watermill=INFO:DEBUG
+      - ORB_HOST_URL=172.20.0.7:443
+      - ORB_VCT_URL=http://orb.vct:8077/maple2020
+      # ORB_EXTERNAL_ENDPOINT is the endpoint that external clients use to invoke services. This endpoint is used
+      # to generate IDs of anchor credentials and ActivityPub objects and should be resolvable by external
+      # clients. This endpoint does not (typically) target a single node in the cluster but instead, a load
+      # balancer servicing multiple nodes.
+      - ORB_EXTERNAL_ENDPOINT=https://orb.domain4.com
+      - ORB_TLS_CERTIFICATE=/etc/orb/tls/ec-pubCert.pem
+      - ORB_TLS_KEY=/etc/orb/tls/ec-key.pem
+      - ORB_TLS_SYSTEMCERTPOOL=true
+      - ORB_TLS_CACERTS=/etc/orb/tls/ec-cacert.pem
+      - ORB_DISCOVERY_DOMAIN=shared.domain.com
+      - DID_NAMESPACE=did:orb
+      - SIDETREE_PROTOCOL_VERSIONS=${SIDETREE_VERSIONS}
+      - CURRENT_SIDETREE_PROTOCOL_VERSION=${CURRENT_SIDETREE_VERSION}
+      - ALLOWED_ORIGINS=https://orb.domain1.com,https://orb.domain2.com,https://orb.domain3.com,https://orb.domain4.com,ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q
+      # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
+      - BATCH_WRITER_TIMEOUT=2000
+      - CAS_TYPE=${CAS_TYPE}
+      - MQ_URL=amqp://${RABBITMQ_USERNAME}:${RABBITMQ_PASSWORD}@orb.mq.domain4.com:5672/
+      # MQ_OP_POOL specifies the number of subscribers that concurrently process messages in the operation queue (default 5).
+      # - MQ_OP_POOL=5
+      # MQ_OBSERVER_POOL specifies the number of subscribers that concurrently process messages from the observer queue (default 5).
+      - MQ_OBSERVER_POOL=5
+      # MQ_PUBLISHER_POOL specifies the size of a channel pool for an AMQP publisher (default 25). If set to 0 then
+      #	a channel pool is not used and a new channel is opened/closed for every publish to a queue.
+      - MQ_PUBLISHER_POOL=25
+      - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
+      - CID_VERSION=${CID_VERSION_DOMAIN3}
+      - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain4.com
+      - ANCHOR_CREDENTIAL_URL=https://orb.domain4.com/vc
+      # used in case that orb server signs anchor credential (there is no local witness log)
+      - ANCHOR_CREDENTIAL_DOMAIN=https://orb.domain4.com
+      - DATABASE_TYPE=mongodb
+      - DATABASE_URL=mongodb://mongodb.shared.com:27017
+      - DATABASE_PREFIX=domain4
+      - HTTP_SIGNATURES_ENABLED=true
+      - UNPUBLISHED_OPERATION_STORE_ENABLED=true
+      - UNPUBLISHED_OPERATION_STORE_OPERATION_TYPES=update
+      - INCLUDE_UNPUBLISHED_OPERATIONS_IN_METADATA=true
+      - INCLUDE_PUBLISHED_OPERATIONS_IN_METADATA=true
+      - RESOLVE_FROM_ANCHOR_ORIGIN=true
+      - VERIFY_LATEST_FROM_ANCHOR_ORIGIN=true
+
+      # ORB_AUTH_TOKENS_DEF contains the authorization definition for each of the REST endpoints. Format:
+      #
+      # <path-expr>|<read-token1>&<read-token2>&...>|<write-token1>&<write-token2>&...>,<path-expr> ...
+      #
+      # Where:
+      # - path-expr contains a regular expression for a path. Path expressions are processed in the order they are specified.
+      # - read-token defines a token for a read (GET) operation. If not specified then authorization is not performed.
+      # - write-token defines a token for a write (POST) operation. If not specified then authorization is not performed.
+      #
+      # If no definition is included for an endpoint then authorization is NOT performed for that endpoint.
+      #
+      # Example:
+      #
+      # ORB_AUTH_TOKENS_DEF=/services/orb/outbox|admin&read|admin,/services/orb/.*|read&admin
+      # - The client requires a 'read' or 'admin' token in order to view the outbox's contents
+      # - The client requires an 'admin' token in order to post to the outbox
+      # - The client requires a 'read' or 'admin' token in order to perform a GET on any endpoint starting with /services/orb/
+      - ORB_AUTH_TOKENS_DEF=/services/orb/outbox||admin,/services/orb/inbox||admin,/sidetree/.*/operations||admin
+      # ORB_AUTH_TOKENS specifies the actual values of the tokens defined in ORB_AUTH_TOKENS_DEF.
+      - ORB_AUTH_TOKENS=admin=ADMIN_TOKEN
+      # ORB_CLIENT_AUTH_TOKENS_DEF follows the same rules as ORB_AUTH_TOKENS_DEF but is used by the Orb client transport to
+      # determine whether an HTTP signature is required for an outbound HTTP request. If not specified then it is assumed
+      # to be the same as ORB_AUTH_TOKENS_DEF.
+      - ORB_CLIENT_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/acceptlist|admin&read|admin,/services/orb/.*|read&admin,/transactions|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin
+      # ORB_CLIENT_AUTH_TOKENS specifies the actual values of the tokens defined in ORB_CLIENT_AUTH_TOKENS_DEF. If not specified
+      # then it is assumed to be the same as ORB_AUTH_TOKENS.
+      - ORB_CLIENT_AUTH_TOKENS=admin=ADMIN_TOKEN,read=READ_TOKEN
+      # FOLLOW_AUTH_POLICY indicates whether a 'Follow' request is automatically accepted by this service (accept-all policy)
+      # or if the requesting service needs to be in an 'accept list' (accept-list policy).
+      - FOLLOW_AUTH_POLICY=accept-all
+      # INVITE_WITNESS_AUTH_POLICY indicates whether an 'Invite' witness request is automatically accepted (accept-all policy)
+      # or if the requesting service needs to be in an 'accept list' (accept-list policy).
+      - INVITE_WITNESS_AUTH_POLICY=accept-all
+      # TASK_MANAGER_CHECK_INTERVAL is the interval in which to check for scheduled tasks to be run. Note that this value is
+      # merely the 'check' interval since each task has its own interval.
+      # Default value: 10s.
+      - TASK_MANAGER_CHECK_INTERVAL=5s
+      # ANCHOR_EVENT_SYNC_INTERVAL is the interval in which anchor events are synchronized with other services that
+      # we're following.
+      # Default value: 1m.
+      - ANCHOR_EVENT_SYNC_INTERVAL=1m
+      # ANCHOR_EVENT_SYNC_MIN_ACTIVITY_AGE is the minimum age of an activity to be synchronized. The activity will be processed
+      # only if its age is greater than this value.
+      # Default value: 1m
+      - ANCHOR_EVENT_SYNC_MIN_ACTIVITY_AGE=1m
+      - VCT_LOG_ENTRIES_STORE_ENABLED=true
+      - VCT_LOG_MONITORING_INTERVAL=5s
+    ports:
+      - 48726:443
+      - 48727:48727
+    command: start
+    volumes:
+      - ./keys/tls:/etc/orb/tls
+      - ./testdata/keys/domain3:/etc/orb/activitypub
+    depends_on:
+      - orb.kms
+      - mongodb.shared.com
+      - orb.mq.domain4.com
+    networks:
+      orb_net:
+        ipv4_address: 172.20.0.7
+
   mongodb.shared.com:
     container_name: mongodb.shared.com
     image: ${MONGODB_IMAGE}:${MONGODB_IMAGE_TAG}
@@ -484,6 +599,7 @@ services:
       orb_net:
         ipv4_address: 172.20.0.18
 
+
   orb.mq.domain3.com:
     container_name: orb.mq.domain3.com
     image: rabbitmq:3-management-alpine
@@ -499,6 +615,22 @@ services:
     networks:
       orb_net:
         ipv4_address: 172.20.0.19
+
+  orb.mq.domain4.com:
+    container_name: orb.mq.domain4.com
+    image: rabbitmq:3-management-alpine
+    environment:
+      - CONFIG_FILE=/etc/rabbitmq/ext-config/rabbitmq.conf
+    volumes:
+      - ./rabbitmq-config/rabbitmq.conf:/etc/rabbitmq/ext-config/rabbitmq.conf
+    ports:
+      - 5694:5672
+      # Management port
+      - 15694:15672
+    restart: unless-stopped
+    networks:
+      orb_net:
+        ipv4_address: 172.20.0.20
 
   orb.file-server.com: # file server for hosting static resources (e.g. JSON-LD contexts)
     container_name: orb.file-server.com


### PR DESCRIPTION
Add BDD test for verifying log's Merkle tree STH from get-entries. This happens when domain starts to follow another domain with log size > 0.

Closes #1197

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>