### PR TITLE
feat: Optimized stores for anchor/VC

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -703,7 +703,7 @@ func startOrbServices(parameters *orbParameters) error {
 		return fmt.Errorf("failed to create vc builder: %s", err.Error())
 	}
 
-	alStore, err := anchorlinkstore.New(storeProviders.provider, orbDocumentLoader)
+	alStore, err := anchorlinkstore.New(storeProviders.provider)
 	if err != nil {
 		return fmt.Errorf("failed to create anchor event store: %s", err.Error())
 	}
@@ -973,7 +973,7 @@ func startOrbServices(parameters *orbParameters) error {
 
 	go monitorActivities(activityPubService.Subscribe(), logger)
 
-	vcStore, err := storeProviders.provider.OpenStore("verifiable")
+	vcStore, err := store.Open(storeProviders.provider, "verifiable")
 	if err != nil {
 		return fmt.Errorf("open store: %w", err)
 	}

--- a/pkg/anchor/handler/proof/handler_test.go
+++ b/pkg/anchor/handler/proof/handler_test.go
@@ -45,7 +45,7 @@ const (
 func TestNew(t *testing.T) {
 	ps := mempubsub.New(mempubsub.Config{})
 
-	store, err := anchorlinkstore.New(mem.NewProvider(), testutil.GetLoader(t))
+	store, err := anchorlinkstore.New(mem.NewProvider())
 	require.NoError(t, err)
 
 	providers := &Providers{
@@ -68,7 +68,7 @@ func TestWitnessProofHandler(t *testing.T) {
 	expiryTime := time.Now().Add(60 * time.Second)
 
 	t.Run("success - witness policy not satisfied", func(t *testing.T) {
-		aeStore, err := anchorlinkstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		aeStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		als := &linkset.Linkset{}
@@ -123,7 +123,7 @@ func TestWitnessProofHandler(t *testing.T) {
 	})
 
 	t.Run("success - witness policy satisfied", func(t *testing.T) {
-		aeStore, err := anchorlinkstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		aeStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		als := &linkset.Linkset{}
@@ -173,7 +173,7 @@ func TestWitnessProofHandler(t *testing.T) {
 	})
 
 	t.Run("success - status is completed", func(t *testing.T) {
-		aeStore, err := anchorlinkstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		aeStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		als := &linkset.Linkset{}
@@ -209,7 +209,7 @@ func TestWitnessProofHandler(t *testing.T) {
 	})
 
 	t.Run("success - policy satisfied but some witness proofs are empty", func(t *testing.T) {
-		aeStore, err := anchorlinkstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		aeStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		als := &linkset.Linkset{}
@@ -252,7 +252,7 @@ func TestWitnessProofHandler(t *testing.T) {
 	})
 
 	t.Run("success - duplicate proofs", func(t *testing.T) {
-		aeStore, err := anchorlinkstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		aeStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		als := &linkset.Linkset{}
@@ -302,7 +302,7 @@ func TestWitnessProofHandler(t *testing.T) {
 	})
 
 	t.Run("error - get status error", func(t *testing.T) {
-		aeStore, err := anchorlinkstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		aeStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		als := &linkset.Linkset{}
@@ -348,7 +348,7 @@ func TestWitnessProofHandler(t *testing.T) {
 	})
 
 	t.Run("error - second get status error", func(t *testing.T) {
-		aeStore, err := anchorlinkstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		aeStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		als := &linkset.Linkset{}
@@ -387,7 +387,7 @@ func TestWitnessProofHandler(t *testing.T) {
 	})
 
 	t.Run("error - set status to complete error", func(t *testing.T) {
-		aeStore, err := anchorlinkstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		aeStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		als := &linkset.Linkset{}
@@ -425,7 +425,7 @@ func TestWitnessProofHandler(t *testing.T) {
 	})
 
 	t.Run("status already completed", func(t *testing.T) {
-		aeStore, err := anchorlinkstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		aeStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		als := &linkset.Linkset{}
@@ -473,7 +473,7 @@ func TestWitnessProofHandler(t *testing.T) {
 	})
 
 	t.Run("error - witness policy error", func(t *testing.T) {
-		aeStore, err := anchorlinkstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		aeStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		als := &linkset.Linkset{}
@@ -511,7 +511,7 @@ func TestWitnessProofHandler(t *testing.T) {
 	})
 
 	t.Run("error - status not found store error", func(t *testing.T) {
-		aeStore, err := anchorlinkstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		aeStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		als := &linkset.Linkset{}
@@ -541,7 +541,7 @@ func TestWitnessProofHandler(t *testing.T) {
 		err = proofHandler.HandleProof(witnessIRI, "testVC",
 			expiryTime, []byte(witnessProof))
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "status not found for anchor event[testVC]")
+		require.Contains(t, err.Error(), "status not found for anchor [testVC]")
 	})
 
 	t.Run("error - store error", func(t *testing.T) {
@@ -551,7 +551,7 @@ func TestWitnessProofHandler(t *testing.T) {
 		provider := &storemocks.Provider{}
 		provider.OpenStoreReturns(store, nil)
 
-		aeStore, err := anchorlinkstore.New(provider, testutil.GetLoader(t))
+		aeStore, err := anchorlinkstore.New(provider)
 		require.NoError(t, err)
 
 		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
@@ -577,7 +577,7 @@ func TestWitnessProofHandler(t *testing.T) {
 	})
 
 	t.Run("error - witness store add proof error", func(t *testing.T) {
-		aeStore, err := anchorlinkstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		aeStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		als := &linkset.Linkset{}
@@ -613,7 +613,7 @@ func TestWitnessProofHandler(t *testing.T) {
 	})
 
 	t.Run("error - witness store add proof error", func(t *testing.T) {
-		aeStore, err := anchorlinkstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		aeStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		als := &linkset.Linkset{}
@@ -649,7 +649,7 @@ func TestWitnessProofHandler(t *testing.T) {
 	})
 
 	t.Run("error - unmarshal witness proof", func(t *testing.T) {
-		aeStore, err := anchorlinkstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		aeStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
@@ -675,7 +675,7 @@ func TestWitnessProofHandler(t *testing.T) {
 	})
 
 	t.Run("error - monitoring error", func(t *testing.T) {
-		aeStore, err := anchorlinkstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		aeStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		als := &linkset.Linkset{}

--- a/pkg/anchor/witness/policy/inspector/inspector_test.go
+++ b/pkg/anchor/witness/policy/inspector/inspector_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
 	policymocks "github.com/trustbloc/orb/pkg/anchor/witness/policy/mocks"
 	"github.com/trustbloc/orb/pkg/anchor/witness/proof"
-	"github.com/trustbloc/orb/pkg/internal/testutil"
 	"github.com/trustbloc/orb/pkg/linkset"
 	"github.com/trustbloc/orb/pkg/pubsub/mempubsub"
 	anchorlinkstore "github.com/trustbloc/orb/pkg/store/anchorlink"
@@ -35,7 +34,7 @@ const (
 )
 
 func TestNew(t *testing.T) {
-	anchorLinkStore, err := anchorlinkstore.New(mem.NewProvider(), testutil.GetLoader(t))
+	anchorLinkStore, err := anchorlinkstore.New(mem.NewProvider())
 	require.NoError(t, err)
 
 	providers := &Providers{
@@ -69,7 +68,7 @@ func TestInspector_CheckPolicy(t *testing.T) {
 		p := &mocks.Provider{}
 		p.OpenStoreReturns(s, nil)
 
-		anchorLinkStore, err := anchorlinkstore.New(p, testutil.GetLoader(t))
+		anchorLinkStore, err := anchorlinkstore.New(p)
 		require.NoError(t, err)
 
 		err = anchorLinkStore.Put(anchorLink)
@@ -102,7 +101,7 @@ func TestInspector_CheckPolicy(t *testing.T) {
 	})
 
 	t.Run("error - get anchor event error", func(t *testing.T) {
-		anchorLinkStore, err := anchorlinkstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		anchorLinkStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		selectedWitnessURL, err := url.Parse("http://domain.com/service")
@@ -133,7 +132,7 @@ func TestInspector_CheckPolicy(t *testing.T) {
 	})
 
 	t.Run("error - post offer to outbox error", func(t *testing.T) {
-		anchorLinkStore, err := anchorlinkstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		anchorLinkStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		err = anchorLinkStore.Put(anchorLink)
@@ -167,7 +166,7 @@ func TestInspector_CheckPolicy(t *testing.T) {
 	})
 
 	t.Run("error - no additional witnesses selected", func(t *testing.T) {
-		anchorLinkStore, err := anchorlinkstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		anchorLinkStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		err = anchorLinkStore.Put(anchorLink)
@@ -203,7 +202,7 @@ func TestInspector_CheckPolicy(t *testing.T) {
 	})
 
 	t.Run("error - witness store error", func(t *testing.T) {
-		anchorLinkStore, err := anchorlinkstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		anchorLinkStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		err = anchorLinkStore.Put(anchorLink)
@@ -225,7 +224,7 @@ func TestInspector_CheckPolicy(t *testing.T) {
 	})
 
 	t.Run("error - witness policy selection error", func(t *testing.T) {
-		anchorLinkStore, err := anchorlinkstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		anchorLinkStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		err = anchorLinkStore.Put(anchorLink)

--- a/pkg/anchor/writer/writer_test.go
+++ b/pkg/anchor/writer/writer_test.go
@@ -48,7 +48,7 @@ import (
 	"github.com/trustbloc/orb/pkg/mocks"
 	"github.com/trustbloc/orb/pkg/pubsub/mempubsub"
 	resourceresolver "github.com/trustbloc/orb/pkg/resolver/resource"
-	anchoreventstore "github.com/trustbloc/orb/pkg/store/anchorlink"
+	anchorlinkstore "github.com/trustbloc/orb/pkg/store/anchorlink"
 	"github.com/trustbloc/orb/pkg/store/anchorstatus"
 	"github.com/trustbloc/orb/pkg/store/cas"
 	storemocks "github.com/trustbloc/orb/pkg/store/mocks"
@@ -80,7 +80,7 @@ func TestNew(t *testing.T) {
 	casIRI, err := url.Parse(casURL)
 	require.NoError(t, err)
 
-	anchorEventStore, err := anchoreventstore.New(mem.NewProvider(), testutil.GetLoader(t))
+	anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 	require.NoError(t, err)
 
 	providers := &Providers{
@@ -149,7 +149,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 
 	t.Run("success - no local witness configured, "+
 		"witness needs to be resolved via HTTP", func(t *testing.T) {
-		anchorEventStore, err := anchoreventstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
@@ -201,7 +201,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 	})
 
 	t.Run("success - witness needs to be resolved via IPNS", func(t *testing.T) {
-		anchorEventStore, err := anchoreventstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
@@ -254,7 +254,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 	})
 
 	t.Run("success - local witness configured, sign with default witness is false", func(t *testing.T) {
-		anchorEventStore, err := anchoreventstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
@@ -306,7 +306,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 	})
 
 	t.Run("success - local witness", func(t *testing.T) {
-		anchorEventStore, err := anchoreventstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		wit := &mockWitness{proofBytes: []byte(`{"proof": {"domain":"domain","created": "2021-02-23T19:36:07Z"}}`)}
@@ -360,7 +360,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 	})
 
 	t.Run("error - status store error", func(t *testing.T) {
-		anchorEventStore, err := anchoreventstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		wit := &mockWitness{proofBytes: []byte(`{"proof": {"domain":"domain","created": "2021-02-23T19:36:07Z"}}`)}
@@ -412,7 +412,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 	})
 
 	t.Run("Parse created time (error)", func(t *testing.T) {
-		anchorEventStore, err := anchoreventstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		wit := &mockWitness{proofBytes: []byte(`{"proof": {"created": "021-02-23T:07Z"}}`)}
@@ -462,7 +462,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 	})
 
 	t.Run("error - failed to get witness list", func(t *testing.T) {
-		anchorEventStore, err := anchoreventstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		providers := &Providers{
@@ -497,7 +497,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 	})
 
 	t.Run("error - build anchor event error", func(t *testing.T) {
-		anchorEventStore, err := anchoreventstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
@@ -580,7 +580,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 	})
 
 	t.Run("error - local witness (monitoring error)", func(t *testing.T) {
-		anchorEventStore, err := anchoreventstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		providersWithErr := &Providers{
@@ -660,7 +660,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			OpenStoreReturn: &mockstore.Store{ErrPut: fmt.Errorf("error put")},
 		}
 
-		anchorEventStoreWithErr, err := anchoreventstore.New(storeProviderWithErr, testutil.GetLoader(t))
+		anchorEventStoreWithErr, err := anchorlinkstore.New(storeProviderWithErr)
 		require.NoError(t, err)
 
 		providersWithErr := &Providers{
@@ -699,7 +699,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			OpenStoreReturn: &mockstore.Store{ErrPut: fmt.Errorf("error put (local witness)")},
 		}
 
-		anchorEventStoreWithErr, err := anchoreventstore.New(storeProviderWithErr, testutil.GetLoader(t))
+		anchorEventStoreWithErr, err := anchorlinkstore.New(storeProviderWithErr)
 		require.NoError(t, err)
 
 		providersWithErr := &Providers{
@@ -736,7 +736,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 	})
 
 	t.Run("error - previous did anchor reference not found for non-create operations", func(t *testing.T) {
-		anchorEventStore, err := anchoreventstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		providers := &Providers{
@@ -759,7 +759,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 	})
 
 	t.Run("error - publish anchor", func(t *testing.T) {
-		anchorEventStore, err := anchoreventstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
@@ -813,7 +813,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 	})
 
 	t.Run("error - fail to resolve anchor origin via IPNS (IPFS node not reachable)", func(t *testing.T) {
-		anchorEventStore, err := anchoreventstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
@@ -856,7 +856,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 	})
 
 	t.Run("error - no witnesses configured", func(t *testing.T) {
-		anchorEventStore, err := anchoreventstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
@@ -926,7 +926,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 	})
 
 	t.Run("success - no witnesses required", func(t *testing.T) {
-		anchorEventStore, err := anchoreventstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
@@ -1016,7 +1016,7 @@ func TestWriter_handle(t *testing.T) {
 	anchorGraph := graph.New(graphProviders)
 
 	t.Run("success", func(t *testing.T) {
-		anchorEventStore, err := anchoreventstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		vcStore, err := mem.NewProvider().OpenStore("verifiable")
@@ -1045,7 +1045,7 @@ func TestWriter_handle(t *testing.T) {
 	})
 
 	t.Run("error - add anchor credential to txn graph error", func(t *testing.T) {
-		anchorEventStore, err := anchoreventstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		vcStore, err := mem.NewProvider().OpenStore("verifiable")
@@ -1076,7 +1076,7 @@ func TestWriter_handle(t *testing.T) {
 	})
 
 	t.Run("error - add anchor credential cid to did anchors error", func(t *testing.T) {
-		anchorEventStore, err := anchoreventstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		vcStore, err := mem.NewProvider().OpenStore("verifiable")
@@ -1112,7 +1112,7 @@ func TestWriter_handle(t *testing.T) {
 	})
 
 	t.Run("error - outbox error", func(t *testing.T) {
-		anchorEventStore, err := anchoreventstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		vcStore, err := mem.NewProvider().OpenStore("verifiable")
@@ -1143,7 +1143,7 @@ func TestWriter_handle(t *testing.T) {
 	})
 
 	t.Run("error - delete transient data from witness store error", func(t *testing.T) {
-		anchorEventStore, err := anchoreventstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		vcStore, err := mem.NewProvider().OpenStore("verifiable")
@@ -1176,7 +1176,7 @@ func TestWriter_handle(t *testing.T) {
 			OpenStoreReturn: &mockstore.Store{ErrDelete: fmt.Errorf("error delete")},
 		}
 
-		anchorEventStoreWithErr, err := anchoreventstore.New(storeProviderWithErr, testutil.GetLoader(t))
+		anchorEventStoreWithErr, err := anchorlinkstore.New(storeProviderWithErr)
 		require.NoError(t, err)
 
 		vcStore, err := mem.NewProvider().OpenStore("verifiable")
@@ -1206,7 +1206,7 @@ func TestWriter_handle(t *testing.T) {
 	})
 
 	t.Run("error - parse verifiable credential from anchor event error", func(t *testing.T) {
-		anchorEventStore, err := anchoreventstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		vcStore, err := mem.NewProvider().OpenStore("verifiable")
@@ -1238,7 +1238,7 @@ func TestWriter_handle(t *testing.T) {
 	})
 
 	t.Run("error - store to verifiable credential store", func(t *testing.T) {
-		anchorEventStore, err := anchoreventstore.New(mem.NewProvider(), testutil.GetLoader(t))
+		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
 		vcStore := &storemocks.Store{}

--- a/pkg/store/anchorlink/store.go
+++ b/pkg/store/anchorlink/store.go
@@ -12,11 +12,11 @@ import (
 	"fmt"
 
 	"github.com/hyperledger/aries-framework-go/spi/storage"
-	"github.com/piprate/json-gold/ld"
 	"github.com/trustbloc/edge-core/pkg/log"
 
 	orberrors "github.com/trustbloc/orb/pkg/errors"
 	"github.com/trustbloc/orb/pkg/linkset"
+	"github.com/trustbloc/orb/pkg/store"
 )
 
 const nameSpace = "anchor-link"
@@ -24,26 +24,24 @@ const nameSpace = "anchor-link"
 var logger = log.New("anchor-link-store")
 
 // New returns new instance of anchor event store.
-func New(provider storage.Provider, loader ld.DocumentLoader) (*Store, error) {
-	store, err := provider.OpenStore(nameSpace)
+func New(p storage.Provider) (*Store, error) {
+	s, err := store.Open(p, nameSpace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open vc store: %w", err)
 	}
 
 	return &Store{
-		documentLoader: loader,
-		store:          store,
-		marshal:        json.Marshal,
-		unmarshal:      json.Unmarshal,
+		store:     s,
+		marshal:   json.Marshal,
+		unmarshal: json.Unmarshal,
 	}, nil
 }
 
 // Store implements storage for anchor event.
 type Store struct {
-	store          storage.Store
-	documentLoader ld.DocumentLoader
-	marshal        func(v interface{}) ([]byte, error)
-	unmarshal      func(data []byte, v interface{}) error
+	store     storage.Store
+	marshal   func(v interface{}) ([]byte, error)
+	unmarshal func(data []byte, v interface{}) error
 }
 
 // Put saves an anchor event. If it already exists it will be overwritten.

--- a/pkg/store/anchorlink/store_test.go
+++ b/pkg/store/anchorlink/store_test.go
@@ -25,7 +25,7 @@ var anchorIndexURL = testutil.MustParseURL("hl:uEiBL1RVIr2DdyRE5h6b8bPys-PuVs5mM
 
 func TestNew(t *testing.T) {
 	t.Run("test new store", func(t *testing.T) {
-		s, err := New(mem.NewProvider(), testutil.GetLoader(t))
+		s, err := New(mem.NewProvider())
 		require.NoError(t, err)
 		require.NotNil(t, s)
 	})
@@ -33,7 +33,7 @@ func TestNew(t *testing.T) {
 	t.Run("test error from open store", func(t *testing.T) {
 		s, err := New(&mockstore.Provider{
 			ErrOpenStore: fmt.Errorf("failed to open store"),
-		}, testutil.GetLoader(t))
+		})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to open store")
 		require.Nil(t, s)
@@ -42,7 +42,7 @@ func TestNew(t *testing.T) {
 
 func TestStore_Put(t *testing.T) {
 	t.Run("test save anchor event - success", func(t *testing.T) {
-		s, err := New(mem.NewProvider(), testutil.GetLoader(t))
+		s, err := New(mem.NewProvider())
 		require.NoError(t, err)
 
 		err = s.Put(linkset.NewLink(anchorIndexURL, nil, nil, nil, nil, nil))
@@ -54,7 +54,7 @@ func TestStore_Put(t *testing.T) {
 			ErrPut: fmt.Errorf("error put"),
 		}}
 
-		s, err := New(storeProvider, testutil.GetLoader(t))
+		s, err := New(storeProvider)
 		require.NoError(t, err)
 
 		err = s.Put(linkset.NewLink(anchorIndexURL, nil, nil, nil, nil, nil))
@@ -65,7 +65,7 @@ func TestStore_Put(t *testing.T) {
 
 func TestStore_Get(t *testing.T) {
 	t.Run("test success", func(t *testing.T) {
-		s, err := New(mem.NewProvider(), testutil.GetLoader(t))
+		s, err := New(mem.NewProvider())
 		require.NoError(t, err)
 
 		err = s.Put(linkset.NewLink(anchorIndexURL, nil, nil, nil, nil, nil))
@@ -77,7 +77,7 @@ func TestStore_Get(t *testing.T) {
 	})
 
 	t.Run("test success - with proof", func(t *testing.T) {
-		s, err := New(mem.NewProvider(), testutil.GetLoader(t))
+		s, err := New(mem.NewProvider())
 		require.NoError(t, err)
 
 		err = s.Put(linkset.NewLink(anchorIndexURL, nil, nil, nil, nil, nil))
@@ -89,7 +89,7 @@ func TestStore_Get(t *testing.T) {
 	})
 
 	t.Run("error - nil anchors URL", func(t *testing.T) {
-		s, err := New(mem.NewProvider(), testutil.GetLoader(t))
+		s, err := New(mem.NewProvider())
 		require.NoError(t, err)
 
 		err = s.Put(&linkset.Link{})
@@ -102,7 +102,7 @@ func TestStore_Get(t *testing.T) {
 			ErrGet: fmt.Errorf("error get"),
 		}}
 
-		s, err := New(storeProvider, testutil.GetLoader(t))
+		s, err := New(storeProvider)
 		require.NoError(t, err)
 
 		vc, err := s.Get("vc1")
@@ -116,7 +116,7 @@ func TestStore_Get(t *testing.T) {
 			ErrGet: storage.ErrDataNotFound,
 		}}
 
-		s, err := New(storeProvider, testutil.GetLoader(t))
+		s, err := New(storeProvider)
 		require.NoError(t, err)
 
 		vc, err := s.Get("vc1")
@@ -125,7 +125,7 @@ func TestStore_Get(t *testing.T) {
 	})
 
 	t.Run("test marshal error", func(t *testing.T) {
-		s, err := New(mem.NewProvider(), testutil.GetLoader(t))
+		s, err := New(mem.NewProvider())
 		require.NoError(t, err)
 
 		errExpected := errors.New("injected marshal error")
@@ -140,7 +140,7 @@ func TestStore_Get(t *testing.T) {
 	})
 
 	t.Run("test unmarshal error", func(t *testing.T) {
-		s, err := New(mem.NewProvider(), testutil.GetLoader(t))
+		s, err := New(mem.NewProvider())
 		require.NoError(t, err)
 
 		errExpected := errors.New("injected unmarshal error")
@@ -161,7 +161,7 @@ func TestStore_Get(t *testing.T) {
 
 func TestStore_Delete(t *testing.T) {
 	t.Run("test success", func(t *testing.T) {
-		s, err := New(mem.NewProvider(), testutil.GetLoader(t))
+		s, err := New(mem.NewProvider())
 		require.NoError(t, err)
 
 		err = s.Put(linkset.NewLink(anchorIndexURL, nil, nil, nil, nil, nil))
@@ -181,7 +181,7 @@ func TestStore_Delete(t *testing.T) {
 			ErrDelete: fmt.Errorf("error delete"),
 		}}
 
-		s, err := New(storeProvider, testutil.GetLoader(t))
+		s, err := New(storeProvider)
 		require.NoError(t, err)
 
 		err = s.Delete("vc1")

--- a/pkg/store/publickey/publickeystore.go
+++ b/pkg/store/publickey/publickeystore.go
@@ -16,6 +16,8 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	"github.com/hyperledger/aries-framework-go/spi/storage"
 	"github.com/trustbloc/edge-core/pkg/log"
+
+	"github.com/trustbloc/orb/pkg/store"
 )
 
 var logger = log.New("public-key-store")
@@ -40,7 +42,7 @@ type cacheKey struct {
 
 // New returns a new public key store.
 func New(p storage.Provider, fetchPublicKey verifiable.PublicKeyFetcher) (*Store, error) {
-	s, err := p.OpenStore(storeName)
+	s, err := store.Open(p, storeName)
 	if err != nil {
 		return nil, fmt.Errorf("open store [%s]: %w", storeName, err)
 	}


### PR DESCRIPTION
The following stores were converted to use the optimized storage interface:

- anchor-link
- anchor-status
- anchor-ref
- verifiable
- public-key

closes #1325
closes #1330

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>