### PR TITLE
fix: Discover actor from service endpoint in orb-cli

### DIFF
--- a/cmd/orb-cli/common/activitypubclient.go
+++ b/cmd/orb-cli/common/activitypubclient.go
@@ -1,0 +1,186 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package common
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/spf13/cobra"
+	cmdutils "github.com/trustbloc/edge-core/pkg/utils/cmd"
+
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+	orberrors "github.com/trustbloc/orb/pkg/errors"
+)
+
+// ActivityPubClient reads ActivityPub actors and collections from the service endpoint.
+type ActivityPubClient struct {
+	cmd          *cobra.Command
+	sendRequest  requestSender
+	overridesMap map[string]string
+}
+
+// NewActivityPubClient returns a new ActivityPub client.
+func NewActivityPubClient(cmd *cobra.Command) (*ActivityPubClient, error) {
+	httpClient, err := NewHTTPClient(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	headers := newAuthTokenHeader(cmd)
+
+	overridesMap := make(map[string]string)
+
+	const mappingParts = 2
+
+	for _, mapping := range cmdutils.GetUserSetOptionalVarFromArrayString(cmd, TargetOverrideFlagName,
+		TargetOverrideEnvKey) {
+		pair := strings.Split(mapping, "->")
+		if len(pair) != mappingParts {
+			return nil, fmt.Errorf("invalid target override %s", mapping)
+		}
+
+		overridesMap[pair[0]] = pair[1]
+	}
+
+	return &ActivityPubClient{
+		cmd:          cmd,
+		overridesMap: overridesMap,
+		sendRequest: func(req []byte, method, endpointURL string) ([]byte, error) {
+			return SendRequest(httpClient, req, headers, method, endpointURL)
+		},
+	}, nil
+}
+
+// ResolveActor returns the actor for the given endpoint.
+func (c *ActivityPubClient) ResolveActor(actorEndpoint string) (*vocab.ActorType, error) {
+	resp, err := c.sendRequest(nil, http.MethodGet, c.overrideTarget(actorEndpoint))
+	if err != nil {
+		return nil, fmt.Errorf("send http request: %w", err)
+	}
+
+	actor := &vocab.ActorType{}
+
+	if err := json.Unmarshal(resp, actor); err != nil {
+		return nil, fmt.Errorf("unmarshal actor: %w", err)
+	}
+
+	return actor, nil
+}
+
+// GetCollection returns an ActivityPub collection iterator for the given collection IRI.
+func (c *ActivityPubClient) GetCollection(collURI *url.URL) (*ActivityPubCollectionIterator, error) {
+	return newAPCollIterator(c.cmd, collURI.String(), c.sendRequest, c.overrideTarget)
+}
+
+// CollectionContains returns true if the given ActivityPub collection contains the given IRI.
+func (c *ActivityPubClient) CollectionContains(collURI *url.URL, iri string) (bool, error) {
+	it, err := c.GetCollection(collURI)
+	if err != nil {
+		return false, fmt.Errorf("get ActivityPub collection iterator: %w", err)
+	}
+
+	for {
+		item, err := it.Next()
+		if err != nil {
+			if errors.Is(err, orberrors.ErrContentNotFound) {
+				return false, nil
+			}
+
+			return false, err
+		}
+
+		if item.String() == iri {
+			return true, nil
+		}
+	}
+}
+
+// overrideTarget checks if there is an override for the given target (specified with the --target-override flag).
+// If so, a new target URL is returned, otherwise the same target is returned.
+func (c *ActivityPubClient) overrideTarget(targetURI string) string {
+	for oldTarget, newTarget := range c.overridesMap {
+		if strings.Contains(targetURI, "//"+oldTarget) {
+			return strings.Replace(targetURI, "//"+oldTarget, "//"+newTarget, 1)
+		}
+	}
+
+	return targetURI
+}
+
+// ActivityPubCollectionIterator iterates over an ActivityPub collection.
+type ActivityPubCollectionIterator struct {
+	cmd               *cobra.Command
+	sendRequest       requestSender
+	getTargetOverride targetOverrideFunc
+	nextPage          *url.URL
+	items             []*vocab.ObjectProperty
+	index             int
+}
+
+type requestSender func(req []byte, method, endpointURL string) ([]byte, error)
+
+type targetOverrideFunc func(targetURI string) string
+
+func newAPCollIterator(cmd *cobra.Command, collURI string, sendRequest requestSender,
+	getTargetOverride targetOverrideFunc) (*ActivityPubCollectionIterator, error) {
+	resp, err := sendRequest(nil, http.MethodGet, getTargetOverride(collURI))
+	if err != nil {
+		return nil, fmt.Errorf("failed to send http request: %w", err)
+	}
+
+	coll := &vocab.CollectionType{}
+
+	if err := json.Unmarshal(resp, coll); err != nil {
+		return nil, err
+	}
+
+	return &ActivityPubCollectionIterator{
+		cmd:               cmd,
+		sendRequest:       sendRequest,
+		getTargetOverride: getTargetOverride,
+		nextPage:          coll.First(),
+	}, nil
+}
+
+// Next returns the next item in the collection.
+func (it *ActivityPubCollectionIterator) Next() (*url.URL, error) {
+	if it.index >= len(it.items) {
+		if it.nextPage == nil {
+			return nil, orberrors.ErrContentNotFound
+		}
+
+		resp, err := it.sendRequest(nil, http.MethodGet, it.getTargetOverride(it.nextPage.String()))
+		if err != nil {
+			return nil, fmt.Errorf("send http request: %w", err)
+		}
+
+		collPage := &vocab.CollectionPageType{}
+
+		if err := json.Unmarshal(resp, collPage); err != nil {
+			return nil, err
+		}
+
+		it.items = collPage.Items()
+		it.index = 0
+		it.nextPage = collPage.Next()
+	}
+
+	i := it.index
+
+	it.index++
+
+	if i >= len(it.items) {
+		return nil, orberrors.ErrContentNotFound
+	}
+
+	return it.items[i].IRI(), nil
+}

--- a/cmd/orb-cli/common/activitypubclient_test.go
+++ b/cmd/orb-cli/common/activitypubclient_test.go
@@ -1,0 +1,261 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package common
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+	orberrors "github.com/trustbloc/orb/pkg/errors"
+)
+
+func TestNewActivityPubClient(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		cmd := newMockCmd(func(command *cobra.Command, args []string) error { return nil })
+
+		client, err := NewActivityPubClient(cmd)
+		require.NoError(t, err)
+		require.NotNil(t, client)
+	})
+}
+
+func TestActivityPubIterator(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		cmd := newMockCmd(func(command *cobra.Command, args []string) error { return nil })
+
+		client, err := NewActivityPubClient(cmd)
+		require.NoError(t, err)
+		require.NotNil(t, client)
+
+		client.sendRequest = func(req []byte, method, endpointURL string) ([]byte, error) {
+			if strings.Contains(endpointURL, "page-num=1") {
+				return []byte(jsonCollectionLastPage), nil
+			}
+
+			if strings.Contains(endpointURL, "page=true") {
+				return []byte(jsonCollectionFirstPage), nil
+			}
+
+			return []byte(jsonCollection), nil
+		}
+
+		it, err := client.GetCollection(vocab.MustParseURL("https://orb.domain1.com/services/orb/following"))
+		require.NoError(t, err)
+		require.NotNil(t, it)
+
+		u, err := it.Next()
+		require.NoError(t, err)
+		require.Equal(t, "https://orb.domain2.com/services/orb", u.String())
+
+		u, err = it.Next()
+		require.NoError(t, err)
+		require.Equal(t, "https://orb.domain3.com/services/orb", u.String())
+
+		u, err = it.Next()
+		require.NoError(t, err)
+		require.Equal(t, "https://orb.domain4.com/services/orb", u.String())
+
+		_, err = it.Next()
+		require.True(t, errors.Is(err, orberrors.ErrContentNotFound))
+	})
+}
+
+func TestActivityPubCollectionContains(t *testing.T) {
+	cmd := newMockCmd(func(command *cobra.Command, args []string) error { return nil })
+
+	t.Run("Success", func(t *testing.T) {
+		collURL := vocab.MustParseURL("https://orb.domain1.com/services/orb/following")
+
+		client, err := NewActivityPubClient(cmd)
+		require.NoError(t, err)
+		require.NotNil(t, client)
+
+		client.sendRequest = func(req []byte, method, endpointURL string) ([]byte, error) {
+			if strings.Contains(endpointURL, "page-num=1") {
+				return []byte(jsonCollectionLastPage), nil
+			}
+
+			if strings.Contains(endpointURL, "page=true") {
+				return []byte(jsonCollectionFirstPage), nil
+			}
+
+			return []byte(jsonCollection), nil
+		}
+
+		ok, err := client.CollectionContains(collURL, "https://orb.domain2.com/services/orb")
+		require.NoError(t, err)
+		require.True(t, ok)
+
+		ok, err = client.CollectionContains(collURL, "https://orb.domain4.com/services/orb")
+		require.NoError(t, err)
+		require.True(t, ok)
+
+		ok, err = client.CollectionContains(collURL, "https://orb.domain5.com/services/orb")
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("HTTP error", func(t *testing.T) {
+		collURL := vocab.MustParseURL("https://orb.domain1.com/services/orb/following")
+
+		client, err := NewActivityPubClient(cmd)
+		require.NoError(t, err)
+
+		_, err = client.CollectionContains(collURL, "https://orb.domain2.com/services/orb")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to send request")
+	})
+}
+
+func TestActivityPubClient_ResolveActor(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		client, err := NewActivityPubClient(newMockCmd(func(command *cobra.Command, args []string) error { return nil }))
+		require.NoError(t, err)
+		require.NotNil(t, client)
+
+		client.sendRequest = func(req []byte, method, endpointURL string) ([]byte, error) {
+			return []byte(jsonActor), nil
+		}
+
+		actor, err := client.ResolveActor("https://orb.domain1.com/services/anchor")
+		require.NoError(t, err)
+		require.NotNil(t, actor)
+		require.Equal(t, "https://orb.domain1.com/services/anchor", actor.ID().String())
+	})
+
+	t.Run("Send error", func(t *testing.T) {
+		client, err := NewActivityPubClient(newMockCmd(func(command *cobra.Command, args []string) error { return nil }))
+		require.NoError(t, err)
+		require.NotNil(t, client)
+
+		errExpected := errors.New("injected send error")
+
+		client.sendRequest = func(req []byte, method, endpointURL string) ([]byte, error) {
+			return nil, errExpected
+		}
+
+		actor, err := client.ResolveActor("https://orb.domain1.com/services/anchor")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+		require.Nil(t, actor)
+	})
+
+	t.Run("Unmarshal error", func(t *testing.T) {
+		client, err := NewActivityPubClient(newMockCmd(func(command *cobra.Command, args []string) error { return nil }))
+		require.NoError(t, err)
+		require.NotNil(t, client)
+
+		client.sendRequest = func(req []byte, method, endpointURL string) ([]byte, error) {
+			return []byte("}"), nil
+		}
+
+		actor, err := client.ResolveActor("https://orb.domain1.com/services/anchor")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unmarshal actor: invalid character")
+		require.Nil(t, actor)
+	})
+
+	t.Run("Target override error", func(t *testing.T) {
+		cmd := newMockCmd(func(command *cobra.Command, args []string) error { return nil })
+
+		var args []string
+		args = append(args, "--"+TargetOverrideFlagName, "orb.domain1.com")
+
+		cmd.SetArgs(args)
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		client, err := NewActivityPubClient(cmd)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid target override")
+		require.Nil(t, client)
+	})
+}
+
+func TestActivityPubClient_OverrideTarget(t *testing.T) {
+	cmd := newMockCmd(func(command *cobra.Command, args []string) error { return nil })
+
+	cmd.SetArgs([]string{
+		"--" + TargetOverrideFlagName, "orb.domain1.com->localhost:48326",
+		"--" + TargetOverrideFlagName, "orb.domain2.com->localhost:48426",
+	})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	client, err := NewActivityPubClient(cmd)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	require.Equal(t, "https://localhost:48326", client.overrideTarget("https://orb.domain1.com"))
+	require.Equal(t, "https://localhost:48426", client.overrideTarget("https://orb.domain2.com"))
+	require.Equal(t, "https://orb.domain3.com", client.overrideTarget("https://orb.domain3.com"))
+}
+
+const (
+	jsonActor = `{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://w3id.org/security/v1",
+    "https://w3id.org/activityanchors/v1"
+  ],
+  "id": "https://orb.domain1.com/services/anchor",
+  "publicKey": {
+    "id": "https://orb.domain1.com/services/anchor/keys/main-key",
+    "owner": "https://orb.domain1.com/services/anchor",
+    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhki....."
+  },
+  "followers": "https://orb.domain1.com/services/anchor/followers",
+  "following": "https://orb.domain1.com/services/anchor/following",
+  "inbox": "https://orb.domain1.com/services/anchor/inbox",
+  "liked": "https://orb.domain1.com/services/anchor/liked",
+  "likes": "https://orb.domain1.com/services/anchor/likes",
+  "outbox": "https://orb.domain1.com/services/anchor/outbox",
+  "shares": "https://orb.domain1.com/services/anchor/shares",
+  "type": "Service",
+  "witnesses": "https://orb.domain1.com/services/anchor/witnesses",
+  "witnessing": "https://orb.domain1.com/services/anchor/witnessing"
+}`
+
+	jsonCollection = `{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "first": "https://orb.domain1.com/services/orb/following?page=true",
+  "id": "https://orb.domain1.com/services/orb/following",
+  "last": "https://orb.domain1.com/services/orb/following?page=true&page-num=1",
+  "totalItems": 3,
+  "type": "Collection"
+ }`
+
+	jsonCollectionFirstPage = `{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "id": "https://orb.domain1.com/services/orb/following?page=true&page-num=0",
+  "next": "https://orb.domain1.com/services/orb/following?page=true&page-num=1",
+  "items": [
+    "https://orb.domain2.com/services/orb",
+    "https://orb.domain3.com/services/orb"
+  ],
+  "totalItems": 3,
+  "type": "CollectionPage"
+ }`
+
+	jsonCollectionLastPage = `{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "id": "https://orb.domain1.com/services/orb/following?page=true&page-num=1",
+  "prev": "https://orb.domain1.com/services/orb/following?page=true&page-num=0",
+  "items": [
+    "https://orb.domain4.com/services/orb"
+  ],
+  "totalItems": 3,
+  "type": "CollectionPage"
+ }`
+)

