### PR TITLE
feat: Add witness policy management to Orb CLI

### DIFF
--- a/cmd/orb-cli/main.go
+++ b/cmd/orb-cli/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/trustbloc/orb/cmd/orb-cli/ipfskeygencmd"
 	"github.com/trustbloc/orb/cmd/orb-cli/ipnshostmetagencmd"
 	"github.com/trustbloc/orb/cmd/orb-cli/ipnshostmetauploadcmd"
+	"github.com/trustbloc/orb/cmd/orb-cli/policycmd"
 	"github.com/trustbloc/orb/cmd/orb-cli/recoverdidcmd"
 	"github.com/trustbloc/orb/cmd/orb-cli/resolvedidcmd"
 	"github.com/trustbloc/orb/cmd/orb-cli/updatedidcmd"
@@ -62,6 +63,7 @@ func main() {
 	rootCmd.AddCommand(followcmd.GetCmd())
 	rootCmd.AddCommand(witnesscmd.GetCmd())
 	rootCmd.AddCommand(acceptlistcmd.GetCmd())
+	rootCmd.AddCommand(policycmd.GetCmd())
 
 	if err := rootCmd.Execute(); err != nil {
 		logger.Fatalf("Failed to run orb-cli: %s", err.Error())

--- a/cmd/orb-cli/policycmd/getcmd.go
+++ b/cmd/orb-cli/policycmd/getcmd.go
@@ -1,0 +1,57 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package policycmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/spf13/cobra"
+	cmdutils "github.com/trustbloc/edge-core/pkg/utils/cmd"
+
+	"github.com/trustbloc/orb/cmd/orb-cli/common"
+)
+
+func newGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "get",
+		Short:        "Retrieves the witness policy.",
+		Long:         `Retrieves the witness policy. For example: policy get --url https://orb.domain1.com/policy`,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return executeGet(cmd)
+		},
+	}
+
+	common.AddCommonFlags(cmd)
+
+	cmd.Flags().StringP(urlFlagName, "", "", urlFlagUsage)
+
+	return cmd
+}
+
+func executeGet(cmd *cobra.Command) error {
+	u, err := cmdutils.GetUserSetVarFromString(cmd, urlFlagName, urlEnvKey, false)
+	if err != nil {
+		return err
+	}
+
+	_, err = url.Parse(u)
+	if err != nil {
+		return fmt.Errorf("invalid URL %s: %w", u, err)
+	}
+
+	resp, err := common.SendHTTPRequest(cmd, nil, http.MethodGet, u)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(resp))
+
+	return nil
+}

--- a/cmd/orb-cli/policycmd/getcmd_test.go
+++ b/cmd/orb-cli/policycmd/getcmd_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package policycmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCmd(t *testing.T) {
+	t.Run("test missing url arg", func(t *testing.T) {
+		cmd := GetCmd()
+		cmd.SetArgs([]string{"get"})
+
+		err := cmd.Execute()
+
+		require.Error(t, err)
+		require.Equal(t,
+			"Neither url (command line flag) nor ORB_CLI_URL (environment variable) have been set.",
+			err.Error())
+	})
+
+	t.Run("test invalid url arg", func(t *testing.T) {
+		cmd := GetCmd()
+
+		args := []string{"get"}
+		args = append(args, urlArg(":invalid")...)
+		cmd.SetArgs(args)
+
+		err := cmd.Execute()
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid URL")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, err := fmt.Fprint(w, "d1")
+			require.NoError(t, err)
+		}))
+
+		cmd := GetCmd()
+
+		args := []string{"get"}
+		args = append(args, urlArg(serv.URL)...)
+		cmd.SetArgs(args)
+
+		cmd.SetArgs(args)
+		err := cmd.Execute()
+
+		require.NoError(t, err)
+	})
+}

