### PR TITLE
feat: Enable AMQP publisher delivery confirmation

### DIFF
--- a/cmd/orb-cli/go.sum
+++ b/cmd/orb-cli/go.sum
@@ -1288,6 +1288,7 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/pseudomuto/protoc-gen-doc v1.4.1/go.mod h1:exDTOVwqpp30eV/EDPFLZy3Pwr2sn6hBC1WIYH/UbIg=
 github.com/pseudomuto/protokit v0.2.0/go.mod h1:2PdH30hxVHsup8KpBTOXTBeMVhJZVio3Q8ViKSAXT0Q=
 github.com/rabbitmq/amqp091-go v1.2.0/go.mod h1:ogQDLSOACsLPsIq0NpbtiifNZi2YOz0VTJ0kHRghqbM=
+github.com/rabbitmq/amqp091-go v1.3.4/go.mod h1:ogQDLSOACsLPsIq0NpbtiifNZi2YOz0VTJ0kHRghqbM=
 github.com/rboyer/safeio v0.2.1/go.mod h1:Cq/cEPK+YXFn622lsQ0K4KsPZSPtaptHHEldsy7Fmig=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/cmd/orb-driver/go.sum
+++ b/cmd/orb-driver/go.sum
@@ -1283,6 +1283,7 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/pseudomuto/protoc-gen-doc v1.4.1/go.mod h1:exDTOVwqpp30eV/EDPFLZy3Pwr2sn6hBC1WIYH/UbIg=
 github.com/pseudomuto/protokit v0.2.0/go.mod h1:2PdH30hxVHsup8KpBTOXTBeMVhJZVio3Q8ViKSAXT0Q=
 github.com/rabbitmq/amqp091-go v1.2.0/go.mod h1:ogQDLSOACsLPsIq0NpbtiifNZi2YOz0VTJ0kHRghqbM=
+github.com/rabbitmq/amqp091-go v1.3.4/go.mod h1:ogQDLSOACsLPsIq0NpbtiifNZi2YOz0VTJ0kHRghqbM=
 github.com/rboyer/safeio v0.2.1/go.mod h1:Cq/cEPK+YXFn622lsQ0K4KsPZSPtaptHHEldsy7Fmig=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/cmd/orb-server/go.mod
+++ b/cmd/orb-server/go.mod
@@ -90,7 +90,7 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.26.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
-	github.com/rabbitmq/amqp091-go v1.2.0 // indirect
+	github.com/rabbitmq/amqp091-go v1.3.4 // indirect
 	github.com/rs/cors v1.7.0 // indirect
 	github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
@@ -123,3 +123,5 @@ require (
 )
 
 replace github.com/trustbloc/orb => ../..
+
+replace github.com/ThreeDotsLabs/watermill-amqp/v2 => github.com/trustbloc/watermill-amqp/v2 v2.0.5-0.20220510153053-678b4a0b3cd6

--- a/cmd/orb-server/go.sum
+++ b/cmd/orb-server/go.sum
@@ -147,8 +147,6 @@ github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrU
 github.com/ThreeDotsLabs/watermill v1.1.0/go.mod h1:Qd1xNFxolCAHCzcMrm6RnjW0manbvN+DJVWc1MWRFlI=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.7 h1:c7rlzfhUFPtNo2WiJuIhrdwAfZcuAfbvB29uF+I0z7c=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.7/go.mod h1:QLZSaklpSZ/7yv288LL2DFOgCEi86VYEmQvzmaMlHoA=
-github.com/ThreeDotsLabs/watermill-amqp/v2 v2.0.3 h1:SubQYc1EYX75t+BaoYY9QIsqqC2w+y6Q5aLHNrG0J9Q=
-github.com/ThreeDotsLabs/watermill-amqp/v2 v2.0.3/go.mod h1:DKOBUoMVtPMV8jBEbRP3NL6TgnOMyRvVza3W297cdqU=
 github.com/ThreeDotsLabs/watermill-http v1.1.3 h1:2jHbbE+gbq7pKWBCtOxeHTWSBNrS44Oh7QOzuAeHH/g=
 github.com/ThreeDotsLabs/watermill-http v1.1.3/go.mod h1:mkQ9CC0pxTZerNwr281rBoOy355vYt/lePkmYSX/BRg=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=
