### PR TITLE
feat: Add REST endpoint to deactivate/activate log URL

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -143,6 +143,7 @@ import (
 	"github.com/trustbloc/orb/pkg/vct"
 	"github.com/trustbloc/orb/pkg/vct/logmonitoring"
 	"github.com/trustbloc/orb/pkg/vct/logmonitoring/handler"
+	logmonitorhandler "github.com/trustbloc/orb/pkg/vct/logmonitoring/resthandler"
 	"github.com/trustbloc/orb/pkg/vct/proofmonitoring"
 	vcthandler "github.com/trustbloc/orb/pkg/vct/resthandler"
 	"github.com/trustbloc/orb/pkg/webcas"
@@ -1140,6 +1141,7 @@ func startOrbServices(parameters *orbParameters) error {
 		),
 		auth.NewHandlerWrapper(policyhandler.New(configStore), authTokenManager),
 		auth.NewHandlerWrapper(policyhandler.NewRetriever(configStore), authTokenManager),
+		auth.NewHandlerWrapper(logmonitorhandler.NewUpdateHandler(logMonitorStore), authTokenManager),
 		auth.NewHandlerWrapper(vcthandler.New(configStore, logMonitorStore), authTokenManager),
 		auth.NewHandlerWrapper(vcthandler.NewRetriever(configStore), authTokenManager),
 		auth.NewHandlerWrapper(nodeinfo.NewHandler(nodeinfo.V2_0, nodeInfoService, nodeInfoLogger), authTokenManager),

--- a/pkg/vct/logmonitoring/resthandler/update.go
+++ b/pkg/vct/logmonitoring/resthandler/update.go
@@ -1,0 +1,176 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resthandler
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/trustbloc/edge-core/pkg/log"
+	"github.com/trustbloc/sidetree-core-go/pkg/restapi/common"
+)
+
+const (
+	endpoint = "/log-monitor"
+)
+
+const (
+	badRequestResponse          = "Bad Request."
+	internalServerErrorResponse = "Internal Server Error."
+)
+
+var logger = log.New("log-monitor-rest-handler")
+
+// UpdateHandler activates VCT log URL in log monitor store.
+type UpdateHandler struct {
+	logMonitorStore logMonitorStore
+
+	unmarshal func([]byte, interface{}) error
+}
+
+type logMonitorStore interface {
+	Activate(logURL string) error
+	Deactivate(logURL string) error
+}
+
+// Path returns the HTTP REST endpoint for the UpdateHandler service.
+func (a *UpdateHandler) Path() string {
+	return endpoint
+}
+
+// Method returns the HTTP REST method for activating VCT log for log monitoring service.
+func (a *UpdateHandler) Method() string {
+	return http.MethodPost
+}
+
+// Handler returns the HTTP REST handle for activating VCT log for log monitoring service.
+func (a *UpdateHandler) Handler() common.HTTPRequestHandler {
+	return a.handle
+}
+
+// NewUpdateHandler returns a new UpdateHandler.
+func NewUpdateHandler(store logMonitorStore) *UpdateHandler {
+	h := &UpdateHandler{
+		logMonitorStore: store,
+		unmarshal:       json.Unmarshal,
+	}
+
+	return h
+}
+
+func (a *UpdateHandler) handle(w http.ResponseWriter, req *http.Request) {
+	reqBytes, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		logger.Errorf("[%s] Error reading request body: %s", endpoint, err)
+
+		writeResponse(w, http.StatusBadRequest, []byte(badRequestResponse))
+
+		return
+	}
+
+	logger.Debugf("[%s] Got request to activate/deactivate log monitors: %s", endpoint, reqBytes)
+
+	request, err := a.unmarshalAndValidateRequest(reqBytes)
+	if err != nil {
+		logger.Infof("[%s] Error validating request: %s", endpoint, err)
+
+		writeResponse(w, http.StatusBadRequest, []byte(badRequestResponse))
+
+		return
+	}
+
+	for _, logURL := range request.Activate {
+		err = a.logMonitorStore.Activate(logURL)
+		if err != nil {
+			logger.Errorf("[%s] Error while activating log monitoring for log URL[%s]: %s", endpoint, logURL, err)
+
+			writeResponse(w, http.StatusInternalServerError, []byte(internalServerErrorResponse))
+
+			return
+		}
+	}
+
+	for _, logURL := range request.Deactivate {
+		err = a.logMonitorStore.Deactivate(logURL)
+		if err != nil {
+			logger.Errorf("[%s] Error while de-activating log monitoring for log URL[%s]: %s", endpoint, logURL, err)
+
+			writeResponse(w, http.StatusInternalServerError, []byte(internalServerErrorResponse))
+
+			return
+		}
+	}
+
+	writeResponse(w, http.StatusOK, nil)
+}
+
+func writeResponse(w http.ResponseWriter, status int, body []byte) {
+	if len(body) > 0 {
+		w.Header().Set("Content-Type", "text/plain")
+	}
+
+	w.WriteHeader(status)
+
+	if len(body) > 0 {
+		if _, err := w.Write(body); err != nil {
+			logger.Warnf("[%s] Unable to write response: %s", endpoint, err)
+
+			return
+		}
+
+		logger.Debugf("[%s] Wrote response: %s", endpoint, body)
+	}
+}
+
+func (a *UpdateHandler) unmarshalAndValidateRequest(reqBytes []byte) (*logRequest, error) {
+	var request logRequest
+
+	err := a.unmarshal(reqBytes, &request)
+	if err != nil {
+		return nil, fmt.Errorf("invalid activate/deactivate log request: %w", err)
+	}
+
+	err = validateRequest(request)
+	if err != nil {
+		return nil, fmt.Errorf("invalid activate/deactivate log request: %w", err)
+	}
+
+	return &request, nil
+}
+
+func validateRequest(r logRequest) error {
+	err := validateURIs(r.Activate)
+	if err != nil {
+		return fmt.Errorf("parse URIs for activate: %w", err)
+	}
+
+	err = validateURIs(r.Deactivate)
+	if err != nil {
+		return fmt.Errorf("parse URIs for deactivate: %w", err)
+	}
+
+	return nil
+}
+
+func validateURIs(rawURIs []string) error {
+	for _, rawURI := range rawURIs {
+		uri, err := url.Parse(rawURI)
+		if err != nil {
+			return fmt.Errorf("invalid URI in the list: %s", uri)
+		}
+	}
+
+	return nil
+}
+
+type logRequest struct {
+	Activate   []string `json:"activate"`
+	Deactivate []string `json:"deactivate"`
+}

