### PR TITLE
feat: Add client for caching config store (config-db parameters)

### DIFF
--- a/pkg/config/client/client.go
+++ b/pkg/config/client/client.go
@@ -1,0 +1,123 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/bluele/gcache"
+	"github.com/hyperledger/aries-framework-go/spi/storage"
+	"github.com/trustbloc/edge-core/pkg/log"
+)
+
+var logger = log.New("config-client")
+
+const (
+	defaultCacheSize       = 100
+	defaultCacheExpiration = time.Minute
+
+	logURL = "log-url"
+)
+
+// Client implements retrieving and caching of config store parameters.
+type Client struct {
+	configStore storage.Store
+
+	configCache gcache.Cache
+	cacheExpiry time.Duration
+	cacheSize   int
+
+	unmarshal func([]byte, interface{}) error
+}
+
+// New returns a new ActivityPub client.
+func New(cfg storage.Store, opts ...Option) *Client {
+	client := &Client{
+		configStore: cfg,
+
+		cacheExpiry: defaultCacheExpiration,
+		cacheSize:   defaultCacheSize,
+
+		unmarshal: json.Unmarshal,
+	}
+
+	for _, opt := range opts {
+		opt(client)
+	}
+
+	logger.Debugf("creating config store cache with size=%d, expiration=%s", client.cacheSize, client.cacheExpiry)
+
+	client.configCache = gcache.New(client.cacheSize).ARC().
+		Expiration(client.cacheExpiry).
+		LoaderFunc(func(key interface{}) (interface{}, error) {
+			return client.get(key.(string))
+		}).Build()
+
+	return client
+}
+
+// Option is a config client instance option.
+type Option func(opts *Client)
+
+// WithCacheLifetime option defines the lifetime of an object in the cache.
+func WithCacheLifetime(expiry time.Duration) Option {
+	return func(opts *Client) {
+		opts.cacheExpiry = expiry
+	}
+}
+
+// WithCacheSize option defines the cache size.
+func WithCacheSize(size int) Option {
+	return func(opts *Client) {
+		opts.cacheSize = size
+	}
+}
+
+func (c *Client) get(key string) ([]byte, error) {
+	val, err := c.configStore.Get(key)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Debugf("loaded key from config store: %s", key)
+
+	return val, nil
+}
+
+// GetValue returns value from config store for specified key.
+func (c *Client) GetValue(key string) ([]byte, error) {
+	value, err := c.configCache.Get(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve key '%s' from config cache: %w", key, err)
+	}
+
+	valueBytes, ok := value.([]byte)
+	if !ok {
+		return nil, fmt.Errorf("unexpected interface '%T' for '%s' value in config cache", value, key)
+	}
+
+	return valueBytes, nil
+}
+
+// GetLogEndpoint returns log endpoint.
+func (c *Client) GetLogEndpoint() (string, error) {
+	value, err := c.GetValue(logURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve log endpoint from config cache: %w", err)
+	}
+
+	var logURLStr string
+
+	err = c.unmarshal(value, &logURLStr)
+	if err != nil {
+		return "", fmt.Errorf("failed to unmarshal log URL: %w", err)
+	}
+
+	return logURLStr, nil
+}