@@ -1302,8 +1300,9 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/pseudomuto/protoc-gen-doc v1.4.1/go.mod h1:exDTOVwqpp30eV/EDPFLZy3Pwr2sn6hBC1WIYH/UbIg=
 github.com/pseudomuto/protokit v0.2.0/go.mod h1:2PdH30hxVHsup8KpBTOXTBeMVhJZVio3Q8ViKSAXT0Q=
-github.com/rabbitmq/amqp091-go v1.2.0 h1:1pHBxAsQh54R9eX/xo679fUEAfv3loMqi0pvRFOj2nk=
 github.com/rabbitmq/amqp091-go v1.2.0/go.mod h1:ogQDLSOACsLPsIq0NpbtiifNZi2YOz0VTJ0kHRghqbM=
+github.com/rabbitmq/amqp091-go v1.3.4 h1:tXuIslN1nhDqs2t6Jrz3BAoqvt4qIZzxvdbdcxWtHYU=
+github.com/rabbitmq/amqp091-go v1.3.4/go.mod h1:ogQDLSOACsLPsIq0NpbtiifNZi2YOz0VTJ0kHRghqbM=
 github.com/rboyer/safeio v0.2.1/go.mod h1:Cq/cEPK+YXFn622lsQ0K4KsPZSPtaptHHEldsy7Fmig=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
@@ -1446,6 +1445,8 @@ github.com/trustbloc/sidetree-core-go v1.0.0-rc.1.0.20220428193233-a1567c33db3e 
 github.com/trustbloc/sidetree-core-go v1.0.0-rc.1.0.20220428193233-a1567c33db3e/go.mod h1:SYCYxrsviTcRoUCoM6VosXF+sqWkKpk8C1dqD0doRYQ=
 github.com/trustbloc/vct v1.0.0-rc1.0.20220426133750-e02ec33d2826 h1:QmpPeWee/b1TbTHjKIGWyFT+tWWWEEcqXWHP7jwUOkQ=
 github.com/trustbloc/vct v1.0.0-rc1.0.20220426133750-e02ec33d2826/go.mod h1:Q2fGxTITe3IWhVOf2aJAKk/CGlMCLsYANdszM70HBcU=