--- a/pkg/vct/logmonitoring/resthandler/update_test.go
+++ b/pkg/vct/logmonitoring/resthandler/update_test.go
@@ -1,0 +1,256 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resthandler
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testPayload       = `{"activate": ["https://vct.com/log"], "deactivate": ["https://old.com/log"]}`
+	activatePayload   = `{"activate": ["https://vct.com/log", "https://second.com/log"]}`
+	deactivatePayload = `{"deactivate": ["https://vct.com/log", "https://second.com/log"]}`
+)
+
+func TestNewActivate(t *testing.T) {
+	handler := NewUpdateHandler(&mockLogMonitorStore{})
+	require.NotNil(t, handler)
+	require.Equal(t, endpoint, handler.Path())
+	require.Equal(t, http.MethodPost, handler.Method())
+	require.NotNil(t, handler.Handler())
+}
+
+func TestActivate(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		handler := NewUpdateHandler(&mockLogMonitorStore{})
+		require.NotNil(t, handler)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer([]byte(activatePayload)))
+
+		handler.handle(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusOK, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+
+		respBytes, err := ioutil.ReadAll(result.Body)
+		require.NoError(t, err)
+		require.Empty(t, respBytes)
+		require.NoError(t, result.Body.Close())
+	})
+
+	t.Run("error - reader error", func(t *testing.T) {
+		handler := NewUpdateHandler(&mockLogMonitorStore{})
+		require.NotNil(t, handler)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, endpoint, errReader(0))
+
+		handler.handle(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusBadRequest, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+
+		respBytes, err := ioutil.ReadAll(result.Body)
+		require.NoError(t, err)
+		require.Equal(t, []byte(badRequestResponse), respBytes)
+		require.NoError(t, result.Body.Close())
+	})
+
+	t.Run("error - unmarshal error", func(t *testing.T) {
+		handler := NewUpdateHandler(&mockLogMonitorStore{})
+		require.NotNil(t, handler)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer([]byte(activatePayload)))
+
+		errExpected := fmt.Errorf("injected unmarshal error")
+
+		handler.unmarshal = func(bytes []byte, i interface{}) error {
+			return errExpected
+		}
+
+		handler.handle(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusBadRequest, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+
+		respBytes, err := ioutil.ReadAll(result.Body)
+		require.NoError(t, err)
+		require.Equal(t, []byte(badRequestResponse), respBytes)
+		require.NoError(t, result.Body.Close())
+	})
+
+	t.Run("error - parse URL error", func(t *testing.T) {
+		handler := NewUpdateHandler(&mockLogMonitorStore{})
+		require.NotNil(t, handler)
+
+		invalidPayload := []byte(`{"activate": [":InvalidURL"]}`)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer(invalidPayload))
+
+		handler.handle(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusBadRequest, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+
+		respBytes, err := ioutil.ReadAll(result.Body)
+		require.NoError(t, err)
+		require.Equal(t, []byte(badRequestResponse), respBytes)
+		require.NoError(t, result.Body.Close())
+	})
+
+	t.Run("error - log monitor store error", func(t *testing.T) {
+		handler := NewUpdateHandler(&mockLogMonitorStore{Err: fmt.Errorf("log monitor store error")})
+		require.NotNil(t, handler)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer([]byte(activatePayload)))
+
+		handler.handle(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusInternalServerError, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+
+		respBytes, err := ioutil.ReadAll(result.Body)
+		require.NoError(t, err)
+		require.Equal(t, []byte(internalServerErrorResponse), respBytes)
+		require.NoError(t, result.Body.Close())
+	})
+}
+
+func TestDeactivate(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		handler := NewUpdateHandler(&mockLogMonitorStore{})
+		require.NotNil(t, handler)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer([]byte(deactivatePayload)))
+
+		handler.handle(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusOK, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+
+		respBytes, err := ioutil.ReadAll(result.Body)
+		require.NoError(t, err)
+		require.Empty(t, respBytes)
+		require.NoError(t, result.Body.Close())
+	})
+
+	t.Run("error - reader error", func(t *testing.T) {
+		handler := NewUpdateHandler(&mockLogMonitorStore{})
+		require.NotNil(t, handler)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, endpoint, errReader(0))
+
+		handler.handle(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusBadRequest, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+
+		respBytes, err := ioutil.ReadAll(result.Body)
+		require.NoError(t, err)
+		require.Equal(t, []byte(badRequestResponse), respBytes)
+		require.NoError(t, result.Body.Close())
+	})
+
+	t.Run("error - parse URL error", func(t *testing.T) {
+		handler := NewUpdateHandler(&mockLogMonitorStore{})
+		require.NotNil(t, handler)
+
+		invalidPayload := []byte(`{"deactivate": [":InvalidURL"]}`)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer(invalidPayload))
+
+		handler.handle(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusBadRequest, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+
+		respBytes, err := ioutil.ReadAll(result.Body)
+		require.NoError(t, err)
+		require.Equal(t, []byte(badRequestResponse), respBytes)
+		require.NoError(t, result.Body.Close())
+	})
+
+	t.Run("error - log monitor store error", func(t *testing.T) {
+		handler := NewUpdateHandler(&mockLogMonitorStore{Err: fmt.Errorf("log monitor store error")})
+		require.NotNil(t, handler)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer([]byte(deactivatePayload)))
+
+		handler.handle(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusInternalServerError, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+
+		respBytes, err := ioutil.ReadAll(result.Body)
+		require.NoError(t, err)
+		require.Equal(t, []byte(internalServerErrorResponse), respBytes)
+		require.NoError(t, result.Body.Close())
+	})
+}
+
+func TestActivateAndDeactivate(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		handler := NewUpdateHandler(&mockLogMonitorStore{})
+		require.NotNil(t, handler)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer([]byte(testPayload)))
+
+		handler.handle(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusOK, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+
+		respBytes, err := ioutil.ReadAll(result.Body)
+		require.NoError(t, err)
+		require.Empty(t, respBytes)
+		require.NoError(t, result.Body.Close())
+	})
+}
+
+type errReader int
+
+func (errReader) Read(p []byte) (n int, err error) {
+	return 0, fmt.Errorf("reader error")
+}
+
+type mockLogMonitorStore struct {
+	Err error
+}
+
+func (m *mockLogMonitorStore) Activate(_ string) error {
+	return m.Err
+}
+
+func (m *mockLogMonitorStore) Deactivate(_ string) error {
+	return m.Err
+}

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -101,11 +101,19 @@ Feature:
   @vct_log_rotation_test
   Scenario: various did doc operations
     Given the authorization bearer token for "POST" requests to path "/log" is set to "ADMIN_TOKEN"
