### PR TITLE
feat: Public key store/cache for Observer

### DIFF
--- a/pkg/discovery/endpoint/client/client_test.go
+++ b/pkg/discovery/endpoint/client/client_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
 	"github.com/stretchr/testify/require"
 
 	"github.com/trustbloc/orb/pkg/activitypub/client/transport"
@@ -47,6 +48,20 @@ func TestNew(t *testing.T) {
 
 		require.Equal(t, time.Minute, cs.cacheLifetime)
 		require.Equal(t, 500, cs.cacheSize)
+	})
+
+	t.Run("success - with public key fetcher", func(t *testing.T) {
+		cs, err := New(nil, &referenceCASReaderImplementation{},
+			WithAuthToken("t1"),
+			WithPublicKeyFetcher(func(issuerID, keyID string) (*verifier.PublicKey, error) {
+				return &verifier.PublicKey{}, nil
+			}),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, cs)
+
+		require.Equal(t, defaultCacheLifetime, cs.cacheLifetime)
+		require.Equal(t, defaultCacheSize, cs.cacheSize)
 	})
 }
 

--- a/pkg/store/anchorstatus/store.go
+++ b/pkg/store/anchorstatus/store.go
@@ -364,7 +364,7 @@ func (s *Store) processIndex(encodedAnchorID string) error {
 
 	err = s.policyHandler.CheckPolicy(anchorID)
 	if err != nil {
-		return fmt.Errorf("failed to re-evalue policy for anchorID[%s]: %w", anchorID, err)
+		return fmt.Errorf("failed to re-evaluate policy for anchorID[%s]: %w", anchorID, err)
 	}
 
 	logger.Debugf("successfully re-evaluated policy for anchorID[%s]", anchorID)

--- a/pkg/store/anchorstatus/store_test.go
+++ b/pkg/store/anchorstatus/store_test.go
@@ -619,7 +619,7 @@ func TestStore_processIndex(t *testing.T) {
 
 		err = s.processIndex(encoder.EncodeToString([]byte(vcID)))
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to re-evalue policy for anchorID[vcID]: policy error")
+		require.Contains(t, err.Error(), "failed to re-evaluate policy for anchorID[vcID]: policy error")
 	})
 
 	t.Run("error - status not found", func(t *testing.T) {

--- a/pkg/store/publickey/publickeystore.go
+++ b/pkg/store/publickey/publickeystore.go
@@ -1,0 +1,151 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package publickey
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/bluele/gcache"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+	"github.com/hyperledger/aries-framework-go/spi/storage"
+	"github.com/trustbloc/edge-core/pkg/log"
+)
+
+var logger = log.New("public-key-store")
+
+const (
+	storeName    = "public-key"
+	maxCacheSize = 1000
+)
+
+// Store manages a persistent store of public keys for issuers. The store also caches
+// the public keys for better performance.
+type Store struct {
+	cache          gcache.Cache
+	store          storage.Store
+	fetchPublicKey verifiable.PublicKeyFetcher
+}
+
+type cacheKey struct {
+	issuerID string
+	keyID    string
+}
+
+// New returns a new public key store.
+func New(p storage.Provider, fetchPublicKey verifiable.PublicKeyFetcher) (*Store, error) {
+	s, err := p.OpenStore(storeName)
+	if err != nil {
+		return nil, fmt.Errorf("open store [%s]: %w", storeName, err)
+	}
+
+	pkStore := &Store{
+		store:          s,
+		fetchPublicKey: fetchPublicKey,
+	}
+
+	pkCache := gcache.New(maxCacheSize).ARC().
+		LoaderFunc(
+			func(k interface{}) (interface{}, error) {
+				ck := k.(cacheKey) //nolint:errcheck,forcetypeassert
+
+				return pkStore.get(ck.issuerID, ck.keyID)
+			},
+		).Build()
+
+	pkStore.cache = pkCache
+
+	logger.Infof("Created public key store [%s]", storeName)
+
+	return pkStore, nil
+}
+
+// GetPublicKey returns the public key for the given issuer and key ID.
+func (c *Store) GetPublicKey(issuerID, keyID string) (*verifier.PublicKey, error) {
+	pk, err := c.cache.Get(cacheKey{issuerID, keyID})
+	if err != nil {
+		return nil, err
+	}
+
+	return pk.(*verifier.PublicKey), nil
+}
+
+func (c *Store) get(issuerID, keyID string) (*verifier.PublicKey, error) {
+	logger.Infof("Loading public key into cache for issuer [%s], key ID [%s]",
+		issuerID, keyID)
+
+	pk, err := c.getFromDB(issuerID, keyID)
+	if err == nil {
+		return pk, nil
+	}
+
+	if !errors.Is(err, storage.ErrDataNotFound) {
+		return nil, fmt.Errorf("get from DB: %w", err)
+	}
+
+	logger.Infof("Public key not found in storage. Fetching public key from server for issuer [%s], key ID [%s]",
+		issuerID, keyID)
+
+	// Public key not found in storage. Retrieve it from the server.
+	pk, err = c.fetchPublicKey(issuerID, keyID)
+	if err != nil {
+		return nil, fmt.Errorf("fetch public key from server - issuer [%s], key ID [%s]: %w",
+			issuerID, keyID, err)
+	}
+
+	err = c.putToDB(issuerID, keyID, pk)
+	if err != nil {
+		// We couldn't store the public key but this shouldn't result in a client error. Just log a warning.
+		logger.Warnf("Error storing public key for issuer [%s], key ID [%s]: %s", issuerID, keyID, err)
+	}
+
+	return pk, nil
+}
+
+func (c *Store) getFromDB(issuerID, keyID string) (*verifier.PublicKey, error) {
+	key := fmt.Sprintf("%s-%s", issuerID, keyID)
+
+	pkBytes, err := c.store.Get(key)
+	if err != nil {
+		return nil, fmt.Errorf("get key - issuer [%s], key ID [%s]: %w", issuerID, keyID, err)
+	}
+
+	logger.Infof("Public key found in storage for issuer [%s], key ID [%s]", issuerID, keyID)
+
+	pk := &verifier.PublicKey{}
+
+	err = json.Unmarshal(pkBytes, pk)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal public key - issuer [%s], key ID [%s]: %w",
+			issuerID, keyID, err)
+	}
+
+	return pk, nil
+}
+
+func (c *Store) putToDB(issuerID, keyID string, pk *verifier.PublicKey) error {
+	key := fmt.Sprintf("%s-%s", issuerID, keyID)
+
+	pkBytes, err := json.Marshal(pk)
+	if err != nil {
+		return fmt.Errorf("marshal public key - issuer [%s], key ID [%s]: %w",
+			issuerID, keyID, err)
+	}
+
+	logger.Infof("Storing public key for issuer [%s], key ID [%s]",
+		issuerID, keyID)
+
+	err = c.store.Put(key, pkBytes)
+	if err != nil {
+		return fmt.Errorf("store public key - issuer [%s], key ID [%s]: %w",
+			issuerID, keyID, err)
+	}
+
+	return nil
+}