+github.com/trustbloc/watermill-amqp/v2 v2.0.5-0.20220510153053-678b4a0b3cd6 h1:sgVrCXWpq18uz0Ly2ZtOyKf22wGEjtCzQg8ktGmNPk8=
+github.com/trustbloc/watermill-amqp/v2 v2.0.5-0.20220510153053-678b4a0b3cd6/go.mod h1:DKOBUoMVtPMV8jBEbRP3NL6TgnOMyRvVza3W297cdqU=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -715,6 +715,7 @@ func startOrbServices(parameters *orbParameters) error {
 			URI:                        mqParams.endpoint,
 			MaxConnectionSubscriptions: mqParams.maxConnectionSubscriptions,
 			PublisherChannelPoolSize:   mqParams.publisherChannelPoolSize,
+			PublisherConfirmDelivery:   mqParams.publisherConfirmDelivery,
 			MaxConnectRetries:          mqParams.maxConnectRetries,
 			MaxRedeliveryAttempts:      mqParams.maxRedeliveryAttempts,
 			RedeliveryMultiplier:       mqParams.redeliveryMultiplier,

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/ory/dockertest/v3 v3.8.1
 	github.com/piprate/json-gold v0.4.1
 	github.com/prometheus/client_golang v1.11.0
-	github.com/rabbitmq/amqp091-go v1.2.0
+	github.com/rabbitmq/amqp091-go v1.3.4
 	github.com/rs/cors v1.7.0
 	github.com/stretchr/testify v1.7.0
 	github.com/transparency-dev/merkle v0.0.0-20220208131541-728dc2de1344
@@ -127,3 +127,5 @@ require (
 )
 
 go 1.17
+
+replace github.com/ThreeDotsLabs/watermill-amqp/v2 => github.com/trustbloc/watermill-amqp/v2 v2.0.5-0.20220510153053-678b4a0b3cd6

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,6 @@ github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrU
 github.com/ThreeDotsLabs/watermill v1.1.0/go.mod h1:Qd1xNFxolCAHCzcMrm6RnjW0manbvN+DJVWc1MWRFlI=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.7 h1:c7rlzfhUFPtNo2WiJuIhrdwAfZcuAfbvB29uF+I0z7c=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.7/go.mod h1:QLZSaklpSZ/7yv288LL2DFOgCEi86VYEmQvzmaMlHoA=
-github.com/ThreeDotsLabs/watermill-amqp/v2 v2.0.3 h1:SubQYc1EYX75t+BaoYY9QIsqqC2w+y6Q5aLHNrG0J9Q=
-github.com/ThreeDotsLabs/watermill-amqp/v2 v2.0.3/go.mod h1:DKOBUoMVtPMV8jBEbRP3NL6TgnOMyRvVza3W297cdqU=
 github.com/ThreeDotsLabs/watermill-http v1.1.3 h1:2jHbbE+gbq7pKWBCtOxeHTWSBNrS44Oh7QOzuAeHH/g=
 github.com/ThreeDotsLabs/watermill-http v1.1.3/go.mod h1:mkQ9CC0pxTZerNwr281rBoOy355vYt/lePkmYSX/BRg=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=
@@ -1293,8 +1291,9 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/pseudomuto/protoc-gen-doc v1.4.1/go.mod h1:exDTOVwqpp30eV/EDPFLZy3Pwr2sn6hBC1WIYH/UbIg=
 github.com/pseudomuto/protokit v0.2.0/go.mod h1:2PdH30hxVHsup8KpBTOXTBeMVhJZVio3Q8ViKSAXT0Q=
-github.com/rabbitmq/amqp091-go v1.2.0 h1:1pHBxAsQh54R9eX/xo679fUEAfv3loMqi0pvRFOj2nk=
 github.com/rabbitmq/amqp091-go v1.2.0/go.mod h1:ogQDLSOACsLPsIq0NpbtiifNZi2YOz0VTJ0kHRghqbM=
+github.com/rabbitmq/amqp091-go v1.3.4 h1:tXuIslN1nhDqs2t6Jrz3BAoqvt4qIZzxvdbdcxWtHYU=
+github.com/rabbitmq/amqp091-go v1.3.4/go.mod h1:ogQDLSOACsLPsIq0NpbtiifNZi2YOz0VTJ0kHRghqbM=
 github.com/rboyer/safeio v0.2.1/go.mod h1:Cq/cEPK+YXFn622lsQ0K4KsPZSPtaptHHEldsy7Fmig=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
@@ -1433,6 +1432,8 @@ github.com/trustbloc/sidetree-core-go v1.0.0-rc.1.0.20220428193233-a1567c33db3e 
 github.com/trustbloc/sidetree-core-go v1.0.0-rc.1.0.20220428193233-a1567c33db3e/go.mod h1:SYCYxrsviTcRoUCoM6VosXF+sqWkKpk8C1dqD0doRYQ=
 github.com/trustbloc/vct v1.0.0-rc1.0.20220426133750-e02ec33d2826 h1:QmpPeWee/b1TbTHjKIGWyFT+tWWWEEcqXWHP7jwUOkQ=
 github.com/trustbloc/vct v1.0.0-rc1.0.20220426133750-e02ec33d2826/go.mod h1:Q2fGxTITe3IWhVOf2aJAKk/CGlMCLsYANdszM70HBcU=
+github.com/trustbloc/watermill-amqp/v2 v2.0.5-0.20220510153053-678b4a0b3cd6 h1:sgVrCXWpq18uz0Ly2ZtOyKf22wGEjtCzQg8ktGmNPk8=
+github.com/trustbloc/watermill-amqp/v2 v2.0.5-0.20220510153053-678b4a0b3cd6/go.mod h1:DKOBUoMVtPMV8jBEbRP3NL6TgnOMyRvVza3W297cdqU=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/pkg/activitypub/service/activityhandler/inboxhandler.go
+++ b/pkg/activitypub/service/activityhandler/inboxhandler.go
@@ -1011,10 +1011,12 @@ func (h *Inbox) ensureActivityInOutbox(activity *vocab.ActivityType) (*vocab.Act
 	obActivity, err := h.getActivityFromOutbox(activity.ID().URL())
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
-			return nil, fmt.Errorf("get activity from outbox: %w", err)
+			return nil, fmt.Errorf("get activity [%s] of type %s from outbox: %w",
+				activity.ID(), activity.Type(), err)
 		}
 
-		return nil, orberrors.NewTransient(fmt.Errorf("get activity from outbox: %w", err))
+		return nil, orberrors.NewTransient(fmt.Errorf("get activity [%s] of type %s from outbox: %w",
+			activity.ID(), activity.Type(), err))
 	}
 
 	// Ensure the activity in the outbox is the same as the given activity.