+    And the authorization bearer token for "POST" requests to path "/log-monitor" is set to "ADMIN_TOKEN"
 
     Then we wait 2 seconds
 
     # domain1 will start following 2022 VCT log
     When an HTTP POST is sent to "https://orb.domain1.com/log" with content "http://orb.vct:8077/maple2022" of type "text/plain"
+
+    And variable "activateLog" is assigned the JSON value '{"activate":["http://orb.vct:8077/maple2022"]}'
+    And variable "deactivateLog" is assigned the JSON value '{"deactivate":["http://orb.vct:8077/maple2022"]}'
+
+    # next step would be to provide endpoint for listing active and inactive logs in order to check the following two steps
+    When an HTTP POST is sent to "https://orb.domain1.com/log-monitor" with content "${deactivateLog}" of type "text/plain"
+    When an HTTP POST is sent to "https://orb.domain1.com/log-monitor" with content "${activateLog}" of type "text/plain"
 
   @all
   @discover_did_hashlink

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -16,7 +16,6 @@ services:
       - ORB_KMS_TYPE=web
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
       - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:watermill=INFO:DEBUG
-      - ORB_VCT_URL=http://orb.vct:8077/maple2020
       - ORB_HOST_URL=172.20.0.23:443
       - ORB_HOST_METRICS_URL=172.20.0.23:48327
       # ORB_EXTERNAL_ENDPOINT is the endpoint that external clients use to invoke services. This endpoint is used
