### PR TITLE
feat: Add anchor and profile to anchor credential subject

### DIFF
--- a/pkg/anchor/anchorlinkset/generator/didorbtestgenerator/didorbtestgenerator.go
+++ b/pkg/anchor/anchorlinkset/generator/didorbtestgenerator/didorbtestgenerator.go
@@ -9,6 +9,8 @@ package didorbtestgenerator
 import (
 	"net/url"
 
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
 	"github.com/trustbloc/orb/pkg/anchor/anchorlinkset/generator/didorbgenerator"
 	"github.com/trustbloc/orb/pkg/anchor/subject"
@@ -64,4 +66,9 @@ func (g *Generator) CreateContentObject(payload *subject.Payload) (vocab.Documen
 func (g *Generator) CreatePayload(doc vocab.Document, coreIndexURI *url.URL,
 	anchors []*url.URL) (*subject.Payload, error) {
 	return g.orbGenerator.CreatePayload(doc, coreIndexURI, anchors)
+}
+
+// ValidateAnchorCredential validates the anchor credential against the given content.
+func (g *Generator) ValidateAnchorCredential(vc *verifiable.Credential, originalContentBytes []byte) error {
+	return g.orbGenerator.ValidateAnchorCredential(vc, originalContentBytes)
 }

--- a/pkg/anchor/anchorlinkset/generator/didorbtestgenerator/didorbtestgenerator_test.go
+++ b/pkg/anchor/anchorlinkset/generator/didorbtestgenerator/didorbtestgenerator_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	"github.com/stretchr/testify/require"
 	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
 
@@ -127,6 +128,15 @@ func TestGenerator_GetPayloadFromAnchorLink(t *testing.T) {
 	})
 }
 