--- a/pkg/activitypub/service/outbox/outbox.go
+++ b/pkg/activitypub/service/outbox/outbox.go
@@ -257,8 +257,8 @@ func (h *Outbox) handleActivityMsg(msg *message.Message) (*vocab.ActivityType, e
 
 		if err := h.handleResolveIRIs(activityMsg.Activity, activityMsg.TargetIRI.URL(),
 			activityMsg.ExcludeIRIs.URLs()); err != nil {
-			return nil, fmt.Errorf("handle 'resolve-and-deliver' message for activity [%s] to [%s]: %w",
-				activityMsg.Activity.ID(), activityMsg.TargetIRI, err)
+			return nil, fmt.Errorf("handle 'resolve-and-deliver' message for activity [%s] of type [%s] to [%s]: %w",
+				activityMsg.Activity.ID(), activityMsg.Activity.Type(), activityMsg.TargetIRI, err)
 		}
 
 		return activityMsg.Activity, nil
@@ -268,8 +268,8 @@ func (h *Outbox) handleActivityMsg(msg *message.Message) (*vocab.ActivityType, e
 			h.ServiceName, msg.UUID, activityMsg.Activity.ID(), activityMsg.TargetIRI)
 
 		if err := h.sendActivity(activityMsg.Activity, activityMsg.TargetIRI.URL()); err != nil {
-			return nil, fmt.Errorf("handle 'deliver' message for activity [%s] to [%s]: %w",
-				activityMsg.Activity.ID(), activityMsg.TargetIRI, err)
+			return nil, fmt.Errorf("handle 'deliver' message for activity [%s] of type [%s] to [%s]: %w",
+				activityMsg.Activity.ID(), activityMsg.Activity.Type(), activityMsg.TargetIRI, err)
 		}
 
 		return activityMsg.Activity, nil

--- a/pkg/pubsub/amqp/amqppubsub_test.go
+++ b/pkg/pubsub/amqp/amqppubsub_test.go
@@ -250,7 +250,9 @@ func TestAMQP_Error(t *testing.T) {
 		p.Start()
 		defer p.stop()
 
-		require.EqualError(t, p.Publish(topic), errPublish.Error())
+		err := p.Publish(topic)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errPublish.Error())
 	})
 }
 

