### PR TITLE
chore: Update sidetree-core (alsoKnownAs)

### DIFF
--- a/cmd/orb-cli/go.mod
+++ b/cmd/orb-cli/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.8
 	github.com/trustbloc/orb v1.0.0-rc1.0.20220623092839-0a44f37eeba2
-	github.com/trustbloc/sidetree-core-go v1.0.0-rc2
+	github.com/trustbloc/sidetree-core-go v1.0.0-rc2.0.20220721143952-577302c8aca8
 	github.com/trustbloc/vct v1.0.0-rc2
 )
 

--- a/cmd/orb-cli/go.sum
+++ b/cmd/orb-cli/go.sum
@@ -1430,8 +1430,9 @@ github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9I
 github.com/trustbloc/edge-core v0.1.8 h1:m4X5XNDwiHJjGf8gHnpo6aLkBYuqDyNRq+npjxLc5cY=
 github.com/trustbloc/edge-core v0.1.8/go.mod h1:gfoyG/xquRXyHkww0ldM2jwOTuKKZpHYn+87f+TBQ8M=
 github.com/trustbloc/kms v0.1.9-0.20220526151939-d46e46e8f7e1/go.mod h1:a6XvGLZgwVqBAt47550cQeRKm04X2Nn1M8DE0PVb0XA=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc2 h1:Ca/4iuZu/RhzraPfrj/r+tDuJiqYOd3R7bXyBJF+cXg=
 github.com/trustbloc/sidetree-core-go v1.0.0-rc2/go.mod h1:SYCYxrsviTcRoUCoM6VosXF+sqWkKpk8C1dqD0doRYQ=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc2.0.20220721143952-577302c8aca8 h1:mtAVT5A3C5233Nfevgwx1q8eJQ9yQw/QOlcSx2vd6TQ=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc2.0.20220721143952-577302c8aca8/go.mod h1:SYCYxrsviTcRoUCoM6VosXF+sqWkKpk8C1dqD0doRYQ=
 github.com/trustbloc/vct v1.0.0-rc2 h1:iuoG3rLC3V0kuwGnBmnzVPGH6xAxWzpozgkW5T5Qlac=
 github.com/trustbloc/vct v1.0.0-rc2/go.mod h1:k45HahHV0lr2h8ldzITXLjcWpTgXzRE8WL1avfC95po=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/cmd/orb-driver/go.mod
+++ b/cmd/orb-driver/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/trustbloc/edge-core v0.1.8
 	github.com/trustbloc/orb v1.0.0-rc1.0.20220531195220-8fc19d247843
-	github.com/trustbloc/sidetree-core-go v1.0.0-rc2
+	github.com/trustbloc/sidetree-core-go v1.0.0-rc2.0.20220721143952-577302c8aca8
 )
 
 require (

--- a/cmd/orb-driver/go.sum
+++ b/cmd/orb-driver/go.sum
@@ -1426,8 +1426,8 @@ github.com/trustbloc/edge-core v0.1.8/go.mod h1:gfoyG/xquRXyHkww0ldM2jwOTuKKZpHY
 github.com/trustbloc/kms v0.1.9-0.20220526151939-d46e46e8f7e1/go.mod h1:a6XvGLZgwVqBAt47550cQeRKm04X2Nn1M8DE0PVb0XA=
 github.com/trustbloc/sidetree-core-go v1.0.0-rc.1/go.mod h1:SYCYxrsviTcRoUCoM6VosXF+sqWkKpk8C1dqD0doRYQ=
 github.com/trustbloc/sidetree-core-go v1.0.0-rc.1.0.20220428193233-a1567c33db3e/go.mod h1:SYCYxrsviTcRoUCoM6VosXF+sqWkKpk8C1dqD0doRYQ=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc2 h1:Ca/4iuZu/RhzraPfrj/r+tDuJiqYOd3R7bXyBJF+cXg=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc2/go.mod h1:SYCYxrsviTcRoUCoM6VosXF+sqWkKpk8C1dqD0doRYQ=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc2.0.20220721143952-577302c8aca8 h1:mtAVT5A3C5233Nfevgwx1q8eJQ9yQw/QOlcSx2vd6TQ=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc2.0.20220721143952-577302c8aca8/go.mod h1:SYCYxrsviTcRoUCoM6VosXF+sqWkKpk8C1dqD0doRYQ=
 github.com/trustbloc/vct v1.0.0-rc1.0.20220530071917-3aa4f907b424/go.mod h1:k45HahHV0lr2h8ldzITXLjcWpTgXzRE8WL1avfC95po=
 github.com/trustbloc/vct v1.0.0-rc2 h1:iuoG3rLC3V0kuwGnBmnzVPGH6xAxWzpozgkW5T5Qlac=
 github.com/trustbloc/vct v1.0.0-rc2/go.mod h1:k45HahHV0lr2h8ldzITXLjcWpTgXzRE8WL1avfC95po=

--- a/cmd/orb-server/go.mod
+++ b/cmd/orb-server/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/trustbloc/edge-core v0.1.8
 	github.com/trustbloc/kms v0.1.9-0.20220526151939-d46e46e8f7e1
 	github.com/trustbloc/orb v0.1.3
-	github.com/trustbloc/sidetree-core-go v1.0.0-rc2
+	github.com/trustbloc/sidetree-core-go v1.0.0-rc2.0.20220721143952-577302c8aca8
 	go.mongodb.org/mongo-driver v1.9.1
 )
 

