### PR TITLE
fix: Start Orb services after the REST endpoints

### DIFF
--- a/pkg/activitypub/service/vct/logmonitoring/monitor.go
+++ b/pkg/activitypub/service/vct/logmonitoring/monitor.go
@@ -383,13 +383,9 @@ func verifySTHSignature(sth *command.GetSTHResponse, pubKey []byte) error {
 
 // MonitorLogs will monitor logs for consistency.
 func (c *Client) MonitorLogs() {
-	logger.Debugf("start log monitoring...")
-
 	logs, err := c.monitorStore.GetActiveLogs()
 	if err != nil {
-		if errors.Is(err, orberrors.ErrContentNotFound) {
-			logger.Debugf("no active log monitors found - nothing to do")
-		} else {
+		if !errors.Is(err, orberrors.ErrContentNotFound) {
 			logger.Errorf("failed to get active logs: %s", err.Error())
 		}
 
@@ -409,8 +405,6 @@ func (c *Client) MonitorLogs() {
 	}
 
 	wg.Wait()
-
-	logger.Debugf("completed log monitoring...")
 }
 
 func (c *Client) processLog(logMonitor *logmonitor.LogMonitor) {

--- a/pkg/anchor/handler/credential/handler.go
+++ b/pkg/anchor/handler/credential/handler.go
@@ -182,7 +182,7 @@ func (h *AnchorEventHandler) processAnchorEvent(anchorInfo *anchorInfo) error {
 		verifiable.WithJSONLDDocumentLoader(h.documentLoader),
 	)
 	if err != nil {
-		return fmt.Errorf("failed get verifiable credential from anchor event: %w", err)
+		return fmt.Errorf("failed get verifiable credential from anchor link: %w", err)
 	}
 
 	for _, proof := range getUniqueDomainCreated(vc.Proofs) {

--- a/pkg/anchor/writer/writer.go
+++ b/pkg/anchor/writer/writer.go
@@ -509,7 +509,7 @@ func (c *Writer) storeVC(anchorLink *linkset.Link) error {
 		verifiable.WithJSONLDDocumentLoader(c.DocumentLoader),
 	)
 	if err != nil {
-		return fmt.Errorf("failed get verifiable credential from anchor event: %w", err)
+		return fmt.Errorf("failed get verifiable credential from anchor link: %w", err)
 	}
 
 	vcBytes, err := json.Marshal(vc)

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -317,7 +317,7 @@ func (o *Observer) processAnchor(anchor *anchorinfo.AnchorInfo,
 		verifiable.WithJSONLDDocumentLoader(o.DocLoader),
 	)
 	if err != nil {
-		return fmt.Errorf("get verifiable credential from anchor event: %w", err)
+		return fmt.Errorf("get verifiable credential from anchor link: %w", err)
 	}
 
 	sidetreeTxn := txnapi.SidetreeTxn{


### PR DESCRIPTION
The REST endpoints must be up before the background services are started since a background service may trigger an action on an external domain that causes that domain to call back to a local REST endpoint (which may not be available yet).

Also, removed debug logs for Log monitor since they weren't providing any relevant information.

closes #1253

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>