--- a/cmd/orb-cli/policycmd/policy.go
+++ b/cmd/orb-cli/policycmd/policy.go
@@ -1,0 +1,44 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package policycmd
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	urlFlagName  = "url"
+	urlEnvKey    = "ORB_CLI_URL"
+	urlFlagUsage = "The URL of the witness policy REST endpoint." +
+		" Alternatively, this can be set with the following environment variable: " + urlEnvKey
+
+	policyFlagName  = "policy"
+	typeEnvKey      = "ORB_CLI_POLICY"
+	policyFlagUsage = `The witness policy. For example "MinPercent(100,batch) AND OutOf(1,system)".` +
+		" Alternatively, this can be set with the following environment variable: " + typeEnvKey
+)
+
+// GetCmd returns the Cobra policy command.
+func GetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "policy",
+		Short:        "Manages the witness policy.",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("expecting subcommand update or get")
+		},
+	}
+
+	cmd.AddCommand(
+		newUpdateCmd(),
+		newGetCmd(),
+	)
+
+	return cmd
+}

--- a/cmd/orb-cli/policycmd/policy_test.go
+++ b/cmd/orb-cli/policycmd/policy_test.go
@@ -1,0 +1,21 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package policycmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPolicyCmd(t *testing.T) {
+	t.Run("test missing subcommand", func(t *testing.T) {
+		err := GetCmd().Execute()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "expecting subcommand update or get")
+	})
+}

--- a/cmd/orb-cli/policycmd/updatecmd.go
+++ b/cmd/orb-cli/policycmd/updatecmd.go
@@ -1,0 +1,77 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package policycmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/spf13/cobra"
+	cmdutils "github.com/trustbloc/edge-core/pkg/utils/cmd"
+
+	"github.com/trustbloc/orb/cmd/orb-cli/common"
+)
+
+func newUpdateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Updates the witness policy.",
+		Long: `Updates the witness policy. For example: policy update ` +
+			`--policy "MinPercent(100,batch) AND OutOf(1,system)" --url https://orb.domain1.com/policy`,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return executeUpdate(cmd)
+		},
+	}
+
+	addUpdateFlags(cmd)
+
+	return cmd
+}
+
+func executeUpdate(cmd *cobra.Command) error {
+	u, policy, err := getUpdateArgs(cmd)
+	if err != nil {
+		return err
+	}
+
+	_, err = common.SendHTTPRequest(cmd, []byte(policy), http.MethodPost, u)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Witness policy has successfully been updated.")
+
+	return nil
+}
+
+func addUpdateFlags(cmd *cobra.Command) {
+	common.AddCommonFlags(cmd)
+
+	cmd.Flags().StringP(urlFlagName, "", "", urlFlagUsage)
+	cmd.Flags().StringP(policyFlagName, "", "", policyFlagUsage)
+}
+
+func getUpdateArgs(cmd *cobra.Command) (u, policy string, err error) {
+	u, err = cmdutils.GetUserSetVarFromString(cmd, urlFlagName, urlEnvKey, false)
+	if err != nil {
+		return "", "", err
+	}
+
+	_, err = url.Parse(u)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid URL %s: %w", u, err)
+	}
+
+	policy, err = cmdutils.GetUserSetVarFromString(cmd, policyFlagName, typeEnvKey, false)
+	if err != nil {
+		return "", "", err
+	}
+
+	return u, policy, nil
+}

--- a/cmd/orb-cli/policycmd/updatecmd_test.go
+++ b/cmd/orb-cli/policycmd/updatecmd_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package policycmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/cmd/orb-cli/common"
+)
+
+const (
+	flag = "--"
+)
+
+func TestUpdateCmd(t *testing.T) {
+	t.Run("test missing url arg", func(t *testing.T) {
+		cmd := GetCmd()
+		cmd.SetArgs([]string{"update"})
+
+		err := cmd.Execute()
+
+		require.Error(t, err)
+		require.Equal(t,
+			"Neither url (command line flag) nor ORB_CLI_URL (environment variable) have been set.",
+			err.Error())
+	})
+
+	t.Run("test invalid url arg", func(t *testing.T) {
+		cmd := GetCmd()
+
+		args := []string{"update"}
+		args = append(args, urlArg(":invalid")...)
+		cmd.SetArgs(args)
+
+		err := cmd.Execute()
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid URL")
+	})
+
+	t.Run("test missing policy arg", func(t *testing.T) {
+		cmd := GetCmd()
+
+		args := []string{"update"}
+		args = append(args, urlArg("localhost:8080")...)
+		cmd.SetArgs(args)
+
+		err := cmd.Execute()
+
+		require.Error(t, err)
+		require.Equal(t,
+			"Neither policy (command line flag) nor ORB_CLI_POLICY (environment variable) have been set.",
+			err.Error())
+	})
+
+	t.Run("update -> success", func(t *testing.T) {
+		serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, err := fmt.Fprint(w, "d1")
+			require.NoError(t, err)
+		}))
+
+		cmd := GetCmd()
+
+		args := []string{"update"}
+		args = append(args, urlArg(serv.URL)...)
+		args = append(args, policyArg("MinPercent(100,batch) AND OutOf(1,system)")...)
+		args = append(args, authTokenArg("ADMIN_TOKEN")...)
+		cmd.SetArgs(args)
+
+		cmd.SetArgs(args)
+		err := cmd.Execute()
+
+		require.NoError(t, err)
+	})
+}
+
+func urlArg(value string) []string {
+	return []string{flag + urlFlagName, value}
+}
+
+func policyArg(value string) []string {
+	return []string{flag + policyFlagName, value}
+}
+
+func authTokenArg(value string) []string {
+	return []string{flag + common.AuthTokenFlagName, value}
+}

