### PR TITLE
feat: Add environment variable for no VCT version

### DIFF
--- a/cmd/orb-server/startcmd/params.go
+++ b/cmd/orb-server/startcmd/params.go
@@ -511,6 +511,10 @@ const (
 	activityPubPageSizeFlagUsage     = "The maximum page size for an ActivityPub collection or ordered collection. " +
 		commonEnvVarUsageText + activityPubPageSizeEnvKey
 
+	enableVCTFlagName  = "vct-enabled"
+	enableVCTFlagUsage = "Indicates if Orb server has VCT log configured."
+	enabledVCTEnvKey   = "VCT_ENABLED"
+
 	devModeEnabledFlagName = "enable-dev-mode"
 	devModeEnabledEnvKey   = "DEV_MODE_ENABLED"
 	devModeEnabledUsage    = `Set to "true" to enable dev mode. ` +
@@ -703,6 +707,7 @@ type orbParameters struct {
 	clientAuthTokens                        map[string]string
 	activityPubPageSize                     int
 	enableDevMode                           bool
+	enableVCT                               bool
 	nodeInfoRefreshInterval                 time.Duration
 	ipfsTimeout                             time.Duration
 	databaseTimeout                         time.Duration
@@ -1016,6 +1021,18 @@ func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 		}
 
 		didDiscoveryEnabled = enable
+	}
+
+	enableVCTStr := cmdutils.GetUserSetOptionalVarFromString(cmd, enableVCTFlagName, enabledVCTEnvKey)
+
+	enableVCT := defaultVCTEnabled
+	if enableVCTStr != "" {
+		enable, parseErr := strconv.ParseBool(enableVCTStr)
+		if parseErr != nil {
+			return nil, fmt.Errorf("invalid value for %s: %s", enableVCTFlagName, parseErr)
+		}
+
+		enableVCT = enable
 	}
 
 	enableDevModeStr := cmdutils.GetUserSetOptionalVarFromString(cmd, devModeEnabledFlagName, devModeEnabledEnvKey)
@@ -1401,6 +1418,7 @@ func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 		clientAuthTokens:                        clientAuthTokens,
 		activityPubPageSize:                     activityPubPageSize,
 		enableDevMode:                           enableDevMode,
+		enableVCT:                               enableVCT,
 		nodeInfoRefreshInterval:                 nodeInfoRefreshInterval,
 		ipfsTimeout:                             ipfsTimeout,
 		databaseTimeout:                         databaseTimeout,
@@ -2054,6 +2072,7 @@ func createFlags(startCmd *cobra.Command) {
 	startCmd.Flags().StringArrayP(clientAuthTokensFlagName, "", nil, clientAuthTokensFlagUsage)
 	startCmd.Flags().StringP(activityPubPageSizeFlagName, activityPubPageSizeFlagShorthand, "", activityPubPageSizeFlagUsage)
 	startCmd.Flags().String(devModeEnabledFlagName, "false", devModeEnabledUsage)
+	startCmd.Flags().String(enableVCTFlagName, "false", enableVCTFlagUsage)
 	startCmd.Flags().StringP(nodeInfoRefreshIntervalFlagName, nodeInfoRefreshIntervalFlagShorthand, "", nodeInfoRefreshIntervalFlagUsage)
 	startCmd.Flags().StringP(ipfsTimeoutFlagName, ipfsTimeoutFlagShorthand, "", ipfsTimeoutFlagUsage)
 	startCmd.Flags().StringArrayP(contextProviderFlagName, "", []string{}, contextProviderFlagUsage)

--- a/cmd/orb-server/startcmd/params_test.go
+++ b/cmd/orb-server/startcmd/params_test.go
@@ -379,6 +379,32 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 		require.Contains(t, err.Error(), "invalid value for enable-http-signatures")
 	})
 
