### PR TITLE
chore: Update to latest version of watermill-amqp

### DIFF
--- a/cmd/orb-cli/go.sum
+++ b/cmd/orb-cli/go.sum
@@ -147,7 +147,7 @@ github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrU
 github.com/ThreeDotsLabs/watermill v1.1.0/go.mod h1:Qd1xNFxolCAHCzcMrm6RnjW0manbvN+DJVWc1MWRFlI=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.7 h1:c7rlzfhUFPtNo2WiJuIhrdwAfZcuAfbvB29uF+I0z7c=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.7/go.mod h1:QLZSaklpSZ/7yv288LL2DFOgCEi86VYEmQvzmaMlHoA=
-github.com/ThreeDotsLabs/watermill-amqp/v2 v2.0.3/go.mod h1:DKOBUoMVtPMV8jBEbRP3NL6TgnOMyRvVza3W297cdqU=
+github.com/ThreeDotsLabs/watermill-amqp/v2 v2.0.5-0.20220511202644-f8efc8147ada/go.mod h1:DKOBUoMVtPMV8jBEbRP3NL6TgnOMyRvVza3W297cdqU=
 github.com/ThreeDotsLabs/watermill-http v1.1.3/go.mod h1:mkQ9CC0pxTZerNwr281rBoOy355vYt/lePkmYSX/BRg=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=
 github.com/VictoriaMetrics/fastcache v1.5.7/go.mod h1:ptDBkNMQI4RtmVo8VS/XwRY6RoTu1dAWCbrk+6WsEM8=

--- a/cmd/orb-driver/go.sum
+++ b/cmd/orb-driver/go.sum
@@ -147,7 +147,7 @@ github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrU
 github.com/ThreeDotsLabs/watermill v1.1.0/go.mod h1:Qd1xNFxolCAHCzcMrm6RnjW0manbvN+DJVWc1MWRFlI=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.7 h1:c7rlzfhUFPtNo2WiJuIhrdwAfZcuAfbvB29uF+I0z7c=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.7/go.mod h1:QLZSaklpSZ/7yv288LL2DFOgCEi86VYEmQvzmaMlHoA=
-github.com/ThreeDotsLabs/watermill-amqp/v2 v2.0.3/go.mod h1:DKOBUoMVtPMV8jBEbRP3NL6TgnOMyRvVza3W297cdqU=
+github.com/ThreeDotsLabs/watermill-amqp/v2 v2.0.5-0.20220511202644-f8efc8147ada/go.mod h1:DKOBUoMVtPMV8jBEbRP3NL6TgnOMyRvVza3W297cdqU=
 github.com/ThreeDotsLabs/watermill-http v1.1.3/go.mod h1:mkQ9CC0pxTZerNwr281rBoOy355vYt/lePkmYSX/BRg=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=
 github.com/VictoriaMetrics/fastcache v1.5.7/go.mod h1:ptDBkNMQI4RtmVo8VS/XwRY6RoTu1dAWCbrk+6WsEM8=