--- a/test/bdd/cli_steps.go
+++ b/test/bdd/cli_steps.go
@@ -534,13 +534,7 @@ func (e *Steps) createDID() error {
 }
 
 func (e *Steps) execute(argsStr string) error {
-	var args []string
-
-	for _, arg := range strings.Split(argsStr, " ") {
-		args = append(args, arg)
-	}
-
-	value, err := execCMD(args...)
+	value, err := execCMD(parseArgs(argsStr)...)
 	if err != nil {
 		return err
 	}
@@ -633,4 +627,37 @@ func sendHTTPRequest(httpClient *http.Client, request interface{}, headers map[s
 	}
 
 	return json.Unmarshal(responseBytes, response)
+}
+
+func parseArgs(argsStr string) []string {
+	var args []string
+
+	var current string
+
+	startStringIndex := -1
+
+	for i := 0; i < len(argsStr); i++ {
+		c := argsStr[i : i+1]
+
+		switch {
+		case c == "\"":
+			if startStringIndex == -1 {
+				startStringIndex = i
+			} else {
+				current = argsStr[startStringIndex+1 : i]
+				startStringIndex = -1
+			}
+		case c == " " && startStringIndex == -1:
+			args = append(args, current)
+			current = ""
+		default:
+			current += argsStr[i : i+1]
+		}
+	}
+
+	if current != "" {
+		args = append(args, current)
+	}
+
+	return args
 }

--- a/test/bdd/common_steps.go
+++ b/test/bdd/common_steps.go
@@ -439,7 +439,7 @@ func (d *CommonSteps) valueOfJSONStringResponseSavedToVar(varName string) error 
 }
 
 func (d *CommonSteps) responseEquals(value string) error {
-	if d.state.getResponse() == value {
+	if strings.TrimSuffix(d.state.getResponse(), "\n") == value {
 		logger.Infof("Response equals expected value [%s]", value)
 		return nil
 	}

--- a/test/bdd/features/orb-cli.feature
+++ b/test/bdd/features/orb-cli.feature
@@ -81,3 +81,9 @@ Feature: Using Orb CLI
     Then the JSON path '#(type="follow").url' of the response does not contain "https://orb.domainx.com/services/orb"
     And the JSON path '#(type="follow").url' of the response does not contain "https://orb.domainx.com/services/orb"
     And the JSON path '#(type="invite-witness").url' of the response does not contain "https://orb.domainz.com/services/orb"
+
+  @orb_cli_policy
+  Scenario: test witness policy using cli
+    When orb-cli is executed with args 'policy update --url https://localhost:48326/policy --policy "MinPercent(100,batch) AND OutOf(1,system)" --tls-cacerts fixtures/keys/tls/ec-cacert.pem --auth-token ADMIN_TOKEN'
+    And orb-cli is executed with args 'policy get --url https://localhost:48326/policy --tls-cacerts fixtures/keys/tls/ec-cacert.pem --auth-token READ_TOKEN'
+    Then the response equals "MinPercent(100,batch) AND OutOf(1,system)"


### PR DESCRIPTION
Added commands to the Orb CLI to update and retrieve a witness policy for an Orb domain.

closes #1286

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>