### PR TITLE
feat: Add status to log entry store

### DIFF
--- a/pkg/store/logentry/store_test.go
+++ b/pkg/store/logentry/store_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb"
 	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
 	"github.com/hyperledger/aries-framework-go/component/storageutil/mock"
+	"github.com/hyperledger/aries-framework-go/spi/storage"
 	"github.com/stretchr/testify/require"
 	"github.com/trustbloc/vct/pkg/controller/command"
 
@@ -255,6 +256,500 @@ func TestStore_GetLogEntries(t *testing.T) {
 		iter, err := s.GetLogEntries("")
 		require.Error(t, err)
 		require.Nil(t, iter)
+		require.Contains(t, err.Error(), "missing log URL")
+	})
+}
+
+func TestStore_GetLogEntriesFrom(t *testing.T) {
+	t.Run("success - one entry", func(t *testing.T) {
+		mongoDBConnString, stopMongo := mongodbtestutil.StartMongoDB(t)
+		defer stopMongo()
+
+		mongoDBProvider, err := mongodb.NewProvider(mongoDBConnString)
+		require.NoError(t, err)
+
+		s, err := New(mongoDBProvider)
+		require.NoError(t, err)
+
+		testLeafInput := []byte("leafInput")
+
+		entries := []command.LeafEntry{{
+			LeafInput: testLeafInput,
+		}}
+
+		err = s.StoreLogEntries(logURL, 0, 0, entries)
+		require.NoError(t, err)
+
+		iter, err := s.GetLogEntriesFrom(logURL, 0)
+		require.NoError(t, err)
+
+		n, err := iter.TotalItems()
+		require.NoError(t, err)
+		require.Equal(t, 1, n)
+
+		entry, err := iter.Next()
+		require.NoError(t, err)
+		require.True(t, bytes.Equal(testLeafInput, entry.LeafInput))
+
+		err = iter.Close()
+		require.NoError(t, err)
+	})
+
+	t.Run("success - multiple entries", func(t *testing.T) {
+		mongoDBConnString, stopMongo := mongodbtestutil.StartMongoDB(t)
+		defer stopMongo()
+
+		mongoDBProvider, err := mongodb.NewProvider(mongoDBConnString)
+		require.NoError(t, err)
+
+		s, err := New(mongoDBProvider)
+		require.NoError(t, err)
+
+		test0 := []byte("leafInput-0")
+		test1 := []byte("leafInput-1")
+
+		entries := []command.LeafEntry{
+			{
+				LeafInput: test0,
+			},
+			{
+				LeafInput: test1,
+			},
+		}
+
+		err = s.StoreLogEntries(logURL, 0, 1, entries)
+		require.NoError(t, err)
+
+		time.Sleep(time.Second)
+
+		iter, err := s.GetLogEntriesFrom(logURL, 1)
+		require.NoError(t, err)
+
+		n, err := iter.TotalItems()
+		require.NoError(t, err)
+		require.Equal(t, 1, n)
+
+		entry, err := iter.Next()
+		require.NoError(t, err)
+		require.True(t, bytes.Equal(test1, entry.LeafInput))
+
+		err = iter.Close()
+		require.NoError(t, err)
+	})
+
+	t.Run("error - no entries", func(t *testing.T) {
+		mongoDBConnString, stopMongo := mongodbtestutil.StartMongoDB(t)
+		defer stopMongo()
+
+		mongoDBProvider, err := mongodb.NewProvider(mongoDBConnString)
+		require.NoError(t, err)
+
+		s, err := New(mongoDBProvider)
+		require.NoError(t, err)
+
+		iter, err := s.GetLogEntriesFrom(logURL, 1)
+		require.NoError(t, err)
+
+		n, err := iter.TotalItems()
+		require.NoError(t, err)
+		require.Equal(t, 0, n)
+
+		entry, err := iter.Next()
+		require.Error(t, err)
+		require.Nil(t, entry)
+		require.Contains(t, err.Error(), "data not found")
+
+		err = iter.Close()
+		require.NoError(t, err)
+	})
+
+	t.Run("error - empty log URL", func(t *testing.T) {
+		provider := mem.NewProvider()
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		iter, err := s.GetLogEntriesFrom("", 0)
+		require.Error(t, err)
+		require.Nil(t, iter)
+		require.Contains(t, err.Error(), "missing log URL")
+	})
+}
+
+func TestStore_FailLogEntriesFrom(t *testing.T) {
+	t.Run("success - one entry", func(t *testing.T) {
+		mongoDBConnString, stopMongo := mongodbtestutil.StartMongoDB(t)
+		defer stopMongo()
+
+		mongoDBProvider, err := mongodb.NewProvider(mongoDBConnString)
+		require.NoError(t, err)
+
+		s, err := New(mongoDBProvider)
+		require.NoError(t, err)
+
+		testLeafInput := []byte("leafInput")
+
+		entries := []command.LeafEntry{{
+			LeafInput: testLeafInput,
+		}}
+
+		err = s.StoreLogEntries(logURL, 0, 0, entries)
+		require.NoError(t, err)
+
+		iter, err := s.GetLogEntriesFrom(logURL, 0)
+		require.NoError(t, err)
+
+		n, err := iter.TotalItems()
+		require.NoError(t, err)
+		require.Equal(t, 1, n)
+
+		err = iter.Close()
+		require.NoError(t, err)
+
+		err = s.FailLogEntriesFrom(logURL, 0)
+		require.NoError(t, err)
+
+		time.Sleep(time.Second)
+
+		iter, err = s.GetLogEntriesFrom(logURL, 0)
+		require.NoError(t, err)
+
+		n, err = iter.TotalItems()
+		require.NoError(t, err)
+		require.Equal(t, 0, n)
+
+		err = iter.Close()
+		require.NoError(t, err)
+
+		iter, err = s.GetFailedLogEntries(logURL)
+		require.NoError(t, err)
+
+		n, err = iter.TotalItems()
+		require.NoError(t, err)
+		require.Equal(t, 1, n)
+
+		err = iter.Close()
+		require.NoError(t, err)
+	})
+
+	t.Run("success - multiple entries(split)", func(t *testing.T) {
+		mongoDBConnString, stopMongo := mongodbtestutil.StartMongoDB(t)
+		defer stopMongo()
+
+		mongoDBProvider, err := mongodb.NewProvider(mongoDBConnString)
+		require.NoError(t, err)
+
+		s, err := New(mongoDBProvider)
+		require.NoError(t, err)
+
+		test0 := []byte("leafInput-0")
+		test1 := []byte("leafInput-1")
+
+		entries := []command.LeafEntry{
+			{
+				LeafInput: test0,
+			},
+			{
+				LeafInput: test1,
+			},
+		}
+
+		err = s.StoreLogEntries(logURL, 0, 1, entries)
+		require.NoError(t, err)
+
+		time.Sleep(time.Second)
+
+		iter, err := s.GetLogEntries(logURL)
+		require.NoError(t, err)
+
+		n, err := iter.TotalItems()
+		require.NoError(t, err)
+		require.Equal(t, 2, n)
+
+		err = s.FailLogEntriesFrom(logURL, 1)
+		require.NoError(t, err)
+
+		time.Sleep(time.Second)
+
+		iter, err = s.GetLogEntriesFrom(logURL, 0)
+		require.NoError(t, err)
+
+		n, err = iter.TotalItems()
+		require.NoError(t, err)
+		require.Equal(t, 1, n)
+
+		err = iter.Close()
+		require.NoError(t, err)
+
+		iter, err = s.GetFailedLogEntries(logURL)
+		require.NoError(t, err)
+
+		n, err = iter.TotalItems()
+		require.NoError(t, err)
+		require.Equal(t, 1, n)
+
+		err = iter.Close()
+		require.NoError(t, err)
+	})
+
+	t.Run("success - multiple entries (all)", func(t *testing.T) {
+		mongoDBConnString, stopMongo := mongodbtestutil.StartMongoDB(t)
+		defer stopMongo()
+
+		mongoDBProvider, err := mongodb.NewProvider(mongoDBConnString)
+		require.NoError(t, err)
+
+		s, err := New(mongoDBProvider)
+		require.NoError(t, err)
+
+		test0 := []byte("leafInput-0")
+		test1 := []byte("leafInput-1")
+
+		entries := []command.LeafEntry{
+			{
+				LeafInput: test0,
+			},
+			{
+				LeafInput: test1,
+			},
+		}
+
+		err = s.StoreLogEntries(logURL, 0, 1, entries)
+		require.NoError(t, err)
+
+		time.Sleep(time.Second)
+
+		iter, err := s.GetLogEntries(logURL)
+		require.NoError(t, err)
+
+		n, err := iter.TotalItems()
+		require.NoError(t, err)
+		require.Equal(t, 2, n)
+
+		err = s.FailLogEntriesFrom(logURL, 0)
+		require.NoError(t, err)
+
+		time.Sleep(time.Second)
+
+		iter, err = s.GetFailedLogEntries(logURL)
+		require.NoError(t, err)
+
+		n, err = iter.TotalItems()
+		require.NoError(t, err)
+		require.Equal(t, 2, n)
+
+		err = iter.Close()
+		require.NoError(t, err)
+
+		iter, err = s.GetLogEntries(logURL)
+		require.NoError(t, err)
+
+		n, err = iter.TotalItems()
+		require.NoError(t, err)
+		require.Equal(t, 0, n)
+
+		err = iter.Close()
+		require.NoError(t, err)
+	})
+
+	t.Run("success - no entries", func(t *testing.T) {
+		mongoDBConnString, stopMongo := mongodbtestutil.StartMongoDB(t)
+		defer stopMongo()
+
+		mongoDBProvider, err := mongodb.NewProvider(mongoDBConnString)
+		require.NoError(t, err)
+
+		s, err := New(mongoDBProvider)
+		require.NoError(t, err)
+
+		err = s.FailLogEntriesFrom(logURL, 1)
+		require.NoError(t, err)
+	})
+
+	t.Run("error - empty log URL", func(t *testing.T) {
+		provider := mem.NewProvider()
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		err = s.FailLogEntriesFrom("", 0)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing log URL")
+	})
+
+	t.Run("error - query error", func(t *testing.T) {
+		store := &mocks.Store{}
+		store.QueryReturns(nil, fmt.Errorf("query error"))
+
+		provider := &mocks.Provider{}
+		provider.OpenStoreReturns(store, nil)
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		err = s.FailLogEntriesFrom(logURL, 0)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "query error")
+	})
+
+	t.Run("error - iterator next() error ", func(t *testing.T) {
+		iterator := &mocks.Iterator{}
+		iterator.NextReturns(false, fmt.Errorf("iterator next() error"))
+
+		store := &mocks.Store{}
+		store.QueryReturns(iterator, nil)
+
+		provider := &mocks.Provider{}
+		provider.OpenStoreReturns(store, nil)
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		err = s.FailLogEntriesFrom(logURL, 0)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "iterator next() error")
+	})
+
+	t.Run("error - iterator tags() error ", func(t *testing.T) {
+		iterator := &mocks.Iterator{}
+
+		iterator.NextReturnsOnCall(0, true, nil)
+		iterator.NextReturnsOnCall(1, false, nil)
+
+		iterator.TagsReturns(nil, fmt.Errorf("iterator tags() error"))
+
+		store := &mocks.Store{}
+		store.QueryReturns(iterator, nil)
+
+		provider := &mocks.Provider{}
+		provider.OpenStoreReturns(store, nil)
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		err = s.FailLogEntriesFrom(logURL, 0)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "iterator tags() error")
+	})
+
+	t.Run("error - iterator key() error ", func(t *testing.T) {
+		iterator := &mocks.Iterator{}
+
+		iterator.NextReturnsOnCall(0, true, nil)
+		iterator.NextReturnsOnCall(1, false, nil)
+
+		iterator.TagsReturns([]storage.Tag{{Name: statusTagName, Value: string(EntryStatusSuccess)}}, nil)
+
+		iterator.KeyReturns("", fmt.Errorf("iterator key() error"))
+
+		store := &mocks.Store{}
+		store.QueryReturns(iterator, nil)
+
+		provider := &mocks.Provider{}
+		provider.OpenStoreReturns(store, nil)
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		err = s.FailLogEntriesFrom(logURL, 0)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "iterator key() error")
+	})
+
+	t.Run("error - iterator second next() error ", func(t *testing.T) {
+		iterator := &mocks.Iterator{}
+		iterator.NextReturnsOnCall(0, true, nil)
+		iterator.NextReturnsOnCall(1, false, fmt.Errorf("iterator second next() error"))
+
+		store := &mocks.Store{}
+		store.QueryReturns(iterator, nil)
+
+		provider := &mocks.Provider{}
+		provider.OpenStoreReturns(store, nil)
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		err = s.FailLogEntriesFrom(logURL, 0)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "iterator second next() error")
+	})
+}
+
+func TestStore_GetFailedLogEntries(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mongoDBConnString, stopMongo := mongodbtestutil.StartMongoDB(t)
+		defer stopMongo()
+
+		mongoDBProvider, err := mongodb.NewProvider(mongoDBConnString)
+		require.NoError(t, err)
+
+		s, err := New(mongoDBProvider)
+		require.NoError(t, err)
+
+		test0 := []byte("leafInput-0")
+		test1 := []byte("leafInput-1")
+
+		entries := []command.LeafEntry{
+			{
+				LeafInput: test0,
+			},
+			{
+				LeafInput: test1,
+			},
+		}
+
+		err = s.StoreLogEntries(logURL, 0, 1, entries)
+		require.NoError(t, err)
+
+		err = s.FailLogEntriesFrom(logURL, 0)
+		require.NoError(t, err)
+
+		iter, err := s.GetFailedLogEntries(logURL)
+		require.NoError(t, err)
+
+		n, err := iter.TotalItems()
+		require.NoError(t, err)
+		require.Equal(t, 2, n)
+
+		entry, err := iter.Next()
+		require.NoError(t, err)
+		require.True(t, bytes.Equal(test0, entry.LeafInput))
+
+		entry, err = iter.Next()
+		require.NoError(t, err)
+		require.True(t, bytes.Equal(test1, entry.LeafInput))
+	})
+
+	t.Run("error - no entries", func(t *testing.T) {
+		mongoDBConnString, stopMongo := mongodbtestutil.StartMongoDB(t)
+		defer stopMongo()
+
+		mongoDBProvider, err := mongodb.NewProvider(mongoDBConnString)
+		require.NoError(t, err)
+
+		s, err := New(mongoDBProvider)
+		require.NoError(t, err)
+
+		iter, err := s.GetFailedLogEntries(logURL)
+		require.NoError(t, err)
+		require.NotNil(t, iter)
+
+		entry, err := iter.Next()
+		require.Error(t, err)
+		require.Nil(t, entry)
+		require.Contains(t, err.Error(), "data not found")
+	})
+
+	t.Run("error - empty log URL", func(t *testing.T) {
+		provider := mem.NewProvider()
+
+		s, err := New(provider)
+		require.NoError(t, err)
+
+		entries, err := s.GetFailedLogEntries("")
+		require.Error(t, err)
+		require.Nil(t, entries)
 		require.Contains(t, err.Error(), "missing log URL")
 	})
 }


### PR DESCRIPTION
Log entry store should be able to mark 'failed' entries so they can be examined later on.

Closes #1321

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>