--- a/pkg/config/client/client_test.go
+++ b/pkg/config/client/client_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
+	"github.com/stretchr/testify/require"
+
+	storemocks "github.com/trustbloc/orb/pkg/store/mocks"
+)
+
+const (
+	configStoreName = "orb-config"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		configStore, err := mem.NewProvider().OpenStore(configStoreName)
+		require.NoError(t, err)
+
+		configClient := New(configStore)
+		require.NoError(t, err)
+		require.NotNil(t, configClient)
+
+		require.Equal(t, defaultCacheExpiration, configClient.cacheExpiry)
+		require.Equal(t, defaultCacheSize, configClient.cacheSize)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		configStore, err := mem.NewProvider().OpenStore(configStoreName)
+		require.NoError(t, err)
+
+		cacheExpiry := time.Hour
+		cacheSize := 1000
+
+		configClient := New(configStore, WithCacheLifetime(cacheExpiry), WithCacheSize(cacheSize))
+		require.NoError(t, err)
+		require.NotNil(t, configClient)
+
+		require.Equal(t, cacheExpiry, configClient.cacheExpiry)
+		require.Equal(t, cacheSize, configClient.cacheSize)
+	})
+}
+
+func TestGetValue(t *testing.T) {
+	const key = "key"
+
+	const value = "value"
+
+	t.Run("success - call to cache loader function", func(t *testing.T) {
+		configStore, err := mem.NewProvider().OpenStore(configStoreName)
+		require.NoError(t, err)
+
+		configClient := New(configStore, WithCacheLifetime(1*time.Second))
+		require.NoError(t, err)
+		require.NotNil(t, configClient)
+
+		err = configStore.Put(key, []byte(value))
+		require.NoError(t, err)
+
+		// calls cache loader function
+		val, err := configClient.GetValue(key)
+		require.NoError(t, err)
+		require.Equal(t, value, string(val))
+
+		val, err = configClient.GetValue(key)
+		require.NoError(t, err)
+		require.Equal(t, value, string(val))
+
+		time.Sleep(2 * time.Second)
+
+		// calls cache loader function again
+		val, err = configClient.GetValue(key)
+		require.NoError(t, err)
+		require.Equal(t, value, string(val))
+	})
+
+	t.Run("error - config store error", func(t *testing.T) {
+		configStore := &storemocks.Store{}
+		configStore.GetReturns(nil, fmt.Errorf("get error"))
+
+		configClient := New(configStore)
+
+		val, err := configClient.GetValue(key)
+		require.Error(t, err)
+		require.Nil(t, val)
+		require.Contains(t, err.Error(), "get error")
+	})
+}
+
+func TestGetEndpoint(t *testing.T) {
+	const logURLValue = "https://vct.com/log"
+
+	const empty = ""
+
+	t.Run("success - retrieve from cache and from store", func(t *testing.T) {
+		configStore, err := mem.NewProvider().OpenStore(configStoreName)
+		require.NoError(t, err)
+
+		configClient := New(configStore)
+		require.NoError(t, err)
+		require.NotNil(t, configClient)
+
+		logURLValueBytes, err := json.Marshal(logURLValue)
+		require.NoError(t, err)
+
+		err = configStore.Put(logURL, logURLValueBytes)
+		require.NoError(t, err)
+
+		// calls cache loader function
+		endpoint, err := configClient.GetLogEndpoint()
+		require.NoError(t, err)
+		require.Equal(t, logURLValue, endpoint)
+
+		// gets value from cache
+		endpoint, err = configClient.GetLogEndpoint()
+		require.NoError(t, err)
+		require.Equal(t, logURLValue, endpoint)
+	})
+
+	t.Run("success - empty log URL", func(t *testing.T) {
+		configStore, err := mem.NewProvider().OpenStore(configStoreName)
+		require.NoError(t, err)
+
+		configClient := New(configStore)
+		require.NoError(t, err)
+		require.NotNil(t, configClient)
+
+		logURLValueBytes, err := json.Marshal(empty)
+		require.NoError(t, err)
+
+		err = configStore.Put(logURL, logURLValueBytes)
+		require.NoError(t, err)
+
+		// calls cache loader function
+		endpoint, err := configClient.GetLogEndpoint()
+		require.NoError(t, err)
+		require.Equal(t, empty, endpoint)
+
+		// gets value from cache
+		endpoint, err = configClient.GetLogEndpoint()
+		require.NoError(t, err)
+		require.Equal(t, empty, endpoint)
+	})
+
+	t.Run("error - log URL not configured", func(t *testing.T) {
+		configStore, err := mem.NewProvider().OpenStore(configStoreName)
+		require.NoError(t, err)
+
+		configClient := New(configStore)
+		require.NoError(t, err)
+		require.NotNil(t, configClient)
+
+		// calls cache loader function
+		endpoint, err := configClient.GetLogEndpoint()
+		require.Error(t, err)
+		require.Empty(t, endpoint)
+		require.Contains(t, err.Error(), "failed to retrieve log endpoint from config cache: "+
+			"failed to retrieve key 'log-url' from config cache: data not found")
+	})
+
+	t.Run("error - unmarshal log URL ", func(t *testing.T) {
+		configStore, err := mem.NewProvider().OpenStore(configStoreName)
+		require.NoError(t, err)
+
+		configClient := New(configStore)
+		require.NoError(t, err)
+		require.NotNil(t, configClient)
+
+		err = configStore.Put(logURL, []byte(logURLValue))
+		require.NoError(t, err)
+
+		// calls cache loader function
+		endpoint, err := configClient.GetLogEndpoint()
+		require.Error(t, err)
+		require.Equal(t, empty, endpoint)
+		require.Contains(t, err.Error(), "failed to unmarshal log URL: invalid character")
+	})
+}


### PR DESCRIPTION
It will be used by components that use VCT URL as parameter.

Closes #1277

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>