+func TestGenerator_ValidateAnchorCredentialSubject(t *testing.T) {
+	vc, err := verifiable.ParseCredential([]byte(jsonVC),
+		verifiable.WithDisabledProofCheck(),
+		verifiable.WithJSONLDDocumentLoader(testutil.GetLoader(t)),
+	)
+	require.NoError(t, err)
+	require.NoError(t, New().ValidateAnchorCredential(vc, testutil.GetCanonicalBytes(t, jsonOriginalLinkset)))
+}
+
 const (
 	//nolint:lll
 	jsonAnchorLinkset = `{
@@ -142,6 +152,64 @@ const (
           "href": "did:orb:uEiAuBQKPYXl90i3ho0aJsEGJpXCrvZvbRBtXH6RUF0rZLA:EiAPcYpwgg88zOvQ4-sdwpj4UKqZeYS_Ej6kkZl_bZIJjw",
           "previous": [
             "hl:uEiAuBQKPYXl90i3ho0aJsEGJpXCrvZvbRBtXH6RUF0rZLA"
+          ]
+        }
+      ],
+      "profile": "https://w3id.org/orb#v777"
+    }
+  ]
+}`
+
+	jsonVC = `{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://w3id.org/activityanchors/v1",
+    "https://w3id.org/security/suites/jws-2020/v1",
+    "https://w3id.org/security/suites/ed25519-2020/v1"
+  ],
+  "credentialSubject": {
+    "anchor": "hl:uEiDvjtGoMhXcaTYxoLrayFmmtlg2Xh2IWlYTXajyqI8CkA",
+    "id": "hl:uEiDjGG3VbY14Al9B1UeA0UhniLe--pTHSMGNTyxvGir3iA",
+    "profile": "https://w3id.org/orb#v777"
+  },
+  "id": "https://orb.domain1.com/vc/95bd0a07-cd90-423a-87da-0bd2b4d0c00e",
+  "issuanceDate": "2022-07-20T19:14:03.3350642Z",
+  "issuer": "https://orb.domain1.com",
+  "proof": [
+    {
+      "created": "2022-07-20T19:14:03.345Z",
+      "domain": "http://orb.vct:8077/maple2020",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "zmoH8sQ8cV3qsPLmwYipdGgaPbXCU3AmFeKCHjGgSsvq39C5mw6P5RThCaR4hLcUVTqnH1F57qqp3Do9M5sn7DQZ",
+      "type": "Ed25519Signature2020",
+      "verificationMethod": "did:web:orb.domain1.com#3Y4eVe4CCLL-CmBEiSkjgXxdZ_EwK7QU1Qqa0bcGlx0"
+    },
+    {
+      "created": "2022-07-20T19:14:03.426188Z",
+      "domain": "https://orb.domain2.com",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "z5WfMrXTZHrESbcmV4KMNrGVVr5ZNYg6ZFr2Y9xaoS9Xuvaxhgwnrkkg8PHxdb9h6uj3kemJ4UwzkHPXkyqZwASCy",
+      "type": "Ed25519Signature2020",
+      "verificationMethod": "did:web:orb.domain2.com#bJk8awgfjHcg8x0gzO4W9ctBCN9vI3BGLr8usMt9SkE"
+    }
+  ],
+  "type": [
+    "VerifiableCredential",
+    "AnchorCredential"
+  ]
+}`
+
+	//nolint:lll
+	jsonOriginalLinkset = `{
+  "linkset": [
+    {
+      "anchor": "hl:uEiDvjtGoMhXcaTYxoLrayFmmtlg2Xh2IWlYTXajyqI8CkA",
+      "author": "https://orb.domain1.com/services/orb",
+      "item": [
+        {
+          "href": "did:orb:uEiBykP_SkWZoWZfKX1S0-Y2-NDJDGafmlE5q6OMJmAsYXg:EiCmr3DKudaBCve75CRdHF_B3FcdWxtQo8gjL_UhZG9oQg",
+          "previous": [
+            "hl:uEiBykP_SkWZoWZfKX1S0-Y2-NDJDGafmlE5q6OMJmAsYXg"
           ]
         }
       ],

--- a/pkg/anchor/anchorlinkset/generator/generatorregistry.go
+++ b/pkg/anchor/anchorlinkset/generator/generatorregistry.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
 	"github.com/trustbloc/orb/pkg/anchor/anchorlinkset/generator/didorbgenerator"
 	"github.com/trustbloc/orb/pkg/anchor/anchorlinkset/generator/didorbtestgenerator"
@@ -26,6 +28,7 @@ type Generator interface {
 	Version() uint64
 	CreateContentObject(payload *subject.Payload) (vocab.Document, error)
 	CreatePayload(doc vocab.Document, coreIndexURI *url.URL, anchors []*url.URL) (*subject.Payload, error)
+	ValidateAnchorCredential(vc *verifiable.Credential, originalContentBytes []byte) error
 }
 
 // Registry maintains a registry of content object generators.

--- a/pkg/anchor/builder/builder_test.go
+++ b/pkg/anchor/builder/builder_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/pkg/internal/testutil"
 )
 
 func TestSigner_New(t *testing.T) {
@@ -52,7 +54,10 @@ func TestBuilder_Build(t *testing.T) {
 		b, err := New(builderParams)
 		require.NoError(t, err)
 
-		vc, err := b.Build("hl:uEiBy8pPgN9eS3hpQAwpSwJJvm6Awpsnc8kR_fkbUPotehg", []string{})
+		vc, err := b.Build(testutil.MustParseURL("https://profile1"),
+			"hl:uEiBy8pPgN9eS3hpQAwpSwJJvm6Awpsnc8kR_fkbUPotehg",
+			"hl:uEiBy9pSgN9fS3hpQAwpSwJJvm6Awpsnc8kR_fkbUPotfog",
+			[]string{})
 		require.NoError(t, err)
 		require.NotEmpty(t, vc)
 	})

--- a/pkg/anchor/graph/graph.go
+++ b/pkg/anchor/graph/graph.go
@@ -15,7 +15,6 @@ import (
 	"github.com/trustbloc/edge-core/pkg/log"
 	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
 
-	"github.com/trustbloc/orb/pkg/anchor/anchorlinkset"
 	"github.com/trustbloc/orb/pkg/anchor/subject"
 	"github.com/trustbloc/orb/pkg/errors"
 	"github.com/trustbloc/orb/pkg/linkset"
@@ -28,11 +27,16 @@ type Graph struct {
 	*Providers
 }
 
+type anchorLinksetBuilder interface {
+	GetPayloadFromAnchorLink(anchorLink *linkset.Link) (*subject.Payload, error)
+}
+
 // Providers for anchor graph.
 type Providers struct {
-	CasWriter   casWriter
-	CasResolver casResolver
-	DocLoader   ld.DocumentLoader
+	CasWriter            casWriter
+	CasResolver          casResolver
+	DocLoader            ld.DocumentLoader
+	AnchorLinksetBuilder anchorLinksetBuilder
 }
 
 // New creates new graph manager.
@@ -118,7 +122,7 @@ func (g *Graph) GetDidAnchors(hl, suffix string) ([]Anchor, error) {
 			Info: anchorLink,
 		})
 
-		payload, err := anchorlinkset.GetPayloadFromAnchorLink(anchorLink)
+		payload, err := g.AnchorLinksetBuilder.GetPayloadFromAnchorLink(anchorLink)
 		if err != nil {
 			return nil, fmt.Errorf("get payload from anchor link: %w", err)
 		}

--- a/pkg/anchor/handler/credential/handler_test.go
+++ b/pkg/anchor/handler/credential/handler_test.go
@@ -27,6 +27,8 @@ import (
 	servicemocks "github.com/trustbloc/orb/pkg/activitypub/service/mocks"
 	"github.com/trustbloc/orb/pkg/activitypub/store/memstore"
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+	"github.com/trustbloc/orb/pkg/anchor/anchorlinkset/generator"
+	"github.com/trustbloc/orb/pkg/anchor/info"
 	anchormocks "github.com/trustbloc/orb/pkg/anchor/mocks"
 	"github.com/trustbloc/orb/pkg/cas/extendedcasclient"
 	casresolver "github.com/trustbloc/orb/pkg/cas/resolver"
@@ -71,21 +73,6 @@ func TestAnchorCredentialHandler(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("Ignore time and domain", func(t *testing.T) {
-		anchorEvent := &vocab.AnchorEventType{}
-		require.NoError(t, json.Unmarshal([]byte(sampleAnchorEventNoTimeOrDomain), anchorEvent))
-		require.NotNil(t, anchorEvent.Object().Document())
-
-		anchorLinkset := &linkset.Linkset{}
-		require.NoError(t, vocab.UnmarshalFromDoc(anchorEvent.Object().Document(), anchorLinkset), anchorLinkset)
-
-		hl, err := hashlink.New().CreateHashLink(testutil.MarshalCanonical(t, anchorLinkset), nil)
-		require.NoError(t, err)
-
-		require.NoError(t, newAnchorEventHandler(t, createInMemoryCAS(t)).
-			HandleAnchorEvent(actor, testutil.MustParseURL(hl), nil, anchorEvent))
-	})
-
 	t.Run("Neither local nor remote CAS has the anchor credential", func(t *testing.T) {
 		webCAS := webcas.New(&resthandler.Config{}, memstore.New(""), &servicemocks.SignatureVerifier{},
 			createInMemoryCAS(t), &apmocks.AuthTokenMgr{})
@@ -110,21 +97,31 @@ func TestAnchorCredentialHandler(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "content not found")
 	})
+
+	t.Run("Success - embedded anchor Linkset", func(t *testing.T) {
+		handler := newAnchorEventHandler(t, createInMemoryCAS(t))
+
+		anchorEvent := &vocab.AnchorEventType{}
+		require.NoError(t, json.Unmarshal([]byte(sampleGrandparentAnchorEvent), anchorEvent))
+		require.NoError(t, handler.HandleAnchorEvent(actor, anchorEvent.URL()[0], actor, anchorEvent))
+	})
 }
 
 func TestGetUnprocessedParentAnchorEvents(t *testing.T) {
 	const (
 		hl            = "hl:uEiCZCOxPantSTVJRTndP0yIO9PTgk5pRL1eYHD2R-c_quA:uoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQ1pDT3hQYW50U1RWSlJUbmRQMHlJTzlQVGdrNXBSTDFlWUhEMlItY19xdUF4QmlwZnM6Ly9iYWZrcmVpZXpiZHdlNjJ0M2tqZ3ZldWtvbzVoNWdpcW82dDJvYmU0MmtleHZwZ2E0aHdpN3R0N2t4YQ" //nolint:lll
-		parentHL      = "hl:uEiBdCxP8fh2R84KBL4n-GVO5TbjIPTxd-h55XFsw6QZbFA:uoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQmRDeFA4ZmgyUjg0S0JMNG4tR1ZPNVRiaklQVHhkLWg1NVhGc3c2UVpiRkF4QmlwZnM6Ly9iYWZrcmVpYzVibWo3eTdxNXNoenlmYWpwcmg3YnN1NXpqdzRtcXBqNGx4NWI0Nms0bG15b3NiczNjcQ" //nolint:lll
-		grandparentHL = "hl:uEiDB-Nh4kxP2UIzjC-oLbEaW4bHCYaFC9WgvPtbtMtvMuA:uoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpREItTmg0a3hQMlVJempDLW9MYkVhVzRiSENZYUZDOVdndlB0YnRNdHZNdUF4QmlwZnM6Ly9iYWZrcmVpZ2I3ZG1ocmV5dDZ6aWl6eXlsNWlmd3lydXc0Z3k0ZXluYmlsMndxbHo2MjN3dGZ3Nm14YQ" //nolint:lll
+		parentHL      = "hl:uEiDIRyZxpOYDtUlSsr6wU-Ybt17TrBEqCnrlVJsTtCjapg:uoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpRElSeVp4cE9ZRHRVbFNzcjZ3VS1ZYnQxN1RyQkVxQ25ybFZKc1R0Q2phcGd4QmlwZnM6Ly9iYWZrcmVpZ2lpNHRoZGpoZ2FvMnVzdXZzeDJ5Zmh6cTN3NXBuaGxhcmZpZmh2emt1dG1qM2lrZzJ1eQ" //nolint:lll
+		grandparentHL = "hl:uEiDpUqNx6yz_VrkDGMiKdyds3Qotdz3xGUfH7PZpZNsHfQ:uoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpRHBVcU54Nnl6X1Zya0RHTWlLZHlkczNRb3RkejN4R1VmSDdQWnBaTnNIZlF4QmlwZnM6Ly9iYWZrcmVpaGpra3J4ZDJ6bTc1bGxzYXl5emNmaG9qM20zdWZjMjV6NTZlbXVwcjdtNnp1d2p3eWhwdQ" //nolint:lll
 	)
+
+	registry := generator.NewRegistry()
 
 	t.Run("All parents processed -> Success", func(t *testing.T) {
 		casResolver := &mocks2.CASResolver{}
 		anchorLinkStore := &orbmocks.AnchorLinkStore{}
 
 		handler := New(&anchormocks.AnchorPublisher{}, casResolver, testutil.GetLoader(t),
-			time.Second, anchorLinkStore)
+			time.Second, anchorLinkStore, registry)
 		require.NotNil(t, handler)
 
 		anchorEvent := &vocab.AnchorEventType{}
@@ -157,7 +154,7 @@ func TestGetUnprocessedParentAnchorEvents(t *testing.T) {
 			grandparentHL, nil)
 
 		handler := New(&anchormocks.AnchorPublisher{}, casResolver, testutil.GetLoader(t),
-			time.Second, anchorLinkStore)
+			time.Second, anchorLinkStore, registry)
 		require.NotNil(t, handler)
 
 		anchorEvent := &vocab.AnchorEventType{}
@@ -183,7 +180,7 @@ func TestGetUnprocessedParentAnchorEvents(t *testing.T) {
 		anchorLinkStore := &orbmocks.AnchorLinkStore{}
 
 		handler := New(&anchormocks.AnchorPublisher{}, casResolver, testutil.GetLoader(t),
-			time.Second, anchorLinkStore)
+			time.Second, anchorLinkStore, registry)
 		require.NotNil(t, handler)
 
 		anchorLinkStore.GetLinksReturns(nil, nil)
@@ -203,7 +200,7 @@ func TestGetUnprocessedParentAnchorEvents(t *testing.T) {
 		anchorLinkStore := &orbmocks.AnchorLinkStore{}
 
 		handler := New(&anchormocks.AnchorPublisher{}, casResolver, testutil.GetLoader(t),
-			time.Second, anchorLinkStore)
+			time.Second, anchorLinkStore, registry)
 		require.NotNil(t, handler)
 
 		errExpected := errors.New("injected unmarshal error")
@@ -237,7 +234,7 @@ func TestGetUnprocessedParentAnchorEvents(t *testing.T) {
 		anchorLinkStore := &orbmocks.AnchorLinkStore{}
 
 		handler := New(&anchormocks.AnchorPublisher{}, casResolver, testutil.GetLoader(t),
-			time.Second, anchorLinkStore)
+			time.Second, anchorLinkStore, registry)
 		require.NotNil(t, handler)
 
 		anchorLinkset := &linkset.Linkset{}
@@ -255,7 +252,7 @@ func TestGetUnprocessedParentAnchorEvents(t *testing.T) {
 		anchorLinkStore := &orbmocks.AnchorLinkStore{}
 
 		handler := New(&anchormocks.AnchorPublisher{}, casResolver, testutil.GetLoader(t),
-			time.Second, anchorLinkStore)
+			time.Second, anchorLinkStore, registry)
 		require.NotNil(t, handler)
 
 		errExpected := errors.New("injected GetLinks error")
@@ -275,7 +272,7 @@ func TestGetUnprocessedParentAnchorEvents(t *testing.T) {
 		anchorLinkStore := &orbmocks.AnchorLinkStore{}
 
 		handler := New(&anchormocks.AnchorPublisher{}, casResolver, testutil.GetLoader(t),
-			time.Second, anchorLinkStore)
+			time.Second, anchorLinkStore, registry)
 		require.NotNil(t, handler)
 
 		anchorLinkset := &linkset.Linkset{}
@@ -288,6 +285,74 @@ func TestGetUnprocessedParentAnchorEvents(t *testing.T) {
 		_, err := handler.getUnprocessedParentAnchors(parentHL, anchorLinkset.Link())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errExpected.Error())
+	})
+}
+
+func TestAnchorEventHandler_processAnchorEvent(t *testing.T) {
+	casResolver := &mocks2.CASResolver{}
+	anchorLinkStore := &orbmocks.AnchorLinkStore{}
+
+	handler := New(&anchormocks.AnchorPublisher{}, casResolver, testutil.GetLoader(t),
+		time.Second, anchorLinkStore, generator.NewRegistry())
+	require.NotNil(t, handler)
+
+	t.Run("success", func(t *testing.T) {
+		anchorLinkset := &linkset.Linkset{}
+		require.NoError(t, json.Unmarshal([]byte(sampleGrandparentAnchorLinkset), anchorLinkset))
+
+		err := handler.processAnchorEvent(&anchorInfo{
+			AnchorInfo: &info.AnchorInfo{},
+			anchorLink: anchorLinkset.Link(),
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("no replies -> error", func(t *testing.T) {
+		anchorLinkset := &linkset.Linkset{}
+		require.NoError(t, json.Unmarshal([]byte(anchorLinksetNoReplies), anchorLinkset))
+
+		err := handler.processAnchorEvent(&anchorInfo{
+			AnchorInfo: &info.AnchorInfo{},
+			anchorLink: anchorLinkset.Link(),
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no replies in anchor link")
+	})
+
+	t.Run("invalid original content -> error", func(t *testing.T) {
+		anchorLinkset := &linkset.Linkset{}
+		require.NoError(t, json.Unmarshal([]byte(anchorLinksetInvalidContent), anchorLinkset))
+
+		err := handler.processAnchorEvent(&anchorInfo{
+			AnchorInfo: &info.AnchorInfo{},
+			anchorLink: anchorLinkset.Link(),
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unsupported media type")
+	})
+
+	t.Run("unsupported profile -> error", func(t *testing.T) {
+		anchorLinkset := &linkset.Linkset{}
+		require.NoError(t, json.Unmarshal([]byte(anchorLinksetUnsupportedProfile), anchorLinkset))
+
+		err := handler.processAnchorEvent(&anchorInfo{
+			AnchorInfo: &info.AnchorInfo{},
+			anchorLink: anchorLinkset.Link(),
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "generator not found")
+	})
+
+	t.Run("invalid anchor credential -> error", func(t *testing.T) {
+		anchorLinkset := &linkset.Linkset{}
+		require.NoError(t, json.Unmarshal([]byte(anchorLinksetInvalidVC), anchorLinkset))
+
+		err := handler.processAnchorEvent(&anchorInfo{
+			AnchorInfo: &info.AnchorInfo{},
+			anchorLink: anchorLinkset.Link(),
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "validate credential subject for anchor")
 	})
 }
 
@@ -305,7 +370,7 @@ func newAnchorEventHandler(t *testing.T,
 	anchorLinkStore := &orbmocks.AnchorLinkStore{}
 
 	anchorEventHandler := New(&anchormocks.AnchorPublisher{}, casResolver, testutil.GetLoader(t),
-		time.Second, anchorLinkStore)
+		time.Second, anchorLinkStore, generator.NewRegistry())
 	require.NotNil(t, anchorEventHandler)
 
 	return anchorEventHandler
@@ -333,62 +398,28 @@ func createInMemoryCAS(t *testing.T) extendedcasclient.Client {
 
 //nolint:lll
 const sampleAnchorEvent = `{
-    "@context": "https://w3id.org/activityanchors/v1",
-    "object": {
-      "linkset": [
-        {
-          "anchor": "hl:uEiDhi1oX6K76A1ch5WPu2wdNLcizCx08EypO0taw9KHOGw",
-          "author": "https://orb.domain1.com/services/orb",
-          "original": [
-            {
-              "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiAOVteziujP52prEAQrRuE5CXGQ1XR6xwDP86SMPWTOPw%22%2C%22author%22%3A%22https%3A%2F%2Forb.domain1.com%2Fservices%2Forb%22%2C%22item%22%3A%5B%7B%22href%22%3A%22did%3Aorb%3AuEiBdCxP8fh2R84KBL4n-GVO5TbjIPTxd-h55XFsw6QZbFA%3AEiDSqf8owKb84KDjRbIemw-Sv-UoyPcsyPNFEQ9rzT-Uag%22%2C%22previous%22%3A%22hl%3AuEiBdCxP8fh2R84KBL4n-GVO5TbjIPTxd-h55XFsw6QZbFA%22%7D%2C%7B%22href%22%3A%22did%3Aorb%3AuEiBdCxP8fh2R84KBL4n-GVO5TbjIPTxd-h55XFsw6QZbFA%3AEiApcqrvEntohzA1NGNYO9l3N7yyR-dfvotjxTTAzGlTUQ%22%2C%22previous%22%3A%22hl%3AuEiBdCxP8fh2R84KBL4n-GVO5TbjIPTxd-h55XFsw6QZbFA%22%7D%5D%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%7D%5D%7D",
-              "type": "application/linkset+json"
-            }
-          ],
-          "profile": "https://w3id.org/orb#v0",
-          "related": [
-            {
-              "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiDhi1oX6K76A1ch5WPu2wdNLcizCx08EypO0taw9KHOGw%22%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%2C%22up%22%3A%5B%7B%22href%22%3A%22hl%3AuEiBdCxP8fh2R84KBL4n-GVO5TbjIPTxd-h55XFsw6QZbFA%3AuoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQmRDeFA4ZmgyUjg0S0JMNG4tR1ZPNVRiaklQVHhkLWg1NVhGc3c2UVpiRkF4QmlwZnM6Ly9iYWZrcmVpYzVibWo3eTdxNXNoenlmYWpwcmg3YnN1NXpqdzRtcXBqNGx4NWI0Nms0bG15b3NiczNjcQ%22%7D%5D%2C%22via%22%3A%5B%7B%22href%22%3A%22hl%3AuEiAOVteziujP52prEAQrRuE5CXGQ1XR6xwDP86SMPWTOPw%3AuoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQU9WdGV6aXVqUDUycHJFQVFyUnVFNUNYR1ExWFI2eHdEUDg2U01QV1RPUHd4QmlwZnM6Ly9iYWZrcmVpYW9rM2wzaGN4aXo3dHd1MnlxYXF2dW55anpiZnl6YnZsdXBsZHFidDd0dXNnZDJ6Z29oNA%22%7D%5D%7D%5D%7D",
-              "type": "application/linkset+json"
-            }
-          ],
-          "replies": [
-            {
-              "href": "data:application/json,%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww.w3.org%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Fsecurity%2Fsuites%2Fed25519-2020%2Fv1%22%5D%2C%22credentialSubject%22%3A%22hl%3AuEiDhi1oX6K76A1ch5WPu2wdNLcizCx08EypO0taw9KHOGw%22%2C%22id%22%3A%22https%3A%2F%2Forb2.domain1.com%2Fvc%2F01331215-0839-4679-baa2-ba4481bac47b%22%2C%22issuanceDate%22%3A%222022-03-16T18%3A20%3A43.675143863Z%22%2C%22issuer%22%3A%22https%3A%2F%2Forb2.domain1.com%22%2C%22proof%22%3A%5B%7B%22created%22%3A%222022-03-16T18%3A20%3A43.686Z%22%2C%22domain%22%3A%22http%3A%2F%2Forb.vct%3A8077%2Fmaple2020%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%22h7wjce2r6fH8ygSJGkm1yRZ_AvubDiodzn22osuCbYb5RCQaXoEmDtOf1oZMosO1vdeTcobi-CeW77J8_xYrAg%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain1.com%23orb1key2%22%7D%2C%7B%22created%22%3A%222022-03-16T18%3A20%3A43.787088993Z%22%2C%22domain%22%3A%22https%3A%2F%2Forb.domain2.com%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%229griFoChmta0rOXdHJ6WJjoXuxR8efjg9TeqzIyZqP986I9CU9I3a9wf-xVKusNa4ql7NCcvTLCXTUnQbMh2Cg%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain2.com%23orb2key%22%7D%5D%2C%22type%22%3A%22VerifiableCredential%22%7D",
-              "type": "application/ld+json"
-            }
-          ]
-        }
-      ]
-    },
-    "type": "AnchorEvent",
-    "url": "hl:uEiCZCOxPantSTVJRTndP0yIO9PTgk5pRL1eYHD2R-c_quA:uoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQ1pDT3hQYW50U1RWSlJUbmRQMHlJTzlQVGdrNXBSTDFlWUhEMlItY19xdUF4QmlwZnM6Ly9iYWZrcmVpZXpiZHdlNjJ0M2tqZ3ZldWtvbzVoNWdpcW82dDJvYmU0MmtleHZwZ2E0aHdpN3R0N2t4YQ"
-  }`
-
-//nolint:lll
-const sampleParentAnchorEvent = `{
   "@context": "https://w3id.org/activityanchors/v1",
   "object": {
     "linkset": [
       {
-        "anchor": "hl:uEiBpFIScGjmr9GEs2-WIQ-SYZZdfsN_iePnO4kxtRR9A5Q",
+        "anchor": "hl:uEiDzKYFbc6tntXzq7R2uJBA_wI6LhcSDUbXIJmy1zawvpw",
         "author": "https://orb.domain1.com/services/orb",
         "original": [
           {
-            "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiBRe-7-dP9BuarMgsnh0ORnGWi6moc4GmQet-pQUeJjLQ%22%2C%22author%22%3A%22https%3A%2F%2Forb.domain1.com%2Fservices%2Forb%22%2C%22item%22%3A%5B%7B%22href%22%3A%22did%3Aorb%3AuEiDB-Nh4kxP2UIzjC-oLbEaW4bHCYaFC9WgvPtbtMtvMuA%3AEiDSqf8owKb84KDjRbIemw-Sv-UoyPcsyPNFEQ9rzT-Uag%22%2C%22previous%22%3A%22hl%3AuEiDB-Nh4kxP2UIzjC-oLbEaW4bHCYaFC9WgvPtbtMtvMuA%22%7D%2C%7B%22href%22%3A%22did%3Aorb%3AuEiDB-Nh4kxP2UIzjC-oLbEaW4bHCYaFC9WgvPtbtMtvMuA%3AEiApcqrvEntohzA1NGNYO9l3N7yyR-dfvotjxTTAzGlTUQ%22%2C%22previous%22%3A%22hl%3AuEiDB-Nh4kxP2UIzjC-oLbEaW4bHCYaFC9WgvPtbtMtvMuA%22%7D%5D%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%7D%5D%7D",
+            "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiDCkyqOTtGXLOLOsInc_t6X5NMRebZSWlFXfvJmx7Bujg%22%2C%22author%22%3A%22https%3A%2F%2Forb.domain1.com%2Fservices%2Forb%22%2C%22item%22%3A%5B%7B%22href%22%3A%22did%3Aorb%3AuEiDIRyZxpOYDtUlSsr6wU-Ybt17TrBEqCnrlVJsTtCjapg%3AEiC0Iu10PDXwr5XIHgos9TZo1a1N13tq9V5XEk6EePWGkQ%22%2C%22previous%22%3A%5B%22hl%3AuEiDIRyZxpOYDtUlSsr6wU-Ybt17TrBEqCnrlVJsTtCjapg%22%5D%7D%2C%7B%22href%22%3A%22did%3Aorb%3AuEiDIRyZxpOYDtUlSsr6wU-Ybt17TrBEqCnrlVJsTtCjapg%3AEiCP0F5n9PB2tuEPFCc7Oyob_itqrvdfGk_UphBOQ9rZQA%22%2C%22previous%22%3A%5B%22hl%3AuEiDIRyZxpOYDtUlSsr6wU-Ybt17TrBEqCnrlVJsTtCjapg%22%5D%7D%5D%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%7D%5D%7D",
             "type": "application/linkset+json"
           }
         ],
         "profile": "https://w3id.org/orb#v0",
         "related": [
           {
-            "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiBpFIScGjmr9GEs2-WIQ-SYZZdfsN_iePnO4kxtRR9A5Q%22%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%2C%22up%22%3A%5B%7B%22href%22%3A%22hl%3AuEiDB-Nh4kxP2UIzjC-oLbEaW4bHCYaFC9WgvPtbtMtvMuA%3AuoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpREItTmg0a3hQMlVJempDLW9MYkVhVzRiSENZYUZDOVdndlB0YnRNdHZNdUF4QmlwZnM6Ly9iYWZrcmVpZ2I3ZG1ocmV5dDZ6aWl6eXlsNWlmd3lydXc0Z3k0ZXluYmlsMndxbHo2MjN3dGZ3Nm14YQ%22%7D%5D%2C%22via%22%3A%5B%7B%22href%22%3A%22hl%3AuEiBRe-7-dP9BuarMgsnh0ORnGWi6moc4GmQet-pQUeJjLQ%3AuoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQlJlLTctZFA5QnVhck1nc25oME9SbkdXaTZtb2M0R21RZXQtcFFVZUpqTFF4QmlwZnM6Ly9iYWZrcmVpY3JwcHhwNDVoN2lnNDJ2dGVjemhxNWJ6ZGhkZnVsdmd1aGhhbmdpaHZ4NWppZmR5dGRmdQ%22%7D%5D%7D%5D%7D",
+            "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiDzKYFbc6tntXzq7R2uJBA_wI6LhcSDUbXIJmy1zawvpw%22%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%2C%22up%22%3A%5B%7B%22href%22%3A%22hl%3AuEiDIRyZxpOYDtUlSsr6wU-Ybt17TrBEqCnrlVJsTtCjapg%3AuoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpRElSeVp4cE9ZRHRVbFNzcjZ3VS1ZYnQxN1RyQkVxQ25ybFZKc1R0Q2phcGd4QmlwZnM6Ly9iYWZrcmVpZ2lpNHRoZGpoZ2FvMnVzdXZzeDJ5Zmh6cTN3NXBuaGxhcmZpZmh2emt1dG1qM2lrZzJ1eQ%22%7D%5D%2C%22via%22%3A%5B%7B%22href%22%3A%22hl%3AuEiDCkyqOTtGXLOLOsInc_t6X5NMRebZSWlFXfvJmx7Bujg%3AuoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpRENreXFPVHRHWExPTE9zSW5jX3Q2WDVOTVJlYlpTV2xGWGZ2Sm14N0J1amd4QmlwZnM6Ly9iYWZrcmVpZ2NzbXZpNHR3cnM0d29mdHZxcmhvcDV4dXg0dGpyYzZud2tqbmZjdjM2Nmp0bXBtZG9yeQ%22%7D%5D%7D%5D%7D",
             "type": "application/linkset+json"
           }
         ],
         "replies": [
           {
-            "href": "data:application/json,%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww.w3.org%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Fsecurity%2Fsuites%2Fed25519-2020%2Fv1%22%5D%2C%22credentialSubject%22%3A%22hl%3AuEiBpFIScGjmr9GEs2-WIQ-SYZZdfsN_iePnO4kxtRR9A5Q%22%2C%22id%22%3A%22https%3A%2F%2Forb2.domain1.com%2Fvc%2F9e24fe54-097b-418b-8a3f-e948a15bbfb6%22%2C%22issuanceDate%22%3A%222022-03-16T18%3A20%3A38.703155915Z%22%2C%22issuer%22%3A%22https%3A%2F%2Forb2.domain1.com%22%2C%22proof%22%3A%5B%7B%22created%22%3A%222022-03-16T18%3A20%3A38.712Z%22%2C%22domain%22%3A%22http%3A%2F%2Forb.vct%3A8077%2Fmaple2020%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%22aHF4OpYMArTIJLupKMumfXzu_CHgGx40p9haG6N__6bRVNEyFvWEmXvykcQ3DkTy1LVTi6pL3FQfMiCGyfvzCA%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain1.com%23orb1key2%22%7D%2C%7B%22created%22%3A%222022-03-16T18%3A20%3A38.788086226Z%22%2C%22domain%22%3A%22https%3A%2F%2Forb.domain2.com%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%22IMbTYbfpwColUBcD2uzqdTBmuCbauVTmYykPs_ozmf77rN6AEouTZvXmmL8vd-NJuZhQvnG-Vx6RVhrS7DPoBw%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain2.com%23orb2key%22%7D%5D%2C%22type%22%3A%22VerifiableCredential%22%7D",
+            "href": "data:application/json,%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww.w3.org%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Factivityanchors%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Fsecurity%2Fsuites%2Fjws-2020%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Fsecurity%2Fsuites%2Fed25519-2020%2Fv1%22%5D%2C%22credentialSubject%22%3A%7B%22anchor%22%3A%22hl%3AuEiDCkyqOTtGXLOLOsInc_t6X5NMRebZSWlFXfvJmx7Bujg%22%2C%22id%22%3A%22hl%3AuEiDzKYFbc6tntXzq7R2uJBA_wI6LhcSDUbXIJmy1zawvpw%22%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%7D%2C%22id%22%3A%22https%3A%2F%2Forb.domain1.com%2Fvc%2Ffbe7b4ff-788d-409f-846a-1f41fb9cb607%22%2C%22issuanceDate%22%3A%222022-07-19T17%3A38%3A18.6338532Z%22%2C%22issuer%22%3A%22https%3A%2F%2Forb.domain1.com%22%2C%22proof%22%3A%5B%7B%22created%22%3A%222022-07-19T17%3A38%3A18.663Z%22%2C%22domain%22%3A%22http%3A%2F%2Forb.vct%3A8077%2Fmaple2020%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%22zMLgPKMdb5CZPy2fR19dLvcQmVPSidKhrN3ocYgE4TbFGP3gKjAKd2HoLk1mzmMz5sKge7r5mPoCy3WHuDRoqn2U%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain1.com%23GJqG8xWJ4c4NGedg1-S_4FdsPjjFiV2GpZ0muPC_dv0%22%7D%2C%7B%22created%22%3A%222022-07-19T17%3A38%3A18.8748913Z%22%2C%22domain%22%3A%22https%3A%2F%2Forb.domain2.com%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%22z4dAdDepEgQjQ97qPRfjZq2WD16E2u51LnTm2uWN2Zu6G7Fdi66XdKbajy2FxLGXBu8bUzZ22LQBMZ7BJpV9t7qWP%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain2.com%23Tq-S3o_R8fNoiMHPTfWx0Evigk2mPWpnDdsN_biBNqg%22%7D%5D%2C%22type%22%3A%5B%22VerifiableCredential%22%2C%22AnchorCredential%22%5D%7D",
             "type": "application/ld+json"
           }
         ]
@@ -396,31 +427,65 @@ const sampleParentAnchorEvent = `{
     ]
   },
   "type": "AnchorEvent",
-  "url": "hl:uEiBdCxP8fh2R84KBL4n-GVO5TbjIPTxd-h55XFsw6QZbFA:uoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQmRDeFA4ZmgyUjg0S0JMNG4tR1ZPNVRiaklQVHhkLWg1NVhGc3c2UVpiRkF4QmlwZnM6Ly9iYWZrcmVpYzVibWo3eTdxNXNoenlmYWpwcmg3YnN1NXpqdzRtcXBqNGx4NWI0Nms0bG15b3NiczNjcQ"
+  "url": "hl:uEiDbYK4YRQLH0FiD0QpTwAwOYUvvkWu65zbib2SngzuYyA:uoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpRGJZSzRZUlFMSDBGaUQwUXBUd0F3T1lVdnZrV3U2NXpiaWIyU25nenVZeUF4QmlwZnM6Ly9iYWZrcmVpZzNtY3hicXJpY3k3aWZyYTZyYmpqNGFkYW9tZmY2N2VsbHhsdHRueXRwbXN0eWdvNHl6YQ"
+}`
+
+//nolint:lll
+const sampleParentAnchorEvent = `{
+  "@context": "https://w3id.org/activityanchors/v1",
+  "object": {
+    "linkset": [
+      {
+        "anchor": "hl:uEiAf5FKXCAwRBsd-1qf1Em2YiTuK6JxBPS4I5LRtg9EIGA",
+        "author": "https://orb.domain1.com/services/orb",
+        "original": [
+          {
+            "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiD-3kSImysTuPbjAerN0-1p3rSUFOTB86tlaKfuxASkqA%22%2C%22author%22%3A%22https%3A%2F%2Forb.domain1.com%2Fservices%2Forb%22%2C%22item%22%3A%5B%7B%22href%22%3A%22did%3Aorb%3AuEiDpUqNx6yz_VrkDGMiKdyds3Qotdz3xGUfH7PZpZNsHfQ%3AEiC0Iu10PDXwr5XIHgos9TZo1a1N13tq9V5XEk6EePWGkQ%22%2C%22previous%22%3A%5B%22hl%3AuEiDpUqNx6yz_VrkDGMiKdyds3Qotdz3xGUfH7PZpZNsHfQ%22%5D%7D%2C%7B%22href%22%3A%22did%3Aorb%3AuEiDpUqNx6yz_VrkDGMiKdyds3Qotdz3xGUfH7PZpZNsHfQ%3AEiCP0F5n9PB2tuEPFCc7Oyob_itqrvdfGk_UphBOQ9rZQA%22%2C%22previous%22%3A%5B%22hl%3AuEiDpUqNx6yz_VrkDGMiKdyds3Qotdz3xGUfH7PZpZNsHfQ%22%5D%7D%5D%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%7D%5D%7D",
+            "type": "application/linkset+json"
+          }
+        ],
+        "profile": "https://w3id.org/orb#v0",
+        "related": [
+          {
+            "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiAf5FKXCAwRBsd-1qf1Em2YiTuK6JxBPS4I5LRtg9EIGA%22%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%2C%22up%22%3A%5B%7B%22href%22%3A%22hl%3AuEiDpUqNx6yz_VrkDGMiKdyds3Qotdz3xGUfH7PZpZNsHfQ%3AuoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpRHBVcU54Nnl6X1Zya0RHTWlLZHlkczNRb3RkejN4R1VmSDdQWnBaTnNIZlF4QmlwZnM6Ly9iYWZrcmVpaGpra3J4ZDJ6bTc1bGxzYXl5emNmaG9qM20zdWZjMjV6NTZlbXVwcjdtNnp1d2p3eWhwdQ%22%7D%5D%2C%22via%22%3A%5B%7B%22href%22%3A%22hl%3AuEiD-3kSImysTuPbjAerN0-1p3rSUFOTB86tlaKfuxASkqA%3AuoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpRC0za1NJbXlzVHVQYmpBZXJOMC0xcDNyU1VGT1RCODZ0bGFLZnV4QVNrcUF4QmlwZnM6Ly9iYWZrcmVpaDYzemNpcmd6bGNvNHBueXliNWxnNWgzbGozMjJqaWZoZXloejJ3emxpdTd4bWliZmV2YQ%22%7D%5D%7D%5D%7D",
+            "type": "application/linkset+json"
+          }
+        ],
+        "replies": [
+          {
+            "href": "data:application/json,%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww.w3.org%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Factivityanchors%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Fsecurity%2Fsuites%2Fjws-2020%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Fsecurity%2Fsuites%2Fed25519-2020%2Fv1%22%5D%2C%22credentialSubject%22%3A%7B%22anchor%22%3A%22hl%3AuEiD-3kSImysTuPbjAerN0-1p3rSUFOTB86tlaKfuxASkqA%22%2C%22id%22%3A%22hl%3AuEiAf5FKXCAwRBsd-1qf1Em2YiTuK6JxBPS4I5LRtg9EIGA%22%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%7D%2C%22id%22%3A%22https%3A%2F%2Forb.domain1.com%2Fvc%2F680798be-2b67-4c49-8590-961f8946ddd2%22%2C%22issuanceDate%22%3A%222022-07-19T17%3A38%3A13.643727Z%22%2C%22issuer%22%3A%22https%3A%2F%2Forb.domain1.com%22%2C%22proof%22%3A%5B%7B%22created%22%3A%222022-07-19T17%3A38%3A13.66Z%22%2C%22domain%22%3A%22http%3A%2F%2Forb.vct%3A8077%2Fmaple2020%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%22z5aUDn53GzhLAcM2LZ1PPX2XTCreAaHCyHvnA1XhDwUyuBcYqBZihCcRqcWSF1JacihXSmD25Tnr9GLoUJax8CCAg%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain1.com%23GJqG8xWJ4c4NGedg1-S_4FdsPjjFiV2GpZ0muPC_dv0%22%7D%2C%7B%22created%22%3A%222022-07-19T17%3A38%3A13.8227356Z%22%2C%22domain%22%3A%22https%3A%2F%2Forb.domain2.com%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%22z4LwejC2NEqSyt73W8vTv5Fz7mnfDpZXEjWu8RSb88DLZAhER7s96b7QkMNXV9xGkuvDBu8s9hj5Mtzz7J2dgs36R%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain2.com%23Tq-S3o_R8fNoiMHPTfWx0Evigk2mPWpnDdsN_biBNqg%22%7D%5D%2C%22type%22%3A%5B%22VerifiableCredential%22%2C%22AnchorCredential%22%5D%7D",
+            "type": "application/ld+json"
+          }
+        ]
+      }
+    ]
+  },
+  "type": "AnchorEvent",
+  "url": "hl:uEiDIRyZxpOYDtUlSsr6wU-Ybt17TrBEqCnrlVJsTtCjapg:uoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpRElSeVp4cE9ZRHRVbFNzcjZ3VS1ZYnQxN1RyQkVxQ25ybFZKc1R0Q2phcGd4QmlwZnM6Ly9iYWZrcmVpZ2lpNHRoZGpoZ2FvMnVzdXZzeDJ5Zmh6cTN3NXBuaGxhcmZpZmh2emt1dG1qM2lrZzJ1eQ"
 }`
 
 //nolint:lll
 const sampleParentAnchorLinkset = `{
   "linkset": [
     {
-      "anchor": "hl:uEiBpFIScGjmr9GEs2-WIQ-SYZZdfsN_iePnO4kxtRR9A5Q",
+      "anchor": "hl:uEiAf5FKXCAwRBsd-1qf1Em2YiTuK6JxBPS4I5LRtg9EIGA",
       "author": "https://orb.domain1.com/services/orb",
       "original": [
         {
-          "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiBRe-7-dP9BuarMgsnh0ORnGWi6moc4GmQet-pQUeJjLQ%22%2C%22author%22%3A%22https%3A%2F%2Forb.domain1.com%2Fservices%2Forb%22%2C%22item%22%3A%5B%7B%22href%22%3A%22did%3Aorb%3AuEiDB-Nh4kxP2UIzjC-oLbEaW4bHCYaFC9WgvPtbtMtvMuA%3AEiDSqf8owKb84KDjRbIemw-Sv-UoyPcsyPNFEQ9rzT-Uag%22%2C%22previous%22%3A%22hl%3AuEiDB-Nh4kxP2UIzjC-oLbEaW4bHCYaFC9WgvPtbtMtvMuA%22%7D%2C%7B%22href%22%3A%22did%3Aorb%3AuEiDB-Nh4kxP2UIzjC-oLbEaW4bHCYaFC9WgvPtbtMtvMuA%3AEiApcqrvEntohzA1NGNYO9l3N7yyR-dfvotjxTTAzGlTUQ%22%2C%22previous%22%3A%22hl%3AuEiDB-Nh4kxP2UIzjC-oLbEaW4bHCYaFC9WgvPtbtMtvMuA%22%7D%5D%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%7D%5D%7D",
+          "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiD-3kSImysTuPbjAerN0-1p3rSUFOTB86tlaKfuxASkqA%22%2C%22author%22%3A%22https%3A%2F%2Forb.domain1.com%2Fservices%2Forb%22%2C%22item%22%3A%5B%7B%22href%22%3A%22did%3Aorb%3AuEiDpUqNx6yz_VrkDGMiKdyds3Qotdz3xGUfH7PZpZNsHfQ%3AEiC0Iu10PDXwr5XIHgos9TZo1a1N13tq9V5XEk6EePWGkQ%22%2C%22previous%22%3A%5B%22hl%3AuEiDpUqNx6yz_VrkDGMiKdyds3Qotdz3xGUfH7PZpZNsHfQ%22%5D%7D%2C%7B%22href%22%3A%22did%3Aorb%3AuEiDpUqNx6yz_VrkDGMiKdyds3Qotdz3xGUfH7PZpZNsHfQ%3AEiCP0F5n9PB2tuEPFCc7Oyob_itqrvdfGk_UphBOQ9rZQA%22%2C%22previous%22%3A%5B%22hl%3AuEiDpUqNx6yz_VrkDGMiKdyds3Qotdz3xGUfH7PZpZNsHfQ%22%5D%7D%5D%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%7D%5D%7D",
           "type": "application/linkset+json"
         }
       ],
       "profile": "https://w3id.org/orb#v0",
       "related": [
         {
-          "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiBpFIScGjmr9GEs2-WIQ-SYZZdfsN_iePnO4kxtRR9A5Q%22%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%2C%22up%22%3A%5B%7B%22href%22%3A%22hl%3AuEiDB-Nh4kxP2UIzjC-oLbEaW4bHCYaFC9WgvPtbtMtvMuA%3AuoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpREItTmg0a3hQMlVJempDLW9MYkVhVzRiSENZYUZDOVdndlB0YnRNdHZNdUF4QmlwZnM6Ly9iYWZrcmVpZ2I3ZG1ocmV5dDZ6aWl6eXlsNWlmd3lydXc0Z3k0ZXluYmlsMndxbHo2MjN3dGZ3Nm14YQ%22%7D%5D%2C%22via%22%3A%5B%7B%22href%22%3A%22hl%3AuEiBRe-7-dP9BuarMgsnh0ORnGWi6moc4GmQet-pQUeJjLQ%3AuoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQlJlLTctZFA5QnVhck1nc25oME9SbkdXaTZtb2M0R21RZXQtcFFVZUpqTFF4QmlwZnM6Ly9iYWZrcmVpY3JwcHhwNDVoN2lnNDJ2dGVjemhxNWJ6ZGhkZnVsdmd1aGhhbmdpaHZ4NWppZmR5dGRmdQ%22%7D%5D%7D%5D%7D",
+          "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiAf5FKXCAwRBsd-1qf1Em2YiTuK6JxBPS4I5LRtg9EIGA%22%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%2C%22up%22%3A%5B%7B%22href%22%3A%22hl%3AuEiDpUqNx6yz_VrkDGMiKdyds3Qotdz3xGUfH7PZpZNsHfQ%3AuoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpRHBVcU54Nnl6X1Zya0RHTWlLZHlkczNRb3RkejN4R1VmSDdQWnBaTnNIZlF4QmlwZnM6Ly9iYWZrcmVpaGpra3J4ZDJ6bTc1bGxzYXl5emNmaG9qM20zdWZjMjV6NTZlbXVwcjdtNnp1d2p3eWhwdQ%22%7D%5D%2C%22via%22%3A%5B%7B%22href%22%3A%22hl%3AuEiD-3kSImysTuPbjAerN0-1p3rSUFOTB86tlaKfuxASkqA%3AuoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpRC0za1NJbXlzVHVQYmpBZXJOMC0xcDNyU1VGT1RCODZ0bGFLZnV4QVNrcUF4QmlwZnM6Ly9iYWZrcmVpaDYzemNpcmd6bGNvNHBueXliNWxnNWgzbGozMjJqaWZoZXloejJ3emxpdTd4bWliZmV2YQ%22%7D%5D%7D%5D%7D",
           "type": "application/linkset+json"
         }
       ],
       "replies": [
         {
-          "href": "data:application/json,%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww.w3.org%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Fsecurity%2Fsuites%2Fed25519-2020%2Fv1%22%5D%2C%22credentialSubject%22%3A%22hl%3AuEiBpFIScGjmr9GEs2-WIQ-SYZZdfsN_iePnO4kxtRR9A5Q%22%2C%22id%22%3A%22https%3A%2F%2Forb2.domain1.com%2Fvc%2F9e24fe54-097b-418b-8a3f-e948a15bbfb6%22%2C%22issuanceDate%22%3A%222022-03-16T18%3A20%3A38.703155915Z%22%2C%22issuer%22%3A%22https%3A%2F%2Forb2.domain1.com%22%2C%22proof%22%3A%5B%7B%22created%22%3A%222022-03-16T18%3A20%3A38.712Z%22%2C%22domain%22%3A%22http%3A%2F%2Forb.vct%3A8077%2Fmaple2020%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%22aHF4OpYMArTIJLupKMumfXzu_CHgGx40p9haG6N__6bRVNEyFvWEmXvykcQ3DkTy1LVTi6pL3FQfMiCGyfvzCA%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain1.com%23orb1key2%22%7D%2C%7B%22created%22%3A%222022-03-16T18%3A20%3A38.788086226Z%22%2C%22domain%22%3A%22https%3A%2F%2Forb.domain2.com%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%22IMbTYbfpwColUBcD2uzqdTBmuCbauVTmYykPs_ozmf77rN6AEouTZvXmmL8vd-NJuZhQvnG-Vx6RVhrS7DPoBw%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain2.com%23orb2key%22%7D%5D%2C%22type%22%3A%22VerifiableCredential%22%7D",
+          "href": "data:application/json,%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww.w3.org%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Factivityanchors%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Fsecurity%2Fsuites%2Fjws-2020%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Fsecurity%2Fsuites%2Fed25519-2020%2Fv1%22%5D%2C%22credentialSubject%22%3A%7B%22anchor%22%3A%22hl%3AuEiD-3kSImysTuPbjAerN0-1p3rSUFOTB86tlaKfuxASkqA%22%2C%22id%22%3A%22hl%3AuEiAf5FKXCAwRBsd-1qf1Em2YiTuK6JxBPS4I5LRtg9EIGA%22%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%7D%2C%22id%22%3A%22https%3A%2F%2Forb.domain1.com%2Fvc%2F680798be-2b67-4c49-8590-961f8946ddd2%22%2C%22issuanceDate%22%3A%222022-07-19T17%3A38%3A13.643727Z%22%2C%22issuer%22%3A%22https%3A%2F%2Forb.domain1.com%22%2C%22proof%22%3A%5B%7B%22created%22%3A%222022-07-19T17%3A38%3A13.66Z%22%2C%22domain%22%3A%22http%3A%2F%2Forb.vct%3A8077%2Fmaple2020%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%22z5aUDn53GzhLAcM2LZ1PPX2XTCreAaHCyHvnA1XhDwUyuBcYqBZihCcRqcWSF1JacihXSmD25Tnr9GLoUJax8CCAg%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain1.com%23GJqG8xWJ4c4NGedg1-S_4FdsPjjFiV2GpZ0muPC_dv0%22%7D%2C%7B%22created%22%3A%222022-07-19T17%3A38%3A13.8227356Z%22%2C%22domain%22%3A%22https%3A%2F%2Forb.domain2.com%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%22z4LwejC2NEqSyt73W8vTv5Fz7mnfDpZXEjWu8RSb88DLZAhER7s96b7QkMNXV9xGkuvDBu8s9hj5Mtzz7J2dgs36R%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain2.com%23Tq-S3o_R8fNoiMHPTfWx0Evigk2mPWpnDdsN_biBNqg%22%7D%5D%2C%22type%22%3A%5B%22VerifiableCredential%22%2C%22AnchorCredential%22%5D%7D",
           "type": "application/ld+json"
         }
       ]
@@ -434,24 +499,24 @@ const sampleGrandparentAnchorEvent = `{
   "object": {
     "linkset": [
       {
-        "anchor": "hl:uEiCE4J4UpuWwXKb25jDyoVGCQ8F0v1NPTsxz4QMzADBxYA",
+        "anchor": "hl:uEiD07i6t3Cf31sbTepJnigcbM4jVcaT6YqcWMWgDVuiwaw",
         "author": "https://orb.domain1.com/services/orb",
         "original": [
           {
-            "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiAavDOmQylmPGTGBujg_EsbELbdUX9J00i93CELKytYTQ%22%2C%22author%22%3A%22https%3A%2F%2Forb.domain1.com%2Fservices%2Forb%22%2C%22item%22%3A%5B%7B%22href%22%3A%22did%3Aorb%3AuAAA%3AEiDSqf8owKb84KDjRbIemw-Sv-UoyPcsyPNFEQ9rzT-Uag%22%7D%2C%7B%22href%22%3A%22did%3Aorb%3AuAAA%3AEiApcqrvEntohzA1NGNYO9l3N7yyR-dfvotjxTTAzGlTUQ%22%7D%5D%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%7D%5D%7D",
+            "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiCGzuAY1M01uM6mC_vJDUc8iiJXMxqGxl5aBsWqcrWfIg%22%2C%22author%22%3A%22https%3A%2F%2Forb.domain1.com%2Fservices%2Forb%22%2C%22item%22%3A%5B%7B%22href%22%3A%22did%3Aorb%3AuAAA%3AEiC0Iu10PDXwr5XIHgos9TZo1a1N13tq9V5XEk6EePWGkQ%22%7D%2C%7B%22href%22%3A%22did%3Aorb%3AuAAA%3AEiCP0F5n9PB2tuEPFCc7Oyob_itqrvdfGk_UphBOQ9rZQA%22%7D%5D%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%7D%5D%7D",
             "type": "application/linkset+json"
           }
         ],
         "profile": "https://w3id.org/orb#v0",
         "related": [
           {
-            "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiCE4J4UpuWwXKb25jDyoVGCQ8F0v1NPTsxz4QMzADBxYA%22%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%2C%22via%22%3A%5B%7B%22href%22%3A%22hl%3AuEiAavDOmQylmPGTGBujg_EsbELbdUX9J00i93CELKytYTQ%3AuoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQWF2RE9tUXlsbVBHVEdCdWpnX0VzYkVMYmRVWDlKMDBpOTNDRUxLeXRZVFF4QmlwZnM6Ly9iYWZrcmVpYTJ4cXoybXF6am15NmdqcnFnNWRxcHlzeTNjYzNuMnVsN2poanVycG80ZWVmc3drMnlqdQ%22%7D%5D%7D%5D%7D",
+            "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiD07i6t3Cf31sbTepJnigcbM4jVcaT6YqcWMWgDVuiwaw%22%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%2C%22via%22%3A%5B%7B%22href%22%3A%22hl%3AuEiCGzuAY1M01uM6mC_vJDUc8iiJXMxqGxl5aBsWqcrWfIg%3AuoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQ0d6dUFZMU0wMXVNNm1DX3ZKRFVjOGlpSlhNeHFHeGw1YUJzV3FjcldmSWd4QmlwZnM6Ly9iYWZrcmVpZWd6M3FicnZnbmd3NG01anFsN3BlcTJyejRyaXJmb215MnEzZGY0d3FneXd2aGZubTdlaQ%22%7D%5D%7D%5D%7D",
             "type": "application/linkset+json"
           }
         ],
         "replies": [
           {
-            "href": "data:application/json,%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww.w3.org%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Fsecurity%2Fsuites%2Fed25519-2020%2Fv1%22%5D%2C%22credentialSubject%22%3A%22hl%3AuEiCE4J4UpuWwXKb25jDyoVGCQ8F0v1NPTsxz4QMzADBxYA%22%2C%22id%22%3A%22https%3A%2F%2Forb2.domain1.com%2Fvc%2Fc3f5d2a1-3af5-4752-9643-8720bb4add87%22%2C%22issuanceDate%22%3A%222022-03-16T18%3A20%3A35.61714467Z%22%2C%22issuer%22%3A%22https%3A%2F%2Forb2.domain1.com%22%2C%22proof%22%3A%5B%7B%22created%22%3A%222022-03-16T18%3A20%3A35.629Z%22%2C%22domain%22%3A%22http%3A%2F%2Forb.vct%3A8077%2Fmaple2020%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%22esrGz5b_OzMF9YbZzIsu_T9DCWhcq-f63zzDQ36sEESeuyRWAAhsE_z_0N_lWSwSMmrmwPJEP0Fo-X1jNCUKCA%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain1.com%23orb1key2%22%7D%2C%7B%22created%22%3A%222022-03-16T18%3A20%3A35.74959555Z%22%2C%22domain%22%3A%22https%3A%2F%2Forb.domain2.com%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%22U4rJ4ei2mSp99UW44tRDZscuwvoWV56rxVK7Z9cYo6tTwisIIhnd6hqYp8vy-MfzUH85yhvbZBZuLNL-ue51DQ%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain2.com%23orb2key%22%7D%5D%2C%22type%22%3A%22VerifiableCredential%22%7D",
+            "href": "data:application/json,%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww.w3.org%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Factivityanchors%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Fsecurity%2Fsuites%2Fjws-2020%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Fsecurity%2Fsuites%2Fed25519-2020%2Fv1%22%5D%2C%22credentialSubject%22%3A%7B%22anchor%22%3A%22hl%3AuEiCGzuAY1M01uM6mC_vJDUc8iiJXMxqGxl5aBsWqcrWfIg%22%2C%22id%22%3A%22hl%3AuEiD07i6t3Cf31sbTepJnigcbM4jVcaT6YqcWMWgDVuiwaw%22%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%7D%2C%22id%22%3A%22https%3A%2F%2Forb.domain1.com%2Fvc%2Fb1cf5b8e-a236-4410-8cab-56f66e3363c6%22%2C%22issuanceDate%22%3A%222022-07-19T17%3A38%3A10.5475141Z%22%2C%22issuer%22%3A%22https%3A%2F%2Forb.domain1.com%22%2C%22proof%22%3A%5B%7B%22created%22%3A%222022-07-19T17%3A38%3A10.569Z%22%2C%22domain%22%3A%22http%3A%2F%2Forb.vct%3A8077%2Fmaple2020%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%22zkaYZHbisAJpQ6BtBEKJtcMcqZW1D2oEeDo3RfAHhz9MNwM42VatU2M8haoMDDjekUHB5uyUZt76AtPaCT4gcz29%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain1.com%23GJqG8xWJ4c4NGedg1-S_4FdsPjjFiV2GpZ0muPC_dv0%22%7D%2C%7B%22created%22%3A%222022-07-19T17%3A38%3A10.7557806Z%22%2C%22domain%22%3A%22https%3A%2F%2Forb.domain2.com%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%22z3gXGJPpe1CgPNve23hWs78ySbKcy6UDDvxg7CfQSgAfdpVM37zWXAQPpU3ppUhSwhUrUZW345iDL6TrmhYBzV8K4%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain2.com%23Tq-S3o_R8fNoiMHPTfWx0Evigk2mPWpnDdsN_biBNqg%22%7D%5D%2C%22type%22%3A%5B%22VerifiableCredential%22%2C%22AnchorCredential%22%5D%7D",
             "type": "application/ld+json"
           }
         ]
@@ -459,70 +524,36 @@ const sampleGrandparentAnchorEvent = `{
     ]
   },
   "type": "AnchorEvent",
-  "url": "hl:uEiDB-Nh4kxP2UIzjC-oLbEaW4bHCYaFC9WgvPtbtMtvMuA:uoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpREItTmg0a3hQMlVJempDLW9MYkVhVzRiSENZYUZDOVdndlB0YnRNdHZNdUF4QmlwZnM6Ly9iYWZrcmVpZ2I3ZG1ocmV5dDZ6aWl6eXlsNWlmd3lydXc0Z3k0ZXluYmlsMndxbHo2MjN3dGZ3Nm14YQ"
+  "url": "hl:uEiDpUqNx6yz_VrkDGMiKdyds3Qotdz3xGUfH7PZpZNsHfQ:uoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpRHBVcU54Nnl6X1Zya0RHTWlLZHlkczNRb3RkejN4R1VmSDdQWnBaTnNIZlF4QmlwZnM6Ly9iYWZrcmVpaGpra3J4ZDJ6bTc1bGxzYXl5emNmaG9qM20zdWZjMjV6NTZlbXVwcjdtNnp1d2p3eWhwdQ"
 }`
 
 //nolint:lll
 const sampleGrandparentAnchorLinkset = `{
   "linkset": [
     {
-      "anchor": "hl:uEiCE4J4UpuWwXKb25jDyoVGCQ8F0v1NPTsxz4QMzADBxYA",
+      "anchor": "hl:uEiD07i6t3Cf31sbTepJnigcbM4jVcaT6YqcWMWgDVuiwaw",
       "author": "https://orb.domain1.com/services/orb",
       "original": [
         {
-          "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiAavDOmQylmPGTGBujg_EsbELbdUX9J00i93CELKytYTQ%22%2C%22author%22%3A%22https%3A%2F%2Forb.domain1.com%2Fservices%2Forb%22%2C%22item%22%3A%5B%7B%22href%22%3A%22did%3Aorb%3AuAAA%3AEiDSqf8owKb84KDjRbIemw-Sv-UoyPcsyPNFEQ9rzT-Uag%22%7D%2C%7B%22href%22%3A%22did%3Aorb%3AuAAA%3AEiApcqrvEntohzA1NGNYO9l3N7yyR-dfvotjxTTAzGlTUQ%22%7D%5D%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%7D%5D%7D",
+          "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiCGzuAY1M01uM6mC_vJDUc8iiJXMxqGxl5aBsWqcrWfIg%22%2C%22author%22%3A%22https%3A%2F%2Forb.domain1.com%2Fservices%2Forb%22%2C%22item%22%3A%5B%7B%22href%22%3A%22did%3Aorb%3AuAAA%3AEiC0Iu10PDXwr5XIHgos9TZo1a1N13tq9V5XEk6EePWGkQ%22%7D%2C%7B%22href%22%3A%22did%3Aorb%3AuAAA%3AEiCP0F5n9PB2tuEPFCc7Oyob_itqrvdfGk_UphBOQ9rZQA%22%7D%5D%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%7D%5D%7D",
           "type": "application/linkset+json"
         }
       ],
       "profile": "https://w3id.org/orb#v0",
       "related": [
         {
-          "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiCE4J4UpuWwXKb25jDyoVGCQ8F0v1NPTsxz4QMzADBxYA%22%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%2C%22via%22%3A%5B%7B%22href%22%3A%22hl%3AuEiAavDOmQylmPGTGBujg_EsbELbdUX9J00i93CELKytYTQ%3AuoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQWF2RE9tUXlsbVBHVEdCdWpnX0VzYkVMYmRVWDlKMDBpOTNDRUxLeXRZVFF4QmlwZnM6Ly9iYWZrcmVpYTJ4cXoybXF6am15NmdqcnFnNWRxcHlzeTNjYzNuMnVsN2poanVycG80ZWVmc3drMnlqdQ%22%7D%5D%7D%5D%7D",
+          "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiD07i6t3Cf31sbTepJnigcbM4jVcaT6YqcWMWgDVuiwaw%22%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%2C%22via%22%3A%5B%7B%22href%22%3A%22hl%3AuEiCGzuAY1M01uM6mC_vJDUc8iiJXMxqGxl5aBsWqcrWfIg%3AuoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQ0d6dUFZMU0wMXVNNm1DX3ZKRFVjOGlpSlhNeHFHeGw1YUJzV3FjcldmSWd4QmlwZnM6Ly9iYWZrcmVpZWd6M3FicnZnbmd3NG01anFsN3BlcTJyejRyaXJmb215MnEzZGY0d3FneXd2aGZubTdlaQ%22%7D%5D%7D%5D%7D",
           "type": "application/linkset+json"
         }
       ],
       "replies": [
         {
-          "href": "data:application/json,%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww.w3.org%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Fsecurity%2Fsuites%2Fed25519-2020%2Fv1%22%5D%2C%22credentialSubject%22%3A%22hl%3AuEiCE4J4UpuWwXKb25jDyoVGCQ8F0v1NPTsxz4QMzADBxYA%22%2C%22id%22%3A%22https%3A%2F%2Forb2.domain1.com%2Fvc%2Fc3f5d2a1-3af5-4752-9643-8720bb4add87%22%2C%22issuanceDate%22%3A%222022-03-16T18%3A20%3A35.61714467Z%22%2C%22issuer%22%3A%22https%3A%2F%2Forb2.domain1.com%22%2C%22proof%22%3A%5B%7B%22created%22%3A%222022-03-16T18%3A20%3A35.629Z%22%2C%22domain%22%3A%22http%3A%2F%2Forb.vct%3A8077%2Fmaple2020%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%22esrGz5b_OzMF9YbZzIsu_T9DCWhcq-f63zzDQ36sEESeuyRWAAhsE_z_0N_lWSwSMmrmwPJEP0Fo-X1jNCUKCA%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain1.com%23orb1key2%22%7D%2C%7B%22created%22%3A%222022-03-16T18%3A20%3A35.74959555Z%22%2C%22domain%22%3A%22https%3A%2F%2Forb.domain2.com%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%22U4rJ4ei2mSp99UW44tRDZscuwvoWV56rxVK7Z9cYo6tTwisIIhnd6hqYp8vy-MfzUH85yhvbZBZuLNL-ue51DQ%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain2.com%23orb2key%22%7D%5D%2C%22type%22%3A%22VerifiableCredential%22%7D",
+          "href": "data:application/json,%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww.w3.org%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Factivityanchors%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Fsecurity%2Fsuites%2Fjws-2020%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Fsecurity%2Fsuites%2Fed25519-2020%2Fv1%22%5D%2C%22credentialSubject%22%3A%7B%22anchor%22%3A%22hl%3AuEiCGzuAY1M01uM6mC_vJDUc8iiJXMxqGxl5aBsWqcrWfIg%22%2C%22id%22%3A%22hl%3AuEiD07i6t3Cf31sbTepJnigcbM4jVcaT6YqcWMWgDVuiwaw%22%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%7D%2C%22id%22%3A%22https%3A%2F%2Forb.domain1.com%2Fvc%2Fb1cf5b8e-a236-4410-8cab-56f66e3363c6%22%2C%22issuanceDate%22%3A%222022-07-19T17%3A38%3A10.5475141Z%22%2C%22issuer%22%3A%22https%3A%2F%2Forb.domain1.com%22%2C%22proof%22%3A%5B%7B%22created%22%3A%222022-07-19T17%3A38%3A10.569Z%22%2C%22domain%22%3A%22http%3A%2F%2Forb.vct%3A8077%2Fmaple2020%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%22zkaYZHbisAJpQ6BtBEKJtcMcqZW1D2oEeDo3RfAHhz9MNwM42VatU2M8haoMDDjekUHB5uyUZt76AtPaCT4gcz29%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain1.com%23GJqG8xWJ4c4NGedg1-S_4FdsPjjFiV2GpZ0muPC_dv0%22%7D%2C%7B%22created%22%3A%222022-07-19T17%3A38%3A10.7557806Z%22%2C%22domain%22%3A%22https%3A%2F%2Forb.domain2.com%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%22z3gXGJPpe1CgPNve23hWs78ySbKcy6UDDvxg7CfQSgAfdpVM37zWXAQPpU3ppUhSwhUrUZW345iDL6TrmhYBzV8K4%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain2.com%23Tq-S3o_R8fNoiMHPTfWx0Evigk2mPWpnDdsN_biBNqg%22%7D%5D%2C%22type%22%3A%5B%22VerifiableCredential%22%2C%22AnchorCredential%22%5D%7D",
           "type": "application/ld+json"
         }
       ]
     }
   ]
-}`
-
-//nolint:lll
-const sampleAnchorEventNoTimeOrDomain = `{
-  "@context": "https://w3id.org/activityanchors/v1",
-  "object": {
-    "linkset": [
-      {
-        "anchor": "hl:uEiCE4J4UpuWwXKb25jDyoVGCQ8F0v1NPTsxz4QMzADBxYA",
-        "author": "https://orb.domain1.com/services/orb",
-        "original": [
-          {
-            "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiAavDOmQylmPGTGBujg_EsbELbdUX9J00i93CELKytYTQ%22%2C%22author%22%3A%22https%3A%2F%2Forb.domain1.com%2Fservices%2Forb%22%2C%22item%22%3A%5B%7B%22href%22%3A%22did%3Aorb%3AuAAA%3AEiDSqf8owKb84KDjRbIemw-Sv-UoyPcsyPNFEQ9rzT-Uag%22%7D%2C%7B%22href%22%3A%22did%3Aorb%3AuAAA%3AEiApcqrvEntohzA1NGNYO9l3N7yyR-dfvotjxTTAzGlTUQ%22%7D%5D%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%7D%5D%7D",
-            "type": "application/linkset+json"
-          }
-        ],
-        "profile": "https://w3id.org/orb#v0",
-        "related": [
-          {
-            "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiCE4J4UpuWwXKb25jDyoVGCQ8F0v1NPTsxz4QMzADBxYA%22%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%2C%22via%22%3A%5B%7B%22href%22%3A%22hl%3AuEiAavDOmQylmPGTGBujg_EsbELbdUX9J00i93CELKytYTQ%3AuoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQWF2RE9tUXlsbVBHVEdCdWpnX0VzYkVMYmRVWDlKMDBpOTNDRUxLeXRZVFF4QmlwZnM6Ly9iYWZrcmVpYTJ4cXoybXF6am15NmdqcnFnNWRxcHlzeTNjYzNuMnVsN2poanVycG80ZWVmc3drMnlqdQ%22%7D%5D%7D%5D%7D",
-            "type": "application/linkset+json"
-          }
-        ],
-        "replies": [
-          {
-            "href": "data:application/json,%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww.w3.org%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Fsecurity%2Fsuites%2Fed25519-2020%2Fv1%22%5D%2C%22credentialSubject%22%3A%22hl%3AuEiCE4J4UpuWwXKb25jDyoVGCQ8F0v1NPTsxz4QMzADBxYA%22%2C%22id%22%3A%22https%3A%2F%2Forb2.domain1.com%2Fvc%2Fc3f5d2a1-3af5-4752-9643-8720bb4add87%22%2C%22issuanceDate%22%3A%222022-03-16T18%3A20%3A35.61714467Z%22%2C%22issuer%22%3A%22https%3A%2F%2Forb2.domain1.com%22%2C%22proof%22%3A%5B%7B%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%22esrGz5b_OzMF9YbZzIsu_T9DCWhcq-f63zzDQ36sEESeuyRWAAhsE_z_0N_lWSwSMmrmwPJEP0Fo-X1jNCUKCA%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain1.com%23orb1key2%22%7D%5D%2C%22type%22%3A%22VerifiableCredential%22%7D",
-            "type": "application/ld+json"
-          }
-        ]
-      }
-    ]
-  },
-  "type": "AnchorEvent",
-  "url": "hl:uEiDB-Nh4kxP2UIzjC-oLbEaW4bHCYaFC9WgvPtbtMtvMuA:uoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpREItTmg0a3hQMlVJempDLW9MYkVhVzRiSENZYUZDOVdndlB0YnRNdHZNdUF4QmlwZnM6Ly9iYWZrcmVpZ2I3ZG1ocmV5dDZ6aWl6eXlsNWlmd3lydXc0Z3k0ZXluYmlsMndxbHo2MjN3dGZ3Nm14YQ"
 }`
 
 //nolint:lll
@@ -576,6 +607,116 @@ const sampleAnchorLinksetInvalidParent = `{
       "replies": [
         {
           "href": "data:application/json,%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww.w3.org%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Fsecurity%2Fsuites%2Fed25519-2020%2Fv1%22%5D%2C%22credentialSubject%22%3A%22hl%3AuEiDhi1oX6K76A1ch5WPu2wdNLcizCx08EypO0taw9KHOGw%22%2C%22id%22%3A%22https%3A%2F%2Forb2.domain1.com%2Fvc%2F01331215-0839-4679-baa2-ba4481bac47b%22%2C%22issuanceDate%22%3A%222022-03-16T18%3A20%3A43.675143863Z%22%2C%22issuer%22%3A%22https%3A%2F%2Forb2.domain1.com%22%2C%22proof%22%3A%5B%7B%22created%22%3A%222022-03-16T18%3A20%3A43.686Z%22%2C%22domain%22%3A%22http%3A%2F%2Forb.vct%3A8077%2Fmaple2020%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%22h7wjce2r6fH8ygSJGkm1yRZ_AvubDiodzn22osuCbYb5RCQaXoEmDtOf1oZMosO1vdeTcobi-CeW77J8_xYrAg%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain1.com%23orb1key2%22%7D%2C%7B%22created%22%3A%222022-03-16T18%3A20%3A43.787088993Z%22%2C%22domain%22%3A%22https%3A%2F%2Forb.domain2.com%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%229griFoChmta0rOXdHJ6WJjoXuxR8efjg9TeqzIyZqP986I9CU9I3a9wf-xVKusNa4ql7NCcvTLCXTUnQbMh2Cg%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain2.com%23orb2key%22%7D%5D%2C%22type%22%3A%22VerifiableCredential%22%7D",
+          "type": "application/ld+json"
+        }
+      ]
+    }
+  ]
+}`
+
+//nolint:lll
+const anchorLinksetNoReplies = `{
+  "linkset": [
+    {
+      "anchor": "hl:uEiD07i6t3Cf31sbTepJnigcbM4jVcaT6YqcWMWgDVuiwaw",
+      "author": "https://orb.domain1.com/services/orb",
+      "original": [
+        {
+          "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiCGzuAY1M01uM6mC_vJDUc8iiJXMxqGxl5aBsWqcrWfIg%22%2C%22author%22%3A%22https%3A%2F%2Forb.domain1.com%2Fservices%2Forb%22%2C%22item%22%3A%5B%7B%22href%22%3A%22did%3Aorb%3AuAAA%3AEiC0Iu10PDXwr5XIHgos9TZo1a1N13tq9V5XEk6EePWGkQ%22%7D%2C%7B%22href%22%3A%22did%3Aorb%3AuAAA%3AEiCP0F5n9PB2tuEPFCc7Oyob_itqrvdfGk_UphBOQ9rZQA%22%7D%5D%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%7D%5D%7D",
+          "type": "application/linkset+json"
+        }
+      ],
+      "profile": "https://w3id.org/orb#v0",
+      "related": [
+        {
+          "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiD07i6t3Cf31sbTepJnigcbM4jVcaT6YqcWMWgDVuiwaw%22%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%2C%22via%22%3A%5B%7B%22href%22%3A%22hl%3AuEiCGzuAY1M01uM6mC_vJDUc8iiJXMxqGxl5aBsWqcrWfIg%3AuoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQ0d6dUFZMU0wMXVNNm1DX3ZKRFVjOGlpSlhNeHFHeGw1YUJzV3FjcldmSWd4QmlwZnM6Ly9iYWZrcmVpZWd6M3FicnZnbmd3NG01anFsN3BlcTJyejRyaXJmb215MnEzZGY0d3FneXd2aGZubTdlaQ%22%7D%5D%7D%5D%7D",
+          "type": "application/linkset+json"
+        }
+      ]
+    }
+  ]
+}`
+
+//nolint:lll
+const anchorLinksetInvalidContent = `{
+  "linkset": [
+    {
+      "anchor": "hl:uEiD07i6t3Cf31sbTepJnigcbM4jVcaT6YqcWMWgDVuiwaw",
+      "author": "https://orb.domain1.com/services/orb",
+      "original": [
+        {
+          "href": "data:unsupported,xxxxx",
+          "type": "application/linkset+json"
+        }
+      ],
+      "profile": "https://w3id.org/orb#v0",
+      "related": [
+        {
+          "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiD07i6t3Cf31sbTepJnigcbM4jVcaT6YqcWMWgDVuiwaw%22%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%2C%22via%22%3A%5B%7B%22href%22%3A%22hl%3AuEiCGzuAY1M01uM6mC_vJDUc8iiJXMxqGxl5aBsWqcrWfIg%3AuoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQ0d6dUFZMU0wMXVNNm1DX3ZKRFVjOGlpSlhNeHFHeGw1YUJzV3FjcldmSWd4QmlwZnM6Ly9iYWZrcmVpZWd6M3FicnZnbmd3NG01anFsN3BlcTJyejRyaXJmb215MnEzZGY0d3FneXd2aGZubTdlaQ%22%7D%5D%7D%5D%7D",
+          "type": "application/linkset+json"
+        }
+      ],
+      "replies": [
+        {
+          "href": "data:application/json,%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww.w3.org%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Factivityanchors%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Fsecurity%2Fsuites%2Fjws-2020%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Fsecurity%2Fsuites%2Fed25519-2020%2Fv1%22%5D%2C%22credentialSubject%22%3A%7B%22anchor%22%3A%22hl%3AuEiCGzuAY1M01uM6mC_vJDUc8iiJXMxqGxl5aBsWqcrWfIg%22%2C%22id%22%3A%22hl%3AuEiD07i6t3Cf31sbTepJnigcbM4jVcaT6YqcWMWgDVuiwaw%22%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%7D%2C%22id%22%3A%22https%3A%2F%2Forb.domain1.com%2Fvc%2Fb1cf5b8e-a236-4410-8cab-56f66e3363c6%22%2C%22issuanceDate%22%3A%222022-07-19T17%3A38%3A10.5475141Z%22%2C%22issuer%22%3A%22https%3A%2F%2Forb.domain1.com%22%2C%22proof%22%3A%5B%7B%22created%22%3A%222022-07-19T17%3A38%3A10.569Z%22%2C%22domain%22%3A%22http%3A%2F%2Forb.vct%3A8077%2Fmaple2020%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%22zkaYZHbisAJpQ6BtBEKJtcMcqZW1D2oEeDo3RfAHhz9MNwM42VatU2M8haoMDDjekUHB5uyUZt76AtPaCT4gcz29%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain1.com%23GJqG8xWJ4c4NGedg1-S_4FdsPjjFiV2GpZ0muPC_dv0%22%7D%2C%7B%22created%22%3A%222022-07-19T17%3A38%3A10.7557806Z%22%2C%22domain%22%3A%22https%3A%2F%2Forb.domain2.com%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%22z3gXGJPpe1CgPNve23hWs78ySbKcy6UDDvxg7CfQSgAfdpVM37zWXAQPpU3ppUhSwhUrUZW345iDL6TrmhYBzV8K4%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain2.com%23Tq-S3o_R8fNoiMHPTfWx0Evigk2mPWpnDdsN_biBNqg%22%7D%5D%2C%22type%22%3A%5B%22VerifiableCredential%22%2C%22AnchorCredential%22%5D%7D",
+          "type": "application/ld+json"
+        }
+      ]
+    }
+  ]
+}`
+
+//nolint:lll
+const anchorLinksetUnsupportedProfile = `{
+  "linkset": [
+    {
+      "anchor": "hl:uEiD07i6t3Cf31sbTepJnigcbM4jVcaT6YqcWMWgDVuiwaw",
+      "author": "https://orb.domain1.com/services/orb",
+      "original": [
+        {
+          "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiCGzuAY1M01uM6mC_vJDUc8iiJXMxqGxl5aBsWqcrWfIg%22%2C%22author%22%3A%22https%3A%2F%2Forb.domain1.com%2Fservices%2Forb%22%2C%22item%22%3A%5B%7B%22href%22%3A%22did%3Aorb%3AuAAA%3AEiC0Iu10PDXwr5XIHgos9TZo1a1N13tq9V5XEk6EePWGkQ%22%7D%2C%7B%22href%22%3A%22did%3Aorb%3AuAAA%3AEiCP0F5n9PB2tuEPFCc7Oyob_itqrvdfGk_UphBOQ9rZQA%22%7D%5D%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%7D%5D%7D",
+          "type": "application/linkset+json"
+        }
+      ],
+      "profile": "https://w3id.org/orb#vXXX",
+      "related": [
+        {
+          "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiD07i6t3Cf31sbTepJnigcbM4jVcaT6YqcWMWgDVuiwaw%22%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%2C%22via%22%3A%5B%7B%22href%22%3A%22hl%3AuEiCGzuAY1M01uM6mC_vJDUc8iiJXMxqGxl5aBsWqcrWfIg%3AuoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQ0d6dUFZMU0wMXVNNm1DX3ZKRFVjOGlpSlhNeHFHeGw1YUJzV3FjcldmSWd4QmlwZnM6Ly9iYWZrcmVpZWd6M3FicnZnbmd3NG01anFsN3BlcTJyejRyaXJmb215MnEzZGY0d3FneXd2aGZubTdlaQ%22%7D%5D%7D%5D%7D",
+          "type": "application/linkset+json"
+        }
+      ],
+      "replies": [
+        {
+          "href": "data:application/json,%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww.w3.org%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Factivityanchors%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Fsecurity%2Fsuites%2Fjws-2020%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Fsecurity%2Fsuites%2Fed25519-2020%2Fv1%22%5D%2C%22credentialSubject%22%3A%7B%22anchor%22%3A%22hl%3AuEiCGzuAY1M01uM6mC_vJDUc8iiJXMxqGxl5aBsWqcrWfIg%22%2C%22id%22%3A%22hl%3AuEiD07i6t3Cf31sbTepJnigcbM4jVcaT6YqcWMWgDVuiwaw%22%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%7D%2C%22id%22%3A%22https%3A%2F%2Forb.domain1.com%2Fvc%2Fb1cf5b8e-a236-4410-8cab-56f66e3363c6%22%2C%22issuanceDate%22%3A%222022-07-19T17%3A38%3A10.5475141Z%22%2C%22issuer%22%3A%22https%3A%2F%2Forb.domain1.com%22%2C%22proof%22%3A%5B%7B%22created%22%3A%222022-07-19T17%3A38%3A10.569Z%22%2C%22domain%22%3A%22http%3A%2F%2Forb.vct%3A8077%2Fmaple2020%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%22zkaYZHbisAJpQ6BtBEKJtcMcqZW1D2oEeDo3RfAHhz9MNwM42VatU2M8haoMDDjekUHB5uyUZt76AtPaCT4gcz29%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain1.com%23GJqG8xWJ4c4NGedg1-S_4FdsPjjFiV2GpZ0muPC_dv0%22%7D%2C%7B%22created%22%3A%222022-07-19T17%3A38%3A10.7557806Z%22%2C%22domain%22%3A%22https%3A%2F%2Forb.domain2.com%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%22z3gXGJPpe1CgPNve23hWs78ySbKcy6UDDvxg7CfQSgAfdpVM37zWXAQPpU3ppUhSwhUrUZW345iDL6TrmhYBzV8K4%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain2.com%23Tq-S3o_R8fNoiMHPTfWx0Evigk2mPWpnDdsN_biBNqg%22%7D%5D%2C%22type%22%3A%5B%22VerifiableCredential%22%2C%22AnchorCredential%22%5D%7D",
+          "type": "application/ld+json"
+        }
+      ]
+    }
+  ]
+}`
+
+//nolint:lll
+const anchorLinksetInvalidVC = `{
+  "linkset": [
+    {
+      "anchor": "hl:uEiD07i6t3Cf31sbTepJnigcbM4jVcaT6YqcWMWgDVuiwaw",
+      "author": "https://orb.domain1.com/services/orb",
+      "original": [
+        {
+          "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiCGzuAY1M01uM6mC_vJDUc8iiJXMxqGxl5aBsWqcrWfIg%22%2C%22author%22%3A%22https%3A%2F%2Forb.domain1.com%2Fservices%2Forb%22%2C%22item%22%3A%5B%7B%22href%22%3A%22did%3Aorb%3AuAAA%3AEiC0Iu10PDXwr5XIHgos9TZo1a1N13tq9V5XEk6EePWGkQ%22%7D%2C%7B%22href%22%3A%22did%3Aorb%3AuAAA%3AEiCP0F5n9PB2tuEPFCc7Oyob_itqrvdfGk_UphBOQ9rZQA%22%7D%5D%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%7D%5D%7D",
+          "type": "application/linkset+json"
+        }
+      ],
+      "profile": "https://w3id.org/orb#v0",
+      "related": [
+        {
+          "href": "data:application/json,%7B%22linkset%22%3A%5B%7B%22anchor%22%3A%22hl%3AuEiD07i6t3Cf31sbTepJnigcbM4jVcaT6YqcWMWgDVuiwaw%22%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%2C%22via%22%3A%5B%7B%22href%22%3A%22hl%3AuEiCGzuAY1M01uM6mC_vJDUc8iiJXMxqGxl5aBsWqcrWfIg%3AuoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpQ0d6dUFZMU0wMXVNNm1DX3ZKRFVjOGlpSlhNeHFHeGw1YUJzV3FjcldmSWd4QmlwZnM6Ly9iYWZrcmVpZWd6M3FicnZnbmd3NG01anFsN3BlcTJyejRyaXJmb215MnEzZGY0d3FneXd2aGZubTdlaQ%22%7D%5D%7D%5D%7D",
+          "type": "application/linkset+json"
+        }
+      ],
+      "replies": [
+        {
+          "href": "data:application/json,%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww.w3.org%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Factivityanchors%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Fsecurity%2Fsuites%2Fjws-2020%2Fv1%22%2C%22https%3A%2F%2Fw3id.org%2Fsecurity%2Fsuites%2Fed25519-2020%2Fv1%22%5D%2C%22credentialSubject%22%3A%7B%22anchor%22%3A%22hl%3AuEiCGzuAY1M01uM6mC_vJDUc8iiJXMxqGxl5aBsWqcrWfIg%22%2C%22id%22%3A%22hl%3AuEiD07i6txxxx1sbTepJnigcbM4jVcaT6YqcWMWgDVuiwaw%22%2C%22profile%22%3A%22https%3A%2F%2Fw3id.org%2Forb%23v0%22%7D%2C%22id%22%3A%22https%3A%2F%2Forb.domain1.com%2Fvc%2Fb1cf5b8e-a236-4410-8cab-56f66e3363c6%22%2C%22issuanceDate%22%3A%222022-07-19T17%3A38%3A10.5475141Z%22%2C%22issuer%22%3A%22https%3A%2F%2Forb.domain1.com%22%2C%22proof%22%3A%5B%7B%22created%22%3A%222022-07-19T17%3A38%3A10.569Z%22%2C%22domain%22%3A%22http%3A%2F%2Forb.vct%3A8077%2Fmaple2020%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%22zkaYZHbisAJpQ6BtBEKJtcMcqZW1D2oEeDo3RfAHhz9MNwM42VatU2M8haoMDDjekUHB5uyUZt76AtPaCT4gcz29%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain1.com%23GJqG8xWJ4c4NGedg1-S_4FdsPjjFiV2GpZ0muPC_dv0%22%7D%2C%7B%22created%22%3A%222022-07-19T17%3A38%3A10.7557806Z%22%2C%22domain%22%3A%22https%3A%2F%2Forb.domain2.com%22%2C%22proofPurpose%22%3A%22assertionMethod%22%2C%22proofValue%22%3A%22z3gXGJPpe1CgPNve23hWs78ySbKcy6UDDvxg7CfQSgAfdpVM37zWXAQPpU3ppUhSwhUrUZW345iDL6TrmhYBzV8K4%22%2C%22type%22%3A%22Ed25519Signature2020%22%2C%22verificationMethod%22%3A%22did%3Aweb%3Aorb.domain2.com%23Tq-S3o_R8fNoiMHPTfWx0Evigk2mPWpnDdsN_biBNqg%22%7D%5D%2C%22type%22%3A%5B%22VerifiableCredential%22%2C%22AnchorCredential%22%5D%7D",
           "type": "application/ld+json"
         }
       ]

--- a/pkg/anchor/util/util_test.go
+++ b/pkg/anchor/util/util_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/trustbloc/orb/pkg/anchor/anchorlinkset"
+	"github.com/trustbloc/orb/pkg/anchor/anchorlinkset/generator"
 	"github.com/trustbloc/orb/pkg/anchor/builder"
 	"github.com/trustbloc/orb/pkg/anchor/subject"
 	"github.com/trustbloc/orb/pkg/datauri"
@@ -38,8 +39,9 @@ func TestVerifiableCredentialFromAnchorEvent(t *testing.T) {
 			PreviousAnchors: previousAnchors,
 		}
 
-		al, vcBytes, err := anchorlinkset.BuildAnchorLink(payload, datauri.MediaTypeDataURIGzipBase64,
-			func(anchorHashlink string) (*verifiable.Credential, error) {
+		al, vcBytes, err := anchorlinkset.NewBuilder(
+			generator.NewRegistry()).BuildAnchorLink(payload, datauri.MediaTypeDataURIGzipBase64,
+			func(anchorHashlink, coreIndexHashlink string) (*verifiable.Credential, error) {
 				return &verifiable.Credential{
 					Types:   []string{"VerifiableCredential"},
 					Context: []string{defVCContext},

--- a/pkg/anchor/writer/writer_test.go
+++ b/pkg/anchor/writer/writer_test.go
@@ -33,6 +33,8 @@ import (
 	apmocks "github.com/trustbloc/orb/pkg/activitypub/store/mocks"
 	"github.com/trustbloc/orb/pkg/activitypub/store/spi"
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+	"github.com/trustbloc/orb/pkg/anchor/anchorlinkset"
+	"github.com/trustbloc/orb/pkg/anchor/anchorlinkset/generator"
 	"github.com/trustbloc/orb/pkg/anchor/builder"
 	"github.com/trustbloc/orb/pkg/anchor/graph"
 	anchormocks "github.com/trustbloc/orb/pkg/anchor/mocks"
@@ -169,6 +171,8 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			AnchorLinkStore:        anchorEventStore,
 			AnchorEventStatusStore: statusStore,
 			WFClient:               wfClient,
+			GeneratorRegistry:      generator.NewRegistry(),
+			AnchorLinkBuilder:      anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers,
@@ -221,6 +225,8 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			AnchorLinkStore:        anchorEventStore,
 			AnchorEventStatusStore: statusStore,
 			WFClient:               wfClient,
+			GeneratorRegistry:      generator.NewRegistry(),
+			AnchorLinkBuilder:      anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		var testServerURL string
@@ -275,6 +281,8 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			AnchorLinkStore:        anchorEventStore,
 			AnchorEventStatusStore: statusStore,
 			WFClient:               wfClient,
+			GeneratorRegistry:      generator.NewRegistry(),
+			AnchorLinkBuilder:      anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers,
@@ -329,6 +337,8 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			AnchorLinkStore:        anchorEventStore,
 			AnchorEventStatusStore: statusStore,
 			WFClient:               wfClient,
+			GeneratorRegistry:      generator.NewRegistry(),
+			AnchorLinkBuilder:      anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers,
@@ -380,6 +390,8 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			AnchorLinkStore:        anchorEventStore,
 			AnchorEventStatusStore: &mockstatusStore{Err: fmt.Errorf("status error")},
 			WFClient:               wfClient,
+			GeneratorRegistry:      generator.NewRegistry(),
+			AnchorLinkBuilder:      anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers,
@@ -418,18 +430,20 @@ func TestWriter_WriteAnchor(t *testing.T) {
 		wit := &mockWitness{proofBytes: []byte(`{"proof": {"created": "021-02-23T:07Z"}}`)}
 
 		providers := &Providers{
-			AnchorGraph:     anchorGraph,
-			DidAnchors:      memdidanchor.New(),
-			AnchorBuilder:   &mockTxnBuilder{},
-			OpProcessor:     &mockOpProcessor{},
-			Outbox:          &mockOutbox{},
-			Signer:          &mockSigner{},
-			Witness:         wit,
-			MonitoringSvc:   &mockMonitoring{},
-			WitnessStore:    &mockWitnessStore{},
-			ActivityStore:   &mockActivityStore{},
-			AnchorLinkStore: anchorEventStore,
-			WFClient:        wfClient,
+			AnchorGraph:       anchorGraph,
+			DidAnchors:        memdidanchor.New(),
+			AnchorBuilder:     &mockTxnBuilder{},
+			OpProcessor:       &mockOpProcessor{},
+			Outbox:            &mockOutbox{},
+			Signer:            &mockSigner{},
+			Witness:           wit,
+			MonitoringSvc:     &mockMonitoring{},
+			WitnessStore:      &mockWitnessStore{},
+			ActivityStore:     &mockActivityStore{},
+			AnchorLinkStore:   anchorEventStore,
+			WFClient:          wfClient,
+			GeneratorRegistry: generator.NewRegistry(),
+			AnchorLinkBuilder: anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers,
@@ -466,17 +480,19 @@ func TestWriter_WriteAnchor(t *testing.T) {
 		require.NoError(t, err)
 
 		providers := &Providers{
-			AnchorGraph:     anchorGraph,
-			DidAnchors:      &mockDidAnchor{},
-			AnchorBuilder:   &mockTxnBuilder{},
-			Outbox:          &mockOutbox{},
-			Signer:          &mockSigner{},
-			MonitoringSvc:   &mockMonitoring{},
-			WitnessStore:    &mockWitnessStore{},
-			ActivityStore:   &mockActivityStore{},
-			AnchorLinkStore: anchorEventStore,
-			OpProcessor:     &mockOpProcessor{Err: errors.New("operation processor error")},
-			WFClient:        wfClient,
+			AnchorGraph:       anchorGraph,
+			DidAnchors:        &mockDidAnchor{},
+			AnchorBuilder:     &mockTxnBuilder{},
+			Outbox:            &mockOutbox{},
+			Signer:            &mockSigner{},
+			MonitoringSvc:     &mockMonitoring{},
+			WitnessStore:      &mockWitnessStore{},
+			ActivityStore:     &mockActivityStore{},
+			AnchorLinkStore:   anchorEventStore,
+			OpProcessor:       &mockOpProcessor{Err: errors.New("operation processor error")},
+			WFClient:          wfClient,
+			GeneratorRegistry: generator.NewRegistry(),
+			AnchorLinkBuilder: anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers,
@@ -517,6 +533,8 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			AnchorLinkStore:        anchorEventStore,
 			AnchorEventStatusStore: statusStore,
 			WFClient:               wfClient,
+			GeneratorRegistry:      generator.NewRegistry(),
+			AnchorLinkBuilder:      anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers,
@@ -550,11 +568,13 @@ func TestWriter_WriteAnchor(t *testing.T) {
 
 	t.Run("error - anchor credential signing error", func(t *testing.T) {
 		providersWithErr := &Providers{
-			AnchorGraph:   anchorGraph,
-			DidAnchors:    memdidanchor.New(),
-			AnchorBuilder: &mockTxnBuilder{},
-			Outbox:        &mockOutbox{},
-			Signer:        &mockSigner{Err: fmt.Errorf("signer error")},
+			AnchorGraph:       anchorGraph,
+			DidAnchors:        memdidanchor.New(),
+			AnchorBuilder:     &mockTxnBuilder{},
+			Outbox:            &mockOutbox{},
+			Signer:            &mockSigner{Err: fmt.Errorf("signer error")},
+			GeneratorRegistry: generator.NewRegistry(),
+			AnchorLinkBuilder: anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providersWithErr,
@@ -598,6 +618,8 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			ActivityStore:          &mockActivityStore{},
 			MonitoringSvc:          &mockMonitoring{Err: fmt.Errorf("monitoring error")},
 			AnchorLinkStore:        anchorEventStore,
+			GeneratorRegistry:      generator.NewRegistry(),
+			AnchorLinkBuilder:      anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providersWithErr,
@@ -625,12 +647,14 @@ func TestWriter_WriteAnchor(t *testing.T) {
 
 	t.Run("error - local witness log error", func(t *testing.T) {
 		providersWithErr := &Providers{
-			AnchorGraph:   anchorGraph,
-			DidAnchors:    memdidanchor.New(),
-			AnchorBuilder: &mockTxnBuilder{},
-			Outbox:        &mockOutbox{},
-			Signer:        &mockSigner{},
-			Witness:       &mockWitness{Err: fmt.Errorf("witness error")},
+			AnchorGraph:       anchorGraph,
+			DidAnchors:        memdidanchor.New(),
+			AnchorBuilder:     &mockTxnBuilder{},
+			Outbox:            &mockOutbox{},
+			Signer:            &mockSigner{},
+			Witness:           &mockWitness{Err: fmt.Errorf("witness error")},
+			GeneratorRegistry: generator.NewRegistry(),
+			AnchorLinkBuilder: anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providersWithErr,
@@ -664,12 +688,14 @@ func TestWriter_WriteAnchor(t *testing.T) {
 		require.NoError(t, err)
 
 		providersWithErr := &Providers{
-			AnchorGraph:     anchorGraph,
-			DidAnchors:      memdidanchor.New(),
-			AnchorBuilder:   &mockTxnBuilder{},
-			Outbox:          &mockOutbox{},
-			Signer:          &mockSigner{},
-			AnchorLinkStore: anchorEventStoreWithErr,
+			AnchorGraph:       anchorGraph,
+			DidAnchors:        memdidanchor.New(),
+			AnchorBuilder:     &mockTxnBuilder{},
+			Outbox:            &mockOutbox{},
+			Signer:            &mockSigner{},
+			AnchorLinkStore:   anchorEventStoreWithErr,
+			GeneratorRegistry: generator.NewRegistry(),
+			AnchorLinkBuilder: anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providersWithErr,
@@ -703,14 +729,16 @@ func TestWriter_WriteAnchor(t *testing.T) {
 		require.NoError(t, err)
 
 		providersWithErr := &Providers{
-			AnchorGraph:     anchorGraph,
-			DidAnchors:      memdidanchor.New(),
-			AnchorBuilder:   &mockTxnBuilder{},
-			Outbox:          &mockOutbox{},
-			Signer:          &mockSigner{},
-			Witness:         &mockWitness{},
-			MonitoringSvc:   &mockMonitoring{},
-			AnchorLinkStore: anchorEventStoreWithErr,
+			AnchorGraph:       anchorGraph,
+			DidAnchors:        memdidanchor.New(),
+			AnchorBuilder:     &mockTxnBuilder{},
+			Outbox:            &mockOutbox{},
+			Signer:            &mockSigner{},
+			Witness:           &mockWitness{},
+			MonitoringSvc:     &mockMonitoring{},
+			AnchorLinkStore:   anchorEventStoreWithErr,
+			GeneratorRegistry: generator.NewRegistry(),
+			AnchorLinkBuilder: anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providersWithErr,
@@ -740,12 +768,14 @@ func TestWriter_WriteAnchor(t *testing.T) {
 		require.NoError(t, err)
 
 		providers := &Providers{
-			AnchorGraph:     anchorGraph,
-			DidAnchors:      memdidanchor.New(),
-			AnchorBuilder:   &mockTxnBuilder{},
-			Outbox:          &mockOutbox{},
-			Signer:          &mockSigner{},
-			AnchorLinkStore: anchorEventStore,
+			AnchorGraph:       anchorGraph,
+			DidAnchors:        memdidanchor.New(),
+			AnchorBuilder:     &mockTxnBuilder{},
+			Outbox:            &mockOutbox{},
+			Signer:            &mockSigner{},
+			AnchorLinkStore:   anchorEventStore,
+			GeneratorRegistry: generator.NewRegistry(),
+			AnchorLinkBuilder: anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers,
@@ -779,6 +809,8 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			AnchorLinkStore:        anchorEventStore,
 			AnchorEventStatusStore: statusStore,
 			WFClient:               wfClient,
+			GeneratorRegistry:      generator.NewRegistry(),
+			AnchorLinkBuilder:      anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		publisher := &anchormocks.AnchorPublisher{}
@@ -831,6 +863,8 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			ActivityStore:          &mockActivityStore{},
 			AnchorLinkStore:        anchorEventStore,
 			AnchorEventStatusStore: statusStore,
+			GeneratorRegistry:      generator.NewRegistry(),
+			AnchorLinkBuilder:      anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers,
@@ -882,6 +916,8 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			WFClient:               wfClient,
 			WitnessPolicy:          witnessPolicy,
 			ProofHandler:           servicemocks.NewProofHandler(),
+			GeneratorRegistry:      generator.NewRegistry(),
+			AnchorLinkBuilder:      anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers,
@@ -949,6 +985,8 @@ func TestWriter_WriteAnchor(t *testing.T) {
 			WFClient:               wfClient,
 			WitnessPolicy:          &mockWitnessPolicy{},
 			ProofHandler:           servicemocks.NewProofHandler(),
+			GeneratorRegistry:      generator.NewRegistry(),
+			AnchorLinkBuilder:      anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers, &anchormocks.AnchorPublisher{}, ps,
@@ -1023,15 +1061,17 @@ func TestWriter_handle(t *testing.T) {
 		require.NoError(t, err)
 
 		providers := &Providers{
-			AnchorGraph:     anchorGraph,
-			DidAnchors:      memdidanchor.New(),
-			AnchorBuilder:   &mockTxnBuilder{},
-			Outbox:          &mockOutbox{},
-			Signer:          &mockSigner{},
-			AnchorLinkStore: anchorEventStore,
-			WitnessStore:    &mockWitnessStore{},
-			VCStore:         vcStore,
-			DocumentLoader:  testutil.GetLoader(t),
+			AnchorGraph:       anchorGraph,
+			DidAnchors:        memdidanchor.New(),
+			AnchorBuilder:     &mockTxnBuilder{},
+			Outbox:            &mockOutbox{},
+			Signer:            &mockSigner{},
+			AnchorLinkStore:   anchorEventStore,
+			WitnessStore:      &mockWitnessStore{},
+			VCStore:           vcStore,
+			DocumentLoader:    testutil.GetLoader(t),
+			GeneratorRegistry: generator.NewRegistry(),
+			AnchorLinkBuilder: anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers, &anchormocks.AnchorPublisher{}, ps,
@@ -1052,14 +1092,16 @@ func TestWriter_handle(t *testing.T) {
 		require.NoError(t, err)
 
 		providersWithErr := &Providers{
-			AnchorGraph:     &mockAnchorGraph{Err: errors.New("txn graph error")},
-			DidAnchors:      memdidanchor.New(),
-			AnchorBuilder:   &mockTxnBuilder{},
-			Outbox:          &mockOutbox{},
-			Signer:          &mockSigner{},
-			AnchorLinkStore: anchorEventStore,
-			VCStore:         vcStore,
-			DocumentLoader:  testutil.GetLoader(t),
+			AnchorGraph:       &mockAnchorGraph{Err: errors.New("txn graph error")},
+			DidAnchors:        memdidanchor.New(),
+			AnchorBuilder:     &mockTxnBuilder{},
+			Outbox:            &mockOutbox{},
+			Signer:            &mockSigner{},
+			AnchorLinkStore:   anchorEventStore,
+			VCStore:           vcStore,
+			DocumentLoader:    testutil.GetLoader(t),
+			GeneratorRegistry: generator.NewRegistry(),
+			AnchorLinkBuilder: anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providersWithErr,
@@ -1083,15 +1125,17 @@ func TestWriter_handle(t *testing.T) {
 		require.NoError(t, err)
 
 		providersWithErr := &Providers{
-			AnchorGraph:     anchorGraph,
-			DidAnchors:      &mockDidAnchor{Err: errors.New("did references error")},
-			AnchorBuilder:   &mockTxnBuilder{},
-			Outbox:          &mockOutbox{},
-			Signer:          &mockSigner{},
-			AnchorLinkStore: anchorEventStore,
-			WitnessStore:    &mockWitnessStore{},
-			VCStore:         vcStore,
-			DocumentLoader:  testutil.GetLoader(t),
+			AnchorGraph:       anchorGraph,
+			DidAnchors:        &mockDidAnchor{Err: errors.New("did references error")},
+			AnchorBuilder:     &mockTxnBuilder{},
+			Outbox:            &mockOutbox{},
+			Signer:            &mockSigner{},
+			AnchorLinkStore:   anchorEventStore,
+			WitnessStore:      &mockWitnessStore{},
+			VCStore:           vcStore,
+			DocumentLoader:    testutil.GetLoader(t),
+			GeneratorRegistry: generator.NewRegistry(),
+			AnchorLinkBuilder: anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		errExpected := errors.New("anchor publisher error")
@@ -1119,14 +1163,16 @@ func TestWriter_handle(t *testing.T) {
 		require.NoError(t, err)
 
 		providers := &Providers{
-			AnchorGraph:     anchorGraph,
-			DidAnchors:      memdidanchor.New(),
-			AnchorBuilder:   &mockTxnBuilder{},
-			Outbox:          &mockOutbox{Err: errors.New("outbox error")},
-			AnchorLinkStore: anchorEventStore,
-			VCStore:         vcStore,
-			DocumentLoader:  testutil.GetLoader(t),
-			WitnessStore:    &mockWitnessStore{},
+			AnchorGraph:       anchorGraph,
+			DidAnchors:        memdidanchor.New(),
+			AnchorBuilder:     &mockTxnBuilder{},
+			Outbox:            &mockOutbox{Err: errors.New("outbox error")},
+			AnchorLinkStore:   anchorEventStore,
+			VCStore:           vcStore,
+			DocumentLoader:    testutil.GetLoader(t),
+			WitnessStore:      &mockWitnessStore{},
+			GeneratorRegistry: generator.NewRegistry(),
+			AnchorLinkBuilder: anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers, &anchormocks.AnchorPublisher{}, ps,
@@ -1150,15 +1196,17 @@ func TestWriter_handle(t *testing.T) {
 		require.NoError(t, err)
 
 		providers := &Providers{
-			AnchorGraph:     anchorGraph,
-			DidAnchors:      memdidanchor.New(),
-			AnchorBuilder:   &mockTxnBuilder{},
-			Outbox:          &mockOutbox{},
-			Signer:          &mockSigner{},
-			AnchorLinkStore: anchorEventStore,
-			WitnessStore:    &mockWitnessStore{DeleteErr: fmt.Errorf("delete error")},
-			VCStore:         vcStore,
-			DocumentLoader:  testutil.GetLoader(t),
+			AnchorGraph:       anchorGraph,
+			DidAnchors:        memdidanchor.New(),
+			AnchorBuilder:     &mockTxnBuilder{},
+			Outbox:            &mockOutbox{},
+			Signer:            &mockSigner{},
+			AnchorLinkStore:   anchorEventStore,
+			WitnessStore:      &mockWitnessStore{DeleteErr: fmt.Errorf("delete error")},
+			VCStore:           vcStore,
+			DocumentLoader:    testutil.GetLoader(t),
+			GeneratorRegistry: generator.NewRegistry(),
+			AnchorLinkBuilder: anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers, &anchormocks.AnchorPublisher{}, ps,
@@ -1183,15 +1231,17 @@ func TestWriter_handle(t *testing.T) {
 		require.NoError(t, err)
 
 		providersWithErr := &Providers{
-			AnchorGraph:     anchorGraph,
-			DidAnchors:      memdidanchor.New(),
-			AnchorBuilder:   &mockTxnBuilder{},
-			Outbox:          &mockOutbox{},
-			Signer:          &mockSigner{},
-			AnchorLinkStore: anchorEventStoreWithErr,
-			WitnessStore:    &mockWitnessStore{},
-			VCStore:         vcStore,
-			DocumentLoader:  testutil.GetLoader(t),
+			AnchorGraph:       anchorGraph,
+			DidAnchors:        memdidanchor.New(),
+			AnchorBuilder:     &mockTxnBuilder{},
+			Outbox:            &mockOutbox{},
+			Signer:            &mockSigner{},
+			AnchorLinkStore:   anchorEventStoreWithErr,
+			WitnessStore:      &mockWitnessStore{},
+			VCStore:           vcStore,
+			DocumentLoader:    testutil.GetLoader(t),
+			GeneratorRegistry: generator.NewRegistry(),
+			AnchorLinkBuilder: anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providersWithErr,
@@ -1213,15 +1263,17 @@ func TestWriter_handle(t *testing.T) {
 		require.NoError(t, err)
 
 		providers := &Providers{
-			AnchorGraph:     anchorGraph,
-			DidAnchors:      memdidanchor.New(),
-			AnchorBuilder:   &mockTxnBuilder{},
-			Outbox:          &mockOutbox{},
-			Signer:          &mockSigner{},
-			AnchorLinkStore: anchorEventStore,
-			WitnessStore:    &mockWitnessStore{},
-			VCStore:         vcStore,
-			DocumentLoader:  testutil.GetLoader(t),
+			AnchorGraph:       anchorGraph,
+			DidAnchors:        memdidanchor.New(),
+			AnchorBuilder:     &mockTxnBuilder{},
+			Outbox:            &mockOutbox{},
+			Signer:            &mockSigner{},
+			AnchorLinkStore:   anchorEventStore,
+			WitnessStore:      &mockWitnessStore{},
+			VCStore:           vcStore,
+			DocumentLoader:    testutil.GetLoader(t),
+			GeneratorRegistry: generator.NewRegistry(),
+			AnchorLinkBuilder: anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers, &anchormocks.AnchorPublisher{}, ps,
@@ -1245,15 +1297,17 @@ func TestWriter_handle(t *testing.T) {
 		vcStore.PutReturns(fmt.Errorf("anchor event store error"))
 
 		providers := &Providers{
-			AnchorGraph:     anchorGraph,
-			DidAnchors:      memdidanchor.New(),
-			AnchorBuilder:   &mockTxnBuilder{},
-			Outbox:          &mockOutbox{},
-			Signer:          &mockSigner{},
-			AnchorLinkStore: anchorEventStore,
-			WitnessStore:    &mockWitnessStore{},
-			VCStore:         vcStore,
-			DocumentLoader:  testutil.GetLoader(t),
+			AnchorGraph:       anchorGraph,
+			DidAnchors:        memdidanchor.New(),
+			AnchorBuilder:     &mockTxnBuilder{},
+			Outbox:            &mockOutbox{},
+			Signer:            &mockSigner{},
+			AnchorLinkStore:   anchorEventStore,
+			WitnessStore:      &mockWitnessStore{},
+			VCStore:           vcStore,
+			DocumentLoader:    testutil.GetLoader(t),
+			GeneratorRegistry: generator.NewRegistry(),
+			AnchorLinkBuilder: anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers, &anchormocks.AnchorPublisher{}, ps,
@@ -1306,6 +1360,8 @@ func TestWriter_postOfferActivity(t *testing.T) {
 			ActivityStore:          &mockActivityStore{},
 			AnchorEventStatusStore: statusStore,
 			WFClient:               wfClient,
+			GeneratorRegistry:      generator.NewRegistry(),
+			AnchorLinkBuilder:      anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		c, err := New(namespace, apServiceIRI, casIRI, vocab.JSONMediaType, providers, &anchormocks.AnchorPublisher{}, ps,
@@ -1688,12 +1744,17 @@ type mockTxnBuilder struct {
 	Err error
 }
 
-func (m *mockTxnBuilder) Build(anchorHashlink string, context []string) (*verifiable.Credential, error) {
+func (m *mockTxnBuilder) Build(profile *url.URL, anchorHashlink, coreIndexHashlink string,
+	context []string) (*verifiable.Credential, error) {
 	if m.Err != nil {
 		return nil, m.Err
 	}
 
-	return &verifiable.Credential{Subject: &builder.CredentialSubject{ID: anchorHashlink}}, nil
+	return &verifiable.Credential{Subject: &builder.CredentialSubject{
+		ID:      anchorHashlink,
+		Anchor:  coreIndexHashlink,
+		Profile: profile.String(),
+	}}, nil
 }
 
 type mockAnchorGraph struct {

--- a/pkg/internal/testutil/testutil.go
+++ b/pkg/internal/testutil/testutil.go
@@ -55,6 +55,13 @@ func NewMockURLs(num int, getURI func(i int) string) []*url.URL {
 func GetCanonical(t *testing.T, raw string) string {
 	t.Helper()
 
+	return string(GetCanonicalBytes(t, raw))
+}
+
+// GetCanonicalBytes converts the given JSON string into a canonical JSON (returning the bytes).
+func GetCanonicalBytes(t *testing.T, raw string) []byte {
+	t.Helper()
+
 	var expectedDoc map[string]interface{}
 
 	require.NoError(t, json.Unmarshal([]byte(raw), &expectedDoc))
@@ -63,7 +70,7 @@ func GetCanonical(t *testing.T, raw string) string {
 
 	require.NoError(t, err)
 
-	return string(bytes)
+	return bytes
 }
 
 // MarshalCanonical marshals the given object to a canonical JSON.

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/trustbloc/orb/pkg/activitypub/client/transport"
 	apmocks "github.com/trustbloc/orb/pkg/activitypub/service/mocks"
 	"github.com/trustbloc/orb/pkg/anchor/anchorlinkset"
+	"github.com/trustbloc/orb/pkg/anchor/anchorlinkset/generator"
 	"github.com/trustbloc/orb/pkg/anchor/builder"
 	"github.com/trustbloc/orb/pkg/anchor/graph"
 	anchorinfo "github.com/trustbloc/orb/pkg/anchor/info"
@@ -191,6 +192,7 @@ func TestStartObserver(t *testing.T) {
 			Pkf:                    pubKeyFetcherFnc,
 			AnchorLinkStore:        &orbmocks.AnchorLinkStore{},
 			MonitoringSvc:          &obsmocks.MonitoringService{},
+			AnchorLinksetBuilder:   anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		o, err := New(serviceIRI, providers,
@@ -230,7 +232,8 @@ func TestStartObserver(t *testing.T) {
 					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 						transport.DefaultSigner(), transport.DefaultSigner(), &apclientmocks.AuthTokenMgr{}),
 					webfingerclient.New(), "https"), &orbmocks.MetricsProvider{}),
-			DocLoader: testutil.GetLoader(t),
+			DocLoader:            testutil.GetLoader(t),
+			AnchorLinksetBuilder: anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		anchorGraph := graph.New(graphProviders)
@@ -262,6 +265,7 @@ func TestStartObserver(t *testing.T) {
 			Pkf:                    pubKeyFetcherFnc,
 			DocLoader:              testutil.GetLoader(t),
 			AnchorLinkStore:        &orbmocks.AnchorLinkStore{},
+			AnchorLinksetBuilder:   anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		o, err := New(serviceIRI, providers)
@@ -297,7 +301,8 @@ func TestStartObserver(t *testing.T) {
 					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 						transport.DefaultSigner(), transport.DefaultSigner(), &apclientmocks.AuthTokenMgr{}),
 					webfingerclient.New(), "https"), &orbmocks.MetricsProvider{}),
-			DocLoader: testutil.GetLoader(t),
+			DocLoader:            testutil.GetLoader(t),
+			AnchorLinksetBuilder: anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		anchorGraph := graph.New(graphProviders)
@@ -339,6 +344,7 @@ func TestStartObserver(t *testing.T) {
 			DocLoader:              testutil.GetLoader(t),
 			Pkf:                    pubKeyFetcherFnc,
 			AnchorLinkStore:        &orbmocks.AnchorLinkStore{},
+			AnchorLinksetBuilder:   anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		o, err := New(serviceIRI, providers)
@@ -372,7 +378,8 @@ func TestStartObserver(t *testing.T) {
 					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 						transport.DefaultSigner(), transport.DefaultSigner(), &apclientmocks.AuthTokenMgr{}),
 					webfingerclient.New(), "https"), &orbmocks.MetricsProvider{}),
-			DocLoader: testutil.GetLoader(t),
+			DocLoader:            testutil.GetLoader(t),
+			AnchorLinksetBuilder: anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 		anchorGraph := graph.New(graphProviders)
 
@@ -402,6 +409,7 @@ func TestStartObserver(t *testing.T) {
 			DocLoader:              testutil.GetLoader(t),
 			Pkf:                    pubKeyFetcherFnc,
 			AnchorLinkStore:        &orbmocks.AnchorLinkStore{},
+			AnchorLinksetBuilder:   anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		o, err := New(serviceIRI, providers)
@@ -436,7 +444,8 @@ func TestStartObserver(t *testing.T) {
 					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 						transport.DefaultSigner(), transport.DefaultSigner(), &apclientmocks.AuthTokenMgr{}),
 					webfingerclient.New(), "https"), &orbmocks.MetricsProvider{}),
-			DocLoader: testutil.GetLoader(t),
+			DocLoader:            testutil.GetLoader(t),
+			AnchorLinksetBuilder: anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		anchorGraph := graph.New(graphProviders)
@@ -467,6 +476,7 @@ func TestStartObserver(t *testing.T) {
 			Metrics:                &orbmocks.MetricsProvider{},
 			DocLoader:              testutil.GetLoader(t),
 			AnchorLinkStore:        &orbmocks.AnchorLinkStore{},
+			AnchorLinksetBuilder:   anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		o, err := New(serviceIRI, providers)
@@ -502,7 +512,8 @@ func TestStartObserver(t *testing.T) {
 					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 						transport.DefaultSigner(), transport.DefaultSigner(), &apclientmocks.AuthTokenMgr{}),
 					webfingerclient.New(), "https"), &orbmocks.MetricsProvider{}),
-			DocLoader: testutil.GetLoader(t),
+			DocLoader:            testutil.GetLoader(t),
+			AnchorLinksetBuilder: anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		anchorGraph := graph.New(graphProviders)
@@ -542,6 +553,7 @@ func TestStartObserver(t *testing.T) {
 			DocLoader:              testutil.GetLoader(t),
 			Pkf:                    pubKeyFetcherFnc,
 			AnchorLinkStore:        &orbmocks.AnchorLinkStore{},
+			AnchorLinksetBuilder:   anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		o, err := New(serviceIRI, providers)
@@ -576,7 +588,8 @@ func TestStartObserver(t *testing.T) {
 					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 						transport.DefaultSigner(), transport.DefaultSigner(), &apclientmocks.AuthTokenMgr{}),
 					webfingerclient.New(), "https"), &orbmocks.MetricsProvider{}),
-			DocLoader: testutil.GetLoader(t),
+			DocLoader:            testutil.GetLoader(t),
+			AnchorLinksetBuilder: anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		anchorGraph := graph.New(graphProviders)
@@ -590,6 +603,7 @@ func TestStartObserver(t *testing.T) {
 			DocLoader:              testutil.GetLoader(t),
 			Pkf:                    pubKeyFetcherFnc,
 			AnchorLinkStore:        &orbmocks.AnchorLinkStore{},
+			AnchorLinksetBuilder:   anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		o, err := New(serviceIRI, providers)
@@ -620,6 +634,7 @@ func TestStartObserver(t *testing.T) {
 			DocLoader:              testutil.GetLoader(t),
 			Pkf:                    pubKeyFetcherFnc,
 			AnchorLinkStore:        &orbmocks.AnchorLinkStore{},
+			AnchorLinksetBuilder:   anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		o, err := New(serviceIRI, providers)
@@ -656,6 +671,7 @@ func TestStartObserver(t *testing.T) {
 			DocLoader:              testutil.GetLoader(t),
 			Pkf:                    pubKeyFetcherFnc,
 			AnchorLinkStore:        &orbmocks.AnchorLinkStore{},
+			AnchorLinksetBuilder:   anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		o, err := New(serviceIRI, providers)
@@ -689,7 +705,8 @@ func TestStartObserver(t *testing.T) {
 					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 						transport.DefaultSigner(), transport.DefaultSigner(), &apclientmocks.AuthTokenMgr{}),
 					webfingerclient.New(), "https"), &orbmocks.MetricsProvider{}),
-			DocLoader: testutil.GetLoader(t),
+			DocLoader:            testutil.GetLoader(t),
+			AnchorLinksetBuilder: anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		anchorGraph := graph.New(graphProviders)
@@ -725,6 +742,7 @@ func TestStartObserver(t *testing.T) {
 			DocLoader:              testutil.GetLoader(t),
 			Pkf:                    pubKeyFetcherFnc,
 			AnchorLinkStore:        &orbmocks.AnchorLinkStore{},
+			AnchorLinksetBuilder:   anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		o, err := New(serviceIRI, providers)
@@ -763,7 +781,8 @@ func TestStartObserver(t *testing.T) {
 					transport.New(&http.Client{}, testutil.MustParseURL("https://example.com/keys/public-key"),
 						transport.DefaultSigner(), transport.DefaultSigner(), &apclientmocks.AuthTokenMgr{}),
 					webfingerclient.New(), "https"), &orbmocks.MetricsProvider{}),
-			DocLoader: testutil.GetLoader(t),
+			DocLoader:            testutil.GetLoader(t),
+			AnchorLinksetBuilder: anchorlinkset.NewBuilder(generator.NewRegistry()),
 		}
 
 		anchorGraph := graph.New(graphProviders)
@@ -806,6 +825,7 @@ func TestStartObserver(t *testing.T) {
 				DocLoader:              testutil.GetLoader(t),
 				Pkf:                    pubKeyFetcherFnc,
 				AnchorLinkStore:        anchorLinkStore,
+				AnchorLinksetBuilder:   anchorlinkset.NewBuilder(generator.NewRegistry()),
 			}
 
 			o, err := New(serviceIRI, providers, WithDiscoveryDomain("webcas:shared.domain.com"))
@@ -838,6 +858,7 @@ func TestStartObserver(t *testing.T) {
 				DocLoader:              testutil.GetLoader(t),
 				Pkf:                    pubKeyFetcherFnc,
 				AnchorLinkStore:        anchorLinkStore,
+				AnchorLinksetBuilder:   anchorlinkset.NewBuilder(generator.NewRegistry()),
 			}
 
 			o, err := New(serviceIRI, providers, WithDiscoveryDomain("webcas:shared.domain.com"))
@@ -1006,8 +1027,9 @@ func newMockAnchorLinkset(t *testing.T, payload *subject.Payload) *linkset.Links
 		Issued: &util.TimeWrapper{Time: time.Now()},
 	}
 
-	al, _, err := anchorlinkset.BuildAnchorLink(payload, datauri.MediaTypeDataURIGzipBase64,
-		func(anchorHashlink string) (*verifiable.Credential, error) {
+	al, _, err := anchorlinkset.NewBuilder(
+		generator.NewRegistry()).BuildAnchorLink(payload, datauri.MediaTypeDataURIGzipBase64,
+		func(anchorHashlink, coreIndexHashlink string) (*verifiable.Credential, error) {
 			return vc, nil
 		},
 	)

--- a/pkg/orbclient/aoprovider/anchororiginprovider_test.go
+++ b/pkg/orbclient/aoprovider/anchororiginprovider_test.go
@@ -19,6 +19,7 @@ import (
 	coremocks "github.com/trustbloc/sidetree-core-go/pkg/mocks"
 
 	"github.com/trustbloc/orb/pkg/anchor/anchorlinkset"
+	"github.com/trustbloc/orb/pkg/anchor/anchorlinkset/generator"
 	"github.com/trustbloc/orb/pkg/anchor/builder"
 	"github.com/trustbloc/orb/pkg/anchor/subject"
 	"github.com/trustbloc/orb/pkg/datauri"
@@ -297,8 +298,9 @@ func newMockAnchorLinkset(t *testing.T, payload *subject.Payload) *linkset.Links
 		Issued:  &util.TimeWrapper{Time: time.Now()},
 	}
 
-	link, _, err := anchorlinkset.BuildAnchorLink(payload, datauri.MediaTypeDataURIGzipBase64,
-		func(anchorHashlink string) (*verifiable.Credential, error) {
+	link, _, err := anchorlinkset.NewBuilder(
+		generator.NewRegistry()).BuildAnchorLink(payload, datauri.MediaTypeDataURIGzipBase64,
+		func(anchorHashlink, coreIndexHashlink string) (*verifiable.Credential, error) {
 			return vc, nil
 		},
 	)


### PR DESCRIPTION
The credialSubject field in the anchor credential now has:
- id - hashlink of the original content
- anchor - the core index file hashlink
- profile - the ID of the generator that generated the content

When an anchor event is processed, the anchor credential subject is validated against the content.

closes #1348

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>