### PR TITLE
feat: Optimized stores for operation & witness

### DIFF
--- a/cmd/orb-cli/go.mod
+++ b/cmd/orb-cli/go.mod
@@ -30,11 +30,13 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bluele/gcache v0.0.2 // indirect
 	github.com/btcsuite/btcd v0.22.0-beta // indirect
+	github.com/cenkalti/backoff/v4 v4.1.2 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/crackcomm/go-gitignore v0.0.0-20170627025303-887ab5e44cc3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/evanphx/json-patch v4.1.0+incompatible // indirect
 	github.com/fxamacker/cbor/v2 v2.3.0 // indirect
+	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
@@ -43,12 +45,14 @@ require (
 	github.com/google/tink/go v1.6.1 // indirect
 	github.com/google/trillian v1.3.14-0.20210520152752-ceda464a95a3 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220609192245-be476b6ca623 // indirect
 	github.com/hyperledger/aries-framework-go/spi v0.0.0-20220526205258-18d510d84955 // indirect
 	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20220516154446-0ba34929e05b // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/ipfs/go-cid v0.0.7 // indirect
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a // indirect
 	github.com/kilic/bls12-381 v0.1.1-0.20210503002446-7b7597926c69 // indirect
+	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/libp2p/go-buffer-pool v0.0.2 // indirect
 	github.com/libp2p/go-flow-metrics v0.0.3 // indirect
 	github.com/libp2p/go-openssl v0.0.7 // indirect
@@ -80,12 +84,18 @@ require (
 	github.com/teserakt-io/golang-ed25519 v0.0.0-20210104091850-3888c087a4c8 // indirect
 	github.com/whyrusleeping/tar-utils v0.0.0-20180509141711-8c6c8ba81d5c // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
+	github.com/xdg-go/scram v1.0.2 // indirect
+	github.com/xdg-go/stringprep v1.0.2 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
+	github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a // indirect
+	go.mongodb.org/mongo-driver v1.9.1 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20220222213610-43724f9ea8cf // indirect

--- a/cmd/orb-driver/go.mod
+++ b/cmd/orb-driver/go.mod
@@ -20,10 +20,12 @@ require (
 	github.com/bluele/gcache v0.0.2 // indirect
 	github.com/btcsuite/btcd v0.22.0-beta // indirect
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce // indirect
+	github.com/cenkalti/backoff/v4 v4.1.2 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/evanphx/json-patch v4.1.0+incompatible // indirect
 	github.com/fxamacker/cbor/v2 v2.3.0 // indirect
+	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
@@ -33,6 +35,7 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/hyperledger/aries-framework-go v0.1.9-0.20220602200413-1135b419c644 // indirect
+	github.com/hyperledger/aries-framework-go-ext/component/storage/mongodb v0.0.0-20220609192245-be476b6ca623 // indirect
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/sidetree v1.0.0-rc.1.0.20220530114906-35b469518049 // indirect
 	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220428211718-66cc046674a1 // indirect
 	github.com/hyperledger/aries-framework-go/spi v0.0.0-20220526205258-18d510d84955 // indirect
@@ -41,6 +44,7 @@ require (
 	github.com/ipfs/go-cid v0.0.7 // indirect
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a // indirect
 	github.com/kilic/bls12-381 v0.1.1-0.20210503002446-7b7597926c69 // indirect
+	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 // indirect
 	github.com/minio/sha256-simd v0.1.1 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
@@ -62,11 +66,17 @@ require (
 	github.com/teserakt-io/golang-ed25519 v0.0.0-20210104091850-3888c087a4c8 // indirect
 	github.com/trustbloc/vct v1.0.0-rc1.0.20220530071917-3aa4f907b424 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
+	github.com/xdg-go/scram v1.0.2 // indirect
+	github.com/xdg-go/stringprep v1.0.2 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
+	github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a // indirect
+	go.mongodb.org/mongo-driver v1.9.1 // indirect
 	golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20220222213610-43724f9ea8cf // indirect

--- a/pkg/anchor/witness/proof/proof.go
+++ b/pkg/anchor/witness/proof/proof.go
@@ -14,10 +14,10 @@ import (
 
 // Witness contains info about witness.
 type Witness struct {
-	Type     WitnessType
-	URI      *vocab.URLProperty
-	HasLog   bool
-	Selected bool
+	Type     WitnessType        `json:"type"`
+	URI      *vocab.URLProperty `json:"uri"`
+	HasLog   bool               `json:"hasLog"`
+	Selected bool               `json:"selected"`
 }
 
 func (wf *Witness) String() string {

--- a/pkg/context/opqueue/opqueue_test.go
+++ b/pkg/context/opqueue/opqueue_test.go
@@ -399,7 +399,7 @@ func TestQueue_Error(t *testing.T) {
 			Namespace:        "ns1",
 		}
 
-		opMsg := &operationMessage{
+		opMsg := &OperationMessage{
 			ID: uuid.New().String(),
 			Operation: &operation.QueuedOperationAtTime{
 				QueuedOperation: *op,

--- a/pkg/store/operation/store.go
+++ b/pkg/store/operation/store.go
@@ -17,11 +17,12 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 
 	orberrors "github.com/trustbloc/orb/pkg/errors"
+	"github.com/trustbloc/orb/pkg/store"
 )
 
 const (
 	namespace = "operation"
-	index     = "suffix"
+	index     = "uniqueSuffix"
 )
 
 var logger = log.New("operation-store")
@@ -33,18 +34,15 @@ type metricsProvider interface {
 
 // New creates new operation store.
 func New(provider storage.Provider, metrics metricsProvider) (*Store, error) {
-	store, err := provider.OpenStore(namespace)
+	s, err := store.Open(provider, namespace,
+		store.NewTagGroup(index),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open operation store: %w", err)
 	}
 
-	err = provider.SetStoreConfig(namespace, storage.StoreConfiguration{TagNames: []string{index}})
-	if err != nil {
-		return nil, fmt.Errorf("failed to set store configuration: %w", err)
-	}
-
 	return &Store{
-		store:   store,
+		store:   s,
 		metrics: metrics,
 	}, nil
 }

--- a/pkg/store/operation/store_test.go
+++ b/pkg/store/operation/store_test.go
@@ -40,7 +40,7 @@ func TestNew(t *testing.T) {
 
 		s, err := New(provider, &orbmocks.MetricsProvider{})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to open operation store: open store error")
+		require.Contains(t, err.Error(), "open store [operation]: open store error")
 		require.Nil(t, s)
 	})
 
@@ -50,7 +50,7 @@ func TestNew(t *testing.T) {
 
 		s, err := New(provider, &orbmocks.MetricsProvider{})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to set store configuration: set store config error")
+		require.Contains(t, err.Error(), "set store configuration for [operation]: set store config error")
 		require.Nil(t, s)
 	})
 }

--- a/pkg/store/witness/witness_test.go
+++ b/pkg/store/witness/witness_test.go
@@ -48,7 +48,7 @@ func TestNew(t *testing.T) {
 
 		s, err := New(provider, testutil.GetExpiryService(t), expiryTime)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to open anchor witness store: open store error")
+		require.Contains(t, err.Error(), "open store [witness]: open store error")
 		require.Nil(t, s)
 	})
 
@@ -58,7 +58,7 @@ func TestNew(t *testing.T) {
 
 		s, err := New(provider, testutil.GetExpiryService(t), expiryTime)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to set store configuration: set store config error")
+		require.Contains(t, err.Error(), "set store configuration for [witness]: set store config error")
 		require.Nil(t, s)
 	})
 }


### PR DESCRIPTION
Renamed DB, op-queue, to, operation-queue, and the following stores were converted to use the optimized storage interface:

- operation
- operation-queue
- unpublished-operation
- witness

closes #1327
closes #1328

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>