### PR TITLE
feat: Added vct verify command to orb-cli

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,7 @@ jobs:
         timeout-minutes: 60
         run: |
           echo '127.0.0.1 orb.domain1.com' | sudo tee -a /etc/hosts
+          echo '127.0.0.1 orb.vct' | sudo tee -a /etc/hosts
           make bdd-test
 
       - uses: actions/upload-artifact@v2

--- a/cmd/orb-cli/common/common.go
+++ b/cmd/orb-cli/common/common.go
@@ -369,7 +369,7 @@ func SendRequest(httpClient *http.Client, req []byte, headers map[string]string,
 
 // SendHTTPRequest sends the given HTTP request using the options provided on the command-line.
 func SendHTTPRequest(cmd *cobra.Command, reqBytes []byte, method, endpointURL string) ([]byte, error) {
-	c, err := newHTTPClient(cmd)
+	c, err := NewHTTPClient(cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -383,7 +383,8 @@ func closeResponseBody(respBody io.Closer) {
 	}
 }
 
-func newHTTPClient(cmd *cobra.Command) (*http.Client, error) {
+// NewHTTPClient returns a new HTTP client using the arguments from the given command.
+func NewHTTPClient(cmd *cobra.Command) (*http.Client, error) {
 	rootCAs, err := getRootCAs(cmd)
 	if err != nil {
 		return nil, err
@@ -531,4 +532,18 @@ func (s *Signer) Headers() jws.Headers {
 // PublicKeyJWK return public key JWK.
 func (s *Signer) PublicKeyJWK() *jws.JWK {
 	return s.publicKey
+}
+
+// Printf prints to the given writer.
+func Printf(out io.Writer, msg string, args ...interface{}) {
+	if _, err := fmt.Fprintf(out, msg, args...); err != nil {
+		panic(err)
+	}
+}
+
+// Println prints a line to the given writer.
+func Println(out io.Writer, msg string) {
+	if _, err := fmt.Fprintln(out, msg); err != nil {
+		panic(err)
+	}
 }

--- a/cmd/orb-cli/go.mod
+++ b/cmd/orb-cli/go.mod
@@ -12,18 +12,22 @@ require (
 	github.com/hyperledger/aries-framework-go v0.1.9-0.20220516154446-0ba34929e05b
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/orb v1.0.0-rc.1.0.20220428163625-96d8261511e1
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/sidetree v1.0.0-rc.1.0.20220428154356-41d198a5fade
+	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220516154446-0ba34929e05b
 	github.com/ipfs/go-ipfs-api v0.2.0
 	github.com/ipfs/go-ipfs-files v0.0.8
 	github.com/libp2p/go-libp2p-core v0.8.0
+	github.com/piprate/json-gold v0.4.1
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.8
 	github.com/trustbloc/orb v1.0.0-rc.1
 	github.com/trustbloc/sidetree-core-go v1.0.0-rc.1.0.20220428193233-a1567c33db3e
+	github.com/trustbloc/vct v1.0.0-rc1.0.20220519143600-82122f0ed232
 )
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.5.7 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bluele/gcache v0.0.2 // indirect
 	github.com/btcsuite/btcd v0.22.0-beta // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
@@ -38,9 +42,9 @@ require (
 	github.com/google/certificate-transparency-go v1.1.2-0.20210512142713-bed466244fa6 // indirect
 	github.com/google/tink/go v1.6.1 // indirect
 	github.com/google/trillian v1.3.14-0.20210520152752-ceda464a95a3 // indirect
-	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220428211718-66cc046674a1 // indirect
-	github.com/hyperledger/aries-framework-go/spi v0.0.0-20220330140627-07042d78580c // indirect
-	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20220330140627-07042d78580c // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20220516154446-0ba34929e05b // indirect
+	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20220516154446-0ba34929e05b // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/ipfs/go-cid v0.0.7 // indirect
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a // indirect
@@ -48,6 +52,7 @@ require (
 	github.com/libp2p/go-buffer-pool v0.0.2 // indirect
 	github.com/libp2p/go-flow-metrics v0.0.3 // indirect
 	github.com/libp2p/go-openssl v0.0.7 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 // indirect
 	github.com/minio/sha256-simd v0.1.1 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
@@ -60,16 +65,18 @@ require (
 	github.com/multiformats/go-multihash v0.0.14 // indirect
 	github.com/multiformats/go-varint v0.0.6 // indirect
 	github.com/opentracing/opentracing-go v1.1.0 // indirect
-	github.com/piprate/json-gold v0.4.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pquerna/cachecontrol v0.1.0 // indirect
+	github.com/prometheus/client_golang v1.11.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.26.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/square/go-jose/v3 v3.0.0-20200630053402-0a67ce9b0693 // indirect
 	github.com/teserakt-io/golang-ed25519 v0.0.0-20210104091850-3888c087a4c8 // indirect
-	github.com/trustbloc/vct v1.0.0-rc1.0.20220519143600-82122f0ed232 // indirect
 	github.com/whyrusleeping/tar-utils v0.0.0-20180509141711-8c6c8ba81d5c // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect

--- a/cmd/orb-cli/go.sum
+++ b/cmd/orb-cli/go.sum
@@ -214,6 +214,7 @@ github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
@@ -813,8 +814,9 @@ github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-202203220
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220324201531-18c87667df19/go.mod h1:ryG46jQRvQUUH/0wjORghfJnxJVH1yIXIsAv1GXIWp8=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220330133350-1c2d9d65aea4/go.mod h1:ryG46jQRvQUUH/0wjORghfJnxJVH1yIXIsAv1GXIWp8=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220330140627-07042d78580c/go.mod h1:ryG46jQRvQUUH/0wjORghfJnxJVH1yIXIsAv1GXIWp8=
-github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220428211718-66cc046674a1 h1:WSKq2EIrwKbBiN4ljdf10b5PjtVWzCyhuMldYNOeuwU=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220428211718-66cc046674a1/go.mod h1:ryG46jQRvQUUH/0wjORghfJnxJVH1yIXIsAv1GXIWp8=
+github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220516154446-0ba34929e05b h1:G6t6RwcIOn9/0zK4ONVsViBaMAq4oqqzh9mT4WxYrY0=
+github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220516154446-0ba34929e05b/go.mod h1:ryG46jQRvQUUH/0wjORghfJnxJVH1yIXIsAv1GXIWp8=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210320144851-40976de98ccf/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210322152545-e6ebe2c79a2a/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210409151411-eeeb8508bd87/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
@@ -838,8 +840,9 @@ github.com/hyperledger/aries-framework-go/spi v0.0.0-20220308060532-714cd5c18552
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20220322085443-50e8f9bd208b/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20220324201531-18c87667df19/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20220330133350-1c2d9d65aea4/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20220330140627-07042d78580c h1:snzJfKNYzt57Q2/+P0YdCJus+K2k3c3fUTvOSoHSUxU=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20220330140627-07042d78580c/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20220516154446-0ba34929e05b h1:FKKAVz3KHByOxGyy6akY1T8RHlDuYPXiq+OeZB0NL8Q=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20220516154446-0ba34929e05b/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210324232048-34ff560ed041/go.mod h1:eKGEEe+PJNDQo7kVif3sUKBWwnsQDkE3gD/QlpmukcQ=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210409151411-eeeb8508bd87/go.mod h1:JHzDtgJLd0134iLFXLxGBjJF+Z+TgiElA/5oVgMazts=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210421203733-b5dfd703a8fc/go.mod h1:asiCVCtH/nocWKhZRMz12aFgdUh8lRHqKis0M8Ei/4I=
@@ -850,8 +853,9 @@ github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210909135806-a
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20211204013109-366f6ef74861/go.mod h1:UPbljMgUwdph/L36m8LrFxnZ4UP32pXeJ/GfluusI3c=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20220217153004-1622c70e5767/go.mod h1:HojN6OAh8ZtXBe5X2arcSOe1SLo5Dsjqto8ICjSLQ2g=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20220322085443-50e8f9bd208b/go.mod h1:HojN6OAh8ZtXBe5X2arcSOe1SLo5Dsjqto8ICjSLQ2g=
-github.com/hyperledger/aries-framework-go/test/component v0.0.0-20220330140627-07042d78580c h1:Fq9I4mMK1+rNqBTxmsB4dzuUvilaKTPWhtxwuWFrPiI=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20220330140627-07042d78580c/go.mod h1:lykx3N+GX+sAWSxO2Ycc4Dz+ynV9b0Fv4NdP+ms4Alc=
+github.com/hyperledger/aries-framework-go/test/component v0.0.0-20220516154446-0ba34929e05b h1:7PXR4ZkSepcYCsHEfolzG6qvYHTz6h3WVCOhrALNT8Q=
+github.com/hyperledger/aries-framework-go/test/component v0.0.0-20220516154446-0ba34929e05b/go.mod h1:lykx3N+GX+sAWSxO2Ycc4Dz+ynV9b0Fv4NdP+ms4Alc=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -1055,6 +1059,7 @@ github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/mattn/go-shellwords v1.0.5/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/go-shellwords v1.0.10/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-zglob v0.0.1/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=
+github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/mholt/archiver v3.1.1+incompatible/go.mod h1:Dh2dOXnSdiLxRiPoVfIr/fI1TwETms9B8CTWfeh7ROU=
@@ -1261,12 +1266,14 @@ github.com/prometheus/client_golang v1.4.0/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3O
 github.com/prometheus/client_golang v1.5.1/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.10.0/go.mod h1:WJM3cc3yu7XKBKa/I8WeZm+V3eltZnBwfENSU7mdogU=
+github.com/prometheus/client_golang v1.11.0 h1:HNkLOAEQMIDv/K+04rukrLx6ch7msSRwf3/SASFAGtQ=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.1.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.2.0 h1:uq5h0d+GuxiXLJLNABMgp2qUWDPiLvgCzz2dUR+/W/M=
 github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.0.0-20181126121408-4724e9255275/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
@@ -1277,6 +1284,7 @@ github.com/prometheus/common v0.7.0/go.mod h1:DjGbpBbp5NYNiECxcL/VnbXCCaQpKd3tt2
 github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8bs7vj7HSQ4=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.18.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
+github.com/prometheus/common v0.26.0 h1:iMAkS2TDoNWnKM+Kopnx/8tnEStIfpYA0ur0xQzzhMQ=
 github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9VFqTh1DIvc=
 github.com/prometheus/procfs v0.0.0-20180125133057-cb4147076ac7/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
@@ -1287,6 +1295,7 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
+github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/pseudomuto/protoc-gen-doc v1.4.1/go.mod h1:exDTOVwqpp30eV/EDPFLZy3Pwr2sn6hBC1WIYH/UbIg=

--- a/cmd/orb-cli/main.go
+++ b/cmd/orb-cli/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/trustbloc/orb/cmd/orb-cli/recoverdidcmd"
 	"github.com/trustbloc/orb/cmd/orb-cli/resolvedidcmd"
 	"github.com/trustbloc/orb/cmd/orb-cli/updatedidcmd"
+	"github.com/trustbloc/orb/cmd/orb-cli/vctcmd"
 	"github.com/trustbloc/orb/cmd/orb-cli/witnesscmd"
 )
 
@@ -69,6 +70,8 @@ func main() {
 
 	rootCmd.AddCommand(logmonitorcmd.GetCmd())
 	rootCmd.AddCommand(logcmd.GetCmd())
+
+	rootCmd.AddCommand(vctcmd.GetCmd())
 
 	if err := rootCmd.Execute(); err != nil {
 		logger.Fatalf("Failed to run orb-cli: %s", err.Error())

--- a/cmd/orb-cli/policycmd/policy.go
+++ b/cmd/orb-cli/policycmd/policy.go
@@ -19,9 +19,9 @@ const (
 		" Alternatively, this can be set with the following environment variable: " + urlEnvKey
 
 	policyFlagName  = "policy"
-	typeEnvKey      = "ORB_CLI_POLICY"
+	policyEnvKey    = "ORB_CLI_POLICY"
 	policyFlagUsage = `The witness policy. For example "MinPercent(100,batch) AND OutOf(1,system)".` +
-		" Alternatively, this can be set with the following environment variable: " + typeEnvKey
+		" Alternatively, this can be set with the following environment variable: " + policyEnvKey
 )
 
 // GetCmd returns the Cobra policy command.

--- a/cmd/orb-cli/policycmd/updatecmd.go
+++ b/cmd/orb-cli/policycmd/updatecmd.go
@@ -68,7 +68,7 @@ func getUpdateArgs(cmd *cobra.Command) (u, policy string, err error) {
 		return "", "", fmt.Errorf("invalid URL %s: %w", u, err)
 	}
 
-	policy, err = cmdutils.GetUserSetVarFromString(cmd, policyFlagName, typeEnvKey, false)
+	policy, err = cmdutils.GetUserSetVarFromString(cmd, policyFlagName, policyEnvKey, false)
 	if err != nil {
 		return "", "", err
 	}

--- a/cmd/orb-cli/vctcmd/vct.go
+++ b/cmd/orb-cli/vctcmd/vct.go
@@ -1,0 +1,53 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vctcmd
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	casURLFlagName  = "cas-url"
+	casURLEnvKey    = "ORB_CAS_URL"
+	casURLFlagUsage = "The URL of the CAS endpoint. If not specified then IPFS is assumed." +
+		" Alternatively, this can be set with the following environment variable: " + casURLEnvKey
+
+	anchorHashFlagName  = "anchor"
+	anchorHashEnvKey    = "ORB_CLI_ANCHOR"
+	anchorHashFlagUsage = `The hash of the anchor linkset.` +
+		" Alternatively, this can be set with the following environment variable: " + anchorHashEnvKey
+
+	verboseFlagName  = "verbose"
+	verboseEnvKey    = "ORB_CLI_VERBOSE"
+	verboseFlagUsage = `Sets verbose mode, i.e. additional information is output..` +
+		" Alternatively, this can be set with the following environment variable: " + verboseEnvKey
+
+	vctAuthTokenFlagName  = "vct-auth-token" //nolint:gosec
+	vctAuthTokenFlagUsage = "VCT auth token." +
+		" Alternatively, this can be set with the following environment variable: " + vctAuthTokenEnvKey
+	vctAuthTokenEnvKey = "ORB_CLI_VCT_AUTH_TOKEN" //nolint:gosec
+)
+
+// GetCmd returns the Cobra policy command.
+func GetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "vct",
+		Short:        "Examines the VCT log.",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("expecting subcommand: verify")
+		},
+	}
+
+	cmd.AddCommand(
+		newVerifyCmd(&clientProvider{}),
+	)
+
+	return cmd
+}

--- a/cmd/orb-cli/vctcmd/vct_test.go
+++ b/cmd/orb-cli/vctcmd/vct_test.go
@@ -1,0 +1,21 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vctcmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVCTCmd(t *testing.T) {
+	t.Run("test missing subcommand", func(t *testing.T) {
+		err := GetCmd().Execute()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "expecting subcommand: verify")
+	})
+}

--- a/cmd/orb-cli/vctcmd/verifycmd.go
+++ b/cmd/orb-cli/vctcmd/verifycmd.go
@@ -1,0 +1,350 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vctcmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/hyperledger/aries-framework-go/component/storageutil/cachedstore"
+	ariesmemstorage "github.com/hyperledger/aries-framework-go/component/storageutil/mem"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/ld"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+	ldstore "github.com/hyperledger/aries-framework-go/pkg/store/ld"
+	jsonld "github.com/piprate/json-gold/ld"
+	"github.com/spf13/cobra"
+	cmdutils "github.com/trustbloc/edge-core/pkg/utils/cmd"
+	"github.com/trustbloc/vct/pkg/client/vct"
+	"github.com/trustbloc/vct/pkg/controller/command"
+
+	"github.com/trustbloc/orb/cmd/orb-cli/common"
+	"github.com/trustbloc/orb/internal/pkg/ldcontext"
+	"github.com/trustbloc/orb/pkg/anchor/util"
+	"github.com/trustbloc/orb/pkg/linkset"
+)
+
+func newVerifyCmd(vctClientProvider vctClientProvider) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "verify",
+		Short: "Updates the witness policy.",
+		Long: `Verifies that a verifiable credential exists in the given VCT log. For example: vct verify ` +
+			`--vc-hash 98752bbb-0140-47ca-85ab-e725807c9ae8 --url https://orb.domain1.com/vc ` +
+			`--vct-url https://orb.vct/maple2022/v1`,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return executeVerify(cmd, vctClientProvider)
+		},
+	}
+
+	addUpdateFlags(cmd)
+
+	return cmd
+}
+
+func executeVerify(cmd *cobra.Command, vctClientProvider vctClientProvider) error {
+	casURL, anchorHash, authToken, verbose, err := getVerifyArgs(cmd)
+	if err != nil {
+		return err
+	}
+
+	vc, err := getVC(cmd, anchorHash, casURL, verbose)
+	if err != nil {
+		return err
+	}
+
+	if verbose {
+		common.Printf(cmd.OutOrStdout(), "Verifying %d proof(s) ...\n", len(vc.Proofs))
+	}
+
+	httpClient, err := common.NewHTTPClient(cmd)
+	if err != nil {
+		return fmt.Errorf("new HTTP client: %w", err)
+	}
+
+	var verifyResults []*verifyResult
+
+	for _, proof := range vc.Proofs {
+		result, e := verifyProof(cmd.OutOrStdout(), vc, proof, httpClient, authToken, verbose, vctClientProvider)
+		if e != nil {
+			common.Println(cmd.OutOrStdout(), e.Error())
+
+			continue
+		}
+
+		verifyResults = append(verifyResults, result)
+	}
+
+	resultBytes, err := json.MarshalIndent(verifyResults, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal verify results: %w", err)
+	}
+
+	common.Println(cmd.OutOrStdout(), string(resultBytes))
+
+	return nil
+}
+
+type vctClient interface {
+	GetSTH(ctx context.Context) (*command.GetSTHResponse, error)
+	GetProofByHash(ctx context.Context, hash string, treeSize uint64) (*command.GetProofByHashResponse, error)
+}
+
+type vctClientProvider interface {
+	GetVCTClient(domain string, opts ...vct.ClientOpt) vctClient
+}
+
+func verifyProof(out io.Writer, vc *verifiable.Credential, proof verifiable.Proof, httpClient *http.Client,
+	authToken string, verbose bool, vctClientProvider vctClientProvider,
+) (*verifyResult, error) {
+	domain, proofValue, createdTime, err := getVCParameters(proof)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &verifyResult{
+		Domain:     domain,
+		ProofValue: proofValue,
+	}
+
+	// calculates leaf hash for given timestamp and initial credential to be able to query proof by hash.
+	leafHash, err := vct.CalculateLeafHash(uint64(createdTime.UnixNano()/int64(time.Millisecond)), vc)
+	if err != nil {
+		result.Error = fmt.Errorf("calculate leaf hash: %w", err).Error()
+
+		return result, nil
+	}
+
+	// TODO: Auth read token should be per domain.
+	client := vctClientProvider.GetVCTClient(domain,
+		vct.WithHTTPClient(httpClient),
+		vct.WithAuthReadToken(authToken),
+	)
+
+	// Get the latest signed tree head to get the tree size.
+	sth, err := client.GetSTH(context.Background())
+	if err != nil {
+		result.Error = err.Error()
+
+		return result, nil //nolint:nilerr
+	}
+
+	if verbose {
+		common.Printf(out, "... retrieved STH from %s - Tree size: %d\n\n", domain, sth.TreeSize)
+	}
+
+	resp, err := client.GetProofByHash(context.Background(), leafHash, sth.TreeSize)
+	if err != nil {
+		if strings.Contains(err.Error(), "no proof") {
+			if verbose {
+				common.Printf(out, "... proof was NOT found in VCT log %s\n", domain)
+			}
+		} else {
+			result.Error = err.Error()
+		}
+
+		return result, nil
+	}
+
+	if verbose {
+		common.Printf(out, "... proof was found in VCT log %s at leaf index: %d\n", domain, resp.LeafIndex)
+	}
+
+	result.Found = true
+	result.Index = resp.LeafIndex
+	result.AuditPath = resp.AuditPath
+
+	return result, nil
+}
+
+func addUpdateFlags(cmd *cobra.Command) {
+	common.AddCommonFlags(cmd)
+
+	cmd.Flags().StringP(casURLFlagName, "", "", casURLFlagUsage)
+	cmd.Flags().StringP(anchorHashFlagName, "", "", anchorHashFlagUsage)
+	cmd.Flags().StringP(verboseFlagName, "", "false", verboseFlagUsage)
+	cmd.Flags().StringP(vctAuthTokenFlagName, "", "false", vctAuthTokenFlagUsage)
+}
+
+func getVerifyArgs(cmd *cobra.Command) (casURL, anchorHash, authToken string, verbose bool, err error) {
+	casURL = cmdutils.GetUserSetOptionalVarFromString(cmd, casURLFlagName, casURLEnvKey)
+
+	if casURL != "" {
+		_, err = url.Parse(casURL)
+		if err != nil {
+			return "", "", "", false, fmt.Errorf("invalid CAS URL %s: %w", casURL, err)
+		}
+	}
+
+	anchorHash, err = cmdutils.GetUserSetVarFromString(cmd, anchorHashFlagName, anchorHashEnvKey, false)
+	if err != nil {
+		return "", "", "", false, err
+	}
+
+	authToken = cmdutils.GetUserSetOptionalVarFromString(cmd, vctAuthTokenFlagName, vctAuthTokenEnvKey)
+
+	verboseStr := cmdutils.GetUserSetOptionalVarFromString(cmd, verboseFlagName, verboseEnvKey)
+	if verboseStr != "" {
+		verbose = true
+	}
+
+	return casURL, anchorHash, authToken, verbose, nil
+}
+
+func getVC(cmd *cobra.Command, anchorHash, casURL string, verbose bool) (*verifiable.Credential, error) {
+	var anchorLinksetBytes []byte
+
+	var err error
+
+	if casURL == "" {
+		anchorLinksetBytes, err = getFromIPFS(anchorHash)
+		if err != nil {
+			return nil, fmt.Errorf("get anchor linkset from IPFS: %w", err)
+		}
+	} else {
+		anchorLinksetBytes, err = common.SendHTTPRequest(cmd, nil, http.MethodGet,
+			fmt.Sprintf("%s/%s", casURL, anchorHash))
+		if err != nil {
+			return nil, fmt.Errorf("get anchor linkset from %s: %w", casURL, err)
+		}
+	}
+
+	if verbose {
+		common.Printf(cmd.OutOrStdout(), "Anchor linkset:\n%s\n\n", anchorLinksetBytes)
+	}
+
+	anchorLinkset := &linkset.Linkset{}
+
+	err = json.Unmarshal(anchorLinksetBytes, anchorLinkset)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal anchor linkset: %w", err)
+	}
+
+	docLoader, err := newDocumentLoader()
+	if err != nil {
+		return nil, fmt.Errorf("new document loader: %w", err)
+	}
+
+	vc, err := util.VerifiableCredentialFromAnchorLink(anchorLinkset.Link(),
+		verifiable.WithDisabledProofCheck(),
+		verifiable.WithJSONLDDocumentLoader(docLoader),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get verifiable credential from anchor link: %w", err)
+	}
+
+	if verbose {
+		vcBytes, err := json.MarshalIndent(vc, "", "  ")
+		if err != nil {
+			common.Printf(cmd.OutOrStdout(), "Verifiable credential: %s", err)
+		} else {
+			common.Printf(cmd.OutOrStdout(), "Verifiable credential:\n%s\n\n", vcBytes)
+		}
+	}
+
+	return vc, nil
+}
+
+func getFromIPFS(string) ([]byte, error) {
+	// TODO: Add support for IPFS.
+	return nil, errors.New("IPFS not supported")
+}
+
+func newDocumentLoader() (jsonld.DocumentLoader, error) {
+	ldStorageProvider := cachedstore.NewProvider(ariesmemstorage.NewProvider(), ariesmemstorage.NewProvider())
+
+	contextStore, err := ldstore.NewContextStore(ldStorageProvider)
+	if err != nil {
+		return nil, fmt.Errorf("create JSON-LD context store: %w", err)
+	}
+
+	remoteProviderStore, err := ldstore.NewRemoteProviderStore(ldStorageProvider)
+	if err != nil {
+		return nil, fmt.Errorf("create remote provider store: %w", err)
+	}
+
+	ldStore := &ldStoreProvider{
+		ContextStore:        contextStore,
+		RemoteProviderStore: remoteProviderStore,
+	}
+
+	docLoader, err := createJSONLDDocumentLoader(ldStore)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load Orb contexts: %w", err)
+	}
+
+	return docLoader, nil
+}
+
+func createJSONLDDocumentLoader(ldStore *ldStoreProvider) (jsonld.DocumentLoader, error) {
+	loaderOpts := []ld.DocumentLoaderOpts{ld.WithExtraContexts(ldcontext.MustGetAll()...)}
+
+	loader, err := ld.NewDocumentLoader(ldStore, loaderOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("new document loader: %w", err)
+	}
+
+	return loader, nil
+}
+
+func getVCParameters(proof verifiable.Proof) (domain, proofValue string, created time.Time, err error) {
+	d, ok := proof["domain"]
+	if !ok {
+		return "", "", time.Time{}, errors.New("'domain' not found in VC")
+	}
+
+	v, ok := proof["proofValue"]
+	if !ok {
+		return "", "", time.Time{}, errors.New("'proofValue' not found in VC")
+	}
+
+	c, ok := proof["created"]
+	if !ok {
+		return "", "", time.Time{}, errors.New("'created' not found in VC")
+	}
+
+	createdTime, err := time.Parse(time.RFC3339, c.(string))
+	if err != nil {
+		return "", "", time.Time{}, fmt.Errorf("parse 'created': %w", err)
+	}
+
+	return d.(string), v.(string), createdTime, nil
+}
+
+type ldStoreProvider struct {
+	ContextStore        ldstore.ContextStore
+	RemoteProviderStore ldstore.RemoteProviderStore
+}
+
+func (p *ldStoreProvider) JSONLDContextStore() ldstore.ContextStore {
+	return p.ContextStore
+}
+
+func (p *ldStoreProvider) JSONLDRemoteProviderStore() ldstore.RemoteProviderStore {
+	return p.RemoteProviderStore
+}
+
+type verifyResult struct {
+	Domain     string   `json:"domain"`
+	ProofValue string   `json:"proofValue"`
+	Found      bool     `json:"found"`
+	Index      int64    `json:"leafIndex"`
+	AuditPath  [][]byte `json:"auditPath"`
+	Error      string   `json:"error,omitempty"`
+}
+
+type clientProvider struct{}
+
+func (p *clientProvider) GetVCTClient(domain string, opts ...vct.ClientOpt) vctClient {
+	return vct.New(domain, opts...)
+}

