### PR TITLE
fix: Use dedicated publisher pool for wait queue

### DIFF
--- a/pkg/pubsub/amqp/amqppubsub.go
+++ b/pkg/pubsub/amqp/amqppubsub.go
@@ -31,10 +31,11 @@ import (
 var logger = log.New("pubsub")
 
 const (
-	defaultMaxConnectRetries          = 25
-	defaultMaxConnectInterval         = 5 * time.Second
-	defaultMaxConnectElapsedTime      = 3 * time.Minute
-	defaultMaxConnectionSubscriptions = 1000
+	defaultMaxConnectRetries                 = 25
+	defaultMaxConnectInterval                = 5 * time.Second
+	defaultMaxConnectElapsedTime             = 3 * time.Minute
+	defaultMaxConnectionSubscriptions        = 1000
+	defaultWaitQueuePublisherChannelPoolSize = 5
 
 	defaultMaxRedeliveryAttempts     = 10
 	defaultRedeliveryMultiplier      = 1.5
@@ -798,6 +799,7 @@ func newWaitQueueConfig(cfg Config) amqp.Config {
 		metadataDeadLetterRoutingKey: redeliveryQueue,
 		metadataDeadLetterExchange:   redeliveryExchange,
 	})
+	queueConfig.Publish.ChannelPoolSize = defaultWaitQueuePublisherChannelPoolSize
 
 	return queueConfig
 }


### PR DESCRIPTION
Configure the wait queue with a small publisher pool so as not to waste resources.

closes #1370

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>