### PR TITLE
docs: Swagger docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ test/bdd/website
 test/bdd/OrbBDDTestKey.key
 /test/bdd/fixtures/mongodbbackup/
 /test/bdd/fixtures/dids.txt
+/test/bdd/fixtures/specs/openAPI.yml

--- a/cmd/orb-server/main.go
+++ b/cmd/orb-server/main.go
@@ -4,6 +4,15 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
+// Package main Orb.
+//
+// Terms Of Service:
+//
+//     Schemes: http
+//     Version: 1.0
+//     License: SPDX-License-Identifier: Apache-2.0
+//
+// swagger:meta
 package main
 
 import (

--- a/pkg/activitypub/resthandler/openapi.go
+++ b/pkg/activitypub/resthandler/openapi.go
@@ -1,0 +1,410 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resthandler
+
+import "github.com/trustbloc/orb/pkg/activitypub/vocab"
+
+// Request message
+//
+// swagger:parameters acceptListGetReq
+type acceptListGetReq struct { // nolint: unused,deadcode
+	// Type
+	// enum: follow,invite-witness
+	Type string `json:"type"`
+}
+
+// Response message
+//
+// swagger:response acceptListGetResp
+type acceptListGetResp struct { // nolint: unused,deadcode
+	// in: body
+	Body []acceptList
+}
+
+//nolint:lll
+// handleGet swagger:route GET /acceptlist ActivityPub acceptListGetReq
+//
+// Returns the accept-list. If type is specified then the accept-list for the given type (follow or invite-witness) is returned, otherwise all accept-lists are returned.
+//
+// Responses:
+//        200: acceptListGetResp
+func acceptlistGetRequest() { // nolint: unused,deadcode
+}
+
+// Request message
+//
+// swagger:parameters acceptListPostReq
+type acceptListPostReq struct { // nolint: unused,deadcode
+	// in: body
+	Body []acceptListRequest
+}
+
+// Response message
+//
+// swagger:response acceptListPostResp
+type acceptListPostResp struct { // nolint: unused,deadcode
+	Body string
+}
+
+// handlePost swagger:route POST /acceptlist ActivityPub acceptListPostReq
+//
+// Updates the accept-list.
+//
+// Responses:
+//    200: acceptListPostResp
+func acceptlistPostRequest() { // nolint: unused,deadcode
+}
+
+// swagger:parameters serviceGetReq
+type serviceGetReq struct { // nolint: unused,deadcode
+}
+
+// swagger:response serviceGetResp
+type serviceGetResp struct { // nolint: unused,deadcode
+	// in: body
+	Body vocab.ActorType
+}
+
+//nolint:lll
+// serviceGetRequest swagger:route GET /services/orb ActivityPub serviceGetReq
+//
+// The Orb service is retrieved using the /services/orb endpoint. The returned data is a JSON document that contains REST endpoints that may be queried to return additional information.
+//
+// Produces:
+// - application/json
+//
+// Responses:
+//        200: serviceGetResp
+func serviceGetRequest() { // nolint: unused,deadcode
+}
+
+// swagger:parameters serviceKeysGetReq
+type serviceKeysGetReq struct { // nolint: unused,deadcode
+	// In: path
+	ID string `json:"id"`
+}
+
+// swagger:response serviceKeysGetResp
+type serviceKeysGetResp struct { // nolint: unused,deadcode
+	// in: body
+	Body vocab.PublicKeyType
+}
+
+// serviceKeysGetRequest swagger:route GET /services/orb/keys/{id} ActivityPub serviceKeysGetReq
+//
+// The public key of an Orb service is retrieved using this endpoint.
+//
+// Produces:
+// - application/json
+//
+// Responses:
+//        200: serviceKeysGetResp
+func serviceKeysGetRequest() { // nolint: unused,deadcode
+}
+
+// swagger:parameters followersGetReq
+type followersGetReq struct { // nolint: unused,deadcode
+	Page    bool   `json:"page"`
+	PageNum string `json:"page-num"`
+}
+
+// swagger:response followersGetResp
+type followersGetResp struct { // nolint: unused,deadcode
+	// in: body
+	Body vocab.CollectionType
+}
+
+//nolint:lll
+// followersGetRequest swagger:route GET /services/orb/followers ActivityPub followersGetReq
+//
+// The followers of this Orb service are returned via this endpoint. If no paging parameters are specified in the URL then the response contains information about the collection, i.e. the links to the first and last page, as well as the total number of items in the collection. A subsequent request may be made using parameters that include a specified page number in order to retrieve the actual items.
+//
+// Produces:
+// - application/json
+//
+// Responses:
+//        200: followersGetResp
+func followersGetRequest() { // nolint: unused,deadcode
+}
+
+// swagger:parameters followingGetReq
+type followingGetReq struct { // nolint: unused,deadcode
+	Page    bool   `json:"page"`
+	PageNum string `json:"page-num"`
+}
+
+// swagger:response followingGetResp
+type followingGetResp struct { // nolint: unused,deadcode
+	// in: body
+	Body vocab.CollectionType
+}
+
+//nolint:lll
+// followingGetRequest swagger:route GET /services/orb/following ActivityPub followingGetReq
+//
+// The services following this Orb service are returned via this endpoint. If no paging parameters are specified in the URL then the response contains information about the collection, i.e. the links to the first and last page, as well as the total number of items in the collection. A subsequent request may be made using parameters that include a specified page number in order to retrieve the actual items.
+//
+// Produces:
+// - application/json
+//
+// Responses:
+//        200: followingGetResp
+func followingGetRequest() { // nolint: unused,deadcode
+}
+
+// swagger:parameters witnessesGetReq
+type witnessesGetReq struct { // nolint: unused,deadcode
+	Page    bool   `json:"page"`
+	PageNum string `json:"page-num"`
+}
+
+// swagger:response witnessesGetResp
+type witnessesGetResp struct { // nolint: unused,deadcode
+	// in: body
+	Body vocab.CollectionType
+}
+
+//nolint:lll
+// witnessesGetRequest swagger:route GET /services/orb/witnesses ActivityPub witnessesGetReq
+//
+// The witnesses of this service are returned via this endpoint. If no paging parameters are specified in the URL then the response contains information about the witnesses collection, i.e. the links to the first and last page, as well as the total number of items in the collection. A subsequent request may be made using parameters that include a specified page number in order to retrieve the actual items.
+//
+// Produces:
+// - application/json
+//
+// Responses:
+//        200: witnessesGetResp
+func witnessesGetRequest() { // nolint: unused,deadcode
+}
+
+// swagger:parameters witnessingGetReq
+type witnessingGetReq struct { // nolint: unused,deadcode
+	Page    bool   `json:"page"`
+	PageNum string `json:"page-num"`
+}
+
+// swagger:response witnessingGetResp
+type witnessingGetResp struct { // nolint: unused,deadcode
+	// in: body
+	Body vocab.CollectionType
+}
+
+//nolint:lll
+// witnessingGetRequest swagger:route GET /services/orb/witnessing ActivityPub witnessingGetReq
+//
+// The services that are witnessing anchor events for this service are returned via this endpoint. If no paging parameters are specified in the URL then the response contains information about the collection, i.e. the links to the first and last page, as well as the total number of items in the collection. A subsequent request may be made using parameters that include a specified page number in order to retrieve the actual items.
+//
+// Produces:
+// - application/json
+//
+// Responses:
+//        200: witnessingGetResp
+func witnessingGetRequest() { // nolint: unused,deadcode
+}
+
+// swagger:parameters inboxGetReq
+type inboxGetReq struct { // nolint: unused,deadcode
+	Page    bool   `json:"page"`
+	PageNum string `json:"page-num"`
+}
+
+// swagger:response inboxGetResp
+type inboxGetResp struct { // nolint: unused,deadcode
+	// in: body
+	Body vocab.CollectionType
+}
+
+//nolint:lll
+// inboxGetRequest swagger:route GET /services/orb/inbox ActivityPub inboxGetReq
+//
+// The activities posted to the inbox of this service are returned via this endpoint. If no paging parameters are specified in the URL then the response contains information about the inbox collection, i.e. the links to the first and last page, as well as the total number of items in the inbox. A subsequent request may be made using parameters that include a specified page number in order to retrieve the actual items.
+//
+// Produces:
+// - application/json
+//
+// Responses:
+//        200: inboxGetResp
+func inboxGetRequest() { // nolint: unused,deadcode
+}
+
+// swagger:parameters inboxPostReq
+type inboxPostReq struct { // nolint: unused,deadcode
+	// in: body
+	Body vocab.ActivityType
+}
+
+// swagger:response inboxPostResp
+type inboxPostResp struct { // nolint: unused,deadcode
+	// in: body
+	Body string
+}
+
+//nolint:lll
+// inboxPostRequest swagger:route POST /services/orb/inbox ActivityPub inboxPostReq
+//
+// A POST request to the inbox endpoint adds the activity contained in the request to the service’s Inbox, which will be processed by the ActivityPub Inbox. This endpoint is restricted by authorization rules, i.e. the requester must sign the HTTP request. Some activities also have authorization rules such that the actor must be in the destination server’s followers and/or witnessing collection.
+//
+// Consumes:
+// - application/json
+//
+// Responses:
+//        200: inboxPostResp
+func inboxPostRequest() { // nolint: unused,deadcode
+}
+
+// swagger:parameters outboxGetReq
+type outboxGetReq struct { // nolint: unused,deadcode
+	Page    bool   `json:"page"`
+	PageNum string `json:"page-num"`
+}
+
+// swagger:response outboxGetResp
+type outboxGetResp struct { // nolint: unused,deadcode
+	// in: body
+	Body vocab.CollectionType
+}
+
+//nolint:lll
+// outboxGetRequest swagger:route GET /services/orb/outbox ActivityPub outboxGetReq
+//
+// A GET request to the outbox endpoint returns the activities that were posted to a service’s Outbox. This endpoint is restricted by authorization rules, i.e. the requester must have a valid authorization bearer token or must be verified using HTTP signatures and also must be in the following or witnesses collection. Although, any activity sent to a public URI, is returned without authorization. If no paging parameters are specified in the URL then the response contains information about the outbox collection, i.e. the links to the first and last page, as well as the total number of items in the collection. A subsequent request may be made using parameters that include a specified page number in order to retrieve the actual items.
+//
+// Produces:
+// - application/json
+//
+// Responses:
+//        200: outboxGetResp
+func outboxGetRequest() { // nolint: unused,deadcode
+}
+
+// swagger:parameters outboxPostReq
+type outboxPostReq struct { // nolint: unused,deadcode
+	// in: body
+	Body vocab.ActivityType
+}
+
+// swagger:response outboxPostResp
+type outboxPostResp struct { // nolint: unused,deadcode
+	// in: body
+	Body string
+}
+
+//nolint:lll
+// outboxPostRequest swagger:route POST /services/orb/outbox ActivityPub outboxPostReq
+//
+// A POST request to the outbox endpoint adds the activity contained in the request to the service’s Outbox, which will be processed by the ActivityPub Outbox. This endpoint is restricted by authorization rules, i.e. the requester must have a valid authorization bearer token, which is usually an administrator token.
+//
+// Consumes:
+// - application/json
+//
+// Responses:
+//        200: outboxPostResp
+func outboxPostRequest() { // nolint: unused,deadcode
+}
+
+// swagger:parameters likesGetReq
+type likesGetReq struct { // nolint: unused,deadcode
+	// In: path
+	ID      string `json:"id"`
+	Page    bool   `json:"page"`
+	PageNum string `json:"page-num"`
+}
+
+// swagger:response likesGetResp
+type likesGetResp struct { // nolint: unused,deadcode
+	// in: body
+	Body vocab.CollectionType
+}
+
+//nolint:lll
+// likesGetRequest swagger:route GET /services/orb/likes/{id} ActivityPub likesGetReq
+//
+// This endpoint returns a collection of Like activities for a given anchor. If no paging parameters are specified in the URL then the response contains information about the collection, i.e. the links to the first and last page, as well as the total number of items in the collection. A subsequent request may be made using parameters that include a specified page number in order to retrieve the actual items.
+//
+// Produces:
+// - application/json
+//
+// Responses:
+//        200: likesGetResp
+func likesGetRequest() { // nolint: unused,deadcode
+}
+
+// swagger:parameters likedGetReq
+type likedGetReq struct { // nolint: unused,deadcode
+	Page    bool   `json:"page"`
+	PageNum string `json:"page-num"`
+}
+
+// swagger:response likedGetResp
+type likedGetResp struct { // nolint: unused,deadcode
+	// in: body
+	Body vocab.CollectionType
+}
+
+//nolint:lll
+// likedGetRequest swagger:route GET /services/orb/liked ActivityPub likedGetReq
+//
+// The anchor events that are liked are returned via this endpoint. (Liked means that the anchors in the response were all added to the ledger.) If no paging parameters are specified in the URL then the response contains information about the collection, i.e. the links to the first and last page, as well as the total number of items in the collection. A subsequent request may be made using parameters that include a specified page number in order to retrieve the actual items.
+//
+// Produces:
+// - application/json
+//
+// Responses:
+//        200: likedGetResp
+func likedGetRequest() { // nolint: unused,deadcode
+}
+
+// swagger:parameters sharesGetReq
+type sharesGetReq struct { // nolint: unused,deadcode
+	// In: path
+	ID      string `json:"id"`
+	Page    bool   `json:"page"`
+	PageNum string `json:"page-num"`
+}
+
+// swagger:response sharesGetResp
+type sharesGetResp struct { // nolint: unused,deadcode
+	// in: body
+	Body vocab.CollectionType
+}
+
+//nolint:lll
+// sharesGetRequest swagger:route GET /services/orb/shares/{id} ActivityPub sharesGetReq
+//
+// The Create activities that were Announced are returned via this endpoint. If no paging parameters are specified in the URL then the response contains information about the collection, i.e. the links to the first and last page, as well as the total number of items in the collection. A subsequent request may be made using parameters that include a specified page number in order to retrieve the actual items.
+//
+// Produces:
+// - application/json
+//
+// Responses:
+//        200: sharesGetResp
+func sharesGetRequest() { // nolint: unused,deadcode
+}
+
+// swagger:parameters activitiesGetReq
+type activitiesGetReq struct { // nolint: unused,deadcode
+	// In: path
+	ID string `json:"id"`
+}
+
+// swagger:response activitiesGetResp
+type activitiesGetResp struct { // nolint: unused,deadcode
+	// in: body
+	Body vocab.ActivityType
+}
+
+// activitiesGetRequest swagger:route GET /services/orb/activities/{id} ActivityPub activitiesGetReq
+//
+// This endpoint returns an activity for the specified ID.
+//
+// Produces:
+// - application/json
+//
+// Responses:
+//        200: activitiesGetResp
+func activitiesGetRequest() { // nolint: unused,deadcode
+}

--- a/pkg/anchor/anchorlinkset/vcresthandler/openapi.go
+++ b/pkg/anchor/anchorlinkset/vcresthandler/openapi.go
@@ -1,0 +1,27 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vcresthandler
+
+// swagger:parameters vcGetReq
+type vcGetReq struct { // nolint: unused,deadcode
+	// in: path
+	ID string `json:"id"`
+}
+
+// swagger:response vcGetResp
+type vcGetResp struct { // nolint: unused,deadcode
+	Body string
+}
+
+// getVC swagger:route GET /vc/{id} VC vcGetReq
+//
+// Retrieves the current witness vc.
+//
+// Responses:
+//        200: vcGetResp
+func getVC() { // nolint: unused,deadcode
+}

--- a/pkg/anchor/witness/policy/resthandler/openapi.go
+++ b/pkg/anchor/witness/policy/resthandler/openapi.go
@@ -1,0 +1,45 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resthandler
+
+// swagger:parameters policyGetReq
+type policyGetReq struct { // nolint: unused,deadcode
+}
+
+// swagger:response policyGetResp
+type policyGetResp struct { // nolint: unused,deadcode
+	Body string
+}
+
+// getPolicy swagger:route GET /policy policy policyGetReq
+//
+// Retrieves the current witness policy.
+//
+// Responses:
+//        200: policyGetResp
+func getPolicy() { // nolint: unused,deadcode
+}
+
+// swagger:parameters policyPostReq
+type policyPostReq struct { // nolint: unused,deadcode
+	// in: body
+	Body string
+}
+
+// swagger:response policyPostResp
+type policyPostResp struct { // nolint: unused,deadcode
+	Body string
+}
+
+// postPolicy swagger:route POST /policy policy policyPostReq
+//
+// Retrieves the current witness policy.
+//
+// Responses:
+//        200: policyPostResp
+func postPolicy() { // nolint: unused,deadcode
+}

--- a/pkg/discovery/endpoint/restapi/openapi.go
+++ b/pkg/discovery/endpoint/restapi/openapi.go
@@ -30,7 +30,7 @@ type wellKnownResp struct { // nolint: unused,deadcode
 //
 // swagger:parameters webFingerReq
 type webFingerReq struct { // nolint: unused,deadcode
-	// in: path
+	// in: query
 	Resource string `json:"resource"`
 }
 

--- a/pkg/discovery/endpoint/restapi/operations.go
+++ b/pkg/discovery/endpoint/restapi/operations.go
@@ -268,7 +268,7 @@ func (o *Operation) webFingerHandler(rw http.ResponseWriter, r *http.Request) {
 
 // nodeInfoHandler swagger:route Get /.well-known/nodeinfo discovery wellKnownNodeInfoReq
 //
-// webDIDHandler.
+// Returns the NodeInfo endpoints that may be queried to provide general information about an Orb server.
 //
 // Responses:
 //    default: genericError

--- a/pkg/metrics/openapi.go
+++ b/pkg/metrics/openapi.go
@@ -1,0 +1,25 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package metrics
+
+// swagger:parameters metricsGetReq
+type metricsGetReq struct { // nolint: unused,deadcode
+}
+
+// swagger:response metricsGetResp
+type metricsGetResp struct { // nolint: unused,deadcode
+	Body string
+}
+
+// getMetrics swagger:route GET /metrics System metricsGetReq
+//
+// Retrieves the current witness metrics.
+//
+// Responses:
+//        200: metricsGetResp
+func getMetrics() { // nolint: unused,deadcode
+}

--- a/pkg/nodeinfo/openapi.go
+++ b/pkg/nodeinfo/openapi.go
@@ -5,23 +5,48 @@ SPDX-License-Identifier: Apache-2.0
 
 package nodeinfo
 
-// genericError model
+// nodeInfo20Req model
 //
-// swagger:response genericError
-type genericError struct { // nolint: unused,deadcode
-	// in: body
-	Body string
-}
+// swagger:parameters nodeInfo20Req
+type nodeInfo20Req struct{} // nolint: unused,deadcode
 
-// nodeInfoReq model
+// nodeInfo20Resp model
 //
-// swagger:parameters nodeInfoReq
-type nodeInfoReq struct{} // nolint: unused,deadcode
-
-// nodeInfoResp model
-//
-// swagger:response NodeInfo
-type nodeInfoResp struct { // nolint: unused,deadcode
+// swagger:response nodeInfo20Resp
+type nodeInfo20Resp struct { // nolint: unused,deadcode
 	// in: body
 	Body *NodeInfo
+}
+
+//nolint:lll
+// handle swagger:route Get /nodeinfo/2.0 System nodeInfo20Req
+//
+// The NodeInfo endpoints provide general information about an Orb server, including the version, the number of posts (Create activities) and the number of comments (Like activities). This endpoint returns a version 2.0 response.
+//
+// Responses:
+//        200: nodeInfo20Resp
+func (h *Handler) nodeInfo20GetReq() { // nolint: unused
+}
+
+// nodeInfo21Req model
+//
+// swagger:parameters nodeInfo21Req
+type nodeInfo21Req struct{} // nolint: unused,deadcode
+
+// nodeInfo21Resp model
+//
+// swagger:response nodeInfo21Resp
+type nodeInfo21Resp struct { // nolint: unused,deadcode
+	// in: body
+	Body *NodeInfo
+}
+
+//nolint:lll
+// handle swagger:route Get /nodeinfo/2.1 System nodeInfo21Req
+//
+// The NodeInfo endpoints provide general information about an Orb server, including the version, the number of posts (Create activities) and the number of comments (Like activities). This endpoint returns a version 2.1 response.
+//
+// Responses:
+//        200: nodeInfo21Resp
+func (h *Handler) nodeInfo21GetReq() { // nolint: unused
 }

--- a/pkg/vct/resthandler/openapi.go
+++ b/pkg/vct/resthandler/openapi.go
@@ -1,0 +1,45 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resthandler
+
+// swagger:parameters logGetReq
+type logGetReq struct { // nolint: unused,deadcode
+}
+
+// swagger:response logGetResp
+type logGetResp struct { // nolint: unused,deadcode
+	Body string
+}
+
+// getLog swagger:route GET /log Log logGetReq
+//
+// Retrieves the current witness log.
+//
+// Responses:
+//        200: logGetResp
+func getLog() { // nolint: unused,deadcode
+}
+
+// swagger:parameters logPostReq
+type logPostReq struct { // nolint: unused,deadcode
+	// in: body
+	Body string
+}
+
+// swagger:response logPostResp
+type logPostResp struct { // nolint: unused,deadcode
+	Body string
+}
+
+// postLog swagger:route Post /log Log logPostReq
+//
+// Sets the current witness log.
+//
+// Responses:
+//        200: logPostResp
+func postLog() { // nolint: unused,deadcode
+}

--- a/pkg/webcas/openapi.go
+++ b/pkg/webcas/openapi.go
@@ -1,0 +1,28 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package webcas
+
+// swagger:parameters casGetReq
+type casGetReq struct { // nolint: unused,deadcode
+	// in: path
+	ID string `json:"id"`
+}
+
+// swagger:response casGetResp
+type casGetResp struct { // nolint: unused,deadcode
+	Body string
+}
+
+//nolint:lll
+// handleGet swagger:route GET /cas/{id} CAS casGetReq
+//
+// Returns content stored in the Content Addressable Storage (CAS). The ID is either an IPFS CID or the hash of the content.
+//
+// Responses:
+//        200: casGetResp
+func casGetRequest() { // nolint: unused,deadcode
+}


### PR DESCRIPTION
Added swagger docs for:

- /acceptlist
- /services/orb
- /services/orb/activities
- /services/orb/followers
- /services/orb/following
- /services/orb/inbox
- /services/orb/keys
- /services/orb/liked
- /services/orb/outbox
- /services/orb/shares
- /services/orb/witnesses
- /services/orb/witnessing
- /cas
- /log
- /metrics
- /nodeinfo
- /policy
- /vc

Also updated the Makefile 'checks' target to also validate the open-api-spec.

closes #575
closes #1351

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>