--- a/cmd/orb-cli/common/common.go
+++ b/cmd/orb-cli/common/common.go
@@ -69,6 +69,16 @@ const (
 		" Alternatively, this can be set with the following environment variable: " + AuthTokenEnvKey
 	// AuthTokenEnvKey defines the environment variable for the authorization bearer token flag.
 	AuthTokenEnvKey = "ORB_CLI_AUTH_TOKEN" //nolint:gosec
+
+	// TargetOverrideFlagName defines the flag for specifying target overrides.
+	TargetOverrideFlagName = "target-override"
+	// TargetOverrideFlagUsage defines the flag for target override usage.
+	TargetOverrideFlagUsage = "Overrides one or more targets used for resolving HTTP endpoints. " +
+		" For example, --target-override orb.domain2.com->localhost:48426 will use localhost:48426 instead of" +
+		" orb.domain2.com for HTTP requests. This flag should only be used for testing." +
+		" Alternatively, this can be set with the following environment variable: " + TargetOverrideEnvKey
+	// TargetOverrideEnvKey defines the flag for target override environment variable.
+	TargetOverrideEnvKey = "ORB_CLI_OUTBOX_URL"
 )
 
 // PublicKey struct.
@@ -458,6 +468,7 @@ func AddCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP(TLSSystemCertPoolFlagName, "", "", TLSSystemCertPoolFlagUsage)
 	cmd.Flags().StringArrayP(TLSCACertsFlagName, "", nil, TLSCACertsFlagUsage)
 	cmd.Flags().StringP(AuthTokenFlagName, "", "", AuthTokenFlagUsage)
+	cmd.Flags().StringArrayP(TargetOverrideFlagName, "", nil, TargetOverrideFlagUsage)
 }
 
 // Signer operation.

