### PR TITLE
feat: Use multiple publisher pools if pool size is to large

### DIFF
--- a/cmd/orb-server/startcmd/params.go
+++ b/cmd/orb-server/startcmd/params.go
@@ -290,11 +290,11 @@ const (
 	mqInboxPoolFlagUsage = "The size of the inbox queue subscriber pool. If not specified then the default size is used. " +
 		commonEnvVarUsageText + mqInboxPoolEnvKey
 
-	mqMaxConnectionSubscriptionsFlagName      = "mq-max-connection-subscriptions"
-	mqMaxConnectionSubscriptionsFlagShorthand = "C"
-	mqMaxConnectionSubscriptionsEnvKey        = "MQ_MAX_CONNECTION_SUBSCRIPTIONS"
-	mqMaxConnectionSubscriptionsFlagUsage     = "The maximum number of subscriptions per connection. " +
-		commonEnvVarUsageText + mqMaxConnectionSubscriptionsEnvKey
+	mqMaxConnectionChannelsFlagName      = "mq-max-connection-channels"
+	mqMaxConnectionChannelsFlagShorthand = "C"
+	mqMaxConnectionChannelsEnvKey        = "MQ_MAX_CONNECTION_CHANNELS"
+	mqMaxConnectionChannelsFlagUsage     = "The maximum number of channels per connection. " +
+		commonEnvVarUsageText + mqMaxConnectionChannelsEnvKey
 
 	mqPublisherChannelPoolSizeFlagName  = "mq-publisher-channel-pool-size"
 	mqPublisherChannelPoolSizeEnvKey    = "MQ_PUBLISHER_POOL"
@@ -1724,18 +1724,18 @@ func getBool(cmd *cobra.Command, flagName, envKey string, defaultValue bool) (bo
 }
 
 type mqParams struct {
-	endpoint                   string
-	observerPoolSize           int
-	outboxPoolSize             int
-	inboxPoolSize              int
-	maxConnectionSubscriptions int
-	publisherChannelPoolSize   int
-	publisherConfirmDelivery   bool
-	maxConnectRetries          int
-	maxRedeliveryAttempts      int
-	redeliveryMultiplier       float64
-	redeliveryInitialInterval  time.Duration
-	maxRedeliveryInterval      time.Duration
+	endpoint                  string
+	observerPoolSize          int
+	outboxPoolSize            int
+	inboxPoolSize             int
+	maxConnectionChannels     int
+	publisherChannelPoolSize  int
+	publisherConfirmDelivery  bool
+	maxConnectRetries         int
+	maxRedeliveryAttempts     int
+	redeliveryMultiplier      float64
+	redeliveryInitialInterval time.Duration
+	maxRedeliveryInterval     time.Duration
 }
 
 func getMQParameters(cmd *cobra.Command) (*mqParams, error) {
@@ -1759,8 +1759,8 @@ func getMQParameters(cmd *cobra.Command) (*mqParams, error) {
 		return nil, err
 	}
 
-	mqMaxConnectionSubscriptions, err := getInt(cmd, mqMaxConnectionSubscriptionsFlagName,
-		mqMaxConnectionSubscriptionsEnvKey, mqDefaultMaxConnectionSubscriptions)
+	mqMaxConnectionChannels, err := getInt(cmd, mqMaxConnectionChannelsFlagName,
+		mqMaxConnectionChannelsEnvKey, mqDefaultMaxConnectionSubscriptions)
 	if err != nil {
 		return nil, err
 	}
@@ -1808,18 +1808,18 @@ func getMQParameters(cmd *cobra.Command) (*mqParams, error) {
 	}
 
 	return &mqParams{
-		endpoint:                   mqURL,
-		observerPoolSize:           mqObserverPoolSize,
-		outboxPoolSize:             mqOutboxPoolSize,
-		inboxPoolSize:              mqInboxPoolSize,
-		maxConnectionSubscriptions: mqMaxConnectionSubscriptions,
-		publisherChannelPoolSize:   mqPublisherChannelPoolSize,
-		publisherConfirmDelivery:   mqPublisherConfirmDelivery,
-		maxConnectRetries:          mqMaxConnectRetries,
-		maxRedeliveryAttempts:      mqMaxRedeliveryAttempts,
-		redeliveryMultiplier:       mqRedeliveryMultiplier,
-		redeliveryInitialInterval:  mqRedeliveryInitialInterval,
-		maxRedeliveryInterval:      mqRedeliveryMaxInterval,
+		endpoint:                  mqURL,
+		observerPoolSize:          mqObserverPoolSize,
+		outboxPoolSize:            mqOutboxPoolSize,
+		inboxPoolSize:             mqInboxPoolSize,
+		maxConnectionChannels:     mqMaxConnectionChannels,
+		publisherChannelPoolSize:  mqPublisherChannelPoolSize,
+		publisherConfirmDelivery:  mqPublisherConfirmDelivery,
+		maxConnectRetries:         mqMaxConnectRetries,
+		maxRedeliveryAttempts:     mqMaxRedeliveryAttempts,
+		redeliveryMultiplier:      mqRedeliveryMultiplier,
+		redeliveryInitialInterval: mqRedeliveryInitialInterval,
+		maxRedeliveryInterval:     mqRedeliveryMaxInterval,
 	}, nil
 }
 
@@ -2036,7 +2036,7 @@ func createFlags(startCmd *cobra.Command) {
 	startCmd.Flags().StringP(mqObserverPoolFlagName, mqObserverPoolFlagShorthand, "", mqObserverPoolFlagUsage)
 	startCmd.Flags().StringP(mqOutboxPoolFlagName, "", "", mqOutboxPoolFlagUsage)
 	startCmd.Flags().StringP(mqInboxPoolFlagName, "", "", mqInboxPoolFlagUsage)
-	startCmd.Flags().StringP(mqMaxConnectionSubscriptionsFlagName, mqMaxConnectionSubscriptionsFlagShorthand, "", mqMaxConnectionSubscriptionsFlagUsage)
+	startCmd.Flags().StringP(mqMaxConnectionChannelsFlagName, mqMaxConnectionChannelsFlagShorthand, "", mqMaxConnectionChannelsFlagUsage)
 	startCmd.Flags().StringP(mqPublisherChannelPoolSizeFlagName, "", "", mqPublisherChannelPoolSizeFlagUsage)
 	startCmd.Flags().StringP(mqPublisherConfirmDeliveryEnvKey, "", "", mqPublisherConfirmDeliveryFlagUsage)
 	startCmd.Flags().StringP(mqConnectMaxRetriesFlagName, "", "", mqConnectMaxRetriesFlagUsage)

--- a/cmd/orb-server/startcmd/params_test.go
+++ b/cmd/orb-server/startcmd/params_test.go
@@ -639,8 +639,8 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 		require.Contains(t, err.Error(), "missing unit in duration")
 	})
 
