### PR TITLE
feat: Orb node should detect unexpected VCT log changes

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -812,6 +812,7 @@ func startOrbServices(parameters *orbParameters) error {
 		}
 
 		logMonitoringOpts = append(logMonitoringOpts,
+			logmonitoring.WithLogEntriesStoreEnabled(true),
 			logmonitoring.WithLogEntriesStore(logEntryStore))
 	}
 

--- a/test/bdd/features/onboard-recovery.feature
+++ b/test/bdd/features/onboard-recovery.feature
@@ -235,6 +235,13 @@ Feature:
     When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with interim did
     Then check success response contains "canonicalId"
 
+    When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to create DID document
+    Then check success response contains "#interimDID"
+    Then we wait 2 seconds
+
+    When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with interim did
+    Then check success response contains "canonicalId"
+
     # Take a backup of VCT database (tree size = X)
     # JSON-LD contexts are also stored in Postgres so there will be more than one db (test + JSON-LD contexts)
     When command "pg_dumpall -f pgdbbackup -h localhost -p 5432" is executed

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -139,6 +139,7 @@ services:
       - ANCHOR_DATA_URI_MEDIA_TYPE=application/gzip;base64
       - INCLUDE_PUBLISHED_OPERATIONS_IN_METADATA=true
       - ORB_REQUEST_TOKENS=vct-read=vctread,vct-write=vctwrite
+      - VCT_LOG_ENTRIES_STORE_ENABLED=true
     ports:
       - 48326:443
       - 48327:48327
@@ -272,6 +273,7 @@ services:
       - ANCHOR_DATA_URI_MEDIA_TYPE=application/gzip;base64
       - INCLUDE_PUBLISHED_OPERATIONS_IN_METADATA=true
       - ORB_REQUEST_TOKENS=vct-read=vctread,vct-write=vctwrite
+      - VCT_LOG_ENTRIES_STORE_ENABLED=true
     ports:
       - 48526:443
       - 48527:48527


### PR DESCRIPTION
When Orb server detects that VCT log tree size is behind recorded Orb tree size (which can happen in case that VCT DB is restored from back-up) currently it generates and logs an error.

Instead:
- log that anomaly was detected for stored and log tree size
- flag missing log entries in entry store as failed in log entry DB so they can be identified later on
- adjust current Orb tree size (STH) so that VCT log consistency check can proceed as usual.

Closes #1318

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>