### PR TITLE
chore: specify a subnet for workplace VPN compatibility

### DIFF
--- a/samples/docker/docker-compose-dev-vct.yml
+++ b/samples/docker/docker-compose-dev-vct.yml
@@ -5,6 +5,15 @@
 #
 version: '2'
 
+networks:
+  orbnet:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: "172.28.0.0/24"
+          gateway: "172.28.0.1"
+
 services:
   orb-domain1:
     container_name: orb1.local
@@ -30,6 +39,8 @@ services:
     ports:
       - 48326:80
     command: start
+    networks:
+      - "orbnet"
 
   orb-domain2:
     container_name: orb2.local
@@ -55,6 +66,8 @@ services:
     ports:
       - 48426:80
     command: start
+    networks:
+      - "orbnet"
 
   orb.vct:
     container_name: orb.vct
@@ -75,6 +88,8 @@ services:
       - orb.file-server.com
       - orb.postgres
     command: start
+    networks:
+      - "orbnet"
 
   orb.trillian.log.server:
     container_name: orb.trillian.log.server
@@ -90,6 +105,8 @@ services:
       - orb.postgres
     ports:
       - 8090:8090
+    networks:
+      - "orbnet"
 
   orb.trillian.log.signer:
     container_name: orb.trillian.log.signer
@@ -106,6 +123,8 @@ services:
       - orb.postgres
     ports:
       - 8091:8091
+    networks:
+      - "orbnet"
 
   orb.postgres:
     container_name: orb.postgres
@@ -116,6 +135,8 @@ services:
       - POSTGRES_DB=test
     ports:
       - 5432:5432
+    networks:
+      - "orbnet"
 
   orb.file-server.com: # file server for hosting static resources (e.g. JSON-LD contexts)
     container_name: orb.file-server.com
@@ -130,3 +151,5 @@ services:
       - 12096:12096
     volumes:
       - ./contexts:/data
+    networks:
+      - "orbnet"

--- a/samples/docker/docker-compose-dev.yml
+++ b/samples/docker/docker-compose-dev.yml
@@ -5,6 +5,15 @@
 #
 version: '2'
 
+networks:
+  orbnet:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: "172.28.0.0/24"
+          gateway: "172.28.0.1"
+
 services:
 
   orb-domain1:
@@ -30,6 +39,8 @@ services:
     ports:
       - 80:80
     command: start
+    networks:
+      - "orbnet"
 
   orb-domain2:
     container_name: orb2.local
@@ -55,3 +66,5 @@ services:
       - 48426:443
       - 48827:48827
     command: start
+    networks:
+      - "orbnet"

--- a/samples/tutorial/docker-compose-cli.yml
+++ b/samples/tutorial/docker-compose-cli.yml
@@ -14,3 +14,5 @@ services:
     volumes:
       - ../../.build/extract/orb-cli-linux-amd64:/usr/local/sbin/orb-cli
       - .:/orb
+    networks:
+      - "orbnet"


### PR DESCRIPTION
Depending on the routes given out by workplace VPNs somebody may have
trouble running the tutorial when on a workplace VPN.

$ docker-compose -f docker-compose-cli.yml -f ../docker/docker-compose-dev.yml up
Creating network "tutorial_default" with the default driver
ERROR: could not find an available, non-overlapping IPv4 address pool among the defaults to assign to the network

By specifying the network used for all containers we can run all the
"up" parts of the docker-compose step without encountering this error.