### PR TITLE
test: BDD test for database restart

### DIFF
--- a/pkg/anchor/util/util.go
+++ b/pkg/anchor/util/util.go
@@ -35,9 +35,10 @@ func VerifiableCredentialFromAnchorLink(anchorLink *linkset.Link,
 	vc, err := verifiable.ParseCredential(vcBytes, opts...)
 	if err != nil {
 		if strings.Contains(err.Error(), "http request unsuccessful") ||
-			strings.Contains(err.Error(), "http server returned status code") {
+			strings.Contains(err.Error(), "http server returned status code") ||
+			strings.Contains(err.Error(), "database error getting public key for issuer") {
 			// The server is probably down. Return a transient error so that it may be retried.
-			return nil, errors.NewTransient(fmt.Errorf("http error during parse credential: %w", err))
+			return nil, errors.NewTransientf("parse credential: %w", err)
 		}
 
 		return nil, fmt.Errorf("parse credential: %w", err)

--- a/pkg/store/publickey/publickeystore.go
+++ b/pkg/store/publickey/publickeystore.go
@@ -113,7 +113,12 @@ func (c *Store) getFromDB(issuerID, keyID string) (*verifier.PublicKey, error) {
 
 	pkBytes, err := c.store.Get(key)
 	if err != nil {
-		return nil, fmt.Errorf("get key - issuer [%s], key ID [%s]: %w", issuerID, keyID, err)
+		if errors.Is(err, storage.ErrDataNotFound) {
+			return nil, fmt.Errorf("get key - issuer [%s], key ID [%s]: %w", issuerID, keyID, err)
+		}
+
+		return nil, fmt.Errorf("database error getting public key for issuer [%s], key ID [%s]: %w",
+			issuerID, keyID, err)
 	}
 
 	logger.Infof("Public key found in storage for issuer [%s], key ID [%s]", issuerID, keyID)

--- a/pkg/store/publickey/publickeystore_test.go
+++ b/pkg/store/publickey/publickeystore_test.go
@@ -123,6 +123,7 @@ func TestStore_GetPublicKey(t *testing.T) {
 		pk, err := s.GetPublicKey("did:web:orb.domain1.com", "key1")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errExpected.Error())
+		require.Contains(t, err.Error(), "database error getting public key")
 		require.Nil(t, pk)
 	})
 

--- a/test/bdd/did_orb_steps.go
+++ b/test/bdd/did_orb_steps.go
@@ -197,7 +197,7 @@ func (r *createResponses) Get(ctx context.Context, n int) ([]*createDIDResponse,
 			responses := r.responses
 			r.mutex.RUnlock()
 
-			if len(r.responses) >= n {
+			if len(responses) >= n {
 				return responses[0:n], nil
 			}
 


### PR DESCRIPTION
Added a BDD test for restarting a database while Orb instances are up.

Also, added a fix to ensure a transient error is returned after getting a VC parse error due to the DB being down.

closes #1295

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>