@@ -85,7 +84,7 @@ services:
       # - The client requires a 'read' or 'admin' token in order to view the outbox's contents
       # - The client requires an 'admin' token in order to post to the outbox
       # - The client requires a 'read' or 'admin' token in order to perform a GET on any endpoint starting with /services/orb/
-      - ORB_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/acceptlist|admin&read|admin,/services/orb/.*|read&admin,/transactions|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin,/log||admin,/policy||admin
+      - ORB_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/acceptlist|admin&read|admin,/services/orb/.*|read&admin,/transactions|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin,/log-monitor||admin,/log||admin,/policy||admin
       # ORB_AUTH_TOKENS specifies the actual values of the tokens defined in ORB_AUTH_TOKENS_DEF.
       - ORB_AUTH_TOKENS=admin=ADMIN_TOKEN,read=READ_TOKEN
       # FOLLOW_AUTH_POLICY indicates whether a 'Follow' request is automatically accepted by this service (accept-all policy)
@@ -154,7 +153,6 @@ services:
       - ORB_KMS_TYPE=web
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
       - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:watermill=INFO:DEBUG
-      - ORB_VCT_URL=http://orb.vct:8077/maple2020
       - ORB_HOST_URL=172.20.0.2:443
       - ORB_HOST_METRICS_URL=172.20.0.2:48527
       # add delay for starting additional servers within same domain (in seconds)
@@ -221,7 +219,7 @@ services:
       # - The client requires a 'read' or 'admin' token in order to view the outbox's contents
       # - The client requires an 'admin' token in order to post to the outbox
       # - The client requires a 'read' or 'admin' token in order to perform a GET on any endpoint starting with /services/orb/
-      - ORB_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/acceptlist|admin&read|admin,/services/orb/.*|read&admin,/transactions|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin,/log||admin,/policy||admin
+      - ORB_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/acceptlist|admin&read|admin,/services/orb/.*|read&admin,/transactions|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin,/log-monitor||admin,/log||admin,/policy||admin
       # ORB_AUTH_TOKENS specifies the actual values of the tokens defined in ORB_AUTH_TOKENS_DEF.
       - ORB_AUTH_TOKENS=admin=ADMIN_TOKEN,read=READ_TOKEN
       # FOLLOW_AUTH_POLICY indicates whether a 'Follow' request is automatically accepted by this service (accept-all policy)
@@ -356,7 +354,7 @@ services:
       # - The client requires a 'read' or 'admin' token in order to view the outbox's contents
       # - The client requires an 'admin' token in order to post to the outbox
       # - The client requires a 'read' or 'admin' token in order to perform a GET on any endpoint starting with /services/orb/