-	t.Run("Invalid max connection subscriptions", func(t *testing.T) {
-		restoreEnv := setEnv(t, mqMaxConnectionSubscriptionsEnvKey, "xxx")
+	t.Run("Invalid max connection channels", func(t *testing.T) {
+		restoreEnv := setEnv(t, mqMaxConnectionChannelsEnvKey, "xxx")
 		defer restoreEnv()
 
 		startCmd := GetStartCmd()
@@ -649,7 +649,7 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 
 		err := startCmd.Execute()
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "invalid value for mq-max-connection-subscriptions")
+		require.Contains(t, err.Error(), "invalid value for mq-max-connection-channels")
 	})
 
 	t.Run("Invalid follow auth policy", func(t *testing.T) {
@@ -1209,7 +1209,7 @@ func TestGetMQParameters(t *testing.T) {
 		restoreInboxPoolEnv := setEnv(t, mqInboxPoolEnvKey, "7")
 		restoreChannelPoolEnv := setEnv(t, mqPublisherChannelPoolSizeEnvKey, "321")
 		restoreConfirmDeliveryEnv := setEnv(t, mqPublisherConfirmDeliveryEnvKey, "false")
-		restoreConnectionSubscriptionsEnv := setEnv(t, mqMaxConnectionSubscriptionsEnvKey, "456")
+		restoreConnectionSubscriptionsEnv := setEnv(t, mqMaxConnectionChannelsEnvKey, "456")
 		restoreConnectionRetriesEnv := setEnv(t, mqConnectMaxRetriesEnvKey, "12")
 		restoreRedeliveryMaxAttempts := setEnv(t, mqRedeliveryMaxAttemptsEnvKey, "17")
 		restoreRedeliveryMultiplier := setEnv(t, mqRedeliveryMultiplierEnvKey, "1.7")
@@ -1239,7 +1239,7 @@ func TestGetMQParameters(t *testing.T) {
 		require.Equal(t, 3, mqParams.observerPoolSize)
 		require.Equal(t, 4, mqParams.outboxPoolSize)
 		require.Equal(t, 7, mqParams.inboxPoolSize)
-		require.Equal(t, 456, mqParams.maxConnectionSubscriptions)
+		require.Equal(t, 456, mqParams.maxConnectionChannels)
 		require.Equal(t, 321, mqParams.publisherChannelPoolSize)
 		require.False(t, mqParams.publisherConfirmDelivery)
 		require.Equal(t, 12, mqParams.maxConnectRetries)
@@ -1264,7 +1264,7 @@ func TestGetMQParameters(t *testing.T) {
 		require.Equal(t, mqDefaultObserverPoolSize, mqParams.observerPoolSize)
 		require.Equal(t, mqDefaultOutboxPoolSize, mqParams.outboxPoolSize)
 		require.Equal(t, mqDefaultInboxPoolSize, mqParams.inboxPoolSize)
-		require.Equal(t, mqDefaultMaxConnectionSubscriptions, mqParams.maxConnectionSubscriptions)
+		require.Equal(t, mqDefaultMaxConnectionSubscriptions, mqParams.maxConnectionChannels)
 		require.Equal(t, mqDefaultPublisherChannelPoolSize, mqParams.publisherChannelPoolSize)
 		require.Equal(t, mqDefaultPublisherConfirmDelivery, mqParams.publisherConfirmDelivery)
 		require.Equal(t, mqDefaultRedeliveryMaxInterval, mqParams.maxRedeliveryInterval)
@@ -1274,7 +1274,7 @@ func TestGetMQParameters(t *testing.T) {
 	})
 
 	t.Run("Invalid max connection subscriptions value -> error", func(t *testing.T) {
-		restoreEnv := setEnv(t, mqMaxConnectionSubscriptionsEnvKey, "xxx")
+		restoreEnv := setEnv(t, mqMaxConnectionChannelsEnvKey, "xxx")
 
 		defer func() {
 			restoreEnv()

--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -734,15 +734,15 @@ func startOrbServices(parameters *orbParameters) error {
 
 	if mqParams.endpoint != "" {
 		pubSub = amqp.New(amqp.Config{
-			URI:                        mqParams.endpoint,
-			MaxConnectionSubscriptions: mqParams.maxConnectionSubscriptions,
-			PublisherChannelPoolSize:   mqParams.publisherChannelPoolSize,
-			PublisherConfirmDelivery:   mqParams.publisherConfirmDelivery,
-			MaxConnectRetries:          mqParams.maxConnectRetries,
-			MaxRedeliveryAttempts:      mqParams.maxRedeliveryAttempts,
-			RedeliveryMultiplier:       mqParams.redeliveryMultiplier,
-			RedeliveryInitialInterval:  mqParams.redeliveryInitialInterval,
-			MaxRedeliveryInterval:      mqParams.maxRedeliveryInterval,
+			URI:                       mqParams.endpoint,
+			MaxConnectionChannels:     mqParams.maxConnectionChannels,
+			PublisherChannelPoolSize:  mqParams.publisherChannelPoolSize,
+			PublisherConfirmDelivery:  mqParams.publisherConfirmDelivery,
+			MaxConnectRetries:         mqParams.maxConnectRetries,
+			MaxRedeliveryAttempts:     mqParams.maxRedeliveryAttempts,
+			RedeliveryMultiplier:      mqParams.redeliveryMultiplier,
+			RedeliveryInitialInterval: mqParams.redeliveryInitialInterval,
+			MaxRedeliveryInterval:     mqParams.maxRedeliveryInterval,
 		})
 	} else {
 		pubSub = mempubsub.New(mempubsub.DefaultConfig())

--- a/pkg/pubsub/amqp/publisherpool.go
+++ b/pkg/pubsub/amqp/publisherpool.go
@@ -1,0 +1,139 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package amqp
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	"github.com/ThreeDotsLabs/watermill-amqp/v2/pkg/amqp"
+	"github.com/ThreeDotsLabs/watermill/message"
+)
+
+type publishFunc func(topic string, messages ...*message.Message) error
+
+type createPublisherFunc func(cfg *amqp.Config, conn connection) (publisher, error)
+
+type publisherPool struct {
+	publishers []publisher
+	publish    publishFunc
+}
+
+func newPublisherPool(connMgr connMgr, maxChannelsPerConn int, cfg *amqp.Config,
+	createPublisher createPublisherFunc) (*publisherPool, error) {
+	publishers, err := createPublishers(connMgr, maxChannelsPerConn, cfg, createPublisher)
+	if err != nil {
+		return nil, fmt.Errorf("create publishers: %w", err)
+	}
+
+	var publish publishFunc
+
+	if len(publishers) == 1 {
+		publish = publishers[0].Publish
+	} else {
+		lb := newRoundRobin(len(publishers) - 1)
+
+		publish = func(topic string, messages ...*message.Message) error {
+			i := lb.nextIndex()
+
+			logger.Debugf("Using publisher at index %d", i)
+
+			return publishers[i].Publish(topic, messages...)
+		}
+	}
+
+	return &publisherPool{
+		publishers: publishers,
+		publish:    publish,
+	}, nil
+}
+
+func (p *publisherPool) Publish(topic string, messages ...*message.Message) error {
+	return p.publish(topic, messages...)
+}
+
+func (p *publisherPool) Close() error {
+	logger.Debugf("Closing publisher pool.")
+
+	var lastErr error
+
+	for _, p := range p.publishers {
+		if err := p.Close(); err != nil {
+			lastErr = err
+		}
+	}
+
+	return lastErr
+}
+
+func createPublishers(connMgr connMgr, maxChannelsPerConn int, cfg *amqp.Config,
+	createPublisher createPublisherFunc) ([]publisher, error) {
+	var numPublishers int
+
+	if cfg.Publish.ChannelPoolSize == 0 {
+		numPublishers = 1
+	} else {
+		numPublishers = cfg.Publish.ChannelPoolSize / maxChannelsPerConn
+
+		if cfg.Publish.ChannelPoolSize%maxChannelsPerConn > 0 {
+			numPublishers++
+		}
+	}
+
+	newCfg := *cfg
+
+	// Split the channels evenly across the connections.
+	newCfg.Publish.ChannelPoolSize /= numPublishers
+
+	var publishers []publisher
+
+	for i := 0; i < numPublishers; i++ {
+		conn, err := connMgr.getConnection(false)
+		if err != nil {
+			return nil, fmt.Errorf("get connection: %w", err)
+		}
+
+		pub, err := createPublisher(&newCfg, conn)
+		if err != nil {
+			return nil, fmt.Errorf("new publisher: %w", err)
+		}
+
+		publishers = append(publishers, pub)
+	}
+
+	logger.Infof("Created %d publisher connections at [%s], each with a channel pool size of %d",
+		len(publishers), extractEndpoint(newCfg.Connection.AmqpURI), newCfg.Publish.ChannelPoolSize)
+
+	return publishers, nil
+}
+
+type roundRobin struct {
+	max     int
+	current int32
+}
+
+func newRoundRobin(max int) *roundRobin {
+	return &roundRobin{max: max}
+}
+
+func (r *roundRobin) nextIndex() int {
+	var i int32
+
+	for {
+		i = atomic.AddInt32(&r.current, 1)
+
+		if int(i) > r.max {
+			if !atomic.CompareAndSwapInt32(&r.current, i, 0) {
+				continue
+			}
+
+			i = 0
+		}
+
+		return int(i)
+	}
+}

--- a/pkg/pubsub/amqp/publisherpool_test.go
+++ b/pkg/pubsub/amqp/publisherpool_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package amqp
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ThreeDotsLabs/watermill-amqp/v2/pkg/amqp"
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPublisherPool(t *testing.T) {
+	t.Run("No pool", func(t *testing.T) {
+		amqpCfg := newDefaultQueueConfig(Config{URI: mqURI})
+
+		p, err := newPublisherPool(&mockConnectionMgr{}, 9, &amqpCfg,
+			func(cfg *amqp.Config, conn connection) (publisher, error) {
+				return newMockPublisher(), nil
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, p)
+		require.Len(t, p.publishers, 1)
+		require.NoError(t, p.Publish("topic", &message.Message{}))
+		require.NoError(t, p.Close())
+	})
+
+	t.Run("With pool", func(t *testing.T) {
+		amqpCfg := newDefaultQueueConfig(Config{URI: mqURI})
+		amqpCfg.Publish.ChannelPoolSize = 50
+
+		p, err := newPublisherPool(&mockConnectionMgr{}, 9, &amqpCfg,
+			func(cfg *amqp.Config, conn connection) (publisher, error) {
+				return newMockPublisher(), nil
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, p)
+		require.Len(t, p.publishers, 6)
+		require.NoError(t, p.Publish("topic", &message.Message{}))
+		require.NoError(t, p.Close())
+	})
+
+	t.Run("Create connection error", func(t *testing.T) {
+		errExpected := errors.New("injected create connection error")
+
+		amqpCfg := newDefaultQueueConfig(Config{URI: mqURI})
+
+		p, err := newPublisherPool(&mockConnectionMgr{err: errExpected}, 9,
+			&amqpCfg, func(cfg *amqp.Config, conn connection) (publisher, error) {
+				return newMockPublisher(), nil
+			},
+		)
+		require.Error(t, err)
+		require.Nil(t, p)
+		require.Contains(t, err.Error(), errExpected.Error())
+	})
+
+	t.Run("Create publisher error", func(t *testing.T) {
+		errExpected := errors.New("injected create publisher error")
+
+		amqpCfg := newDefaultQueueConfig(Config{URI: mqURI})
+
+		p, err := newPublisherPool(&mockConnectionMgr{}, 9,
+			&amqpCfg, func(cfg *amqp.Config, conn connection) (publisher, error) {
+				return nil, errExpected
+			},
+		)
+		require.Error(t, err)
+		require.Nil(t, p)
+		require.Contains(t, err.Error(), errExpected.Error())
+	})
+
+	t.Run("Close error", func(t *testing.T) {
+		errExpected := errors.New("injected close error")
+
+		amqpCfg := newDefaultQueueConfig(Config{URI: mqURI})
+		amqpCfg.Publish.ChannelPoolSize = 50
+
+		p, err := newPublisherPool(&mockConnectionMgr{}, 9, &amqpCfg,
+			func(cfg *amqp.Config, conn connection) (publisher, error) {
+				return &mockPublisher{mockClosable: &mockClosable{err: errExpected}}, nil
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, p)
+
+		err = p.Close()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+	})
+}
+
+func TestRoundRobinRace(t *testing.T) {
+	const (
+		concurrency = 10
+		num         = 100000
+		maxIndex    = 99
+	)
+
+	lb := newRoundRobin(maxIndex)
+
+	var wg sync.WaitGroup
+
+	for p := 0; p < concurrency; p++ {
+		wg.Add(1)
+
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+
+			for i := 0; i < num; i++ {
+				require.True(t, lb.nextIndex() <= maxIndex)
+			}
+
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+}

--- a/test/bdd/fixtures/docker-compose-testver.yml
+++ b/test/bdd/fixtures/docker-compose-testver.yml
@@ -43,7 +43,7 @@ services:
       # MQ_PUBLISHER_POOL specifies the size of a channel pool for an AMQP publisher (default 25). If set to 0 then
       #	a channel pool is not used and a new channel is opened/closed for every publish to a queue.
       - MQ_PUBLISHER_POOL=50
-      - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
+      - MQ_MAX_CONNECTION_CHANNELS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN1}
       - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain1.com
       - ANCHOR_CREDENTIAL_URL=https://orb.domain1.com/vc
@@ -165,7 +165,7 @@ services:
       # MQ_PUBLISHER_POOL specifies the size of a channel pool for an AMQP publisher (default 25). If set to 0 then
       #	a channel pool is not used and a new channel is opened/closed for every publish to a queue.
       - MQ_PUBLISHER_POOL=25
-      - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
+      - MQ_MAX_CONNECTION_CHANNELS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN2}
       - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain2.com
       - ANCHOR_CREDENTIAL_URL=https://orb.domain2.com/vc
@@ -267,7 +267,7 @@ services:
       # MQ_PUBLISHER_POOL specifies the size of a channel pool for an AMQP publisher (default 25). If set to 0 then
       #	a channel pool is not used and a new channel is opened/closed for every publish to a queue.
       - MQ_PUBLISHER_POOL=25
-      - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
+      - MQ_MAX_CONNECTION_CHANNELS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN3}
       - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain3.com
       - ANCHOR_CREDENTIAL_URL=https://orb.domain3.com/vc
@@ -380,7 +380,7 @@ services:
       # MQ_PUBLISHER_POOL specifies the size of a channel pool for an AMQP publisher (default 25). If set to 0 then
       #	a channel pool is not used and a new channel is opened/closed for every publish to a queue.
       - MQ_PUBLISHER_POOL=25
-      - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
+      - MQ_MAX_CONNECTION_CHANNELS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN3}
       - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain4.com
       - ANCHOR_CREDENTIAL_URL=https://orb.domain4.com/vc

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -68,7 +68,7 @@ services:
       - MQ_PUBLISHER_POOL=50
       # MQ_PUBLISHER_CONFIRM_DELIVERY turns on delivery confirmation of published messages (default true).
       - MQ_PUBLISHER_CONFIRM_DELIVERY=true
-      - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
+      - MQ_MAX_CONNECTION_CHANNELS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN1}
       - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain1.com
       - ANCHOR_CREDENTIAL_URL=https://orb.domain1.com/vc
@@ -205,7 +205,7 @@ services:
       # MQ_PUBLISHER_POOL specifies the size of a channel pool for an AMQP publisher (default 25). If set to 0 then
       #	a channel pool is not used and a new channel is opened/closed for every publish to a queue.
       - MQ_PUBLISHER_POOL=50
-      - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
+      - MQ_MAX_CONNECTION_CHANNELS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN1}
       - ANCHOR_CREDENTIAL_ISSUER=https://orb2.domain1.com
       - ANCHOR_CREDENTIAL_URL=https://orb2.domain1.com/vc
@@ -341,7 +341,7 @@ services:
       # MQ_PUBLISHER_POOL specifies the size of a channel pool for an AMQP publisher (default 25). If set to 0 then
       #	a channel pool is not used and a new channel is opened/closed for every publish to a queue.
       - MQ_PUBLISHER_POOL=25
-      - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
+      - MQ_MAX_CONNECTION_CHANNELS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN2}
       - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain2.com
       - ANCHOR_CREDENTIAL_URL=https://orb.domain2.com/vc
@@ -442,7 +442,7 @@ services:
       # MQ_PUBLISHER_POOL specifies the size of a channel pool for an AMQP publisher (default 25). If set to 0 then
       #	a channel pool is not used and a new channel is opened/closed for every publish to a queue.
       - MQ_PUBLISHER_POOL=25
-      - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
+      - MQ_MAX_CONNECTION_CHANNELS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN2}
       - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain2.com
       - ANCHOR_CREDENTIAL_URL=https://orb.domain2.com/vc
@@ -546,7 +546,7 @@ services:
       # MQ_PUBLISHER_POOL specifies the size of a channel pool for an AMQP publisher (default 25). If set to 0 then
       #	a channel pool is not used and a new channel is opened/closed for every publish to a queue.
       - MQ_PUBLISHER_POOL=25
-      - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
+      - MQ_MAX_CONNECTION_CHANNELS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN3}
       - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain3.com
       - ANCHOR_CREDENTIAL_URL=https://orb.domain3.com/vc
@@ -668,7 +668,7 @@ services:
       # MQ_PUBLISHER_POOL specifies the size of a channel pool for an AMQP publisher (default 25). If set to 0 then
       #	a channel pool is not used and a new channel is opened/closed for every publish to a queue.
       - MQ_PUBLISHER_POOL=25
-      - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
+      - MQ_MAX_CONNECTION_CHANNELS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN4}
       - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain4.com
       - ANCHOR_CREDENTIAL_URL=https://orb.domain4.com/vc
@@ -782,7 +782,7 @@ services:
       # MQ_PUBLISHER_POOL specifies the size of a channel pool for an AMQP publisher (default 25). If set to 0 then
       #	a channel pool is not used and a new channel is opened/closed for every publish to a queue.
       - MQ_PUBLISHER_POOL=25
-      - MQ_MAX_CONNECTION_SUBSCRIPTIONS=1500
+      - MQ_MAX_CONNECTION_CHANNELS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN4}
       - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain5.com
       - ANCHOR_CREDENTIAL_URL=https://orb.domain5.com/vc


### PR DESCRIPTION
If the pool size exceeds the maximum number of channels per connection then multiple publisher pools are created, each pool having a dedicated connection. The pools are distributed evenly.

Also renamed startup parameter/environment variable from mq-max-connection-subscriptions/MQ_MAX_CONNECTION_SUBSCRIPTIONS to mq-max-connection-channels/MQ_MAX_CONNECTION_CHANNELS since it is used for publisher as well as subscriber pools.

closes #1372

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>