--- a/cmd/orb-cli/followcmd/follow.go
+++ b/cmd/orb-cli/followcmd/follow.go
@@ -6,8 +6,6 @@ SPDX-License-Identifier: Apache-2.0
 package followcmd
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -17,7 +15,6 @@ import (
 
 	"github.com/spf13/cobra"
 	cmdutils "github.com/trustbloc/edge-core/pkg/utils/cmd"
-	tlsutils "github.com/trustbloc/edge-core/pkg/utils/tls"
 
 	"github.com/trustbloc/orb/cmd/orb-cli/common"
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
@@ -44,22 +41,6 @@ const (
 		" Alternatively, this can be set with the following environment variable: " + actionEnvKey
 	actionEnvKey = "ORB_CLI_ACTION"
 
-	tlsSystemCertPoolFlagName  = "tls-systemcertpool"
-	tlsSystemCertPoolFlagUsage = "Use system certificate pool." +
-		" Possible values [true] [false]. Defaults to false if not set." +
-		" Alternatively, this can be set with the following environment variable: " + tlsSystemCertPoolEnvKey
-	tlsSystemCertPoolEnvKey = "ORB_CLI_TLS_SYSTEMCERTPOOL"
-
-	tlsCACertsFlagName  = "tls-cacerts"
-	tlsCACertsFlagUsage = "Comma-Separated list of ca certs path." +
-		" Alternatively, this can be set with the following environment variable: " + tlsCACertsEnvKey
-	tlsCACertsEnvKey = "ORB_CLI_TLS_CACERTS"
-
-	authTokenFlagName  = "auth-token"
-	authTokenFlagUsage = "Auth token." +
-		" Alternatively, this can be set with the following environment variable: " + authTokenEnvKey
-	authTokenEnvKey = "ORB_CLI_AUTH_TOKEN" //nolint:gosec
-
 	followIDFlagName  = "follow-id"
 	followIDFlagUsage = "follow id required for undo action." +
 		" Alternatively, this can be set with the following environment variable: " + followIDEnvKey
@@ -83,10 +64,6 @@ const (
 	defaultWaitTime = 1 * time.Second
 )
 
-type followingResp struct {
-	Items []string `json:"items,omitempty"`
-}
-
 // GetCmd returns the Cobra follow command.
 func GetCmd() *cobra.Command {
 	createCmd := createCmd()
@@ -103,19 +80,17 @@ func createCmd() *cobra.Command { //nolint:funlen,gocyclo,cyclop,gocognit
 		Long:         "manage followers ",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			rootCAs, err := getRootCAs(cmd)
+			httpClient, err := common.NewHTTPClient(cmd)
 			if err != nil {
 				return err
 			}
 
-			httpClient := &http.Client{
-				Transport: &http.Transport{
-					ForceAttemptHTTP2: true,
-					TLSClientConfig: &tls.Config{
-						RootCAs:    rootCAs,
-						MinVersion: tls.VersionTLS12,
-					},
-				},
+			authToken := cmdutils.GetUserSetOptionalVarFromString(cmd, common.AuthTokenFlagName,
+				common.AuthTokenEnvKey)
+
+			headers := make(map[string]string)
+			if authToken != "" {
+				headers["Authorization"] = "Bearer " + authToken
 			}
 
 			outboxURL, err := cmdutils.GetUserSetVarFromString(cmd, outboxURLFlagName,
@@ -124,15 +99,10 @@ func createCmd() *cobra.Command { //nolint:funlen,gocyclo,cyclop,gocognit
 				return err
 			}
 
-			actor, err := cmdutils.GetUserSetVarFromString(cmd, actorFlagName,
+			actorIRI, err := cmdutils.GetUserSetVarFromString(cmd, actorFlagName,
 				actorEnvKey, false)
 			if err != nil {
 				return err
-			}
-
-			actorIRI, err := url.Parse(actor)
-			if err != nil {
-				return fmt.Errorf("parse 'actor' URL %s: %w", actor, err)
 			}
 
 			to, err := cmdutils.GetUserSetVarFromString(cmd, toFlagName,
@@ -152,9 +122,6 @@ func createCmd() *cobra.Command { //nolint:funlen,gocyclo,cyclop,gocognit
 				return err
 			}
 
-			authToken := cmdutils.GetUserSetOptionalVarFromString(cmd, authTokenFlagName,
-				authTokenEnvKey)
-
 			maxRetry := defaultMaxRetry
 
 			maxRetryString := cmdutils.GetUserSetOptionalVarFromString(cmd, maxRetryFlagName,
@@ -173,82 +140,80 @@ func createCmd() *cobra.Command { //nolint:funlen,gocyclo,cyclop,gocognit
 				return err
 			}
 
-			var reqBytes []byte
+			var followIRI *url.URL
 
-			switch action {
-			case followAction:
-				req := vocab.NewFollowActivity(
-					vocab.NewObjectProperty(vocab.WithIRI(toIRI)),
-					vocab.WithActor(actorIRI),
-					vocab.WithTo(toIRI),
-				)
-
-				reqBytes, err = json.Marshal(req)
-				if err != nil {
-					return err
-				}
-			case undoAction:
+			if action == undoAction {
 				followID, errGet := cmdutils.GetUserSetVarFromString(cmd, followIDFlagName,
 					followIDEnvKey, false)
 				if errGet != nil {
 					return errGet
 				}
 
-				followIRI, e := url.Parse(followID)
-				if e != nil {
-					return fmt.Errorf("parse 'followID' URL %s: %w", followID, e)
+				followIRI, err = url.Parse(followID)
+				if err != nil {
+					return fmt.Errorf("parse 'followID' URL %s: %w", followID, err)
 				}
+			}
 
+			apClient, err := common.NewActivityPubClient(cmd)
+			if err != nil {
+				return fmt.Errorf("create ActivityPub client: %w", err)
+			}
+
+			actor, err := apClient.ResolveActor(actorIRI)
+			if err != nil {
+				return fmt.Errorf("discover 'actor' at %s: %w", actorIRI, err)
+			}
+
+			toActor, err := apClient.ResolveActor(to)
+			if err != nil {
+				return fmt.Errorf("discover 'to' actor %s: %w", to, err)
+			}
+
+			var reqBytes []byte
+
+			switch action {
+			case followAction:
+				req := vocab.NewFollowActivity(
+					vocab.NewObjectProperty(vocab.WithIRI(toActor.ID().URL())),
+					vocab.WithActor(actor.ID().URL()),
+					vocab.WithTo(toIRI),
+				)
+
+				reqBytes, err = json.Marshal(req)
+				if err != nil {
+					return fmt.Errorf("marshal follow activity: %w", err)
+				}
+			case undoAction:
 				undo := vocab.NewUndoActivity(
 					vocab.NewObjectProperty(vocab.WithActivity(
 						vocab.NewFollowActivity(
-							vocab.NewObjectProperty(vocab.WithIRI(toIRI)),
+							vocab.NewObjectProperty(vocab.WithIRI(toActor.ID().URL())),
 							vocab.WithID(followIRI),
-							vocab.WithActor(actorIRI),
+							vocab.WithActor(actor.ID().URL()),
 						),
 					)),
-					vocab.WithActor(actorIRI),
+					vocab.WithActor(actor.ID().URL()),
 					vocab.WithTo(toIRI),
 				)
 
 				reqBytes, err = json.Marshal(undo)
 				if err != nil {
-					return err
+					return fmt.Errorf("marshal undo activity: %w", err)
 				}
 			default:
 				return fmt.Errorf("action %s not supported", action)
 			}
 
-			headers := make(map[string]string)
-			if authToken != "" {
-				headers["Authorization"] = "Bearer " + authToken
-			}
-
-			result, err := common.SendRequest(httpClient, reqBytes, headers, http.MethodPost,
-				outboxURL)
+			result, err := common.SendRequest(httpClient, reqBytes, headers, http.MethodPost, outboxURL)
 			if err != nil {
 				return fmt.Errorf("failed to send http request: %w", err)
 			}
 
 			for i := 1; i <= maxRetry; i++ {
-				resp, err := common.SendRequest(httpClient, nil, headers, http.MethodGet,
-					fmt.Sprintf("%s/following?page=true", actor))
+				exists, err := apClient.CollectionContains(actor.Following(), toActor.ID().String())
 				if err != nil {
-					return fmt.Errorf("failed to send http request: %w", err)
-				}
-
-				followingResp := &followingResp{}
-
-				if err := json.Unmarshal(resp, followingResp); err != nil {
 					return err
-				}
-
-				exists := false
-
-				for _, item := range followingResp.Items {
-					if item == to {
-						exists = true
-					}
 				}
 
 				if (action == undoAction && !exists) || (action == followAction && exists) {
@@ -269,35 +234,13 @@ func createCmd() *cobra.Command { //nolint:funlen,gocyclo,cyclop,gocognit
 	}
 }
 
-func getRootCAs(cmd *cobra.Command) (*x509.CertPool, error) {
-	tlsSystemCertPoolString := cmdutils.GetUserSetOptionalVarFromString(cmd, tlsSystemCertPoolFlagName,
-		tlsSystemCertPoolEnvKey)
-
-	tlsSystemCertPool := false
-
-	if tlsSystemCertPoolString != "" {
-		var err error
-		tlsSystemCertPool, err = strconv.ParseBool(tlsSystemCertPoolString)
-
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	tlsCACerts := cmdutils.GetUserSetOptionalVarFromArrayString(cmd, tlsCACertsFlagName,
-		tlsCACertsEnvKey)
-
-	return tlsutils.GetCertPool(tlsSystemCertPool, tlsCACerts)
-}
-
 func createFlags(startCmd *cobra.Command) {
-	startCmd.Flags().StringP(tlsSystemCertPoolFlagName, "", "", tlsSystemCertPoolFlagUsage)
-	startCmd.Flags().StringArrayP(tlsCACertsFlagName, "", []string{}, tlsCACertsFlagUsage)
+	common.AddCommonFlags(startCmd)
+
 	startCmd.Flags().StringP(outboxURLFlagName, "", "", outboxURLFlagUsage)
 	startCmd.Flags().StringP(actorFlagName, "", "", actorFlagUsage)
 	startCmd.Flags().StringP(toFlagName, "", "", toFlagUsage)
 	startCmd.Flags().StringP(actionFlagName, "", "", actionFlagUsage)
-	startCmd.Flags().StringP(authTokenFlagName, "", "", authTokenFlagUsage)
 	startCmd.Flags().StringP(followIDFlagName, "", "", followIDFlagUsage)
 	startCmd.Flags().StringP(maxRetryFlagName, "", "", maxRetryFlagUsage)
 	startCmd.Flags().StringP(waitTimeFlagName, "", "", waitTimeFlagUsage)

--- a/cmd/orb-cli/followcmd/follow_test.go
+++ b/cmd/orb-cli/followcmd/follow_test.go
@@ -10,9 +10,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/cmd/orb-cli/common"
 )
 
 const (
@@ -22,7 +25,7 @@ const (
 func TestTLSSystemCertPoolInvalidArgsEnvVar(t *testing.T) {
 	startCmd := GetCmd()
 
-	require.NoError(t, os.Setenv(tlsSystemCertPoolEnvKey, "wrongvalue"))
+	require.NoError(t, os.Setenv(common.TLSSystemCertPoolEnvKey, "wrongvalue"))
 	defer os.Clearenv()
 
 	err := startCmd.Execute()
@@ -62,15 +65,15 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 
 		var args []string
 		args = append(args, outboxURL("localhost:8080")...)
+		args = append(args, to("to")...)
+		args = append(args, action("Follow")...)
 		args = append(args, actor(string([]byte{0x0}))...)
 		startCmd.SetArgs(args)
 
 		err := startCmd.Execute()
 
 		require.Error(t, err)
-		require.Equal(t,
-			"parse 'actor' URL \u0000: parse \"\\x00\": net/url: invalid control character in URL",
-			err.Error())
+		require.Contains(t, err.Error(), "invalid control character in URL")
 	})
 
 	t.Run("test missing to arg", func(t *testing.T) {
@@ -78,7 +81,7 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 
 		var args []string
 		args = append(args, outboxURL("localhost:8080")...)
-		args = append(args, actor("actor")...)
+		args = append(args, actor("http://orb.domain1.com/services/orb")...)
 		startCmd.SetArgs(args)
 
 		err := startCmd.Execute()
@@ -128,7 +131,7 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 
 		var args []string
 		args = append(args, outboxURL("localhost:8080")...)
-		args = append(args, actor("actor")...)
+		args = append(args, actor("http://orb.domain1.com/services/anchor")...)
 		args = append(args, to("to")...)
 		args = append(args, action("Undo")...)
 
@@ -146,7 +149,7 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 		startCmd := GetCmd()
 
 		var args []string
-		args = append(args, outboxURL("https://localhost:8080")...)
+		args = append(args, outboxURL("http://localhost:8080")...)
 		args = append(args, actor("actor")...)
 		args = append(args, to("to")...)
 		args = append(args, action("Undo")...)
@@ -161,15 +164,48 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 			"parse 'followID' URL \u0000: parse \"\\x00\": net/url: invalid control character in URL",
 			err.Error())
 	})
+}
+
+func TestFollow(t *testing.T) {
+	const servicePath = "/services/anchor"
+
+	orb1 := httptest.NewServer(getOrb1Handler(t, servicePath))
+	orb2 := httptest.NewServer(getOrb2Handler(t, servicePath))
+	orb1A := httptest.NewServer(getOrb1AHandler(t, servicePath))
+
+	orb1Domain := strings.Split(orb1.URL, "//")[1]
+	orb1ADomain := strings.Split(orb1A.URL, "//")[1]
+	orb2Domain := strings.Split(orb1.URL, "//")[1]
+
+	t.Run("test failed to follow", func(t *testing.T) {
+		os.Clearenv()
+		cmd := GetCmd()
+
+		var args []string
+		args = append(args, outboxURL("wrongurl")...)
+		args = append(args, actor("http://orb.domain1.com/services/anchor")...)
+		args = append(args, to("to")...)
+		args = append(args, action("Undo")...)
+		args = append(args, followID("followID")...)
+
+		cmd.SetArgs(args)
+		err := cmd.Execute()
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to send request")
+	})
 
 	t.Run("test action value not supported", func(t *testing.T) {
 		startCmd := GetCmd()
 
 		var args []string
-		args = append(args, outboxURL("localhost:8080")...)
-		args = append(args, actor("actor")...)
-		args = append(args, to("to")...)
+		args = append(args, outboxURL(orb1.URL+"/services/anchor/outbox")...)
+		args = append(args, actor(orb1.URL+"/services/anchor")...)
+		args = append(args, to(orb2.URL+"/services/anchor")...)
 		args = append(args, action("wrong")...)
+		args = append(args, targetOverride(fmt.Sprintf("orb.domain1.com->%s", orb1Domain))...)
+		args = append(args, targetOverride(fmt.Sprintf("orb.domain2.com->%s", orb2Domain))...)
+
 		startCmd.SetArgs(args)
 
 		err := startCmd.Execute()
@@ -179,45 +215,36 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 			"action wrong not supported",
 			err.Error())
 	})
-}
 
-func TestFollow(t *testing.T) {
-	serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, err := fmt.Fprint(w, "d1")
-		require.NoError(t, err)
-	}))
-
-	serv1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, err := fmt.Fprint(w, "{ \"items\": [ \"to\" ] }")
-		require.NoError(t, err)
-	}))
-
-	t.Run("test failed to follow", func(t *testing.T) {
-		os.Clearenv()
+	t.Run("Follow -> success", func(t *testing.T) {
 		cmd := GetCmd()
 
 		var args []string
-		args = append(args, outboxURL("wrongurl")...)
-		args = append(args, actor("actor")...)
-		args = append(args, to("to")...)
-		args = append(args, action("Undo")...)
-		args = append(args, followID("followID")...)
+		args = append(args, outboxURL(orb1.URL+"/services/anchor/outbox")...)
+		args = append(args, actor(orb1.URL+"/services/anchor")...)
+		args = append(args, to(orb2.URL+"/services/anchor")...)
+		args = append(args, action("Follow")...)
+		args = append(args, targetOverride(fmt.Sprintf("orb.domain1.com->%s", orb1Domain))...)
+		args = append(args, targetOverride(fmt.Sprintf("orb.domain2.com->%s", orb2Domain))...)
 
 		cmd.SetArgs(args)
 		err := cmd.Execute()
 
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to send http request")
+		require.NoError(t, err)
 	})
 
-	t.Run("success", func(t *testing.T) {
+	t.Run("Undo Follow -> success", func(t *testing.T) {
+		t.Logf("Orb1 URL: %s", orb1.URL)
 		cmd := GetCmd()
 
 		var args []string
-		args = append(args, outboxURL(serv.URL)...)
-		args = append(args, actor(serv1.URL)...)
-		args = append(args, to("to")...)
-		args = append(args, action("Follow")...)
+		args = append(args, outboxURL(orb1A.URL+"/services/anchor/outbox")...)
+		args = append(args, actor(orb1A.URL+"/services/anchor")...)
+		args = append(args, to(orb2.URL+"/services/anchor")...)
+		args = append(args, action("Undo")...)
+		args = append(args, followID("http://orb.domain1.com/services/orb/activities/123456")...)
+		args = append(args, targetOverride(fmt.Sprintf("orb.domain1.com->%s", orb1ADomain))...)
+		args = append(args, targetOverride(fmt.Sprintf("orb.domain2.com->%s", orb2Domain))...)
 
 		cmd.SetArgs(args)
 		err := cmd.Execute()
@@ -245,3 +272,147 @@ func action(value string) []string {
 func followID(value string) []string {
 	return []string{flag + followIDFlagName, value}
 }
+
+func targetOverride(value string) []string {
+	return []string{flag + common.TargetOverrideFlagName, value}
+}
+
+func getOrb1Handler(t *testing.T, servicePath string) http.HandlerFunc {
+	t.Helper()
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.String() == servicePath:
+			_, err := fmt.Fprint(w, jsonActor1)
+			require.NoError(t, err)
+		case r.Method == http.MethodPost && r.URL.String() == fmt.Sprintf("%s/outbox", servicePath):
+			w.WriteHeader(http.StatusOK)
+		case r.URL.String() == fmt.Sprintf("%s/following", servicePath):
+			_, err := fmt.Fprint(w, jsonCollection)
+			require.NoError(t, err)
+		case r.URL.String() == fmt.Sprintf("%s/following?page=true", servicePath):
+			_, err := fmt.Fprint(w, jsonCollectionFirstPage)
+			require.NoError(t, err)
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+			_, err := fmt.Fprint(w, "Bad request")
+			require.NoError(t, err)
+		}
+	}
+}
+
+func getOrb2Handler(t *testing.T, servicePath string) http.HandlerFunc {
+	t.Helper()
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.String() == servicePath:
+			_, err := fmt.Fprint(w, jsonActor2)
+			require.NoError(t, err)
+		case r.URL.String() == fmt.Sprintf("%s/inbox", servicePath):
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+			_, err := fmt.Fprint(w, "Bad request")
+			require.NoError(t, err)
+		}
+	}
+}
+
+func getOrb1AHandler(t *testing.T, servicePath string) http.HandlerFunc {
+	t.Helper()
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.String() == servicePath:
+			_, err := fmt.Fprint(w, jsonActor1)
+			require.NoError(t, err)
+		case r.Method == http.MethodPost && r.URL.String() == fmt.Sprintf("%s/outbox", servicePath):
+			w.WriteHeader(http.StatusOK)
+		case r.URL.String() == fmt.Sprintf("%s/following", servicePath):
+			_, err := fmt.Fprint(w, jsonEmptyCollection)
+			require.NoError(t, err)
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+			_, err := fmt.Fprint(w, "Bad request")
+			require.NoError(t, err)
+		}
+	}
+}
+
+const (
+	jsonActor1 = `{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://w3id.org/security/v1",
+    "https://w3id.org/activityanchors/v1"
+  ],
+  "id": "http://orb.domain1.com/services/anchor",
+  "publicKey": {
+    "id": "http://orb.domain1.com/services/anchor/keys/main-key",
+    "owner": "http://orb.domain1.com/services/anchor",
+    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhki....."
+  },
+  "followers": "http://orb.domain1.com/services/anchor/followers",
+  "following": "http://orb.domain1.com/services/anchor/following",
+  "inbox": "http://orb.domain1.com/services/anchor/inbox",
+  "liked": "http://orb.domain1.com/services/anchor/liked",
+  "likes": "http://orb.domain1.com/services/anchor/likes",
+  "outbox": "http://orb.domain1.com/services/anchor/outbox",
+  "shares": "http://orb.domain1.com/services/anchor/shares",
+  "type": "Service",
+  "witnesses": "http://orb.domain1.com/services/anchor/witnesses",
+  "witnessing": "http://orb.domain1.com/services/anchor/witnessing"
+}`
+
+	jsonActor2 = `{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://w3id.org/security/v1",
+    "https://w3id.org/activityanchors/v1"
+  ],
+  "id": "http://orb.domain2.com/services/anchor",
+  "publicKey": {
+    "id": "http://orb.domain2.com/services/anchor/keys/main-key",
+    "owner": "http://orb.domain2.com/services/anchor",
+    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhki....."
+  },
+  "followers": "http://orb.domain2.com/services/anchor/followers",
+  "following": "http://orb.domain2.com/services/anchor/following",
+  "inbox": "http://orb.domain2.com/services/anchor/inbox",
+  "liked": "http://orb.domain2.com/services/anchor/liked",
+  "likes": "http://orb.domain2.com/services/anchor/likes",
+  "outbox": "http://orb.domain2.com/services/anchor/outbox",
+  "shares": "http://orb.domain2.com/services/anchor/shares",
+  "type": "Service",
+  "witnesses": "http://orb.domain2.com/services/anchor/witnesses",
+  "witnessing": "http://orb.domain2.com/services/anchor/witnessing"
+}`
+
+	jsonCollection = `{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "first": "http://orb.domain1.com/services/anchor/following?page=true",
+  "id": "http://orb.domain1.com/services/anchor/following",
+  "last": "http://orb.domain1.com/services/anchor/following?page=true&page-num=1",
+  "totalItems": 1,
+  "type": "Collection"
+ }`
+
+	jsonEmptyCollection = `{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "id": "http://orb.domain1.com/services/anchor/following",
+  "totalItems": 0,
+  "type": "Collection"
+ }`
+
+	jsonCollectionFirstPage = `{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "id": "http://orb.domain1.com/services/anchor/following?page=true&page-num=0",
+  "next": "http://orb.domain1.com/services/anchor/following?page=true&page-num=1",
+  "items": [
+    "http://orb.domain2.com/services/anchor"
+  ],
+  "totalItems": 1,
+  "type": "CollectionPage"
+ }`
+)

--- a/cmd/orb-cli/witnesscmd/witness.go
+++ b/cmd/orb-cli/witnesscmd/witness.go
@@ -6,8 +6,6 @@ SPDX-License-Identifier: Apache-2.0
 package witnesscmd
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -17,7 +15,6 @@ import (
 
 	"github.com/spf13/cobra"
 	cmdutils "github.com/trustbloc/edge-core/pkg/utils/cmd"
-	tlsutils "github.com/trustbloc/edge-core/pkg/utils/tls"
 
 	"github.com/trustbloc/orb/cmd/orb-cli/common"
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
@@ -44,22 +41,6 @@ const (
 		" Alternatively, this can be set with the following environment variable: " + actionEnvKey
 	actionEnvKey = "ORB_CLI_ACTION"
 
-	tlsSystemCertPoolFlagName  = "tls-systemcertpool"
-	tlsSystemCertPoolFlagUsage = "Use system certificate pool." +
-		" Possible values [true] [false]. Defaults to false if not set." +
-		" Alternatively, this can be set with the following environment variable: " + tlsSystemCertPoolEnvKey
-	tlsSystemCertPoolEnvKey = "ORB_CLI_TLS_SYSTEMCERTPOOL"
-
-	tlsCACertsFlagName  = "tls-cacerts"
-	tlsCACertsFlagUsage = "Comma-Separated list of ca certs path." +
-		" Alternatively, this can be set with the following environment variable: " + tlsCACertsEnvKey
-	tlsCACertsEnvKey = "ORB_CLI_TLS_CACERTS"
-
-	authTokenFlagName  = "auth-token"
-	authTokenFlagUsage = "Auth token." +
-		" Alternatively, this can be set with the following environment variable: " + authTokenEnvKey
-	authTokenEnvKey = "ORB_CLI_AUTH_TOKEN" //nolint:gosec
-
 	inviteWitnessFlagName  = "invite-witness-id"
 	inviteWitnessFlagUsage = "Invite witness id required for undo action." +
 		" Alternatively, this can be set with the following environment variable: " + inviteWitnessEnvKey
@@ -83,10 +64,6 @@ const (
 	defaultWaitTime     = 1 * time.Second
 )
 
-type witnessResp struct {
-	Items []string `json:"items,omitempty"`
-}
-
 // GetCmd returns the Cobra witness command.
 func GetCmd() *cobra.Command {
 	cmd := cmd()
@@ -103,19 +80,17 @@ func cmd() *cobra.Command { //nolint:funlen,gocyclo,cyclop,gocognit
 		Long:         "manage witness ",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			rootCAs, err := getRootCAs(cmd)
+			httpClient, err := common.NewHTTPClient(cmd)
+
+			authToken := cmdutils.GetUserSetOptionalVarFromString(cmd, common.AuthTokenFlagName,
+				common.AuthTokenEnvKey)
 			if err != nil {
 				return err
 			}
 
-			httpClient := &http.Client{
-				Transport: &http.Transport{
-					ForceAttemptHTTP2: true,
-					TLSClientConfig: &tls.Config{
-						RootCAs:    rootCAs,
-						MinVersion: tls.VersionTLS12,
-					},
-				},
+			headers := make(map[string]string)
+			if authToken != "" {
+				headers["Authorization"] = "Bearer " + authToken
 			}
 
 			outboxURL, err := cmdutils.GetUserSetVarFromString(cmd, outboxURLFlagName,
@@ -124,15 +99,10 @@ func cmd() *cobra.Command { //nolint:funlen,gocyclo,cyclop,gocognit
 				return err
 			}
 
-			actor, err := cmdutils.GetUserSetVarFromString(cmd, actorFlagName,
+			actorIRI, err := cmdutils.GetUserSetVarFromString(cmd, actorFlagName,
 				actorEnvKey, false)
 			if err != nil {
 				return err
-			}
-
-			actorIRI, err := url.Parse(actor)
-			if err != nil {
-				return fmt.Errorf("parse 'actor' URL %s: %w", actor, err)
 			}
 
 			to, err := cmdutils.GetUserSetVarFromString(cmd, toFlagName,
@@ -152,9 +122,6 @@ func cmd() *cobra.Command { //nolint:funlen,gocyclo,cyclop,gocognit
 				return err
 			}
 
-			authToken := cmdutils.GetUserSetOptionalVarFromString(cmd, authTokenFlagName,
-				authTokenEnvKey)
-
 			maxRetry := defaultMaxRetry
 
 			maxRetryString := cmdutils.GetUserSetOptionalVarFromString(cmd, maxRetryFlagName,
@@ -173,14 +140,44 @@ func cmd() *cobra.Command { //nolint:funlen,gocyclo,cyclop,gocognit
 				return err
 			}
 
+			var inviteWitnessIRI *url.URL
+
+			if action == undoAction {
+				inviteWitness, errGet := cmdutils.GetUserSetVarFromString(cmd, inviteWitnessFlagName,
+					inviteWitnessEnvKey, false)
+				if errGet != nil {
+					return errGet
+				}
+
+				inviteWitnessIRI, err = url.Parse(inviteWitness)
+				if err != nil {
+					return fmt.Errorf("parse 'witnessID' URL %s: %w", inviteWitness, err)
+				}
+			}
+
+			apClient, err := common.NewActivityPubClient(cmd)
+			if err != nil {
+				return fmt.Errorf("create ActivityPub client: %w", err)
+			}
+
+			actor, err := apClient.ResolveActor(actorIRI)
+			if err != nil {
+				return fmt.Errorf("discover 'actor' at %s: %w", actorIRI, err)
+			}
+
+			toActor, err := apClient.ResolveActor(to)
+			if err != nil {
+				return fmt.Errorf("discover 'to' actor %s: %w", to, err)
+			}
+
 			var reqBytes []byte
 
 			switch action {
 			case inviteWitnessAction:
 				req := vocab.NewInviteActivity(
 					vocab.NewObjectProperty(vocab.WithIRI(vocab.AnchorWitnessTargetIRI)),
-					vocab.WithTarget(vocab.NewObjectProperty(vocab.WithIRI(toIRI))),
-					vocab.WithActor(actorIRI),
+					vocab.WithTarget(vocab.NewObjectProperty(vocab.WithIRI(toActor.ID().URL()))),
+					vocab.WithActor(actor.ID().URL()),
 					vocab.WithTo(toIRI),
 				)
 
@@ -190,27 +187,16 @@ func cmd() *cobra.Command { //nolint:funlen,gocyclo,cyclop,gocognit
 				}
 
 			case undoAction:
-				inviteWitness, errGet := cmdutils.GetUserSetVarFromString(cmd, inviteWitnessFlagName,
-					inviteWitnessEnvKey, false)
-				if errGet != nil {
-					return errGet
-				}
-
-				inviteWitnessIRI, e := url.Parse(inviteWitness)
-				if e != nil {
-					return fmt.Errorf("parse 'witnessID' URL %s: %w", inviteWitness, e)
-				}
-
 				undo := vocab.NewUndoActivity(
 					vocab.NewObjectProperty(vocab.WithActivity(
 						vocab.NewInviteActivity(
 							vocab.NewObjectProperty(vocab.WithIRI(vocab.AnchorWitnessTargetIRI)),
 							vocab.WithID(inviteWitnessIRI),
-							vocab.WithTarget(vocab.NewObjectProperty(vocab.WithIRI(toIRI))),
-							vocab.WithActor(actorIRI),
+							vocab.WithTarget(vocab.NewObjectProperty(vocab.WithIRI(toActor.ID().URL()))),
+							vocab.WithActor(actor.ID().URL()),
 						),
 					)),
-					vocab.WithActor(actorIRI),
+					vocab.WithActor(actor.ID().URL()),
 					vocab.WithTo(toIRI),
 				)
 
@@ -223,36 +209,15 @@ func cmd() *cobra.Command { //nolint:funlen,gocyclo,cyclop,gocognit
 				return fmt.Errorf("action %s not supported", action)
 			}
 
-			headers := make(map[string]string)
-			if authToken != "" {
-				headers["Authorization"] = "Bearer " + authToken
-			}
-
-			result, err := common.SendRequest(httpClient, reqBytes, headers, http.MethodPost,
-				outboxURL)
+			result, err := common.SendRequest(httpClient, reqBytes, headers, http.MethodPost, outboxURL)
 			if err != nil {
 				return fmt.Errorf("failed to send http request: %w", err)
 			}
 
 			for i := 1; i <= maxRetry; i++ {
-				resp, err := common.SendRequest(httpClient, nil, headers, http.MethodGet,
-					fmt.Sprintf("%s/witnesses?page=true", actor))
+				exists, err := apClient.CollectionContains(actor.Witnesses(), toActor.ID().String())
 				if err != nil {
-					return fmt.Errorf("failed to send http request: %w", err)
-				}
-
-				witnessResp := &witnessResp{}
-
-				if err := json.Unmarshal(resp, witnessResp); err != nil {
 					return err
-				}
-
-				exists := false
-
-				for _, item := range witnessResp.Items {
-					if item == to {
-						exists = true
-					}
 				}
 
 				if (action == undoAction && !exists) || (action == inviteWitnessAction && exists) {
@@ -273,35 +238,13 @@ func cmd() *cobra.Command { //nolint:funlen,gocyclo,cyclop,gocognit
 	}
 }
 
-func getRootCAs(cmd *cobra.Command) (*x509.CertPool, error) {
-	tlsSystemCertPoolString := cmdutils.GetUserSetOptionalVarFromString(cmd, tlsSystemCertPoolFlagName,
-		tlsSystemCertPoolEnvKey)
-
-	tlsSystemCertPool := false
-
-	if tlsSystemCertPoolString != "" {
-		var err error
-		tlsSystemCertPool, err = strconv.ParseBool(tlsSystemCertPoolString)
-
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	tlsCACerts := cmdutils.GetUserSetOptionalVarFromArrayString(cmd, tlsCACertsFlagName,
-		tlsCACertsEnvKey)
-
-	return tlsutils.GetCertPool(tlsSystemCertPool, tlsCACerts)
-}
-
 func createFlags(startCmd *cobra.Command) {
-	startCmd.Flags().StringP(tlsSystemCertPoolFlagName, "", "", tlsSystemCertPoolFlagUsage)
-	startCmd.Flags().StringArrayP(tlsCACertsFlagName, "", []string{}, tlsCACertsFlagUsage)
+	common.AddCommonFlags(startCmd)
+
 	startCmd.Flags().StringP(outboxURLFlagName, "", "", outboxURLFlagUsage)
 	startCmd.Flags().StringP(actorFlagName, "", "", actorFlagUsage)
 	startCmd.Flags().StringP(toFlagName, "", "", toFlagUsage)
 	startCmd.Flags().StringP(actionFlagName, "", "", actionFlagUsage)
-	startCmd.Flags().StringP(authTokenFlagName, "", "", authTokenFlagUsage)
 	startCmd.Flags().StringP(inviteWitnessFlagName, "", "", inviteWitnessFlagUsage)
 	startCmd.Flags().StringP(maxRetryFlagName, "", "", maxRetryFlagUsage)
 	startCmd.Flags().StringP(waitTimeFlagName, "", "", waitTimeFlagUsage)

--- a/cmd/orb-cli/witnesscmd/witness_test.go
+++ b/cmd/orb-cli/witnesscmd/witness_test.go
@@ -10,9 +10,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/cmd/orb-cli/common"
 )
 
 const (
@@ -22,7 +25,7 @@ const (
 func TestTLSSystemCertPoolInvalidArgsEnvVar(t *testing.T) {
 	startCmd := GetCmd()
 
-	require.NoError(t, os.Setenv(tlsSystemCertPoolEnvKey, "wrongvalue"))
+	require.NoError(t, os.Setenv(common.TLSSystemCertPoolEnvKey, "wrongvalue"))
 	defer os.Clearenv()
 
 	err := startCmd.Execute()
@@ -62,15 +65,15 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 
 		var args []string
 		args = append(args, outboxURL("localhost:8080")...)
+		args = append(args, to("to")...)
+		args = append(args, action("InviteWitness")...)
 		args = append(args, actor(string([]byte{0x0}))...)
 		startCmd.SetArgs(args)
 
 		err := startCmd.Execute()
 
 		require.Error(t, err)
-		require.Equal(t,
-			"parse 'actor' URL \u0000: parse \"\\x00\": net/url: invalid control character in URL",
-			err.Error())
+		require.Contains(t, err.Error(), "invalid control character in URL")
 	})
 
 	t.Run("test missing to arg", func(t *testing.T) {
@@ -78,7 +81,7 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 
 		var args []string
 		args = append(args, outboxURL("localhost:8080")...)
-		args = append(args, actor("actor")...)
+		args = append(args, actor("https://orb.domain1.com/services/orb")...)
 		startCmd.SetArgs(args)
 
 		err := startCmd.Execute()
@@ -128,7 +131,7 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 
 		var args []string
 		args = append(args, outboxURL("localhost:8080")...)
-		args = append(args, actor("actor")...)
+		args = append(args, actor("https://orb.domain1.com/services/anchor")...)
 		args = append(args, to("to")...)
 		args = append(args, action("Undo")...)
 
@@ -161,15 +164,48 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 			"parse 'witnessID' URL \u0000: parse \"\\x00\": net/url: invalid control character in URL",
 			err.Error())
 	})
+}
+
+func TestInviteWitness(t *testing.T) {
+	const servicePath = "/services/anchor"
+
+	orb1 := httptest.NewServer(getOrb1Handler(t, servicePath))
+	orb2 := httptest.NewServer(getOrb2Handler(t, servicePath))
+	orb1A := httptest.NewServer(getOrb1AHandler(t, servicePath))
+
+	orb1Domain := strings.Split(orb1.URL, "//")[1]
+	orb1ADomain := strings.Split(orb1A.URL, "//")[1]
+	orb2Domain := strings.Split(orb1.URL, "//")[1]
+
+	t.Run("test failed to InviteWitness", func(t *testing.T) {
+		os.Clearenv()
+		cmd := GetCmd()
+
+		var args []string
+		args = append(args, outboxURL("wrongurl")...)
+		args = append(args, actor("http://orb.domain1.com/services/anchor")...)
+		args = append(args, to("to")...)
+		args = append(args, action("Undo")...)
+		args = append(args, inviteWitnessID("inviteWitnessID")...)
+
+		cmd.SetArgs(args)
+		err := cmd.Execute()
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to send request")
+	})
 
 	t.Run("test action value not supported", func(t *testing.T) {
 		startCmd := GetCmd()
 
 		var args []string
-		args = append(args, outboxURL("localhost:8080")...)
-		args = append(args, actor("actor")...)
-		args = append(args, to("to")...)
+		args = append(args, outboxURL(orb1.URL+"/services/anchor/outbox")...)
+		args = append(args, actor(orb1.URL+"/services/anchor")...)
+		args = append(args, to(orb2.URL+"/services/anchor")...)
 		args = append(args, action("wrong")...)
+		args = append(args, targetOverride(fmt.Sprintf("orb.domain1.com->%s", orb1Domain))...)
+		args = append(args, targetOverride(fmt.Sprintf("orb.domain2.com->%s", orb2Domain))...)
+
 		startCmd.SetArgs(args)
 
 		err := startCmd.Execute()
@@ -179,51 +215,104 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 			"action wrong not supported",
 			err.Error())
 	})
+
+	t.Run("InviteWitness -> success", func(t *testing.T) {
+		cmd := GetCmd()
+
+		var args []string
+		args = append(args, outboxURL(orb1.URL+"/services/anchor/outbox")...)
+		args = append(args, actor(orb1.URL+"/services/anchor")...)
+		args = append(args, to(orb2.URL+"/services/anchor")...)
+		args = append(args, action("InviteWitness")...)
+		args = append(args, targetOverride(fmt.Sprintf("orb.domain1.com->%s", orb1Domain))...)
+		args = append(args, targetOverride(fmt.Sprintf("orb.domain2.com->%s", orb2Domain))...)
+
+		cmd.SetArgs(args)
+		err := cmd.Execute()
+
+		require.NoError(t, err)
+	})
+
+	t.Run("Undo InviteWitness -> success", func(t *testing.T) {
+		cmd := GetCmd()
+
+		var args []string
+		args = append(args, outboxURL(orb1A.URL+"/services/anchor/outbox")...)
+		args = append(args, actor(orb1A.URL+"/services/anchor")...)
+		args = append(args, to(orb2.URL+"/services/anchor")...)
+		args = append(args, action("Undo")...)
+		args = append(args, inviteWitnessID("http://orb.domain1.com/services/orb/activities/123456")...)
+		args = append(args, targetOverride(fmt.Sprintf("orb.domain1.com->%s", orb1ADomain))...)
+		args = append(args, targetOverride(fmt.Sprintf("orb.domain2.com->%s", orb2Domain))...)
+
+		cmd.SetArgs(args)
+		err := cmd.Execute()
+
+		require.NoError(t, err)
+	})
 }
 
-func TestWitness(t *testing.T) {
-	serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, err := fmt.Fprint(w, "d1")
-		require.NoError(t, err)
-	}))
+func getOrb1Handler(t *testing.T, servicePath string) http.HandlerFunc {
+	t.Helper()
 
-	serv1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, err := fmt.Fprint(w, "{ \"items\": [ \"to\" ] }")
-		require.NoError(t, err)
-	}))
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.String() == servicePath:
+			_, err := fmt.Fprint(w, jsonActor1)
+			require.NoError(t, err)
+		case r.Method == http.MethodPost && r.URL.String() == fmt.Sprintf("%s/outbox", servicePath):
+			w.WriteHeader(http.StatusOK)
+		case r.URL.String() == fmt.Sprintf("%s/witnesses", servicePath):
+			_, err := fmt.Fprint(w, jsonCollection)
+			require.NoError(t, err)
+		case r.URL.String() == fmt.Sprintf("%s/witnesses?page=true", servicePath):
+			_, err := fmt.Fprint(w, jsonCollectionFirstPage)
+			require.NoError(t, err)
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+			_, err := fmt.Fprint(w, "Bad request")
+			require.NoError(t, err)
+		}
+	}
+}
 
-	t.Run("test failed to witness", func(t *testing.T) {
-		os.Clearenv()
-		cmd := GetCmd()
+func getOrb2Handler(t *testing.T, servicePath string) http.HandlerFunc {
+	t.Helper()
 
-		var args []string
-		args = append(args, outboxURL("wrongurl")...)
-		args = append(args, actor("actor")...)
-		args = append(args, to("to")...)
-		args = append(args, action("Undo")...)
-		args = append(args, inviteWitnessID("inviteWitnessID")...)
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.String() == servicePath:
+			_, err := fmt.Fprint(w, jsonActor2)
+			require.NoError(t, err)
+		case r.URL.String() == fmt.Sprintf("%s/inbox", servicePath):
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+			_, err := fmt.Fprint(w, "Bad request")
+			require.NoError(t, err)
+		}
+	}
+}
 
-		cmd.SetArgs(args)
-		err := cmd.Execute()
+func getOrb1AHandler(t *testing.T, servicePath string) http.HandlerFunc {
+	t.Helper()
 
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to send http request")
-	})
-
-	t.Run("success", func(t *testing.T) {
-		cmd := GetCmd()
-
-		var args []string
-		args = append(args, outboxURL(serv.URL)...)
-		args = append(args, actor(serv1.URL)...)
-		args = append(args, to("to")...)
-		args = append(args, action("InviteWitness")...)
-
-		cmd.SetArgs(args)
-		err := cmd.Execute()
-
-		require.NoError(t, err)
-	})
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.String() == servicePath:
+			_, err := fmt.Fprint(w, jsonActor1)
+			require.NoError(t, err)
+		case r.Method == http.MethodPost && r.URL.String() == fmt.Sprintf("%s/outbox", servicePath):
+			w.WriteHeader(http.StatusOK)
+		case r.URL.String() == fmt.Sprintf("%s/witnesses", servicePath):
+			_, err := fmt.Fprint(w, jsonEmptyCollection)
+			require.NoError(t, err)
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+			_, err := fmt.Fprint(w, "Bad request")
+			require.NoError(t, err)
+		}
+	}
 }
 
 func outboxURL(value string) []string {
@@ -245,3 +334,84 @@ func action(value string) []string {
 func inviteWitnessID(value string) []string {
 	return []string{flag + inviteWitnessFlagName, value}
 }
+
+func targetOverride(value string) []string {
+	return []string{flag + common.TargetOverrideFlagName, value}
+}
+
+const (
+	jsonActor1 = `{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://w3id.org/security/v1",
+    "https://w3id.org/activityanchors/v1"
+  ],
+  "id": "http://orb.domain1.com/services/anchor",
+  "publicKey": {
+    "id": "http://orb.domain1.com/services/anchor/keys/main-key",
+    "owner": "http://orb.domain1.com/services/anchor",
+    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhki....."
+  },
+  "followers": "http://orb.domain1.com/services/anchor/followers",
+  "following": "http://orb.domain1.com/services/anchor/following",
+  "inbox": "http://orb.domain1.com/services/anchor/inbox",
+  "liked": "http://orb.domain1.com/services/anchor/liked",
+  "likes": "http://orb.domain1.com/services/anchor/likes",
+  "outbox": "http://orb.domain1.com/services/anchor/outbox",
+  "shares": "http://orb.domain1.com/services/anchor/shares",
+  "type": "Service",
+  "witnesses": "http://orb.domain1.com/services/anchor/witnesses",
+  "witnessing": "http://orb.domain1.com/services/anchor/witnessing"
+}`
+
+	jsonActor2 = `{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://w3id.org/security/v1",
+    "https://w3id.org/activityanchors/v1"
+  ],
+  "id": "http://orb.domain2.com/services/anchor",
+  "publicKey": {
+    "id": "http://orb.domain2.com/services/anchor/keys/main-key",
+    "owner": "http://orb.domain2.com/services/anchor",
+    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhki....."
+  },
+  "followers": "http://orb.domain2.com/services/anchor/followers",
+  "following": "http://orb.domain2.com/services/anchor/following",
+  "inbox": "http://orb.domain2.com/services/anchor/inbox",
+  "liked": "http://orb.domain2.com/services/anchor/liked",
+  "likes": "http://orb.domain2.com/services/anchor/likes",
+  "outbox": "http://orb.domain2.com/services/anchor/outbox",
+  "shares": "http://orb.domain2.com/services/anchor/shares",
+  "type": "Service",
+  "witnesses": "http://orb.domain2.com/services/anchor/witnesses",
+  "witnessing": "http://orb.domain2.com/services/anchor/witnessing"
+}`
+
+	jsonCollection = `{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "first": "http://orb.domain1.com/services/anchor/witnesses?page=true",
+  "id": "http://orb.domain1.com/services/anchor/witnesses",
+  "last": "http://orb.domain1.com/services/anchor/witnesses?page=true&page-num=1",
+  "totalItems": 1,
+  "type": "Collection"
+ }`
+
+	jsonEmptyCollection = `{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "id": "http://orb.domain1.com/services/anchor/witnesses",
+  "totalItems": 0,
+  "type": "Collection"
+ }`
+
+	jsonCollectionFirstPage = `{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "id": "http://orb.domain1.com/services/anchor/witnesses?page=true&page-num=0",
+  "next": "http://orb.domain1.com/services/anchor/witnesses?page=true&page-num=1",
+  "items": [
+    "http://orb.domain2.com/services/anchor"
+  ],
+  "totalItems": 1,
+  "type": "CollectionPage"
+ }`
+)

--- a/test/bdd/bddtests_test.go
+++ b/test/bdd/bddtests_test.go
@@ -143,11 +143,13 @@ func FeatureContext(s *godog.Suite, state *state) {
 
 	bddContext.SetComposition(composition)
 
+	httpClient := newHTTPClient(state, bddContext)
+
 	// Context is shared between tests - for now
-	NewCommonSteps(bddContext, state).RegisterSteps(s)
+	NewCommonSteps(bddContext, state, httpClient).RegisterSteps(s)
 	NewDockerSteps(bddContext).RegisterSteps(s)
 	NewDIDSideSteps(bddContext, state, "did:orb").RegisterSteps(s)
-	NewCLISteps(bddContext, state).RegisterSteps(s)
+	NewCLISteps(bddContext, state, httpClient).RegisterSteps(s)
 	NewDriverSteps(bddContext, state).RegisterSteps(s)
 	NewStressSteps(bddContext).RegisterSteps(s)
 }

--- a/test/bdd/common_steps.go
+++ b/test/bdd/common_steps.go
@@ -62,11 +62,11 @@ type CommonSteps struct {
 }
 
 // NewCommonSteps create new CommonSteps struct
-func NewCommonSteps(context *BDDContext, state *state) *CommonSteps {
+func NewCommonSteps(context *BDDContext, state *state, httpClient *httpClient) *CommonSteps {
 	return &CommonSteps{
 		BDDContext: context,
 		state:      state,
-		httpClient: newHTTPClient(state, context),
+		httpClient: httpClient,
 	}
 }
 

--- a/test/bdd/features/orb-cli.feature
+++ b/test/bdd/features/orb-cli.feature
@@ -21,6 +21,7 @@ Feature: Using Orb CLI
 
     And orb-cli is executed with args 'acceptlist add --url https://localhost:48326/services/orb/acceptlist --actor https://orb.domain2.com/services/orb --type follow --tls-cacerts fixtures/keys/tls/ec-cacert.pem --auth-token ADMIN_TOKEN'
     And orb-cli is executed with args 'acceptlist add --url https://localhost:48426/services/orb/acceptlist --actor https://orb.domain1.com/services/orb --type invite-witness --tls-cacerts fixtures/keys/tls/ec-cacert.pem --auth-token ADMIN_TOKEN'
+    And orb-cli is executed with args 'acceptlist add --url https://localhost:48426/services/orb/acceptlist --actor https://orb.domain1.com/services/orb --type follow --tls-cacerts fixtures/keys/tls/ec-cacert.pem --auth-token ADMIN_TOKEN'
 
   @orb_cli_did
   Scenario: Create and update did doc using CLI and verify proofs in VCT log

--- a/test/bdd/httpclient.go
+++ b/test/bdd/httpclient.go
@@ -301,6 +301,13 @@ func (c *httpClient) MapDomain(domain string, mapping string) {
 	c.mappings[domain] = mapping
 }
 
+func (c *httpClient) HostMappings() map[string]string {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	return c.mappings
+}
+
 func (c *httpClient) resolveURL(url string) string {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()


### PR DESCRIPTION
For the follow and invite-witness commands, discover the actor ID and the following/witnesses endpoints from the actor at the service endpoint.

closes #1418

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>