--- a/pkg/store/publickey/publickeystore_test.go
+++ b/pkg/store/publickey/publickeystore_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package publickey
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
+	"github.com/hyperledger/aries-framework-go/spi/storage"
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/pkg/store/mocks"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		p := &mocks.Provider{}
+
+		s, err := New(p, func(issuerID, keyID string) (*verifier.PublicKey, error) {
+			return nil, nil
+		})
+		require.NoError(t, err)
+		require.NotNil(t, s)
+	})
+
+	t.Run("open store error", func(t *testing.T) {
+		errExpected := errors.New("injected open store error")
+
+		p := &mocks.Provider{}
+		p.OpenStoreReturns(nil, errExpected)
+
+		s, err := New(p, func(issuerID, keyID string) (*verifier.PublicKey, error) {
+			return nil, nil
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+		require.Nil(t, s)
+	})
+}
+
+func TestStore_GetPublicKey(t *testing.T) {
+	t.Run("found in DB -> success", func(t *testing.T) {
+		pkBytes, err := json.Marshal(&verifier.PublicKey{})
+		require.NoError(t, err)
+
+		store := &mocks.Store{}
+		store.GetReturns(pkBytes, nil)
+
+		p := &mocks.Provider{}
+		p.OpenStoreReturns(store, nil)
+
+		s, err := New(p, func(issuerID, keyID string) (*verifier.PublicKey, error) {
+			return nil, nil
+		})
+		require.NoError(t, err)
+		require.NotNil(t, s)
+
+		pk, err := s.GetPublicKey("did:web:orb.domain1.com", "key1")
+		require.NoError(t, err)
+		require.NotNil(t, pk)
+	})
+
+	t.Run("fetch from remote -> success", func(t *testing.T) {
+		store := &mocks.Store{}
+		store.GetReturns(nil, storage.ErrDataNotFound)
+
+		p := &mocks.Provider{}
+		p.OpenStoreReturns(store, nil)
+
+		s, err := New(p, func(issuerID, keyID string) (*verifier.PublicKey, error) {
+			return &verifier.PublicKey{}, nil
+		})
+		require.NoError(t, err)
+		require.NotNil(t, s)
+
+		pk, err := s.GetPublicKey("did:web:orb.domain1.com", "key1")
+		require.NoError(t, err)
+		require.NotNil(t, pk)
+	})
+
+	t.Run("fetch from remote -> error", func(t *testing.T) {
+		store := &mocks.Store{}
+		store.GetReturns(nil, storage.ErrDataNotFound)
+
+		p := &mocks.Provider{}
+		p.OpenStoreReturns(store, nil)
+
+		errExpected := errors.New("injected fetch error")
+
+		s, err := New(p, func(issuerID, keyID string) (*verifier.PublicKey, error) {
+			return nil, errExpected
+		})
+		require.NoError(t, err)
+		require.NotNil(t, s)
+
+		pk, err := s.GetPublicKey("did:web:orb.domain1.com", "key1")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+		require.Nil(t, pk)
+	})
+
+	t.Run("DB get error -> error", func(t *testing.T) {
+		errExpected := errors.New("injected get from storage error")
+
+		store := &mocks.Store{}
+		store.GetReturns(nil, errExpected)
+
+		p := &mocks.Provider{}
+		p.OpenStoreReturns(store, nil)
+
+		s, err := New(p, func(issuerID, keyID string) (*verifier.PublicKey, error) {
+			return nil, nil
+		})
+		require.NoError(t, err)
+		require.NotNil(t, s)
+
+		pk, err := s.GetPublicKey("did:web:orb.domain1.com", "key1")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+		require.Nil(t, pk)
+	})
+
+	t.Run("DB put error -> success", func(t *testing.T) {
+		errExpected := errors.New("injected put to storage error")
+
+		store := &mocks.Store{}
+		store.GetReturns(nil, storage.ErrDataNotFound)
+		store.PutReturns(errExpected)
+
+		p := &mocks.Provider{}
+		p.OpenStoreReturns(store, nil)
+
+		s, err := New(p, func(issuerID, keyID string) (*verifier.PublicKey, error) {
+			return &verifier.PublicKey{}, nil
+		})
+		require.NoError(t, err)
+		require.NotNil(t, s)
+
+		pk, err := s.GetPublicKey("did:web:orb.domain1.com", "key1")
+		require.NoError(t, err)
+		require.NotNil(t, pk)
+	})
+}


### PR DESCRIPTION
Implemented a public key storage and cache for the Observer. When verifying a witness proof, the Observer will load the public key of the signer from the cache/database. If it doesn't exist in the DB then the public key is retrieved using the public key fetcher.

Also enhanced the BDD test so that, when creating DIDs on multiple targets, the target will be greylisted if it is down and the create will be performed on another target.

closes #1261

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>