--- a/cmd/orb-server/go.sum
+++ b/cmd/orb-server/go.sum
@@ -1441,8 +1441,8 @@ github.com/trustbloc/edge-core v0.1.8 h1:m4X5XNDwiHJjGf8gHnpo6aLkBYuqDyNRq+npjxL
 github.com/trustbloc/edge-core v0.1.8/go.mod h1:gfoyG/xquRXyHkww0ldM2jwOTuKKZpHYn+87f+TBQ8M=
 github.com/trustbloc/kms v0.1.9-0.20220526151939-d46e46e8f7e1 h1:/RqxggSgs1fh8cbifAmkme2LC8Fi1/BBJK9mqyfMWpU=
 github.com/trustbloc/kms v0.1.9-0.20220526151939-d46e46e8f7e1/go.mod h1:a6XvGLZgwVqBAt47550cQeRKm04X2Nn1M8DE0PVb0XA=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc2 h1:Ca/4iuZu/RhzraPfrj/r+tDuJiqYOd3R7bXyBJF+cXg=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc2/go.mod h1:SYCYxrsviTcRoUCoM6VosXF+sqWkKpk8C1dqD0doRYQ=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc2.0.20220721143952-577302c8aca8 h1:mtAVT5A3C5233Nfevgwx1q8eJQ9yQw/QOlcSx2vd6TQ=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc2.0.20220721143952-577302c8aca8/go.mod h1:SYCYxrsviTcRoUCoM6VosXF+sqWkKpk8C1dqD0doRYQ=
 github.com/trustbloc/vct v1.0.0-rc2 h1:iuoG3rLC3V0kuwGnBmnzVPGH6xAxWzpozgkW5T5Qlac=
 github.com/trustbloc/vct v1.0.0-rc2/go.mod h1:k45HahHV0lr2h8ldzITXLjcWpTgXzRE8WL1avfC95po=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/transparency-dev/merkle v0.0.0-20220208131541-728dc2de1344
 	github.com/trustbloc/edge-core v0.1.8
-	github.com/trustbloc/sidetree-core-go v1.0.0-rc2
+	github.com/trustbloc/sidetree-core-go v1.0.0-rc2.0.20220721143952-577302c8aca8
 	github.com/trustbloc/vct v1.0.0-rc2
 	go.mongodb.org/mongo-driver v1.9.1
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd

--- a/go.sum
+++ b/go.sum
@@ -1429,8 +1429,8 @@ github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9I
 github.com/trustbloc/edge-core v0.1.8 h1:m4X5XNDwiHJjGf8gHnpo6aLkBYuqDyNRq+npjxLc5cY=
 github.com/trustbloc/edge-core v0.1.8/go.mod h1:gfoyG/xquRXyHkww0ldM2jwOTuKKZpHYn+87f+TBQ8M=
 github.com/trustbloc/kms v0.1.9-0.20220526151939-d46e46e8f7e1/go.mod h1:a6XvGLZgwVqBAt47550cQeRKm04X2Nn1M8DE0PVb0XA=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc2 h1:Ca/4iuZu/RhzraPfrj/r+tDuJiqYOd3R7bXyBJF+cXg=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc2/go.mod h1:SYCYxrsviTcRoUCoM6VosXF+sqWkKpk8C1dqD0doRYQ=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc2.0.20220721143952-577302c8aca8 h1:mtAVT5A3C5233Nfevgwx1q8eJQ9yQw/QOlcSx2vd6TQ=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc2.0.20220721143952-577302c8aca8/go.mod h1:SYCYxrsviTcRoUCoM6VosXF+sqWkKpk8C1dqD0doRYQ=
 github.com/trustbloc/vct v1.0.0-rc2 h1:iuoG3rLC3V0kuwGnBmnzVPGH6xAxWzpozgkW5T5Qlac=
 github.com/trustbloc/vct v1.0.0-rc2/go.mod h1:k45HahHV0lr2h8ldzITXLjcWpTgXzRE8WL1avfC95po=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/test/bdd/did_orb_steps.go
+++ b/test/bdd/did_orb_steps.go
@@ -113,6 +113,7 @@ const addServicesTemplate = `[
 const removeServicesTemplate = `["%s"]`
 
 const docTemplate = `{
+  "alsoKnownAs": ["https://myblog.example/"],
   "publicKey": [
    {
      "id": "%s",

--- a/test/bdd/features/orb-driver.feature
+++ b/test/bdd/features/orb-driver.feature
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-@all
+
 @orb_driver
 Feature: Using Orb driver
   Background: Setup

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/tidwall/gjson v1.7.4
 	github.com/trustbloc/orb v1.0.0-rc1.0.20220623092839-0a44f37eeba2
-	github.com/trustbloc/sidetree-core-go v1.0.0-rc2
+	github.com/trustbloc/sidetree-core-go v1.0.0-rc2.0.20220721143952-577302c8aca8
 )
 
 require (

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -1683,8 +1683,9 @@ github.com/trustbloc/edge-core v0.1.7/go.mod h1:nQnH3CcEHTRXsWZe/vgj+J0JxxjwFK9I
 github.com/trustbloc/edge-core v0.1.8 h1:m4X5XNDwiHJjGf8gHnpo6aLkBYuqDyNRq+npjxLc5cY=
 github.com/trustbloc/edge-core v0.1.8/go.mod h1:gfoyG/xquRXyHkww0ldM2jwOTuKKZpHYn+87f+TBQ8M=
 github.com/trustbloc/kms v0.1.9-0.20220526151939-d46e46e8f7e1/go.mod h1:a6XvGLZgwVqBAt47550cQeRKm04X2Nn1M8DE0PVb0XA=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc2 h1:Ca/4iuZu/RhzraPfrj/r+tDuJiqYOd3R7bXyBJF+cXg=
 github.com/trustbloc/sidetree-core-go v1.0.0-rc2/go.mod h1:SYCYxrsviTcRoUCoM6VosXF+sqWkKpk8C1dqD0doRYQ=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc2.0.20220721143952-577302c8aca8 h1:mtAVT5A3C5233Nfevgwx1q8eJQ9yQw/QOlcSx2vd6TQ=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc2.0.20220721143952-577302c8aca8/go.mod h1:SYCYxrsviTcRoUCoM6VosXF+sqWkKpk8C1dqD0doRYQ=
 github.com/trustbloc/vct v1.0.0-rc2 h1:iuoG3rLC3V0kuwGnBmnzVPGH6xAxWzpozgkW5T5Qlac=
 github.com/trustbloc/vct v1.0.0-rc2/go.mod h1:k45HahHV0lr2h8ldzITXLjcWpTgXzRE8WL1avfC95po=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=


### PR DESCRIPTION
Update sidetree-core, disable orb-driver-test for now - until aries-framework-go-ext is updated.

Closes #1404

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>