--- a/cmd/orb-server/go.mod
+++ b/cmd/orb-server/go.mod
@@ -26,7 +26,7 @@ require (
 )
 
 require (
-	github.com/ThreeDotsLabs/watermill-amqp/v2 v2.0.3 // indirect
+	github.com/ThreeDotsLabs/watermill-amqp/v2 v2.0.5-0.20220511202644-f8efc8147ada // indirect
 	github.com/ThreeDotsLabs/watermill-http v1.1.3 // indirect
 	github.com/VictoriaMetrics/fastcache v1.5.7 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -123,5 +123,3 @@ require (
 )
 
 replace github.com/trustbloc/orb => ../..
-
-replace github.com/ThreeDotsLabs/watermill-amqp/v2 => github.com/trustbloc/watermill-amqp/v2 v2.0.5-0.20220510153053-678b4a0b3cd6

--- a/cmd/orb-server/go.sum
+++ b/cmd/orb-server/go.sum
@@ -147,6 +147,8 @@ github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrU
 github.com/ThreeDotsLabs/watermill v1.1.0/go.mod h1:Qd1xNFxolCAHCzcMrm6RnjW0manbvN+DJVWc1MWRFlI=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.7 h1:c7rlzfhUFPtNo2WiJuIhrdwAfZcuAfbvB29uF+I0z7c=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.7/go.mod h1:QLZSaklpSZ/7yv288LL2DFOgCEi86VYEmQvzmaMlHoA=
+github.com/ThreeDotsLabs/watermill-amqp/v2 v2.0.5-0.20220511202644-f8efc8147ada h1:e6QsMDRllb3cRdeyPp6Cp9GkDSHOvAYuRZSNrrXhPQg=
+github.com/ThreeDotsLabs/watermill-amqp/v2 v2.0.5-0.20220511202644-f8efc8147ada/go.mod h1:DKOBUoMVtPMV8jBEbRP3NL6TgnOMyRvVza3W297cdqU=
 github.com/ThreeDotsLabs/watermill-http v1.1.3 h1:2jHbbE+gbq7pKWBCtOxeHTWSBNrS44Oh7QOzuAeHH/g=
 github.com/ThreeDotsLabs/watermill-http v1.1.3/go.mod h1:mkQ9CC0pxTZerNwr281rBoOy355vYt/lePkmYSX/BRg=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=
@@ -1445,8 +1447,6 @@ github.com/trustbloc/sidetree-core-go v1.0.0-rc.1.0.20220428193233-a1567c33db3e 
 github.com/trustbloc/sidetree-core-go v1.0.0-rc.1.0.20220428193233-a1567c33db3e/go.mod h1:SYCYxrsviTcRoUCoM6VosXF+sqWkKpk8C1dqD0doRYQ=
 github.com/trustbloc/vct v1.0.0-rc1.0.20220426133750-e02ec33d2826 h1:QmpPeWee/b1TbTHjKIGWyFT+tWWWEEcqXWHP7jwUOkQ=
 github.com/trustbloc/vct v1.0.0-rc1.0.20220426133750-e02ec33d2826/go.mod h1:Q2fGxTITe3IWhVOf2aJAKk/CGlMCLsYANdszM70HBcU=
-github.com/trustbloc/watermill-amqp/v2 v2.0.5-0.20220510153053-678b4a0b3cd6 h1:sgVrCXWpq18uz0Ly2ZtOyKf22wGEjtCzQg8ktGmNPk8=
-github.com/trustbloc/watermill-amqp/v2 v2.0.5-0.20220510153053-678b4a0b3cd6/go.mod h1:DKOBUoMVtPMV8jBEbRP3NL6TgnOMyRvVza3W297cdqU=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ module github.com/trustbloc/orb
 
 require (
 	github.com/ThreeDotsLabs/watermill v1.2.0-rc.7
-	github.com/ThreeDotsLabs/watermill-amqp/v2 v2.0.3
+	github.com/ThreeDotsLabs/watermill-amqp/v2 v2.0.5-0.20220511202644-f8efc8147ada
 	github.com/ThreeDotsLabs/watermill-http v1.1.3
 	github.com/bluele/gcache v0.0.2
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
@@ -127,5 +127,3 @@ require (
 )
 
 go 1.17
-
-replace github.com/ThreeDotsLabs/watermill-amqp/v2 => github.com/trustbloc/watermill-amqp/v2 v2.0.5-0.20220510153053-678b4a0b3cd6

--- a/go.sum
+++ b/go.sum
@@ -147,6 +147,8 @@ github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrU
 github.com/ThreeDotsLabs/watermill v1.1.0/go.mod h1:Qd1xNFxolCAHCzcMrm6RnjW0manbvN+DJVWc1MWRFlI=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.7 h1:c7rlzfhUFPtNo2WiJuIhrdwAfZcuAfbvB29uF+I0z7c=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.7/go.mod h1:QLZSaklpSZ/7yv288LL2DFOgCEi86VYEmQvzmaMlHoA=
+github.com/ThreeDotsLabs/watermill-amqp/v2 v2.0.5-0.20220511202644-f8efc8147ada h1:e6QsMDRllb3cRdeyPp6Cp9GkDSHOvAYuRZSNrrXhPQg=
+github.com/ThreeDotsLabs/watermill-amqp/v2 v2.0.5-0.20220511202644-f8efc8147ada/go.mod h1:DKOBUoMVtPMV8jBEbRP3NL6TgnOMyRvVza3W297cdqU=
 github.com/ThreeDotsLabs/watermill-http v1.1.3 h1:2jHbbE+gbq7pKWBCtOxeHTWSBNrS44Oh7QOzuAeHH/g=
 github.com/ThreeDotsLabs/watermill-http v1.1.3/go.mod h1:mkQ9CC0pxTZerNwr281rBoOy355vYt/lePkmYSX/BRg=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=
@@ -1432,8 +1434,6 @@ github.com/trustbloc/sidetree-core-go v1.0.0-rc.1.0.20220428193233-a1567c33db3e 
 github.com/trustbloc/sidetree-core-go v1.0.0-rc.1.0.20220428193233-a1567c33db3e/go.mod h1:SYCYxrsviTcRoUCoM6VosXF+sqWkKpk8C1dqD0doRYQ=
 github.com/trustbloc/vct v1.0.0-rc1.0.20220426133750-e02ec33d2826 h1:QmpPeWee/b1TbTHjKIGWyFT+tWWWEEcqXWHP7jwUOkQ=
 github.com/trustbloc/vct v1.0.0-rc1.0.20220426133750-e02ec33d2826/go.mod h1:Q2fGxTITe3IWhVOf2aJAKk/CGlMCLsYANdszM70HBcU=
-github.com/trustbloc/watermill-amqp/v2 v2.0.5-0.20220510153053-678b4a0b3cd6 h1:sgVrCXWpq18uz0Ly2ZtOyKf22wGEjtCzQg8ktGmNPk8=
-github.com/trustbloc/watermill-amqp/v2 v2.0.5-0.20220510153053-678b4a0b3cd6/go.mod h1:DKOBUoMVtPMV8jBEbRP3NL6TgnOMyRvVza3W297cdqU=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -179,7 +179,7 @@ github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrU
 github.com/ThreeDotsLabs/watermill v1.1.0/go.mod h1:Qd1xNFxolCAHCzcMrm6RnjW0manbvN+DJVWc1MWRFlI=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.7 h1:c7rlzfhUFPtNo2WiJuIhrdwAfZcuAfbvB29uF+I0z7c=
 github.com/ThreeDotsLabs/watermill v1.2.0-rc.7/go.mod h1:QLZSaklpSZ/7yv288LL2DFOgCEi86VYEmQvzmaMlHoA=
-github.com/ThreeDotsLabs/watermill-amqp/v2 v2.0.3/go.mod h1:DKOBUoMVtPMV8jBEbRP3NL6TgnOMyRvVza3W297cdqU=
+github.com/ThreeDotsLabs/watermill-amqp/v2 v2.0.5-0.20220511202644-f8efc8147ada/go.mod h1:DKOBUoMVtPMV8jBEbRP3NL6TgnOMyRvVza3W297cdqU=
 github.com/ThreeDotsLabs/watermill-http v1.1.3/go.mod h1:mkQ9CC0pxTZerNwr281rBoOy355vYt/lePkmYSX/BRg=
 github.com/VictoriaMetrics/fastcache v1.5.7 h1:4y6y0G8PRzszQUYIQHHssv/jgPHAb5qQuuDNdCbyAgw=
 github.com/VictoriaMetrics/fastcache v1.5.7/go.mod h1:ptDBkNMQI4RtmVo8VS/XwRY6RoTu1dAWCbrk+6WsEM8=


### PR DESCRIPTION
The latest watermill-amqp library fixes a deadlock that occurs in the subscriber after a RabbitMQ restart and adds a publisher delivery confirmation option. This PR replaces the forked version of the watermill-amqp library.

closes #1270

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>