### PR TITLE
fix: Fix for lost DIDs after domain down for long period

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -1027,8 +1027,7 @@ func startOrbServices(parameters *orbParameters) error {
 		return fmt.Errorf("failed to create writer: %s", err.Error())
 	}
 
-	opQueue, err := opqueue.New(*parameters.opQueueParams, pubSub, storeProviders.provider, taskMgr,
-		expiryService, metrics.Get())
+	opQueue, err := opqueue.New(*parameters.opQueueParams, pubSub, storeProviders.provider, taskMgr, metrics.Get())
 	if err != nil {
 		return fmt.Errorf("failed to create operation queue: %s", err.Error())
 	}

--- a/pkg/activitypub/service/inbox/inbox.go
+++ b/pkg/activitypub/service/inbox/inbox.go
@@ -202,7 +202,7 @@ func (h *Inbox) handle(msg *message.Message) {
 			msg.Ack()
 		}
 	} else {
-		logger.Infof("[%s] Acking message [%s] for activity [%s]", h.ServiceEndpoint, msg.UUID, activity.ID())
+		logger.Debugf("[%s] Acking message [%s] for activity [%s]", h.ServiceEndpoint, msg.UUID, activity.ID())
 
 		msg.Ack()
 

--- a/pkg/activitypub/service/outbox/outbox.go
+++ b/pkg/activitypub/service/outbox/outbox.go
@@ -224,7 +224,7 @@ func (h *Outbox) handle(msg *message.Message) {
 			msg.Ack()
 		}
 	} else {
-		logger.Infof("[%s] Acking message [%s] for activity [%s]", h.ServiceName, msg.UUID, activity.ID())
+		logger.Debugf("[%s] Acking message [%s] for activity [%s]", h.ServiceName, msg.UUID, activity.ID())
 
 		msg.Ack()
 	}

--- a/pkg/anchor/handler/proof/handler.go
+++ b/pkg/anchor/handler/proof/handler.go
@@ -148,8 +148,8 @@ func (h *WitnessProofHandler) HandleProof(witness *url.URL, anchor string, endTi
 	}
 
 	if status == proofapi.AnchorIndexStatusCompleted {
-		logger.Infof("Received proof from [%s] but witness policy has already been satisfied for anchor[%s]",
-			witness, anchor, string(proof))
+		logger.Infof("Received proof for anchor [%s] from witness [%s] but witness policy has already "+
+			"been satisfied so it will be ignored. Proof: %s", anchor, witness, proof)
 
 		// witness policy has been satisfied and witness proofs added to verifiable credential - nothing to do
 		return nil

--- a/pkg/anchor/witness/policy/inspector/inspector_test.go
+++ b/pkg/anchor/witness/policy/inspector/inspector_test.go
@@ -196,9 +196,11 @@ func TestInspector_CheckPolicy(t *testing.T) {
 
 		err = c.CheckPolicy(anchorLink.Anchor().String())
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to get additional witnesses: unable to select additional witnesses "+
-			"from newly selected witnesses[[http://domain.com/service]] "+
-			"and previously selected witnesses[[http://domain.com/service]]")
+		require.Contains(t, err.Error(),
+			fmt.Sprintf("failed to get additional witnesses: unable to select additional witnesses for anchorID[%s] "+
+				"from newly selected witnesses[[http://domain.com/service]] "+
+				"and previously selected witnesses[[http://domain.com/service]]", anchorLink.Anchor()),
+		)
 	})
 
 	t.Run("error - witness store error", func(t *testing.T) {
@@ -242,7 +244,10 @@ func TestInspector_CheckPolicy(t *testing.T) {
 
 		err = c.CheckPolicy(anchorLink.Anchor().String())
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to get additional witnesses: select witnesses: witness selection error")
+		require.Contains(t, err.Error(),
+			fmt.Sprintf("failed to get additional witnesses: select witnesses for anchorID[%s]: witness selection error",
+				anchorLink.Anchor()),
+		)
 	})
 }
 

--- a/pkg/context/opqueue/opqueue_test.go
+++ b/pkg/context/opqueue/opqueue_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/trustbloc/orb/pkg/mocks"
 	"github.com/trustbloc/orb/pkg/pubsub/amqp"
 	"github.com/trustbloc/orb/pkg/pubsub/mempubsub"
-	"github.com/trustbloc/orb/pkg/store/expiry"
 )
 
 //go:generate counterfeiter -o ../mocks/pubsub.gen.go --fake-name PubSub . pubSub