--- a/cmd/orb-cli/vctcmd/verifycmd_test.go
+++ b/cmd/orb-cli/vctcmd/verifycmd_test.go
@@ -1,0 +1,275 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vctcmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/vct/pkg/client/vct"
+	"github.com/trustbloc/vct/pkg/controller/command"
+)
+
+const (
+	flag = "--"
+)
+
+func TestVerifyCmd(t *testing.T) {
+	t.Run("test missing url arg", func(t *testing.T) {
+		cmd := GetCmd()
+		cmd.SetArgs([]string{"verify"})
+
+		err := cmd.Execute()
+
+		require.Error(t, err)
+		require.Equal(t,
+			"Neither anchor (command line flag) nor ORB_CLI_ANCHOR (environment variable) have been set.",
+			err.Error())
+	})
+
+	t.Run("test invalid url arg", func(t *testing.T) {
+		cmd := GetCmd()
+
+		args := []string{"verify"}
+		args = append(args, urlArg(":invalid")...)
+		cmd.SetArgs(args)
+
+		err := cmd.Execute()
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing protocol scheme")
+	})
+
+	t.Run("test missing anchor arg", func(t *testing.T) {
+		cmd := GetCmd()
+
+		args := []string{"verify"}
+		args = append(args, urlArg("localhost:8080")...)
+		cmd.SetArgs(args)
+
+		err := cmd.Execute()
+
+		require.Error(t, err)
+		require.Equal(t,
+			"Neither anchor (command line flag) nor ORB_CLI_ANCHOR (environment variable) have been set.",
+			err.Error())
+	})
+
+	t.Run("verify -> success", func(t *testing.T) {
+		serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, err := fmt.Fprint(w, anchorLinkset)
+			require.NoError(t, err)
+		}))
+
+		cmd := GetCmd()
+
+		args := []string{"verify"}
+		args = append(args, urlArg(serv.URL)...)
+		args = append(args, anchorHashArg("uEiDuIicNljP8PoHJk6_aA7w1d4U3FAvDMfF7Dsh7fkw3Wg")...)
+		args = append(args, verboseArg(true)...)
+		cmd.SetArgs(args)
+
+		cmd.SetArgs(args)
+		err := cmd.Execute()
+
+		require.NoError(t, err)
+	})
+}
+
+func TestExecuteVerify(t *testing.T) {
+	const anchorHash = "uEiDuIicNljP8PoHJk6_aA7w1d4U3FAvDMfF7Dsh7fkw3Wg"
+
+	serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := fmt.Fprint(w, anchorLinkset)
+		require.NoError(t, err)
+	}))
+
+	t.Run("success", func(t *testing.T) {
+		vctClient := &mockVCTClient{
+			getSTHResponse: &command.GetSTHResponse{},
+			getProofByHashResponse: &command.GetProofByHashResponse{
+				LeafIndex: 1000,
+				AuditPath: [][]byte{[]byte("fsfsfei34893hwjkh")},
+			},
+		}
+
+		cmd := newVerifyCmd(&mockVCTClientProvider{client: vctClient})
+
+		out := bytes.NewBuffer(nil)
+		cmd.SetOut(out)
+
+		args := []string{}
+		args = append(args, urlArg(serv.URL)...)
+		args = append(args, anchorHashArg(anchorHash)...)
+		args = append(args, verboseArg(true)...)
+		cmd.SetArgs(args)
+		err := cmd.Execute()
+
+		require.NoError(t, err)
+
+		outStr := out.String()
+
+		require.Containsf(t, outStr, "Anchor linkset:", "Output should contain anchor linkset in verbose mode")
+		require.Contains(t, outStr, `"found": true`)
+		require.Contains(t, outStr, `"leafIndex": 1000`)
+	})
+
+	t.Run("no proof -> success", func(t *testing.T) {
+		vctClient := &mockVCTClient{
+			getSTHResponse:    &command.GetSTHResponse{},
+			getProofByHashErr: errors.New("no proof"),
+		}
+
+		cmd := newVerifyCmd(&mockVCTClientProvider{client: vctClient})
+
+		out := bytes.NewBuffer(nil)
+		cmd.SetOut(out)
+
+		args := []string{}
+		args = append(args, urlArg(serv.URL)...)
+		args = append(args, anchorHashArg(anchorHash)...)
+		args = append(args, verboseArg(true)...)
+		cmd.SetArgs(args)
+		err := cmd.Execute()
+
+		require.NoError(t, err)
+
+		outStr := out.String()
+
+		require.Contains(t, outStr, `"found": false`)
+	})
+
+	t.Run("getProofByHash error", func(t *testing.T) {
+		vctClient := &mockVCTClient{
+			getSTHResponse:    &command.GetSTHResponse{},
+			getProofByHashErr: errors.New("injected error"),
+		}
+
+		cmd := newVerifyCmd(&mockVCTClientProvider{client: vctClient})
+
+		out := bytes.NewBuffer(nil)
+		cmd.SetOut(out)
+
+		args := []string{}
+		args = append(args, urlArg(serv.URL)...)
+		args = append(args, anchorHashArg(anchorHash)...)
+		cmd.SetArgs(args)
+		err := cmd.Execute()
+
+		require.NoError(t, err)
+
+		outStr := out.String()
+
+		require.NotContainsf(t, outStr, "Anchor linkset:",
+			"Output should not contain anchor linkset in non-verbose mode")
+		require.Contains(t, outStr, `"error": "injected error"`)
+	})
+
+	t.Run("getSTH error", func(t *testing.T) {
+		vctClient := &mockVCTClient{
+			getSTHErr: errors.New("injected error"),
+		}
+
+		cmd := newVerifyCmd(&mockVCTClientProvider{client: vctClient})
+
+		out := bytes.NewBuffer(nil)
+		cmd.SetOut(out)
+
+		args := []string{}
+		args = append(args, urlArg(serv.URL)...)
+		args = append(args, anchorHashArg(anchorHash)...)
+		cmd.SetArgs(args)
+		err := cmd.Execute()
+
+		require.NoError(t, err)
+
+		outStr := out.String()
+
+		require.Contains(t, outStr, `"error": "injected error"`)
+	})
+
+	t.Run("IPFS CAS -> error (not supported yet)", func(t *testing.T) {
+		cmd := newVerifyCmd(&mockVCTClientProvider{})
+
+		args := []string{}
+		args = append(args, anchorHashArg(anchorHash)...)
+		cmd.SetArgs(args)
+
+		require.Contains(t, cmd.Execute().Error(), "IPFS not supported")
+	})
+}
+
+func urlArg(value string) []string {
+	return []string{flag + casURLFlagName, value}
+}
+
+func anchorHashArg(value string) []string {
+	return []string{flag + anchorHashFlagName, value}
+}
+
+func verboseArg(value bool) []string {
+	return []string{flag + verboseFlagName, strconv.FormatBool(value)}
+}
+
+type mockVCTClient struct {
+	getSTHResponse         *command.GetSTHResponse
+	getSTHErr              error
+	getProofByHashResponse *command.GetProofByHashResponse
+	getProofByHashErr      error
+}
+
+func (m *mockVCTClient) GetSTH(ctx context.Context) (*command.GetSTHResponse, error) {
+	return m.getSTHResponse, m.getSTHErr
+}
+
+func (m *mockVCTClient) GetProofByHash(ctx context.Context, hash string,
+	treeSize uint64) (*command.GetProofByHashResponse, error) {
+	return m.getProofByHashResponse, m.getProofByHashErr
+}
+
+type mockVCTClientProvider struct {
+	client *mockVCTClient
+}
+
+func (m *mockVCTClientProvider) GetVCTClient(domain string, opts ...vct.ClientOpt) vctClient {
+	return m.client
+}
+
+//nolint:lll
+const anchorLinkset = `{
+  "linkset": [
+    {
+      "anchor": "hl:uEiAb66vKOMWatEz861QsrpvTtEFlqftmfw_zGtX7cAlxBQ",
+      "author": "https://orb.domain1.com/services/orb",
+      "original": [
+        {
+          "href": "data:application/gzip;base64,H4sIAAAAAAAA/0zO3U7CMBjG8Xt5PZ2bjMikZ003F6ZmqSjRGEK2frDCtmI/gEh272bGA46fPPn9L9Cqfm+FA/R1gapnjTaAoGmRzxSxZLOZxvXiXNBSuvxhkdA5vpeT9OO9TPAPk0/0tCJvLpltIYDKu/+3cweLokibOuS6q1Q/CZnuIivMUTFhxwECUE50f2xjhAQEXHGkTY08xhhliqxM9jzH3JPvZCf3cRk7tjzn6etuaVNDXx7r27zNi1nhPykM6wAORkvViquA01TxUJvtCN4c72BYD78BAAD//6YQJM3xAAAA",
+          "type": "application/linkset+json"
+        }
+      ],
+      "profile": "https://w3id.org/orb#v0",
+      "related": [
+        {
+          "href": "data:application/gzip;base64,H4sIAAAAAAAA/zzN4XKaMAAA4HfJ/nbTQEXlnxMspYIXpgjZ9TwIUNCEpCEGG893320/9gDffXdAu/4y1Aq4v++g6EnLJXBBS92r361Kx9Fvu+hYKN8sHIgGKfRe+Rv62SjWjCfzorI5WdHbTwSegJC86Wj9lyslBncyGe2u+sHlx4TL8puegiegu+Lf1Mq6+f+sh/XpZFvl6y1Eu0a9LF7naLmaNdDLDrv5ypDmDY3peq/mzod75ej7uvYVr4JkJIbrrbX8yrvZpbRgWxyfb1sW6/LX8pxnka4OqUB27GVwYSIWhrUvkr2Fp4lpwxj6M7RPWXRI8vSwsFEmzviikgpiLw2QHbPqGTE64j5ytl/LLj9iSVgqMIMd8YhNgupKrIoSe8MLL4XlOaGlCS8R86e1hyG2W4mDVuV9ootAfOb9RpIs1pGJYIHA4/3x/vgTAAD//4Gr2I5/AQAA",
+          "type": "application/linkset+json"
+        }
+      ],
+      "replies": [
+        {
+          "href": "data:application/gzip;base64,H4sIAAAAAAAA/6yU22+bSBjF/5fpazAw3Hla7GAcX4OxTXBVWQMMZmxuheHmKv/7ijRJu7uqNpX6zPnOOd/vQ/MN/BXkGcUdBfpnEFNaVDrLtm07aoVRXp5ZyPEqG5Q4xBklKKnYhgd3P4QCCV9kFQ7qktCerWpCccVe2oqBHOQ+KMchlCReex/5cgd+ZDq1f8EBBTqIE702ieHLcrPYrFxEzZsq83ZVFs2OmtPka0TTqD3dLPqkBEbSjW1wB0g4TL42yEt/FOYpIhk/CvKUbQJWwRgLCsaMAFWVESXoMwhqmFGRKqlIQYEYqYNNVdUoC/A9ohjoAHIQMpzE8NqOV3We1zltBGVZ5AT5+KrG5a+DwR0oyjyPgP7527Aqojj8lavKD47fh18dXw2bgOoqpyhsiooED/DefB/rssiroSiqKlxSkmcrTOM8fBMcUFIPn1e7eFWYXTZ1SYb9aTaPZ6RXxvOnx7hO50mbPyy3h9VX5j7xTqLtLq7ljPOZda8dO89Exbm9CLI8babGRtr7on895w+iMWCnfTH4m98v65BzhmhdvpVscEkiEqCfiukgJKHeYl//F6tP+whtHp37U+EYe9WHJ+vmpMcj7zV7pHbrpbPSpHF0m0nuxQbPd//HUxShIsnCf5j+80rw5yt9mOaGzDUva6RyW8b9AUn+ob2azd7wBM8O80WUW1qsZZZlnTZbaTc1JpvI7mzfFwmMRcPYZAi35/nYa+2d2Xc4dfmwv/9jNF92+sRf07U1m6eTRTdZzjw6ThbqgV7N/TFGxuSSGUrb9z3yzw/ch2hqH/474W/z1FLxYiU7U84bYw7PbrpPjorLOF7bSJYWKYL4RMO1HQV2GXS0uZ7NY6SETrSRGkecFofGu0DOu8Xazbwte5MIydWdGH+Kp/DCc+emC1VkynFSCY/uFLq16GacOV/bg8aVlh7nHrdbczVuwfOX9+jDSwbyEzx5f+nA898BAAD//4dCKH2QBQAA",
+          "type": "application/ld+json"
+        }
+      ]
+    }
+  ]
+}`