+	t.Run("test invalid vct enabled flag", func(t *testing.T) {
+		startCmd := GetStartCmd()
+
+		args := []string{
+			"--" + hostURLFlagName, "localhost:8247",
+			"--" + hostMetricsURLFlagName, "localhost:8248",
+			"--" + externalEndpointFlagName, "orb.example.com",
+			"--" + casTypeFlagName, "ipfs",
+			"--" + ipfsURLFlagName, "localhost:8081",
+			"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
+			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption,
+			"--" + anchorCredentialDomainFlagName, "domain.com",
+			"--" + anchorCredentialIssuerFlagName, "issuer.com",
+			"--" + anchorCredentialURLFlagName, "peer.com",
+			"--" + LogLevelFlagName, log.ParseString(log.ERROR),
+			"--" + enableVCTFlagName, "invalid bool",
+		}
+
+		startCmd.SetArgs(args)
+
+		err := startCmd.Execute()
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid value for vct-enabled")
+	})
+
 	t.Run("test invalid enable-did-discovery", func(t *testing.T) {
 		startCmd := GetStartCmd()
 
@@ -1618,6 +1644,9 @@ func setEnvVars(t *testing.T, databaseType, casType, replicateLocalCASToIPFS str
 	err := os.Setenv(hostURLEnvKey, "localhost:8237")
 	require.NoError(t, err)
 
+	err = os.Setenv(enableVCTFlagName, "true")
+	require.NoError(t, err)
+
 	err = os.Setenv(casTypeEnvKey, casType)
 	require.NoError(t, err)
 
@@ -1732,6 +1761,7 @@ func getTestArgs(ipfsURL, casType, localCASReplicateInIPFSEnabled, databaseType,
 		"--" + hostMetricsURLFlagName, "localhost:8248",
 		"--" + externalEndpointFlagName, "orb.example.com",
 		"--" + discoveryDomainFlagName, "shared.example.com",
+		"--" + enableVCTFlagName, "true",
 		"--" + ipfsURLFlagName, ipfsURL,
 		"--" + cidVersionFlagName, "0",
 		"--" + batchWriterTimeoutFlagName, "700",

--- a/test/bdd/features/activitypub.feature
+++ b/test/bdd/features/activitypub.feature
@@ -24,9 +24,7 @@ Feature:
 
     # set up logs for domains
     When an HTTP POST is sent to "https://orb.domain1.com/log" with content "http://orb.vct:8077/maple2020" of type "text/plain"
-    When an HTTP POST is sent to "https://orb.domain2.com/log" with content "" of type "text/plain"
     When an HTTP POST is sent to "https://orb.domain3.com/log" with content "http://orb.vct:8077/maple2020" of type "text/plain"
-    When an HTTP POST is sent to "https://orb.domain4.com/log" with content "" of type "text/plain"
 
   @activitypub_service
   Scenario: Get ActivityPub service

--- a/test/bdd/features/create-dids-to-file.feature
+++ b/test/bdd/features/create-dids-to-file.feature
@@ -13,7 +13,6 @@ Feature:
 
     # set up logs for domains
     When an HTTP POST is sent to "https://orb.domain1.com/log" with content "http://orb.vct:8077/maple2020" of type "text/plain"
-    When an HTTP POST is sent to "https://orb.domain2.com/log" with content "" of type "text/plain"
 
   @create_dids_to_file
   Scenario: Create DIDs and store them in a file. (Uses environment variables.)

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -31,17 +31,13 @@ Feature:
 
     # set up logs for domains
     When an HTTP POST is sent to "https://orb.domain1.com/log" with content "http://orb.vct:8077/maple2020" of type "text/plain"
-    When an HTTP POST is sent to "https://orb.domain2.com/log" with content "" of type "text/plain"
     When an HTTP POST is sent to "https://orb.domain3.com/log" with content "http://orb.vct:8077/maple2020" of type "text/plain"
-    When an HTTP POST is sent to "https://orb.domain4.com/log" with content "" of type "text/plain"
-    When an HTTP POST is sent to "https://orb.domain5.com/log" with content "" of type "text/plain"
 
     Then we wait 1 seconds
 
     When an HTTP GET is sent to "https://orb.domain1.com/log"
     Then the response equals "http://orb.vct:8077/maple2020"
-    When an HTTP GET is sent to "https://orb.domain2.com/log"
-    Then the response equals ""
+    When an HTTP GET is sent to "https://orb.domain2.com/log" and the returned status code is 404
 
     # domain1 adds domain2 and domain3 to its 'follow' and 'invite-witness' accept lists.
     Given variable "domain1AcceptList" is assigned the JSON value '[{"type":"follow","add":["${domain2IRI}","${domain3IRI}"]},{"type":"invite-witness","add":["${domain2IRI}","${domain3IRI}"]}]'

--- a/test/bdd/features/did-sidetree.feature
+++ b/test/bdd/features/did-sidetree.feature
@@ -22,7 +22,6 @@ Feature:
 
     # set up logs for domains
     When an HTTP POST is sent to "https://orb.domain1.com/log" with content "http://orb.vct:8077/maple2020" of type "text/plain"
-    When an HTTP POST is sent to "https://orb.domain2.com/log" with content "" of type "text/plain"
     When an HTTP POST is sent to "https://orb.domain3.com/log" with content "http://orb.vct:8077/maple2020" of type "text/plain"
 
     Then we wait 1 seconds

--- a/test/bdd/features/onboard-recovery.feature
+++ b/test/bdd/features/onboard-recovery.feature
@@ -29,8 +29,6 @@ Feature:
 
     # set up logs for domains
     When an HTTP POST is sent to "https://orb.domain1.com/log" with content "http://orb.vct:8077/maple2020" of type "text/plain"
-    When an HTTP POST is sent to "https://orb.domain2.com/log" with content "" of type "text/plain"
-    When an HTTP POST is sent to "https://orb.domain5.com/log" with content "" of type "text/plain"
 
     # domain1 adds domain2 to its 'follow' and 'invite-witness' accept lists.
     Given variable "domain1AcceptList" is assigned the JSON value '[{"type":"follow","add":["${domain2IRI}"]},{"type":"invite-witness","add":["${domain2IRI}"]}]'

--- a/test/bdd/features/orb-cli.feature
+++ b/test/bdd/features/orb-cli.feature
@@ -18,7 +18,6 @@ Feature: Using Orb CLI
 
     # set up logs for domains
     When an HTTP POST is sent to "https://orb.domain1.com/log" with content "http://orb.vct:8077/maple2020" of type "text/plain"
-    When an HTTP POST is sent to "https://orb.domain2.com/log" with content "" of type "text/plain"
 
     And orb-cli is executed with args 'acceptlist add --url https://localhost:48326/services/orb/acceptlist --actor https://orb.domain2.com/services/orb --type follow --tls-cacerts fixtures/keys/tls/ec-cacert.pem --auth-token ADMIN_TOKEN'
     And orb-cli is executed with args 'acceptlist add --url https://localhost:48426/services/orb/acceptlist --actor https://orb.domain1.com/services/orb --type invite-witness --tls-cacerts fixtures/keys/tls/ec-cacert.pem --auth-token ADMIN_TOKEN'

--- a/test/bdd/features/orb-driver.feature
+++ b/test/bdd/features/orb-driver.feature
@@ -15,7 +15,6 @@ Feature: Using Orb driver
       Given the authorization bearer token for "POST" requests to path "/log" is set to "ADMIN_TOKEN"
 
       # set up logs for domains
-      When an HTTP POST is sent to "https://orb.domain2.com/log" with content "" of type "text/plain"
       When an HTTP POST is sent to "https://orb.domain3.com/log" with content "http://orb.vct:8077/maple2020" of type "text/plain"
 
     And orb-cli is executed with args 'acceptlist add --url https://localhost:48426/services/orb/acceptlist --actor https://orb.domain3.com/services/orb --type invite-witness --tls-cacerts fixtures/keys/tls/ec-cacert.pem --auth-token ADMIN_TOKEN'

--- a/test/bdd/features/orb-stress.feature
+++ b/test/bdd/features/orb-stress.feature
@@ -17,7 +17,6 @@ Feature: Using Orb stress test
 
     # set up logs for domains
     When an HTTP POST is sent to "https://orb.domain1.com/log" with content "http://orb.vct:8077/maple2020" of type "text/plain"
-    When an HTTP POST is sent to "https://orb.domain2.com/log" with content "" of type "text/plain"
 
     Given orb-cli is executed with args 'acceptlist add --url https://localhost:48326/services/orb/acceptlist --actor https://orb.domain2.com/services/orb --type follow --tls-cacerts fixtures/keys/tls/ec-cacert.pem --auth-token ADMIN_TOKEN'
     And orb-cli is executed with args 'acceptlist add --url https://localhost:48426/services/orb/acceptlist --actor https://orb.domain1.com/services/orb --type invite-witness --tls-cacerts fixtures/keys/tls/ec-cacert.pem --auth-token ADMIN_TOKEN'

--- a/test/bdd/features/versions.feature
+++ b/test/bdd/features/versions.feature
@@ -29,9 +29,7 @@ Feature:
 
     # set up logs for domains
     When an HTTP POST is sent to "https://orb.domain1.com/log" with content "http://orb.vct:8077/maple2020" of type "text/plain"
-    When an HTTP POST is sent to "https://orb.domain2.com/log" with content "" of type "text/plain"
     When an HTTP POST is sent to "https://orb.domain3.com/log" with content "http://orb.vct:8077/maple2020" of type "text/plain"
-    When an HTTP POST is sent to "https://orb.domain4.com/log" with content "" of type "text/plain"
 
     # domain1 adds domain2, domain3 and domain4 to its 'follow' and 'invite-witness' accept lists.
     Given variable "domain1AcceptList" is assigned the JSON value '[{"type":"follow","add":["${domain2IRI}","${domain3IRI}","${domain4IRI}"]},{"type":"invite-witness","add":["${domain2IRI}","${domain3IRI}","${domain4IRI}"]}]'

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - ORB_KMS_TYPE=web
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
       - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:watermill=INFO:DEBUG
+      - VCT_ENABLED=true
       - ORB_HOST_URL=172.20.0.23:443
       - ORB_HOST_METRICS_URL=172.20.0.23:48327
       # ORB_EXTERNAL_ENDPOINT is the endpoint that external clients use to invoke services. This endpoint is used
@@ -164,6 +165,7 @@ services:
       - ORB_KMS_TYPE=web
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
       - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:watermill=INFO:DEBUG
+      - VCT_ENABLED=true
       - ORB_HOST_URL=172.20.0.2:443
       - ORB_HOST_METRICS_URL=172.20.0.2:48527
       # add delay for starting additional servers within same domain (in seconds)
@@ -514,6 +516,7 @@ services:
       - ORB_KMS_TYPE=web
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
       - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:watermill=INFO:DEBUG
+      - VCT_ENABLED=true
       - ORB_HOST_URL=172.20.0.6:443
       - ORB_HOST_METRICS_URL=172.20.0.6:48627
       # ORB_EXTERNAL_ENDPOINT is the endpoint that external clients use to invoke services. This endpoint is used


### PR DESCRIPTION
We should be able to spin orb without any configuration so add VCT enabled/disabled flag.

Closes #1287

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>