-      - ORB_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/.*|read&admin,/transactions|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin,/log||admin,/policy||admin
+      - ORB_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/.*|read&admin,/transactions|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin,/log-monitor||admin,/log||admin,/policy||admin
       # ORB_AUTH_TOKENS specifies the actual values of the tokens defined in ORB_AUTH_TOKENS_DEF.
       - ORB_AUTH_TOKENS=admin=ADMIN_TOKEN,read=READ_TOKEN
       # FOLLOW_AUTH_POLICY indicates whether a 'Follow' request is automatically accepted by this service (accept-all policy)
@@ -457,7 +455,7 @@ services:
       # - The client requires a 'read' or 'admin' token in order to view the outbox's contents
       # - The client requires an 'admin' token in order to post to the outbox
       # - The client requires a 'read' or 'admin' token in order to perform a GET on any endpoint starting with /services/orb/
-      - ORB_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/.*|read&admin,/transactions|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin,/log||admin,/policy||admin
+      - ORB_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/.*|read&admin,/transactions|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin,/log-monitor||admin,/log||admin,/policy||admin
       # ORB_AUTH_TOKENS specifies the actual values of the tokens defined in ORB_AUTH_TOKENS_DEF.
       - ORB_AUTH_TOKENS=admin=ADMIN_TOKEN,read=READ_TOKEN
       # FOLLOW_AUTH_POLICY indicates whether a 'Follow' request is automatically accepted by this service (accept-all policy)
@@ -507,7 +505,6 @@ services:
       - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:watermill=INFO:DEBUG
       - ORB_HOST_URL=172.20.0.6:443
       - ORB_HOST_METRICS_URL=172.20.0.6:48627
-      - ORB_VCT_URL=http://orb.vct:8077/maple2020
       # ORB_EXTERNAL_ENDPOINT is the endpoint that external clients use to invoke services. This endpoint is used
       # to generate IDs of anchor credentials and ActivityPub objects and should be resolvable by external
       # clients. This endpoint does not (typically) target a single node in the cluster but instead, a load
@@ -567,7 +564,7 @@ services:
       # - The client requires a 'read' or 'admin' token in order to view the outbox's contents
       # - The client requires an 'admin' token in order to post to the outbox
       # - The client requires a 'read' or 'admin' token in order to perform a GET on any endpoint starting with /services/orb/
-      - ORB_AUTH_TOKENS_DEF=/services/orb/outbox||admin,/services/orb/inbox||admin,/sidetree/.*/operations||admin,/log||admin,/policy||admin
+      - ORB_AUTH_TOKENS_DEF=/services/orb/outbox||admin,/services/orb/inbox||admin,/sidetree/.*/operations||admin,/log-monitor||admin,/log||admin,/policy||admin
       # ORB_AUTH_TOKENS specifies the actual values of the tokens defined in ORB_AUTH_TOKENS_DEF.
       - ORB_AUTH_TOKENS=admin=ADMIN_TOKEN
       # ORB_CLIENT_AUTH_TOKENS_DEF follows the same rules as ORB_AUTH_TOKENS_DEF but is used by the Orb client transport to
@@ -694,7 +691,7 @@ services:
       # - The client requires a 'read' or 'admin' token in order to view the outbox's contents
       # - The client requires an 'admin' token in order to post to the outbox
       # - The client requires a 'read' or 'admin' token in order to perform a GET on any endpoint starting with /services/orb/
-      - ORB_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/acceptlist|admin&read|admin,/services/orb/.*|read&admin,/transactions|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin,/log||admin,/policy||admin
+      - ORB_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/acceptlist|admin&read|admin,/services/orb/.*|read&admin,/transactions|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin,/log-monitor||admin,/log||admin,/policy||admin
       # ORB_AUTH_TOKENS specifies the actual values of the tokens defined in ORB_AUTH_TOKENS_DEF.
       - ORB_AUTH_TOKENS=admin=ADMIN_TOKEN,read=READ_TOKEN
       # FOLLOW_AUTH_POLICY indicates whether a 'Follow' request is automatically accepted by this service (accept-all policy)


### PR DESCRIPTION
Add REST endpoint to deactivate log URL (when it is no longer required to monitor e.g. old log). Also, add endpoint to activate log.

Closes #1276

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>