--- a/pkg/store/expiry/expiry.go
+++ b/pkg/store/expiry/expiry.go
@@ -171,6 +171,8 @@ func (r *registeredStore) deleteExpiredData(logger logger) { //nolint:funlen
 		operations := make([]storage.Operation, len(keysToDelete))
 
 		for i, key := range keysToDelete {
+			logger.Debugf("Deleting expired data for key [%s] in %s.", key, r.name)
+
 			operations[i] = storage.Operation{Key: key}
 		}
 

--- a/test/bdd/docker_steps.go
+++ b/test/bdd/docker_steps.go
@@ -35,6 +35,12 @@ func (d *DockerSteps) stopContainer(containerID string) error {
 	return err
 }
 
+func (d *DockerSteps) restartContainer(containerID string) error {
+	logger.Infof("Restarting Docker container [%s]", containerID)
+	_, err := d.BDDContext.Composition().issueCommand([]string{"restart", containerID})
+	return err
+}
+
 func (d *DockerSteps) pauseContainer(containerID string) error {
 	logger.Infof("Pausing Docker container [%s]", containerID)
 	_, err := d.BDDContext.Composition().issueCommand([]string{"pause", containerID})
@@ -73,4 +79,5 @@ func (d *DockerSteps) RegisterSteps(s *godog.Suite) {
 	s.Step(`^container "([^"]*)" is paused$`, d.pauseContainer)
 	s.Step(`^container "([^"]*)" is unpaused$`, d.unpauseContainer)
 	s.Step(`^container "([^"]*)" is recreated$`, d.recreateContainer)
+	s.Step(`^container "([^"]*)" is restarted$`, d.restartContainer)
 }

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -37,6 +37,15 @@ services:
       - IPFS_URL=ipfs:5001
       - IPFS_TIMEOUT=10s
       - MQ_URL=amqp://${RABBITMQ_USERNAME}:${RABBITMQ_PASSWORD}@orb.mq.domain1.com:5672/
+      # MQ_REDELIVERY_INITIAL_INTERVAL is the delay for the initial redelivery attempt (default is 2s).
+      - MQ_REDELIVERY_INITIAL_INTERVAL=2s
+      # MQ_REDELIVERY_MULTIPLIER is the multiplier for a redelivery attempt. For example, if set to 1.5 and
+      #	the previous redelivery interval was 2s then the next redelivery interval is set 3s (default is 1.5).
+      - MQ_REDELIVERY_MULTIPLIER=1.5
+      # MQ_REDELIVERY_MAX_INTERVAL is the maximum delay for a redelivery (default is 30s).
+      - MQ_REDELIVERY_MAX_INTERVAL=30s
+      # MQ_REDELIVERY_MAX_ATTEMPTS Specifies the maximum number of redelivery attempts for a failed message (default is 20).
+      - MQ_REDELIVERY_MAX_ATTEMPTS=20
       # OP_QUEUE_POOL specifies the number of subscribers that concurrently process messages in the operation queue (default 5).
       - OP_QUEUE_POOL=10
       # OP_QUEUE_TASK_MONITOR_INTERVAL specifies The interval (period) in which operation queue tasks from other servers are monitored (default is 10s).
@@ -56,6 +65,8 @@ services:
       # MQ_PUBLISHER_POOL specifies the size of a channel pool for an AMQP publisher (default 25). If set to 0 then
       #	a channel pool is not used and a new channel is opened/closed for every publish to a queue.
       - MQ_PUBLISHER_POOL=50
+      # MQ_PUBLISHER_CONFIRM_DELIVERY turns on delivery confirmation of published messages (default true).
+      - MQ_PUBLISHER_CONFIRM_DELIVERY=true
       - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN1}
       - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain1.com

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -1532,6 +1532,7 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/pseudomuto/protoc-gen-doc v1.4.1/go.mod h1:exDTOVwqpp30eV/EDPFLZy3Pwr2sn6hBC1WIYH/UbIg=
 github.com/pseudomuto/protokit v0.2.0/go.mod h1:2PdH30hxVHsup8KpBTOXTBeMVhJZVio3Q8ViKSAXT0Q=
 github.com/rabbitmq/amqp091-go v1.2.0/go.mod h1:ogQDLSOACsLPsIq0NpbtiifNZi2YOz0VTJ0kHRghqbM=
+github.com/rabbitmq/amqp091-go v1.3.4/go.mod h1:ogQDLSOACsLPsIq0NpbtiifNZi2YOz0VTJ0kHRghqbM=
 github.com/rboyer/safeio v0.2.1/go.mod h1:Cq/cEPK+YXFn622lsQ0K4KsPZSPtaptHHEldsy7Fmig=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/test/bdd/httpclient.go
+++ b/test/bdd/httpclient.go
@@ -153,7 +153,7 @@ func (c *httpClient) GetWithRetryFunc(url string, attempts int, shouldRetry func
 			break
 		}
 
-		time.Sleep(3 * time.Second)
+		time.Sleep(5 * time.Second)
 	}
 
 	return resp, nil


### PR DESCRIPTION
When an AMQP server is restarted, the Orb pub-sub client receives a success response when publishing a message even though the message may not have been persisted by the AMQP server (because the server has died) and therefore the message is lost. This commit uses the latest version of watermill-amqp which adds a delivery confirmation feature. A failed delivery confirmation results in the message being retried (according to the pub-sub redelivery mechanism).

A new startup parameter was added to enable/disable delivery confirmations. Delivery confirmations are enabled by default.

(Note that the delivery confirmation pull request (https://github.com/ThreeDotsLabs/watermill-amqp/pull/15) has not yet been merged, so this commit points to the TrustBloc fork of watermill-amqp. Once the PR is merged, Orb should be updated to point to the official library.)

Also:
- Added a BDD test for AMQP server restart
- Changed the onboarding-and-recovery BDD test to be run only for local CAS in order to reduce the time to run the integration tests
- Upgrade RabbitMQ library (amqp091-go) to v1.3.4

closes #1290

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>