### PR TITLE
feat: Optimized stores for VCT monitoring

### DIFF
--- a/pkg/store/logentry/store_test.go
+++ b/pkg/store/logentry/store_test.go
@@ -41,7 +41,7 @@ func TestNew(t *testing.T) {
 
 		s, err := New(provider)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to open log entry store: open store error")
+		require.Contains(t, err.Error(), "open store error")
 		require.Nil(t, s)
 	})
 }
@@ -660,6 +660,7 @@ func TestStore_FailLogEntriesFrom(t *testing.T) {
 		iterator := &mocks.Iterator{}
 		iterator.NextReturnsOnCall(0, true, nil)
 		iterator.NextReturnsOnCall(1, false, fmt.Errorf("iterator second next() error"))
+		iterator.ValueReturns([]byte(`{}`), nil)
 
 		store := &mocks.Store{}
 		store.QueryReturns(iterator, nil)

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -108,7 +108,7 @@ Feature:
 
     Then we wait 2 seconds
     When an HTTP GET is sent to "https://orb.domain1.com/log-monitor?status=active"
-    And the JSON path "active.#.log_url" of the response contains "http://orb.vct:8077/maple2022"
+    And the JSON path "active.#.logUrl" of the response contains "http://orb.vct:8077/maple2022"
 
     And variable "activateLog" is assigned the JSON value '{"activate":["http://orb.vct:8077/maple2022"]}'
     And variable "deactivateLog" is assigned the JSON value '{"deactivate":["http://orb.vct:8077/maple2022"]}'
@@ -118,13 +118,13 @@ Feature:
 
     Then we wait 1 seconds
     When an HTTP GET is sent to "https://orb.domain1.com/log-monitor?status=inactive"
-    And the JSON path "inactive.#.log_url" of the response contains "http://orb.vct:8077/maple2022"
+    And the JSON path "inactive.#.logUrl" of the response contains "http://orb.vct:8077/maple2022"
 
     When an HTTP POST is sent to "https://orb.domain1.com/log-monitor" with content "${activateLog}" of type "text/plain"
 
     Then we wait 1 seconds
     When an HTTP GET is sent to "https://orb.domain1.com/log-monitor?status=active"
-    And the JSON path "active.#.log_url" of the response contains "http://orb.vct:8077/maple2022"
+    And the JSON path "active.#.logUrl" of the response contains "http://orb.vct:8077/maple2022"
 
   @all
   @discover_did_hashlink

--- a/test/bdd/features/orb-cli.feature
+++ b/test/bdd/features/orb-cli.feature
@@ -109,7 +109,7 @@ Feature: Using Orb CLI
     Then we wait 1 seconds
 
     When orb-cli is executed with args 'logmonitor get --url https://localhost:48326/log-monitor --tls-cacerts fixtures/keys/tls/ec-cacert.pem --auth-token READ_TOKEN'
-    Then the JSON path "active.#.log_url" of the response contains "http://orb.vct:8077/maple2022"
+    Then the JSON path "active.#.logUrl" of the response contains "http://orb.vct:8077/maple2022"
 
      # Deactivate log - remove from log monitoring list.
     When orb-cli is executed with args 'logmonitor deactivate --url https://localhost:48326/log-monitor --log http://orb.vct:8077/maple2022 --tls-cacerts fixtures/keys/tls/ec-cacert.pem --auth-token ADMIN_TOKEN'
@@ -117,5 +117,5 @@ Feature: Using Orb CLI
     Then we wait 1 seconds
 
     When orb-cli is executed with args 'logmonitor get --url https://localhost:48326/log-monitor --status inactive --tls-cacerts fixtures/keys/tls/ec-cacert.pem --auth-token READ_TOKEN'
-    Then the JSON path "inactive.#.log_url" of the response contains "http://orb.vct:8077/maple2022"
+    Then the JSON path "inactive.#.logUrl" of the response contains "http://orb.vct:8077/maple2022"
 


### PR DESCRIPTION
The DB, monitoring, was renamed to proof-monitor and the following stores were converted to use the optimized storage interface:

- log-monitor
- proof-monitor
- log-entry

closes #1326

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>