@@ -74,7 +73,6 @@ func TestQueue(t *testing.T) {
 			RetriesMultiplier:   1.0,
 		},
 		ps1, storageProvider, taskMgr1,
-		expiry.NewService(taskMgr1, 750*time.Millisecond),
 		&mocks.MetricsProvider{},
 	)
 	require.NoError(t, err)
@@ -100,7 +98,6 @@ func TestQueue(t *testing.T) {
 		},
 
 		ps2, storageProvider, taskMgr2,
-		expiry.NewService(taskMgr2, 750*time.Millisecond),
 		&mocks.MetricsProvider{},
 	)
 	require.NoError(t, err)
@@ -203,11 +200,10 @@ func TestQueue_Error(t *testing.T) {
 	defer ps.Stop()
 
 	taskMgr := servicemocks.NewTaskManager("taskmgr1")
-	expirySvc := expiry.NewService(taskMgr, 750*time.Millisecond)
 
 	t.Run("Not started error", func(t *testing.T) {
 		q, err := New(Config{}, ps, storage.NewMockStoreProvider(),
-			taskMgr, expirySvc, &mocks.MetricsProvider{})
+			taskMgr, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 		require.NotNil(t, q)
 
@@ -235,7 +231,7 @@ func TestQueue_Error(t *testing.T) {
 		ps.PublishWithOptsReturns(errExpected)
 
 		q, err := New(Config{}, ps, storage.NewMockStoreProvider(),
-			taskMgr, expirySvc, &mocks.MetricsProvider{})
+			taskMgr, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 		require.NotNil(t, q)
 
@@ -254,14 +250,14 @@ func TestQueue_Error(t *testing.T) {
 		ps.SubscribeWithOptsReturns(nil, errExpected)
 
 		_, err := New(Config{}, ps, storage.NewMockStoreProvider(),
-			taskMgr, expirySvc, &mocks.MetricsProvider{})
+			taskMgr, &mocks.MetricsProvider{})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errExpected.Error())
 	})
 
 	t.Run("Marshal error", func(t *testing.T) {
 		q, err := New(Config{}, ps, storage.NewMockStoreProvider(),
-			taskMgr, expirySvc, &mocks.MetricsProvider{})
+			taskMgr, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 		require.NotNil(t, q)
 
@@ -281,7 +277,7 @@ func TestQueue_Error(t *testing.T) {
 
 	t.Run("Unmarshal error", func(t *testing.T) {
 		q, err := New(Config{}, ps, storage.NewMockStoreProvider(),
-			taskMgr, expirySvc, &mocks.MetricsProvider{})
+			taskMgr, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 		require.NotNil(t, q)
 
@@ -315,7 +311,7 @@ func TestQueue_Error(t *testing.T) {
 		s.(*storage.MockStore).ErrPut = errExpected
 
 		q, err := New(Config{}, ps, p,
-			taskMgr, expirySvc, &mocks.MetricsProvider{})
+			taskMgr, &mocks.MetricsProvider{})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errExpected.Error())
 		require.Nil(t, q)
@@ -337,7 +333,7 @@ func TestQueue_Error(t *testing.T) {
 		s.(*storage.MockStore).ErrQuery = errExpected
 
 		q, err := New(Config{}, ps, p,
-			mgr, expirySvc, &mocks.MetricsProvider{})
+			mgr, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 		require.NotNil(t, q)
 
@@ -363,7 +359,7 @@ func TestQueue_Error(t *testing.T) {
 		s.(*storage.MockStore).ErrNext = errExpected
 
 		q, err := New(Config{}, ps, p,
-			mgr, expirySvc, &mocks.MetricsProvider{})
+			mgr, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 		require.NotNil(t, q)
 
@@ -380,7 +376,7 @@ func TestQueue_Error(t *testing.T) {
 		defer mgr.Stop()
 
 		q, err := New(Config{}, ps, storage.NewMockStoreProvider(),
-			mgr, expirySvc, &mocks.MetricsProvider{})
+			mgr, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 		require.NotNil(t, q)
 
@@ -403,7 +399,7 @@ func TestQueue_Error(t *testing.T) {
 		ps.PublishWithOptsReturnsOnCall(0, errExpected)
 
 		q, err := New(Config{}, ps, storage.NewMockStoreProvider(),
-			taskMgr, expirySvc, &mocks.MetricsProvider{})
+			taskMgr, &mocks.MetricsProvider{})
 		require.NoError(t, err)
 		require.NotNil(t, q)
 
@@ -473,7 +469,6 @@ func TestRepostWithMaxRetries(t *testing.T) {
 			RetriesMultiplier:   1.0,
 		},
 		ps, storageProvider, taskMgr,
-		expiry.NewService(taskMgr, 750*time.Millisecond),
 		&mocks.MetricsProvider{},
 	)
 	require.NoError(t, err)

--- a/pkg/observer/pubsub.go
+++ b/pkg/observer/pubsub.go
@@ -206,7 +206,7 @@ func (h *PubSub) handleDIDMessage(msg *message.Message) {
 func (h *PubSub) ackNackMessage(msg *message.Message, info fmt.Stringer, err error) {
 	switch {
 	case err == nil:
-		logger.Infof("Acking message [%s] for %s", msg.UUID, info)
+		logger.Debugf("Acking message [%s] for %s", msg.UUID, info)
 
 		msg.Ack()
 	case errors.IsTransient(err):

--- a/pkg/store/didanchor/store.go
+++ b/pkg/store/didanchor/store.go
@@ -59,9 +59,9 @@ func (s *Store) PutBulk(suffixes []string, areNew []bool, cid string) error {
 	err := s.store.Batch(operations)
 	if err != nil {
 		if errors.Is(err, storage.ErrDuplicateKey) {
-			logger.Warnf("Failed to add cid[%s] to suffixes%s using the batch speed optimization. "+
+			logger.Warnf("Failed to add cid[%s] to suffixes using the batch speed optimization. "+
 				"This can happen if this Orb server is in a recovery flow. Will retry without the "+
-				"optimization now (will be slower). Underlying error message: %s", cid, suffixes, err.Error())
+				"optimization now (will be slower). Underlying error message: %s", cid, err.Error())
 
 			for i, suffix := range suffixes {
 				op := storage.Operation{
@@ -74,11 +74,10 @@ func (s *Store) PutBulk(suffixes []string, areNew []bool, cid string) error {
 
 			err = s.store.Batch(operations)
 			if err != nil {
-				return orberrors.NewTransient(fmt.Errorf("failed to add cid[%s] to suffixes%s: %w",
-					cid, suffixes, err))
+				return orberrors.NewTransient(fmt.Errorf("failed to add cid[%s] to suffixes: %w", cid, err))
 			}
 		} else {
-			return orberrors.NewTransient(fmt.Errorf("failed to add cid[%s] to suffixes%s: %w", cid, suffixes, err))
+			return orberrors.NewTransient(fmt.Errorf("failed to add cid[%s] to suffixes: %w", cid, err))
 		}
 	}
 

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -44,10 +44,10 @@ services:
       # MQ_REDELIVERY_MULTIPLIER is the multiplier for a redelivery attempt. For example, if set to 1.5 and
       #	the previous redelivery interval was 2s then the next redelivery interval is set 3s (default is 1.5).
       - MQ_REDELIVERY_MULTIPLIER=1.5
-      # MQ_REDELIVERY_MAX_INTERVAL is the maximum delay for a redelivery (default is 30s).
-      - MQ_REDELIVERY_MAX_INTERVAL=30s
-      # MQ_REDELIVERY_MAX_ATTEMPTS Specifies the maximum number of redelivery attempts for a failed message (default is 20).
-      - MQ_REDELIVERY_MAX_ATTEMPTS=20
+      # MQ_REDELIVERY_MAX_INTERVAL is the maximum delay for a redelivery (default is 1m).
+      - MQ_REDELIVERY_MAX_INTERVAL=1m
+      # MQ_REDELIVERY_MAX_ATTEMPTS Specifies the maximum number of redelivery attempts for a failed message (default is 30).
+      - MQ_REDELIVERY_MAX_ATTEMPTS=30
       # OP_QUEUE_POOL specifies the number of subscribers that concurrently process messages in the operation queue (default 5).
       - OP_QUEUE_POOL=10
       # OP_QUEUE_TASK_MONITOR_INTERVAL specifies The interval (period) in which operation queue tasks from other servers are monitored (default is 10s).


### PR DESCRIPTION
- Don't use the expiry service to expire DID operations in the operation-queue. Instead, delete the operations after they fail to be delivered after the configured number of retries.
- Increase the default value for max redelivery attempts and max interval so that retries occur for an extended period of time

closes #1395
closes #1396

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>