--- a/test/bdd/bddtests_test.go
+++ b/test/bdd/bddtests_test.go
@@ -114,7 +114,7 @@ func TestMain(m *testing.M) {
 		FeatureContext(s, state)
 	}, godog.Options{
 		Tags:          tags,
-		Format:        "progress",
+		Format:        "pretty",
 		Paths:         []string{"features"},
 		Randomize:     time.Now().UTC().UnixNano(), // randomize scenario execution order
 		Strict:        true,

--- a/test/bdd/cli_steps.go
+++ b/test/bdd/cli_steps.go
@@ -247,6 +247,8 @@ func (e *Steps) cliResolveDID() error {
 		return err
 	}
 
+	e.state.setResponse(value)
+
 	if strings.Contains(value, e.createdDID.ID) {
 		return nil
 	}
@@ -466,6 +468,8 @@ func (e *Steps) updateDID() error {
 
 	e.cliValue = value
 
+	e.state.setResponse(value)
+
 	return nil
 }
 
@@ -530,10 +534,16 @@ func (e *Steps) createDID() error {
 
 	e.cliValue = value
 
+	e.state.setResponse(value)
+
 	return nil
 }
 
 func (e *Steps) execute(argsStr string) error {
+	if err := e.state.resolveVarsInExpression(&argsStr); err != nil {
+		return err
+	}
+
 	value, err := execCMD(parseArgs(argsStr)...)
 	if err != nil {
 		return err

--- a/test/bdd/common_steps.go
+++ b/test/bdd/common_steps.go
@@ -1029,6 +1029,7 @@ func (d *CommonSteps) RegisterSteps(s *godog.Suite) {
 	s.Step(`^the JSON path '([^']*)' of the response equals "([^"]*)"$`, d.jsonPathOfResponseEquals)
 	s.Step(`^the JSON path "([^"]*)" of the numeric response equals "([^"]*)"$`, d.jsonPathOfNumericResponseEquals)
 	s.Step(`^the JSON path "([^"]*)" of the boolean response equals "([^"]*)"$`, d.jsonPathOfBoolResponseEquals)
+	s.Step(`^the JSON path '([^']*)' of the boolean response equals "([^"]*)"$`, d.jsonPathOfBoolResponseEquals)
 	s.Step(`^the JSON path "([^"]*)" of the response has (\d+) items$`, d.jsonPathOfResponseHasNumItems)
 	s.Step(`^the JSON path "([^"]*)" of the response contains "([^"]*)"$`, d.jsonPathOfResponseContains)
 	s.Step(`^the JSON path '([^']*)' of the response contains "([^"]*)"$`, d.jsonPathOfResponseContains)

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -18,8 +18,8 @@ require (
 	github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220428163625-96d8261511e1
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/orb v1.0.0-rc.1.0.20220428163625-96d8261511e1
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/sidetree v1.0.0-rc.1.0.20220428154356-41d198a5fade
-	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220428211718-66cc046674a1
-	github.com/hyperledger/aries-framework-go/spi v0.0.0-20220330140627-07042d78580c
+	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220516154446-0ba34929e05b
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20220516154446-0ba34929e05b
 	github.com/igor-pavlenko/httpsignatures-go v0.0.23
 	github.com/ipfs/go-ipfs-api v0.2.0
 	github.com/mr-tron/base58 v1.2.0

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -1000,8 +1000,9 @@ github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-202203220
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220324201531-18c87667df19/go.mod h1:ryG46jQRvQUUH/0wjORghfJnxJVH1yIXIsAv1GXIWp8=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220330133350-1c2d9d65aea4/go.mod h1:ryG46jQRvQUUH/0wjORghfJnxJVH1yIXIsAv1GXIWp8=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220330140627-07042d78580c/go.mod h1:ryG46jQRvQUUH/0wjORghfJnxJVH1yIXIsAv1GXIWp8=
-github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220428211718-66cc046674a1 h1:WSKq2EIrwKbBiN4ljdf10b5PjtVWzCyhuMldYNOeuwU=
 github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220428211718-66cc046674a1/go.mod h1:ryG46jQRvQUUH/0wjORghfJnxJVH1yIXIsAv1GXIWp8=
+github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220516154446-0ba34929e05b h1:G6t6RwcIOn9/0zK4ONVsViBaMAq4oqqzh9mT4WxYrY0=
+github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220516154446-0ba34929e05b/go.mod h1:ryG46jQRvQUUH/0wjORghfJnxJVH1yIXIsAv1GXIWp8=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210320144851-40976de98ccf/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210322152545-e6ebe2c79a2a/go.mod h1:fDr9wW00GJJl1lR1SFHmJW8utIocdvjO5RNhAYS05EY=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20210409151411-eeeb8508bd87/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
@@ -1025,8 +1026,9 @@ github.com/hyperledger/aries-framework-go/spi v0.0.0-20220308060532-714cd5c18552
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20220322085443-50e8f9bd208b/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20220324201531-18c87667df19/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20220330133350-1c2d9d65aea4/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20220330140627-07042d78580c h1:snzJfKNYzt57Q2/+P0YdCJus+K2k3c3fUTvOSoHSUxU=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20220330140627-07042d78580c/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20220516154446-0ba34929e05b h1:FKKAVz3KHByOxGyy6akY1T8RHlDuYPXiq+OeZB0NL8Q=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20220516154446-0ba34929e05b/go.mod h1:4bD5c5fj5K7rkQurVa/8I8+TfNcI4bxIBzaUNcxTOTg=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210324232048-34ff560ed041/go.mod h1:eKGEEe+PJNDQo7kVif3sUKBWwnsQDkE3gD/QlpmukcQ=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210409151411-eeeb8508bd87/go.mod h1:JHzDtgJLd0134iLFXLxGBjJF+Z+TgiElA/5oVgMazts=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210421203733-b5dfd703a8fc/go.mod h1:asiCVCtH/nocWKhZRMz12aFgdUh8lRHqKis0M8Ei/4I=


### PR DESCRIPTION
The orb-cli vct verify command verifies that the proofs of an anchor linkset are actually included in the VCT log.

closes #1302

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>