### PR TITLE
refactor: Remove hard-coded URLs from BDD tests

### DIFF
--- a/test/bdd/bddtests_test.go
+++ b/test/bdd/bddtests_test.go
@@ -148,7 +148,7 @@ func FeatureContext(s *godog.Suite, state *state) {
 	// Context is shared between tests - for now
 	NewCommonSteps(bddContext, state, httpClient).RegisterSteps(s)
 	NewDockerSteps(bddContext).RegisterSteps(s)
-	NewDIDSideSteps(bddContext, state, "did:orb").RegisterSteps(s)
+	NewDIDSideSteps(bddContext, state, httpClient, "did:orb").RegisterSteps(s)
 	NewCLISteps(bddContext, state, httpClient).RegisterSteps(s)
 	NewDriverSteps(bddContext, state).RegisterSteps(s)
 	NewStressSteps(bddContext).RegisterSteps(s)

--- a/test/bdd/features/activitypub.feature
+++ b/test/bdd/features/activitypub.feature
@@ -13,10 +13,15 @@ Feature:
     And variable "domain3IRI" is assigned the value "https://orb.domain3.com/services/orb"
     And variable "domain4IRI" is assigned the value "https://orb.domain4.com/services/orb"
 
-    Given domain "orb.domain1.com" is mapped to "localhost:48326"
-    And domain "orb.domain2.com" is mapped to "localhost:48426"
-    And domain "orb.domain3.com" is mapped to "localhost:48626"
-    And domain "orb.domain4.com" is mapped to "localhost:48726"
+    Given variable "domain1ID" is assigned the value "${domain1IRI}"
+    And variable "domain2ID" is assigned the value "${domain2IRI}"
+    And variable "domain3ID" is assigned the value "${domain3IRI}"
+    And variable "domain4ID" is assigned the value "${domain4IRI}"
+
+    Given host "orb.domain1.com" is mapped to "localhost:48326"
+    And host "orb.domain2.com" is mapped to "localhost:48426"
+    And host "orb.domain3.com" is mapped to "localhost:48626"
+    And host "orb.domain4.com" is mapped to "localhost:48726"
 
     Given the authorization bearer token for "POST" requests to path "/services/orb/acceptlist" is set to "ADMIN_TOKEN"
     And the authorization bearer token for "GET" requests to path "/services/orb/acceptlist" is set to "READ_TOKEN"
@@ -28,7 +33,7 @@ Feature:
 
   @activitypub_service
   Scenario: Get ActivityPub service
-    When an HTTP GET is sent to "https://orb.domain1.com/services/orb"
+    When an HTTP GET is sent to "${domain1IRI}"
     Then the JSON path "type" of the response equals "Service"
     And the JSON path "inbox" of the response equals "${domain1IRI}/inbox"
     And the JSON path "outbox" of the response equals "${domain1IRI}/outbox"
@@ -37,9 +42,10 @@ Feature:
     And the JSON path "liked" of the response equals "${domain1IRI}/liked"
     And the JSON path "witnesses" of the response equals "${domain1IRI}/witnesses"
     And the JSON path "witnessing" of the response equals "${domain1IRI}/witnessing"
+    And the JSON path "shares" of the response equals "${domain1IRI}/shares"
     And the JSON path "publicKey.id" of the response equals "${domain1IRI}/keys/main-key"
 
-    When an HTTP GET is sent to "https://orb.domain2.com/services/orb"
+    When an HTTP GET is sent to "${domain2IRI}"
     Then the JSON path "type" of the response equals "Service"
     And the JSON path "inbox" of the response equals "${domain2IRI}/inbox"
     And the JSON path "outbox" of the response equals "${domain2IRI}/outbox"
@@ -49,19 +55,14 @@ Feature:
     And the JSON path "likes" of the response equals "${domain2IRI}/likes"
     And the JSON path "witnesses" of the response equals "${domain2IRI}/witnesses"
     And the JSON path "witnessing" of the response equals "${domain2IRI}/witnessing"
-    And the JSON path "publicKey.id" of the response equals "${domain2IRI}/keys/main-key"
     And the JSON path "shares" of the response equals "${domain2IRI}/shares"
+    And the JSON path "publicKey.id" of the response equals "${domain2IRI}/keys/main-key"
 
   @activitypub_pubkey
   Scenario: Get service public key
-    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/keys/main-key"
-    Then the JSON path "id" of the response equals "https://orb.domain1.com/services/orb/keys/main-key"
-    Then the JSON path "owner" of the response equals "https://orb.domain1.com/services/orb"
-    Then the JSON path "publicKeyPem" of the response is not empty
-
-    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/keys/main-key"
-    Then the JSON path "id" of the response equals "https://orb.domain2.com/services/orb/keys/main-key"
-    Then the JSON path "owner" of the response equals "https://orb.domain2.com/services/orb"
+    When an HTTP GET is sent to "${domain1IRI}/keys/main-key"
+    Then the JSON path "id" of the response equals "${domain1IRI}/keys/main-key"
+    Then the JSON path "owner" of the response equals "${domain1IRI}"
     Then the JSON path "publicKeyPem" of the response is not empty
 
   @activitypub_follow
@@ -71,38 +72,38 @@ Feature:
 
     # Invalid activity posted to Outbox
     Given variable "invalidActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","to":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${invalidActivity}" of type "application/json" and the returned status code is 400
+    When an HTTP POST is sent to "${domain2IRI}/outbox" with content "${invalidActivity}" of type "application/json" and the returned status code is 400
 
     # domain1 adds domain2 and domain3 to its 'follow' accept list.
-    Given variable "domain1AcceptList" is assigned the JSON value '[{"type":"follow","add":["${domain2IRI}","${domain3IRI}"]}]'
+    Given variable "domain1AcceptList" is assigned the JSON value '[{"type":"follow","add":["${domain2ID}","${domain3ID}"]}]'
     When an HTTP POST is sent to "${domain1IRI}/acceptlist" with content "${domain1AcceptList}" of type "application/json"
 
     When an HTTP GET is sent to "${domain1IRI}/acceptlist?type=follow"
-    Then the JSON path "url" of the response contains "${domain2IRI}"
-    Then the JSON path "url" of the response contains "${domain3IRI}"
+    Then the JSON path "url" of the response contains "${domain2ID}"
+    Then the JSON path "url" of the response contains "${domain3ID}"
 
     # domain1 removes domain3 from its 'follow' accept list.
-    Given variable "domain1AcceptList" is assigned the JSON value '[{"type":"follow","remove":["${domain3IRI}"]}]'
+    Given variable "domain1AcceptList" is assigned the JSON value '[{"type":"follow","remove":["${domain3ID}"]}]'
     When an HTTP POST is sent to "${domain1IRI}/acceptlist" with content "${domain1AcceptList}" of type "application/json"
 
     When an HTTP GET is sent to "${domain1IRI}/acceptlist?type=follow"
-    Then the JSON path "url" of the response contains "${domain2IRI}"
-    Then the JSON path "url" of the response does not contain "${domain3IRI}"
+    Then the JSON path "url" of the response contains "${domain2ID}"
+    Then the JSON path "url" of the response does not contain "${domain3ID}"
 
     # domain2 follows domain1
-    Given variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
+    Given variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain2ID}","to":"${domain1IRI}","object":"${domain1ID}"}'
+    When an HTTP POST is sent to "${domain2IRI}/outbox" with content "${followActivity}" of type "application/json"
     Then the value of the JSON string response is saved to variable "followID"
 
     # domain3 attempts to follow domain1 (should be rejected since domain3 is not in domain1's accept list)
-    Given variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain3IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
+    Given variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain3ID}","to":"${domain1IRI}","object":"${domain1ID}"}'
     When an HTTP POST is sent to "${domain3IRI}/outbox" with content "${followActivity}" of type "application/json"
 
     Then we wait 3 seconds
 
     # domain3 should have received a "Reject" from domain1.
     When an HTTP GET is sent to "${domain3IRI}/inbox?page=true"
-    Then the JSON path 'orderedItems.#(type="Reject").actor' of the response equals "https://orb.domain1.com/services/orb"
+    Then the JSON path 'orderedItems.#(type="Reject").actor' of the response equals "${domain1ID}"
     And the JSON path 'orderedItems.#(type="Reject").object.type' of the response equals "Follow"
 
     Given the authorization bearer token for "POST" requests to path "/services/orb/outbox" is set to "READ_TOKEN"
@@ -111,48 +112,48 @@ Feature:
     Then the JSON path "id" of the response equals "${followID}"
     And the JSON path "type" of the response equals "Follow"
 
-    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/inbox"
+    When an HTTP GET is sent to "${domain1IRI}/inbox"
     Then the JSON path "type" of the response equals "OrderedCollection"
     And the JSON path "id" of the response equals "${domain1IRI}/inbox"
     And the JSON path "first" of the response equals "${domain1IRI}/inbox?page=true"
 
-    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/inbox?page=true"
+    When an HTTP GET is sent to "${domain1IRI}/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.id" of the response contains "${followID}"
 
-    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/followers"
+    When an HTTP GET is sent to "${domain1IRI}/followers"
     Then the JSON path "type" of the response equals "Collection"
     And the JSON path "id" of the response equals "${domain1IRI}/followers"
     And the JSON path "first" of the response equals "${domain1IRI}/followers?page=true"
 
-    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/followers?page=true"
+    When an HTTP GET is sent to "${domain1IRI}/followers?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
-    And the JSON path "items" of the response contains "${domain2IRI}"
-    And the JSON path "items" of the response does not contain "${domain3IRI}"
+    And the JSON path "items" of the response contains "${domain2ID}"
+    And the JSON path "items" of the response does not contain "${domain3ID}"
 
-    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/following"
+    When an HTTP GET is sent to "${domain2IRI}/following"
     Then the JSON path "type" of the response equals "Collection"
     And the JSON path "id" of the response equals "${domain2IRI}/following"
     And the JSON path "first" of the response equals "${domain2IRI}/following?page=true"
 
-    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/following?page=true"
+    When an HTTP GET is sent to "${domain2IRI}/following?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
-    And the JSON path "items" of the response contains "${domain1IRI}"
+    And the JSON path "items" of the response contains "${domain1ID}"
 
     Given the authorization bearer token for "POST" requests to path "/services/orb/outbox" is set to "ADMIN_TOKEN"
 
-    And variable "undoFollowActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain2IRI}","to":"${domain1IRI}","object":{"actor":"${domain2IRI}","id":"${followID}","object":"${domain1IRI}","type":"Follow"}}'
-    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${undoFollowActivity}" of type "application/json"
+    And variable "undoFollowActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain2ID}","to":"${domain1IRI}","object":{"actor":"${domain2ID}","id":"${followID}","object":"${domain1ID}","type":"Follow"}}'
+    When an HTTP POST is sent to "${domain2IRI}/outbox" with content "${undoFollowActivity}" of type "application/json"
 
     Then we wait 3 seconds
 
-    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/following?page=true"
+    When an HTTP GET is sent to "${domain2IRI}/following?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
-    And the JSON path "items" of the response does not contain "${domain1IRI}"
+    And the JSON path "items" of the response does not contain "${domain1ID}"
 
-    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/followers?page=true"
+    When an HTTP GET is sent to "${domain1IRI}/followers?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
-    And the JSON path "items" of the response does not contain "${domain2IRI}"
+    And the JSON path "items" of the response does not contain "${domain2ID}"
 
   @activitypub_create
   Scenario: create/announce
@@ -160,62 +161,66 @@ Feature:
     And the authorization bearer token for "GET" requests to path "/services/orb" is set to "READ_TOKEN"
 
     # domain1 adds domain2 to its 'follow' accept list.
-    Given variable "domain1AcceptList" is assigned the JSON value '[{"type":"follow","add":["${domain2IRI}"]}]'
+    Given variable "domain1AcceptList" is assigned the JSON value '[{"type":"follow","add":["${domain2ID}"]}]'
     When an HTTP POST is sent to "${domain1IRI}/acceptlist" with content "${domain1AcceptList}" of type "application/json"
 
     # domain2 adds domain3 to its 'follow' accept list.
-    Given variable "domain2AcceptList" is assigned the JSON value '[{"type":"follow","add":["${domain3IRI}"]}]'
+    Given variable "domain2AcceptList" is assigned the JSON value '[{"type":"follow","add":["${domain3ID}"]}]'
     When an HTTP POST is sent to "${domain2IRI}/acceptlist" with content "${domain2AcceptList}" of type "application/json"
 
     # domain2 follows domain1
-    Given variable "followDomain1Activity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${followDomain1Activity}" of type "application/json"
+    Given variable "followDomain1Activity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain2ID}","to":"${domain1IRI}","object":"${domain1ID}"}'
+    When an HTTP POST is sent to "${domain2IRI}/outbox" with content "${followDomain1Activity}" of type "application/json"
     Then the value of the JSON string response is saved to variable "follow1ID"
 
     # domain3 follows domain2
-    And variable "followDomain2Activity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain3IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain3.com/services/orb/outbox" with content "${followDomain2Activity}" of type "application/json"
+    And variable "followDomain2Activity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain3ID}","to":"${domain2IRI}","object":"${domain2ID}"}'
+    When an HTTP POST is sent to "${domain3IRI}/outbox" with content "${followDomain2Activity}" of type "application/json"
     Then the value of the JSON string response is saved to variable "follow2ID"
 
     Then we wait 2 seconds
 
-    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/followers?page=true"
+    When an HTTP GET is sent to "${domain2IRI}/followers?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
-    And the JSON path "items" of the response contains "${domain3IRI}"
+    And the JSON path "items" of the response contains "${domain3ID}"
+
+    When an HTTP GET is sent to "${domain3IRI}/following?page=true"
+    Then the JSON path "type" of the response equals "CollectionPage"
+    And the JSON path "items" of the response contains "${domain2ID}"
 
     # Post 'Create' activity to domain1's outbox
-    When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content from file "./fixtures/testdata/create_activity.json"
+    When an HTTP POST is sent to "${domain1IRI}/outbox" with content from file "./fixtures/testdata/create_activity.json"
 
     Then we wait 2 seconds
 
     # A 'Create' activity should have been posted to domain1's followers (domain2).
-    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/inbox?page=true"
+    When an HTTP GET is sent to "${domain2IRI}/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.id" of the response contains "${domain1IRI}/activities/292c7239-74a6-4837-93af-5103f37c3999"
 
     # An 'Announce' activity should have been posted to domain2's followers (domain3).
-    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/outbox?page=true"
+    When an HTTP GET is sent to "${domain2IRI}/outbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.type" of the response contains "Announce"
 
     # An 'Announce' activity should have been received by domain3 since it's a follower of domain2.
-    When an HTTP GET is sent to "https://orb.domain3.com/services/orb/inbox?page=true"
+    When an HTTP GET is sent to "${domain3IRI}/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.type" of the response contains "Announce"
 
-    And variable "undoFollow1Activity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain2IRI}","to":"${domain1IRI}","object":{"actor":"${domain2IRI}","id":"${follow1ID}","object":"${domain1IRI}","type":"Follow"}}'
-    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${undoFollow1Activity}" of type "application/json"
+    And variable "undoFollow1Activity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain2ID}","to":"${domain1IRI}","object":{"actor":"${domain2ID}","id":"${follow1ID}","object":"${domain1ID}","type":"Follow"}}'
+    When an HTTP POST is sent to "${domain2IRI}/outbox" with content "${undoFollow1Activity}" of type "application/json"
 
-    And variable "undoFollow2Activity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain3IRI}","to":"${domain2IRI}","object":{"actor":"${domain3IRI}","id":"${follow2ID}","object":"${domain2IRI}","type":"Follow"}}'
-    When an HTTP POST is sent to "https://orb.domain3.com/services/orb/outbox" with content "${undoFollow2Activity}" of type "application/json"
+    And variable "undoFollow2Activity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain3ID}","to":"${domain2IRI}","object":{"actor":"${domain3ID}","id":"${follow2ID}","object":"${domain2ID}","type":"Follow"}}'
+    When an HTTP POST is sent to "${domain3IRI}/outbox" with content "${undoFollow2Activity}" of type "application/json"
 
     Then we wait 2 seconds
 
-    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/followers?page=true"
+    When an HTTP GET is sent to "${domain2IRI}/followers?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
-    And the JSON path "items" of the response does not contain "${domain3IRI}"
+    And the JSON path "items" of the response does not contain "${domain3ID}"
 
-    When an HTTP GET is sent to "https://orb.domain3.com/services/orb/shares/hl%3AuEiDrc_UAilungcq-Q31iKZu6fiAMYCcZ8PpFycl55dstGg%3AuoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpRHJjX1VBaWx1bmdjcS1RMzFpS1p1NmZpQU1ZQ2NaOFBwRnljbDU1ZHN0R2d4QmlwZnM6Ly9iYWZrcmVpaGxvcDJxYmNzM3U2YTR2cHNkcHZyY3RnNTJweXFheXliaGRoeXB1cm9qemY0Nmx3em5kaQ"
+    When an HTTP GET is sent to "${domain3IRI}/shares/hl%3AuEiDrc_UAilungcq-Q31iKZu6fiAMYCcZ8PpFycl55dstGg%3AuoQ-CeEtodHRwczovL29yYi5kb21haW4xLmNvbS9jYXMvdUVpRHJjX1VBaWx1bmdjcS1RMzFpS1p1NmZpQU1ZQ2NaOFBwRnljbDU1ZHN0R2d4QmlwZnM6Ly9iYWZrcmVpaGxvcDJxYmNzM3U2YTR2cHNkcHZyY3RnNTJweXFheXliaGRoeXB1cm9qemY0Nmx3em5kaQ"
     Then the JSON path "type" of the response equals "OrderedCollection"
     Then the JSON path "first" of the response is saved to variable "sharesFirstPage"
     When an HTTP GET is sent to "${sharesFirstPage}"
@@ -228,64 +233,64 @@ Feature:
     And the authorization bearer token for "GET" requests to path "/services/orb" is set to "READ_TOKEN"
 
     # domain2 adds domain1 to its 'invite-witness' accept list.
-    Given variable "domain2AcceptList" is assigned the JSON value '[{"type":"invite-witness","add":["${domain1IRI}"]}]'
+    Given variable "domain2AcceptList" is assigned the JSON value '[{"type":"invite-witness","add":["${domain1ID}"]}]'
     When an HTTP POST is sent to "${domain2IRI}/acceptlist" with content "${domain2AcceptList}" of type "application/json"
 
     # domain1 invites domain2 to be a witness
-    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain1IRI}","to":"${domain2IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain1ID}","to":"${domain2IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain2ID}"}'
+    When an HTTP POST is sent to "${domain1IRI}/outbox" with content "${inviteWitnessActivity}" of type "application/json"
     Then the value of the JSON string response is saved to variable "inviteWitnessID"
 
     # domain4 attempts to invite domain2 to be a witness (the request is rejected since domain4 is not in domain2's accept list)
-    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain4IRI}","to":"${domain2IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain2IRI}"}'
+    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain4ID}","to":"${domain2IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain2ID}"}'
     When an HTTP POST is sent to "${domain4IRI}/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     Then we wait 3 seconds
 
     # domain4 should have received a "Reject" from domain2.
     When an HTTP GET is sent to "${domain4IRI}/inbox?page=true"
-    Then the JSON path 'orderedItems.#(type="Reject").actor' of the response equals "https://orb.domain2.com/services/orb"
+    Then the JSON path 'orderedItems.#(type="Reject").actor' of the response equals "${domain2ID}"
     And the JSON path 'orderedItems.#(type="Reject").object.type' of the response equals "Invite"
     And the JSON path 'orderedItems.#(type="Reject").object.object' of the response equals "https://w3id.org/activityanchors#AnchorWitness"
 
-    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/inbox?page=true"
+    When an HTTP GET is sent to "${domain2IRI}/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.id" of the response contains "${inviteWitnessID}"
 
-    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/witnesses"
+    When an HTTP GET is sent to "${domain1IRI}/witnesses"
     Then the JSON path "type" of the response equals "Collection"
     And the JSON path "id" of the response equals "${domain1IRI}/witnesses"
     And the JSON path "first" of the response equals "${domain1IRI}/witnesses?page=true"
 
-    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/witnesses?page=true"
+    When an HTTP GET is sent to "${domain1IRI}/witnesses?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
-    And the JSON path "items" of the response contains "${domain2IRI}"
+    And the JSON path "items" of the response contains "${domain2ID}"
 
-    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/witnessing"
+    When an HTTP GET is sent to "${domain2IRI}/witnessing"
     Then the JSON path "type" of the response equals "Collection"
     And the JSON path "id" of the response equals "${domain2IRI}/witnessing"
     And the JSON path "first" of the response equals "${domain2IRI}/witnessing?page=true"
 
-    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/witnessing?page=true"
+    When an HTTP GET is sent to "${domain2IRI}/witnessing?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
-    And the JSON path "items" of the response contains "${domain1IRI}"
-    And the JSON path "items" of the response does not contain "${domain3IRI}"
+    And the JSON path "items" of the response contains "${domain1ID}"
+    And the JSON path "items" of the response does not contain "${domain3ID}"
 
-    When variable "invalidUndoInviteWitnessActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain2IRI}","to":"${domain2IRI}","object":{"actor":"${domain1IRI}","id":"${inviteWitnessID}","object":"${domain2IRI}","type":"Invite"}}'
-    Then an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${invalidUndoInviteWitnessActivity}" of type "application/json" and the returned status code is 400
+    When variable "invalidUndoInviteWitnessActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain2ID}","to":"${domain2IRI}","object":{"actor":"${domain1ID}","id":"${inviteWitnessID}","object":"${domain2ID}","type":"Invite"}}'
+    Then an HTTP POST is sent to "${domain1IRI}/outbox" with content "${invalidUndoInviteWitnessActivity}" of type "application/json" and the returned status code is 400
 
-    And variable "undoInviteWitnessActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain1IRI}","to":"${domain2IRI}","object":{"actor":"${domain1IRI}","id":"${inviteWitnessID}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain2IRI}","type":"Invite"}}'
-    When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${undoInviteWitnessActivity}" of type "application/json"
+    And variable "undoInviteWitnessActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain1ID}","to":"${domain2IRI}","object":{"actor":"${domain1ID}","id":"${inviteWitnessID}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain2ID}","type":"Invite"}}'
+    When an HTTP POST is sent to "${domain1IRI}/outbox" with content "${undoInviteWitnessActivity}" of type "application/json"
 
     Then we wait 3 seconds
 
-    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/witnesses?page=true"
+    When an HTTP GET is sent to "${domain1IRI}/witnesses?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
-    And the JSON path "items" of the response does not contain "${domain2IRI}"
+    And the JSON path "items" of the response does not contain "${domain2ID}"
 
-    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/witnessing?page=true"
+    When an HTTP GET is sent to "${domain2IRI}/witnessing?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
-    And the JSON path "items" of the response does not contain "${domain1IRI}"
+    And the JSON path "items" of the response does not contain "${domain1ID}"
 
   @activitypub_offer
   Scenario: offer/like
@@ -293,102 +298,102 @@ Feature:
     And the authorization bearer token for "GET" requests to path "/services/orb" is set to "READ_TOKEN"
 
     # domain2 invites domain1 to be a witness
-    Given variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain2IRI}","to":"${domain1IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    Given variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain2ID}","to":"${domain1IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain1ID}"}'
+    When an HTTP POST is sent to "${domain2IRI}/outbox" with content "${inviteWitnessActivity}" of type "application/json"
     Then the value of the JSON string response is saved to variable "inviteWitnessID"
 
     Then we wait 2 seconds
 
-    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/inbox?page=true"
+    When an HTTP GET is sent to "${domain1IRI}/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.id" of the response contains "${inviteWitnessID}"
 
-    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content from file "./fixtures/testdata/offer_activity.json"
+    When an HTTP POST is sent to "${domain2IRI}/outbox" with content from file "./fixtures/testdata/offer_activity.json"
 
     Then we wait 2 seconds
 
     # The 'Offer' activity should be in the inbox of domain1.
-    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/inbox?page=true"
+    When an HTTP GET is sent to "${domain1IRI}/inbox?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#.id" of the response contains "${domain2IRI}/activities/cbc4ebd2-d30d-4cc3-80d4-dcd770904f1c"
 
-    And variable "undoInviteWitnessActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain2IRI}","to":"${domain1IRI}","object":{"actor":"${domain2IRI}","id":"${inviteWitnessID}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain1IRI}","type":"Invite"}}'
-    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${undoInviteWitnessActivity}" of type "application/json"
+    And variable "undoInviteWitnessActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain2ID}","to":"${domain1IRI}","object":{"actor":"${domain2ID}","id":"${inviteWitnessID}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain1ID}","type":"Invite"}}'
+    When an HTTP POST is sent to "${domain2IRI}/outbox" with content "${undoInviteWitnessActivity}" of type "application/json"
 
-    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/witnessing?page=true"
+    When an HTTP GET is sent to "${domain2IRI}/witnessing?page=true"
     Then the JSON path "type" of the response equals "CollectionPage"
-    And the JSON path "items" of the response does not contain "${domain1IRI}"
+    And the JSON path "items" of the response does not contain "${domain1ID}"
 
 #  @activitypub_httpsig
 #  Scenario: Tests HTTP signature verification
-#    Given variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
+#    Given variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain2ID}","to":"${domain1IRI}","object":"${domain1ID}"}'
 #
 #    # No signature on POST
-#    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${followActivity}" of type "application/json" and the returned status code is 401
+#    When an HTTP POST is sent to "${domain2IRI}/outbox" with content "${followActivity}" of type "application/json" and the returned status code is 401
 #
 #    # Invalid signature on POST
-#    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${followActivity}" of type "application/json" signed with KMS key from "domain1" and the returned status code is 401
+#    When an HTTP POST is sent to "${domain2IRI}/outbox" with content "${followActivity}" of type "application/json" signed with KMS key from "domain1" and the returned status code is 401
 #
 #    # Valid signature on POST
-#    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${followActivity}" of type "application/json" signed with KMS key from "domain2"
+#    When an HTTP POST is sent to "${domain2IRI}/outbox" with content "${followActivity}" of type "application/json" signed with KMS key from "domain2"
 #    Then the value of the JSON string response is saved to variable "followID"
 #
 #    Then we wait 2 seconds
 #
 #    # No signature on GET
-#    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/inbox" and the returned status code is 401
-#    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/followers" and the returned status code is 401
+#    When an HTTP GET is sent to "${domain1IRI}/inbox" and the returned status code is 401
+#    When an HTTP GET is sent to "${domain1IRI}/followers" and the returned status code is 401
 #
 #    # Valid signature on GET with actor as a follower - should be allowed
-#    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/inbox" signed with KMS key from "domain2"
+#    When an HTTP GET is sent to "${domain1IRI}/inbox" signed with KMS key from "domain2"
 #    Then the JSON path "type" of the response equals "OrderedCollection"
 #
 #    # Valid signature on GET with actor as non-follower/non-witness - should be denied
-#    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/inbox" signed with KMS key from "domain3" and the returned status code is 401
+#    When an HTTP GET is sent to "${domain1IRI}/inbox" signed with KMS key from "domain3" and the returned status code is 401
 #
-#    And variable "undoFollowActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain2IRI}","to":"${domain1IRI}","object":{"actor":"${domain2IRI}","id":"${followID}","object":"${domain1IRI}","type":"Follow"}}'
-#    Then an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${undoFollowActivity}" of type "application/json" signed with KMS key from "domain2"
+#    And variable "undoFollowActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain2ID}","to":"${domain1IRI}","object":{"actor":"${domain2ID}","id":"${followID}","object":"${domain1ID}","type":"Follow"}}'
+#    Then an HTTP POST is sent to "${domain2IRI}/outbox" with content "${undoFollowActivity}" of type "application/json" signed with KMS key from "domain2"
 
   @activitypub_auth_token
   Scenario: Tests authorization tokens
     # No auth token or signature on POST
-    Given variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${followActivity}" of type "application/json" and the returned status code is 401
-    When an HTTP POST is sent to "https://orb.domain3.com/services/orb/inbox" with content "${followActivity}" of type "application/json" and the returned status code is 401
-    When an HTTP POST is sent to "https://orb.domain3.com/services/orb/outbox" with content "${followActivity}" of type "application/json" and the returned status code is 401
+    Given variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain2ID}","to":"${domain1IRI}","object":"${domain1ID}"}'
+    When an HTTP POST is sent to "${domain2IRI}/outbox" with content "${followActivity}" of type "application/json" and the returned status code is 401
+    When an HTTP POST is sent to "${domain3IRI}/inbox" with content "${followActivity}" of type "application/json" and the returned status code is 401
+    When an HTTP POST is sent to "${domain3IRI}/outbox" with content "${followActivity}" of type "application/json" and the returned status code is 401
 
     # Set auth token
     Given the authorization bearer token for "POST" requests to path "/services/orb/outbox" is set to "ADMIN_TOKEN"
-    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
+    When an HTTP POST is sent to "${domain2IRI}/outbox" with content "${followActivity}" of type "application/json"
     Then the value of the JSON string response is saved to variable "followID"
 
     Then we wait 2 seconds
 
-    And variable "undoFollowActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain2IRI}","to":["${domain1IRI}","https://www.w3.org/ns/activitystreams#Public"],"object":{"actor":"${domain2IRI}","id":"${followID}","object":"${domain1IRI}","type":"Follow"}}'
-    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${undoFollowActivity}" of type "application/json"
+    And variable "undoFollowActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain2ID}","to":["${domain1IRI}","https://www.w3.org/ns/activitystreams#Public"],"object":{"actor":"${domain2ID}","id":"${followID}","object":"${domain1ID}","type":"Follow"}}'
+    When an HTTP POST is sent to "${domain2IRI}/outbox" with content "${undoFollowActivity}" of type "application/json"
     Then the value of the JSON string response is saved to variable "undoFollowID"
 
     # No auth token or signature on GET
     When an HTTP GET is sent to "${followID}" and the returned status code is 401
-    And an HTTP GET is sent to "https://orb.domain1.com/services/orb/inbox" and the returned status code is 401
+    And an HTTP GET is sent to "${domain1IRI}/inbox" and the returned status code is 401
 
     # Domain3 doesn't require authorization for reads
-    When an HTTP GET is sent to "https://orb.domain3.com/services/orb/inbox"
+    When an HTTP GET is sent to "${domain3IRI}/inbox"
     Then the JSON path "type" of the response equals "OrderedCollection"
-    When an HTTP GET is sent to "https://orb.domain3.com/services/orb/outbox"
+    When an HTTP GET is sent to "${domain3IRI}/outbox"
     Then the JSON path "type" of the response equals "OrderedCollection"
-    When an HTTP GET is sent to "https://orb.domain3.com/services/orb/followers"
+    When an HTTP GET is sent to "${domain3IRI}/followers"
     Then the JSON path "type" of the response equals "Collection"
-    When an HTTP GET is sent to "https://orb.domain3.com/services/orb/witnesses"
+    When an HTTP GET is sent to "${domain3IRI}/witnesses"
     Then the JSON path "type" of the response equals "Collection"
-    When an HTTP GET is sent to "https://orb.domain3.com/services/orb/liked"
+    When an HTTP GET is sent to "${domain3IRI}/liked"
     Then the JSON path "type" of the response equals "OrderedCollection"
 
     # Activities that are sent to https://www.w3.org/ns/activitystreams#Public don't require authentication
     When an HTTP GET is sent to "${undoFollowID}"
     Then the JSON path "type" of the response equals "Undo"
 
-    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/outbox?page=true"
+    When an HTTP GET is sent to "${domain2IRI}/outbox?page=true"
     # Public activities should be returned
     Then the JSON path "orderedItems.#.id" of the response contains "${undoFollowID}"
     # Non-public activities should be excluded with no authentication
@@ -402,9 +407,9 @@ Feature:
     When an HTTP GET is sent to "${followID}"
     Then the JSON path "type" of the response equals "Follow"
 
-    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/inbox"
+    When an HTTP GET is sent to "${domain1IRI}/inbox"
     Then the JSON path "type" of the response equals "OrderedCollection"
 
-    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/outbox?page=true"
+    When an HTTP GET is sent to "${domain2IRI}/outbox?page=true"
     Then the JSON path "orderedItems.#.id" of the response contains "${undoFollowID}"
     And the JSON path "orderedItems.#.id" of the response contains "${followID}"

--- a/test/bdd/features/create-dids-to-file.feature
+++ b/test/bdd/features/create-dids-to-file.feature
@@ -21,10 +21,11 @@ Feature:
   @all
   @create_and_verify_dids_from_file
   Scenario: Create DIDs, store them in a file and verify the DIDs from the file.
-    Given domain "orb.domain1.com" is mapped to "localhost:48326"
-    And domain "orb.domain2.com" is mapped to "localhost:48426"
+    Given host "orb.domain1.com" is mapped to "localhost:48326"
+    And host "orb.domain2.com" is mapped to "localhost:48426"
     And variable "domain1IRI" is assigned the value "https://orb.domain1.com/services/orb"
     And variable "domain2IRI" is assigned the value "https://orb.domain2.com/services/orb"
+    And variable "domain2ID" is assigned the value "${domain2IRI}"
 
     Given the authorization bearer token for "GET" requests to path "/sidetree/v1/identifiers" is set to "READ_TOKEN"
     And the authorization bearer token for "POST" requests to path "/sidetree/v1/operations" is set to "ADMIN_TOKEN"
@@ -39,8 +40,8 @@ Feature:
     When an HTTP POST is sent to "${domain2IRI}/acceptlist" with content "${domain2AcceptList}" of type "application/json"
 
     # domain1 invites domain2 to be a witness
-    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain1IRI}","to":"${domain2IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain1IRI}","to":"${domain2IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain2ID}"}'
+    When an HTTP POST is sent to "${domain1IRI}/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     Then client sends request to domains "https://orb.domain1.com" to create "50" DID documents using "5" concurrent requests and a maximum of "2" attempts, storing the dids to file "./fixtures/dids.txt"
     And client sends request to domains "https://orb.domain1.com" to verify the DID documents that were created from file "./fixtures/dids.txt" with a maximum of "25" attempts

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -13,11 +13,24 @@ Feature:
     And variable "domain3IRI" is assigned the value "https://orb.domain3.com/services/orb"
     And variable "domain4IRI" is assigned the value "https://orb.domain4.com/services/orb"
 
-    Given domain "orb.domain1.com" is mapped to "localhost:48326"
-    And domain "orb.domain2.com" is mapped to "localhost:48426"
-    And domain "orb.domain3.com" is mapped to "localhost:48626"
-    And domain "orb.domain4.com" is mapped to "localhost:48726"
-    And domain "orb.domain5.com" is mapped to "localhost:49026"
+    Given variable "domain1ID" is assigned the value "${domain1IRI}"
+    And variable "domain2ID" is assigned the value "${domain2IRI}"
+    And variable "domain3ID" is assigned the value "${domain3IRI}"
+    And variable "domain4ID" is assigned the value "${domain4IRI}"
+
+    Given host "orb.domain1.com" is mapped to "localhost:48326"
+    And host "orb2.domain1.com" is mapped to "localhost:48526"
+    And host "orb.domain2.com" is mapped to "localhost:48426"
+    And host "orb.domain3.com" is mapped to "localhost:48626"
+    And host "orb.domain4.com" is mapped to "localhost:48726"
+    And host "orb.domain5.com" is mapped to "localhost:49026"
+
+    Given anchor origin for host "orb.domain1.com" is set to "https://orb.domain1.com"
+    And anchor origin for host "orb2.domain1.com" is set to "ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q"
+    And anchor origin for host "orb.domain2.com" is set to "https://orb.domain1.com"
+    And anchor origin for host "orb.domain3.com" is set to "https://orb.domain3.com"
+    And anchor origin for host "orb.domain4.com" is set to "https://orb.domain1.com"
+    And anchor origin for host "orb.domain5.com" is set to "https://orb.domain5.com"
 
     Given the authorization bearer token for "POST" requests to path "/services/orb/outbox" is set to "ADMIN_TOKEN"
     And the authorization bearer token for "POST" requests to path "/services/orb/acceptlist" is set to "ADMIN_TOKEN"
@@ -42,51 +55,51 @@ Feature:
     When an HTTP GET is sent to "https://orb.domain2.com/log" and the returned status code is 404
 
     # domain1 adds domain2 and domain3 to its 'follow' and 'invite-witness' accept lists.
-    Given variable "domain1AcceptList" is assigned the JSON value '[{"type":"follow","add":["${domain2IRI}","${domain3IRI}"]},{"type":"invite-witness","add":["${domain2IRI}","${domain3IRI}"]}]'
+    Given variable "domain1AcceptList" is assigned the JSON value '[{"type":"follow","add":["${domain2ID}","${domain3ID}"]},{"type":"invite-witness","add":["${domain2ID}","${domain3ID}"]}]'
     When an HTTP POST is sent to "${domain1IRI}/acceptlist" with content "${domain1AcceptList}" of type "application/json"
 
     # domain2 adds domain1 to its 'follow' and 'invite-witness' accept lists.
-    Given variable "domain2AcceptList" is assigned the JSON value '[{"type":"follow","add":["${domain1IRI}"]},{"type":"invite-witness","add":["${domain1IRI}","${domain4IRI}"]}]'
+    Given variable "domain2AcceptList" is assigned the JSON value '[{"type":"follow","add":["${domain1ID}"]},{"type":"invite-witness","add":["${domain1ID}","${domain4ID}"]}]'
     When an HTTP POST is sent to "${domain2IRI}/acceptlist" with content "${domain2AcceptList}" of type "application/json"
 
     When an HTTP GET is sent to "${domain1IRI}/acceptlist"
-    Then the JSON path '#(type="follow").url' of the response contains "${domain2IRI}"
-    Then the JSON path '#(type="follow").url' of the response contains "${domain3IRI}"
-    Then the JSON path '#(type="invite-witness").url' of the response contains "${domain2IRI}"
-    Then the JSON path '#(type="invite-witness").url' of the response contains "${domain3IRI}"
+    Then the JSON path '#(type="follow").url' of the response contains "${domain2ID}"
+    Then the JSON path '#(type="follow").url' of the response contains "${domain3ID}"
+    Then the JSON path '#(type="invite-witness").url' of the response contains "${domain2ID}"
+    Then the JSON path '#(type="invite-witness").url' of the response contains "${domain3ID}"
 
     # domain2 server follows domain1 server
-    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
+    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain2ID}","to":"${domain1IRI}","object":"${domain1ID}"}'
+    When an HTTP POST is sent to "${domain2IRI}/outbox" with content "${followActivity}" of type "application/json"
 
     # domain1 server follows domain2 server
-    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
+    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain1ID}","to":"${domain2IRI}","object":"${domain2ID}"}'
+    When an HTTP POST is sent to "${domain1IRI}/outbox" with content "${followActivity}" of type "application/json"
 
     # domain3 server follows domain1 server. Domain3 needs to be a follower of domain1 so that HTTP signature validation succeeds when
     # the /cas endpoint is invoked on domain1 (since only followers and witnesses are authorized).
-    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain3IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain3.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
+    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain3ID}","to":"${domain1IRI}","object":"${domain1ID}"}'
+    When an HTTP POST is sent to "${domain3IRI}/outbox" with content "${followActivity}" of type "application/json"
 
     # domain1 invites domain2 to be a witness
-    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain1IRI}","to":"${domain2IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain1ID}","to":"${domain2IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain2ID}"}'
+    When an HTTP POST is sent to "${domain1IRI}/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     # domain2 invites domain1 to be a witness
-    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain2IRI}","to":"${domain1IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain2ID}","to":"${domain1IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain1ID}"}'
+    When an HTTP POST is sent to "${domain2IRI}/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     # domain3 invites domain1 to be a witness
-    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain3IRI}","to":"${domain1IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain3.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain3ID}","to":"${domain1IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain1ID}"}'
+    When an HTTP POST is sent to "${domain3IRI}/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     # domain4 invites domain3 to be a witness
-    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain4IRI}","to":"${domain3IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain3IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain4.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain4ID}","to":"${domain3IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain3ID}"}'
+    When an HTTP POST is sent to "${domain4IRI}/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     # domain4 invites domain2 to be a witness
-    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain4IRI}","to":"${domain2IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain4.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain4ID}","to":"${domain2IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain2ID}"}'
+    When an HTTP POST is sent to "${domain4IRI}/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     # set witness policy for domain1
     When an HTTP POST is sent to "https://orb.domain1.com/policy" with content "MinPercent(100,batch) AND MinPercent(50,system)" of type "text/plain"
@@ -97,7 +110,7 @@ Feature:
     Then we wait 3 seconds
 
   @vct_log_rotation_REST_test
-  Scenario: various did doc operations
+  Scenario: rotate VCT log
     Given the authorization bearer token for "POST" requests to path "/log" is set to "ADMIN_TOKEN"
     And the authorization bearer token for "POST" requests to path "/log-monitor" is set to "ADMIN_TOKEN"
 
@@ -360,7 +373,7 @@ Feature:
     Then we wait 5 seconds
     Then client sends request to "https://orb.domain3.com/sidetree/v1/identifiers,https://orb.domain1.com/sidetree/v1/identifiers,https://orb2.domain1.com/sidetree/v1/identifiers,https://orb.domain2.com/sidetree/v1/identifiers" to verify the DID documents that were created
 
-    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/liked?page=true"
+    When an HTTP GET is sent to "${domain1IRI}/liked?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems" of the array response is not empty
     And the JSON path "orderedItems.0" of the response is saved to variable "anchorLink"
@@ -381,36 +394,36 @@ Feature:
     When an HTTP GET is sent to "${vcID}"
     Then the JSON path "id" of the response equals "${vcID}"
 
-    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/likes/${anchorLinkEncoded}?page=true"
+    When an HTTP GET is sent to "${domain2IRI}/likes/${anchorLinkEncoded}?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
      # There should be two Like's:
      # 1 - From domain1 (which received the 'Create');
      # 2 - From domain3 (which received the 'Announce')
     And the JSON path "orderedItems.#" of the response has 2 items
-    And the JSON path "orderedItems.#.actor" of the response contains "${domain1IRI}"
-    And the JSON path "orderedItems.#.actor" of the response contains "${domain3IRI}"
+    And the JSON path "orderedItems.#.actor" of the response contains "${domain1ID}"
+    And the JSON path "orderedItems.#.actor" of the response contains "${domain3ID}"
     And the JSON path "orderedItems.0.object.url" of the response equals "${anchorLink}"
-    And the JSON path 'orderedItems.#(actor="https://orb.domain1.com/services/orb")' of the raw response is saved to variable "likeActivity"
+    And the JSON path 'orderedItems.#(actor="${domain1ID}")' of the raw response is saved to variable "likeActivity"
 
-    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/likes/${anchorLinkEncoded}?page=true"
+    When an HTTP GET is sent to "${domain1IRI}/likes/${anchorLinkEncoded}?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
      # There should be one Like:
      # 1 - From domain3 (which received the 'Announce')
     And the JSON path "orderedItems.#" of the response has 1 items
-    And the JSON path "orderedItems.#.actor" of the response contains "${domain3IRI}"
+    And the JSON path "orderedItems.#.actor" of the response contains "${domain3ID}"
     And the JSON path "orderedItems.0.object.url" of the response equals "${anchorLink}"
 
-    Given variable "undoLikeActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain1IRI}","to":"${domain2IRI}","object":#{likeActivity}}'
+    Given variable "undoLikeActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Undo","actor":"${domain1ID}","to":"${domain2IRI}","object":#{likeActivity}}'
     When an HTTP POST is sent to "${domain1IRI}/outbox" with content "${undoLikeActivity}" of type "application/json"
 
     Then we wait 2 seconds
 
-    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/liked?page=true"
+    When an HTTP GET is sent to "${domain1IRI}/liked?page=true"
     Then the JSON path "orderedItems.0.object.url" of the response does not contain "${anchorLink}"
 
-    When an HTTP GET is sent to "https://orb.domain2.com/services/orb/likes/${anchorLinkEncoded}?page=true"
+    When an HTTP GET is sent to "${domain2IRI}/likes/${anchorLinkEncoded}?page=true"
     Then the JSON path "orderedItems.#" of the response has 1 items
-    And the JSON path "orderedItems.#.actor" of the response contains "${domain3IRI}"
+    And the JSON path "orderedItems.#.actor" of the response contains "${domain3ID}"
 
   @all
   @resolve_unpublished_create
@@ -651,7 +664,7 @@ Feature:
     And the JSON path "links.#.href" of the response contains expression ".*orb\.domain2\.com.*"
     And the JSON path "links.#.href" of the response contains expression ".*orb\.domain3\.com.*"
 
-    When an HTTP GET is sent to "https://orb.domain1.com/services/orb/likes/${anchorLinkEncoded}?page=true"
+    When an HTTP GET is sent to "${domain1IRI}/likes/${anchorLinkEncoded}?page=true"
     Then the JSON path "type" of the response equals "OrderedCollectionPage"
     And the JSON path "orderedItems.#" of the response has 2 items
     And the JSON path "orderedItems.0" of the raw response is saved to variable "likeActivity_1"

--- a/test/bdd/features/did-sidetree.feature
+++ b/test/bdd/features/did-sidetree.feature
@@ -11,9 +11,17 @@ Feature:
     Given variable "domain1IRI" is assigned the value "https://orb.domain1.com/services/orb"
     And variable "domain2IRI" is assigned the value "https://orb.domain2.com/services/orb"
 
-    Given domain "orb.domain1.com" is mapped to "localhost:48326"
-    And domain "orb.domain2.com" is mapped to "localhost:48426"
-    And domain "orb.domain3.com" is mapped to "localhost:48626"
+    Given variable "domain1ID" is assigned the value "${domain1IRI}"
+    And variable "domain2ID" is assigned the value "${domain2IRI}"
+
+    Given host "orb.domain1.com" is mapped to "localhost:48326"
+    And host "orb2.domain1.com" is mapped to "localhost:48526"
+    And host "orb.domain2.com" is mapped to "localhost:48426"
+    And host "orb.domain3.com" is mapped to "localhost:48626"
+
+    Given anchor origin for host "orb.domain1.com" is set to "https://orb.domain1.com"
+    And anchor origin for host "orb2.domain1.com" is set to "https://orb.domain1.com"
+    And anchor origin for host "orb.domain2.com" is set to "https://orb.domain1.com"
 
     Given the authorization bearer token for "POST" requests to path "/services/orb/outbox" is set to "ADMIN_TOKEN"
     And the authorization bearer token for "POST" requests to path "/services/orb/acceptlist" is set to "ADMIN_TOKEN"
@@ -27,32 +35,28 @@ Feature:
     Then we wait 1 seconds
 
     # domain1 adds domain2 and domain3 to its 'follow' and 'invite-witness' accept lists.
-    Given variable "domain1AcceptList" is assigned the JSON value '[{"type":"follow","add":["${domain2IRI}","${domain3IRI}"]},{"type":"invite-witness","add":["${domain2IRI}","${domain3IRI}"]}]'
+    Given variable "domain1AcceptList" is assigned the JSON value '[{"type":"follow","add":["${domain2ID}","${domain3IRI}"]},{"type":"invite-witness","add":["${domain2ID}","${domain3IRI}"]}]'
     When an HTTP POST is sent to "${domain1IRI}/acceptlist" with content "${domain1AcceptList}" of type "application/json"
 
     # domain2 adds domain1 to its 'follow' and 'invite-witness' accept lists.
-    Given variable "domain2AcceptList" is assigned the JSON value '[{"type":"follow","add":["${domain1IRI}"]},{"type":"invite-witness","add":["${domain1IRI}"]}]'
+    Given variable "domain2AcceptList" is assigned the JSON value '[{"type":"follow","add":["${domain1ID}"]},{"type":"invite-witness","add":["${domain1ID}"]}]'
     When an HTTP POST is sent to "${domain2IRI}/acceptlist" with content "${domain2AcceptList}" of type "application/json"
 
     # domain2 server follows domain1 server
-    Given variable "followID" is assigned a unique ID
-    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain2IRI}/activities/${followID}","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
+    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain2ID}","to":"${domain1IRI}","object":"${domain1ID}"}'
+    When an HTTP POST is sent to "${domain2IRI}/outbox" with content "${followActivity}" of type "application/json"
 
     # domain1 server follows domain2 server
-    Given variable "followID" is assigned a unique ID
-    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","id":"${domain1IRI}/activities/${followID}","type":"Follow","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
+    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain1ID}","to":"${domain2IRI}","object":"${domain2ID}"}'
+    When an HTTP POST is sent to "${domain1IRI}/outbox" with content "${followActivity}" of type "application/json"
 
     # domain1 invites domain2 to be a witness
-    Given variable "inviteWitnessID" is assigned a unique ID
-    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"id":"${domain1IRI}/activities/${inviteWitnessID}","type":"Invite","actor":"${domain1IRI}","to":"${domain2IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain1ID}","to":"${domain2IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain2ID}"}'
+    When an HTTP POST is sent to "${domain1IRI}/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     # domain2 invites domain1 to be a witness
-    Given variable "inviteWitnessID" is assigned a unique ID
-    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"id":"${domain2IRI}/activities/${inviteWitnessID}","type":"Invite","actor":"${domain2IRI}","to":"${domain1IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain2ID}","to":"${domain1IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain1ID}"}'
+    When an HTTP POST is sent to "${domain2IRI}/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     Then we wait 3 seconds
 

--- a/test/bdd/features/nodeinfo.feature
+++ b/test/bdd/features/nodeinfo.feature
@@ -8,7 +8,7 @@
 @nodeinfo
 Feature: NodeInfo
   Background: Setup
-    Given domain "orb.domain1.com" is mapped to "localhost:48326"
+    Given host "orb.domain1.com" is mapped to "localhost:48326"
 
   @node_info
   Scenario: Tests NodeInfo response from the server

--- a/test/bdd/features/onboard-recovery.feature
+++ b/test/bdd/features/onboard-recovery.feature
@@ -12,10 +12,20 @@ Feature:
     And variable "domain2IRI" is assigned the value "https://orb.domain2.com/services/orb"
     And variable "domain5IRI" is assigned the value "https://orb.domain5.com/services/orb"
 
-    Given domain "orb.domain1.com" is mapped to "localhost:48326"
-    And domain "orb2.domain1.com" is mapped to "localhost:48526"
-    And domain "orb.domain2.com" is mapped to "localhost:48426"
-    And domain "orb.domain5.com" is mapped to "localhost:49026"
+    Given variable "domain1ID" is assigned the value "${domain1IRI}"
+    And variable "domain2ID" is assigned the value "${domain2IRI}"
+    And variable "domain5ID" is assigned the value "${domain5IRI}"
+
+    Given host "orb.domain1.com" is mapped to "localhost:48326"
+    And host "orb2.domain1.com" is mapped to "localhost:48526"
+    And host "orb.domain2.com" is mapped to "localhost:48426"
+    And host "orb1-domain2.backend" is mapped to "localhost:48926"
+    And host "orb.domain5.com" is mapped to "localhost:49026"
+
+    Given anchor origin for host "orb.domain1.com" is set to "https://orb.domain1.com"
+    And anchor origin for host "orb2.domain1.com" is set to "ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q"
+    And anchor origin for host "orb.domain2.com" is set to "https://orb.domain1.com"
+    And anchor origin for host "orb.domain5.com" is set to "https://orb.domain5.com"
 
     Given the authorization bearer token for "POST" requests to path "/services/orb/outbox" is set to "ADMIN_TOKEN"
     And the authorization bearer token for "POST" requests to path "/services/orb/acceptlist" is set to "ADMIN_TOKEN"
@@ -31,28 +41,28 @@ Feature:
     When an HTTP POST is sent to "https://orb.domain1.com/log" with content "http://orb.vct:8077/maple2020" of type "text/plain"
 
     # domain1 adds domain2 to its 'follow' and 'invite-witness' accept lists.
-    Given variable "domain1AcceptList" is assigned the JSON value '[{"type":"follow","add":["${domain2IRI}"]},{"type":"invite-witness","add":["${domain2IRI}"]}]'
+    Given variable "domain1AcceptList" is assigned the JSON value '[{"type":"follow","add":["${domain2ID}"]},{"type":"invite-witness","add":["${domain2ID}"]}]'
     When an HTTP POST is sent to "${domain1IRI}/acceptlist" with content "${domain1AcceptList}" of type "application/json"
 
     # domain2 adds domain1 to its 'follow' and 'invite-witness' accept lists.
-    Given variable "domain2AcceptList" is assigned the JSON value '[{"type":"follow","add":["${domain1IRI}"]},{"type":"invite-witness","add":["${domain1IRI}"]}]'
+    Given variable "domain2AcceptList" is assigned the JSON value '[{"type":"follow","add":["${domain1ID}"]},{"type":"invite-witness","add":["${domain1ID}"]}]'
     When an HTTP POST is sent to "${domain2IRI}/acceptlist" with content "${domain2AcceptList}" of type "application/json"
 
     # domain2 server follows domain1 server
-    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain2IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
+    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain2ID}","to":"${domain1IRI}","object":"${domain1ID}"}'
+    When an HTTP POST is sent to "${domain2IRI}/outbox" with content "${followActivity}" of type "application/json"
 
     # domain1 server follows domain2 server
-    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain1IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
+    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain1ID}","to":"${domain2IRI}","object":"${domain2ID}"}'
+    When an HTTP POST is sent to "${domain1IRI}/outbox" with content "${followActivity}" of type "application/json"
 
     # domain1 invites domain2 to be a witness
-    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain1IRI}","to":"${domain2IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain2IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain1ID}","to":"${domain2IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain2ID}"}'
+    When an HTTP POST is sent to "${domain1IRI}/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     # domain2 invites domain1 to be a witness
-    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain2IRI}","to":"${domain1IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain1IRI}"}'
-    When an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain2ID}","to":"${domain1IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain1ID}"}'
+    When an HTTP POST is sent to "${domain2IRI}/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     # set witness policy for domain1
     When an HTTP POST is sent to "https://orb.domain1.com/policy" with content "OutOf(1,system)" of type "text/plain"
@@ -71,7 +81,7 @@ Feature:
     # to the AMQP queue so that they are processed by the other instance (orb1-domain2.backend).
     Then container "orb-domain2.backend" is stopped
     And we wait up to "2m" for 200 DID documents to be created
-    Then client sends request to "https://orb.domain1.com/sidetree/v1/identifiers,https://orb.domain2.com/sidetree/v1/identifiers" to verify the DID documents that were created
+    Then client sends request to "https://orb.domain1.com/sidetree/v1/identifiers,http://orb1-domain2.backend/sidetree/v1/identifiers" to verify the DID documents that were created
     Then container "orb-domain2.backend" is started
 
     When client sends request to "https://orb.domain1.com/sidetree/v1/operations,https://orb.domain2.com/sidetree/v1/operations" to update the DID documents that were created with public key ID "newkey_1_1" using 10 concurrent requests
@@ -85,33 +95,33 @@ Feature:
     # Onboard domain5 by asking to follow domain1 and domain2:
     When an HTTP POST is sent to "https://orb.domain5.com/policy" with content "OutOf(1,system)" of type "text/plain"
     # --- domain1 and domain2 add domain5 to the 'follow' and 'invite-witness' accept lists.
-    Given variable "acceptList" is assigned the JSON value '[{"type":"follow","add":["${domain5IRI}"]},{"type":"invite-witness","add":["${domain5IRI}"]}]'
+    Given variable "acceptList" is assigned the JSON value '[{"type":"follow","add":["${domain5ID}"]},{"type":"invite-witness","add":["${domain5ID}"]}]'
     Then an HTTP POST is sent to "${domain1IRI}/acceptlist" with content "${acceptList}" of type "application/json"
     Then an HTTP POST is sent to "${domain2IRI}/acceptlist" with content "${acceptList}" of type "application/json"
     # --- domain5 server follows domain1 server
-    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain5IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    Then an HTTP POST is sent to "https://orb.domain5.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
+    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain5ID}","to":"${domain1IRI}","object":"${domain1ID}"}'
+    Then an HTTP POST is sent to "${domain5IRI}/outbox" with content "${followActivity}" of type "application/json"
     # --- domain5 server follows domain2 server
-    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain5IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
-    Then an HTTP POST is sent to "https://orb.domain5.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
+    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain5ID}","to":"${domain2IRI}","object":"${domain2ID}"}'
+    Then an HTTP POST is sent to "${domain5IRI}/outbox" with content "${followActivity}" of type "application/json"
     # --- domain5 invites domain1 to be a witness
-    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain5IRI}","to":"${domain1IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain1IRI}"}'
-    Then an HTTP POST is sent to "https://orb.domain5.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain5ID}","to":"${domain1IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain1ID}"}'
+    Then an HTTP POST is sent to "${domain5IRI}/outbox" with content "${inviteWitnessActivity}" of type "application/json"
     # --- domain5 invites domain2 to be a witness
-    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain5IRI}","to":"${domain2IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain2IRI}"}'
-    Then an HTTP POST is sent to "https://orb.domain5.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain5ID}","to":"${domain2IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain2ID}"}'
+    Then an HTTP POST is sent to "${domain5IRI}/outbox" with content "${inviteWitnessActivity}" of type "application/json"
     # --- domain1 server follows domain5 server
-    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain1IRI}","to":"${domain5IRI}","object":"${domain5IRI}"}'
-    Then an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
+    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain1ID}","to":"${domain5IRI}","object":"${domain5ID}"}'
+    Then an HTTP POST is sent to "${domain1IRI}/outbox" with content "${followActivity}" of type "application/json"
     # --- domain1 invites domain5 to be a witness
-    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain1IRI}","to":"${domain5IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain5IRI}"}'
-    Then an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain1ID}","to":"${domain5IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain5ID}"}'
+    Then an HTTP POST is sent to "${domain1IRI}/outbox" with content "${inviteWitnessActivity}" of type "application/json"
     # --- domain2 server follows domain5 server
-    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain2IRI}","to":"${domain5IRI}","object":"${domain5IRI}"}'
-    Then an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
+    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain2ID}","to":"${domain5IRI}","object":"${domain5ID}"}'
+    Then an HTTP POST is sent to "${domain2IRI}/outbox" with content "${followActivity}" of type "application/json"
     # --- domain2 invites domain5 to be a witness
-    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain2IRI}","to":"${domain5IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain5IRI}"}'
-    Then an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain2ID}","to":"${domain5IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain5ID}"}'
+    Then an HTTP POST is sent to "${domain2IRI}/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     # The synchronization process should kick in for domain5, i.e. domain5 will read all missed 'Create' and 'Announce'
     # activities from domain1 and domain2's outbox to figure out which events were missed (which should be all of them)
@@ -156,33 +166,33 @@ Feature:
     # Onboard domain5 by asking to follow domain1 and domain2:
     When an HTTP POST is sent to "https://orb.domain5.com/policy" with content "OutOf(1,system)" of type "text/plain"
     # --- domain1 and domain2 add domain5 to the 'follow' and 'invite-witness' accept lists.
-    Given variable "acceptList" is assigned the JSON value '[{"type":"follow","add":["${domain5IRI}"]},{"type":"invite-witness","add":["${domain5IRI}"]}]'
+    Given variable "acceptList" is assigned the JSON value '[{"type":"follow","add":["${domain5ID}"]},{"type":"invite-witness","add":["${domain5ID}"]}]'
     Then an HTTP POST is sent to "${domain1IRI}/acceptlist" with content "${acceptList}" of type "application/json"
     Then an HTTP POST is sent to "${domain2IRI}/acceptlist" with content "${acceptList}" of type "application/json"
     # --- domain5 server follows domain1 server
-    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain5IRI}","to":"${domain1IRI}","object":"${domain1IRI}"}'
-    Then an HTTP POST is sent to "https://orb.domain5.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
+    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain5ID}","to":"${domain1IRI}","object":"${domain1ID}"}'
+    Then an HTTP POST is sent to "${domain5IRI}/outbox" with content "${followActivity}" of type "application/json"
     # --- domain5 server follows domain2 server
-    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain5IRI}","to":"${domain2IRI}","object":"${domain2IRI}"}'
-    Then an HTTP POST is sent to "https://orb.domain5.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
+    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain5ID}","to":"${domain2IRI}","object":"${domain2ID}"}'
+    Then an HTTP POST is sent to "${domain5IRI}/outbox" with content "${followActivity}" of type "application/json"
     # --- domain5 invites domain1 to be a witness
-    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain5IRI}","to":"${domain1IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain1IRI}"}'
-    Then an HTTP POST is sent to "https://orb.domain5.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain5ID}","to":"${domain1IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain1ID}"}'
+    Then an HTTP POST is sent to "${domain5IRI}/outbox" with content "${inviteWitnessActivity}" of type "application/json"
     # --- domain5 invites domain2 to be a witness
-    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain5IRI}","to":"${domain2IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain2IRI}"}'
-    Then an HTTP POST is sent to "https://orb.domain5.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain5ID}","to":"${domain2IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain2ID}"}'
+    Then an HTTP POST is sent to "${domain5IRI}/outbox" with content "${inviteWitnessActivity}" of type "application/json"
     # --- domain1 server follows domain5 server
-    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain1IRI}","to":"${domain5IRI}","object":"${domain5IRI}"}'
-    Then an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
+    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain1ID}","to":"${domain5IRI}","object":"${domain5ID}"}'
+    Then an HTTP POST is sent to "${domain1IRI}/outbox" with content "${followActivity}" of type "application/json"
     # --- domain1 invites domain5 to be a witness
-    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain1IRI}","to":"${domain5IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain5IRI}"}'
-    Then an HTTP POST is sent to "https://orb.domain1.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain1ID}","to":"${domain5IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain5ID}"}'
+    Then an HTTP POST is sent to "${domain1IRI}/outbox" with content "${inviteWitnessActivity}" of type "application/json"
     # --- domain2 server follows domain5 server
-    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain2IRI}","to":"${domain5IRI}","object":"${domain5IRI}"}'
-    Then an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${followActivity}" of type "application/json"
+    And variable "followActivity" is assigned the JSON value '{"@context":"https://www.w3.org/ns/activitystreams","type":"Follow","actor":"${domain2ID}","to":"${domain5IRI}","object":"${domain5ID}"}'
+    Then an HTTP POST is sent to "${domain2IRI}/outbox" with content "${followActivity}" of type "application/json"
     # --- domain2 invites domain5 to be a witness
-    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain2IRI}","to":"${domain5IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain5IRI}"}'
-    Then an HTTP POST is sent to "https://orb.domain2.com/services/orb/outbox" with content "${inviteWitnessActivity}" of type "application/json"
+    And variable "inviteWitnessActivity" is assigned the JSON value '{"@context":["https://www.w3.org/ns/activitystreams","https://w3id.org/activityanchors/v1"],"type":"Invite","actor":"${domain2ID}","to":"${domain5IRI}","object":"https://w3id.org/activityanchors#AnchorWitness","target":"${domain5ID}"}'
+    Then an HTTP POST is sent to "${domain2IRI}/outbox" with content "${inviteWitnessActivity}" of type "application/json"
 
     # Take a backup of the domain5 database.
     When command "mongodump --out ./fixtures/mongodbbackup --host localhost --port 28017" is executed

--- a/test/bdd/features/orb-cli.feature
+++ b/test/bdd/features/orb-cli.feature
@@ -10,8 +10,8 @@
 Feature: Using Orb CLI
   Background: Setup
 
-    Given domain "orb.domain1.com" is mapped to "localhost:48326"
-    And domain "orb.domain2.com" is mapped to "localhost:48426"
+    Given host "orb.domain1.com" is mapped to "localhost:48326"
+    And host "orb.domain2.com" is mapped to "localhost:48426"
 
     Given the authorization bearer token for "GET" requests to path "/sidetree/v1/identifiers" is set to "READ_TOKEN"
     And the authorization bearer token for "POST" requests to path "/log" is set to "ADMIN_TOKEN"

--- a/test/bdd/features/orb-driver.feature
+++ b/test/bdd/features/orb-driver.feature
@@ -9,13 +9,17 @@
 @orb_driver
 Feature: Using Orb driver
   Background: Setup
-      And domain "orb.domain2.com" is mapped to "localhost:48426"
-      And domain "orb.domain3.com" is mapped to "localhost:48626"
+    And host "orb.domain2.com" is mapped to "localhost:48426"
+    And host "orb.domain3.com" is mapped to "localhost:48626"
 
-      Given the authorization bearer token for "POST" requests to path "/log" is set to "ADMIN_TOKEN"
+    Given anchor origin for host "orb.domain1.com" is set to "https://orb.domain1.com"
+    And anchor origin for host "orb.domain2.com" is set to "https://orb.domain1.com"
+    And anchor origin for host "orb.domain3.com" is set to "https://orb.domain3.com"
 
-      # set up logs for domains
-      When an HTTP POST is sent to "https://orb.domain3.com/log" with content "http://orb.vct:8077/maple2020" of type "text/plain"
+    Given the authorization bearer token for "POST" requests to path "/log" is set to "ADMIN_TOKEN"
+
+    # set up logs for domains
+    When an HTTP POST is sent to "https://orb.domain3.com/log" with content "http://orb.vct:8077/maple2020" of type "text/plain"
 
     And orb-cli is executed with args 'acceptlist add --url https://localhost:48426/services/orb/acceptlist --actor https://orb.domain3.com/services/orb --type invite-witness --tls-cacerts fixtures/keys/tls/ec-cacert.pem --auth-token ADMIN_TOKEN'
 
@@ -28,5 +32,5 @@ Feature: Using Orb driver
     # domain1 invites domain2 to be a witness
     When user create "witness" activity with outbox-url "https://localhost:48626/services/orb/outbox" actor "https://orb.domain3.com/services/orb" to "https://orb.domain2.com/services/orb" action "InviteWitness"
     Then we wait 3 seconds
-    When client sends request to "https://localhost:48626/sidetree/v1/operations" to create DID document
+    When client sends request to "https://orb.domain3.com/sidetree/v1/operations" to create DID document
     Then check cli created valid DID through universal resolver

--- a/test/bdd/features/orb-stress.feature
+++ b/test/bdd/features/orb-stress.feature
@@ -10,8 +10,8 @@
 Feature: Using Orb stress test
   @orb_did_stress_test_setup
   Scenario:
-    Given domain "orb.domain1.com" is mapped to "localhost:48326"
-    And domain "orb.domain2.com" is mapped to "localhost:48426"
+    Given host "orb.domain1.com" is mapped to "localhost:48326"
+    And host "orb.domain2.com" is mapped to "localhost:48426"
 
     And the authorization bearer token for "POST" requests to path "/log" is set to "ADMIN_TOKEN"
 
@@ -20,6 +20,7 @@ Feature: Using Orb stress test
 
     Given orb-cli is executed with args 'acceptlist add --url https://localhost:48326/services/orb/acceptlist --actor https://orb.domain2.com/services/orb --type follow --tls-cacerts fixtures/keys/tls/ec-cacert.pem --auth-token ADMIN_TOKEN'
     And orb-cli is executed with args 'acceptlist add --url https://localhost:48426/services/orb/acceptlist --actor https://orb.domain1.com/services/orb --type invite-witness --tls-cacerts fixtures/keys/tls/ec-cacert.pem --auth-token ADMIN_TOKEN'
+    And orb-cli is executed with args 'acceptlist add --url https://localhost:48426/services/orb/acceptlist --actor https://orb.domain1.com/services/orb --type follow --tls-cacerts fixtures/keys/tls/ec-cacert.pem --auth-token ADMIN_TOKEN'
     # domain2 server follows domain1 server
     When user create "follower" activity with outbox-url "https://localhost:48426/services/orb/outbox" actor "https://orb.domain2.com/services/orb" to "https://orb.domain1.com/services/orb" action "Follow"
       # domain1 invites domain2 to be a witness

--- a/test/bdd/features/versions.feature
+++ b/test/bdd/features/versions.feature
@@ -12,10 +12,10 @@ Feature:
     And variable "domain3IRI" is assigned the value "https://orb.domain3.com/services/orb"
     And variable "domain4IRI" is assigned the value "https://orb.domain4.com/services/orb"
 
-    Given domain "orb.domain1.com" is mapped to "localhost:48326"
-    And domain "orb.domain2.com" is mapped to "localhost:48426"
-    And domain "orb.domain3.com" is mapped to "localhost:48626"
-    And domain "orb.domain4.com" is mapped to "localhost:48726"
+    Given host "orb.domain1.com" is mapped to "localhost:48326"
+    And host "orb.domain2.com" is mapped to "localhost:48426"
+    And host "orb.domain3.com" is mapped to "localhost:48626"
+    And host "orb.domain4.com" is mapped to "localhost:48726"
 
     Given the authorization bearer token for "POST" requests to path "/services/orb/outbox" is set to "ADMIN_TOKEN"
     And the authorization bearer token for "POST" requests to path "/services/orb/acceptlist" is set to "ADMIN_TOKEN"

--- a/test/bdd/httpclient.go
+++ b/test/bdd/httpclient.go
@@ -217,7 +217,7 @@ func (c *httpClient) PostWithSignature(url string, data []byte, contentType, dom
 
 	return &httpResponse{
 		Payload:    payload,
-		StatusCode: resp.StatusCode,
+		StatusCode: http.StatusOK,
 		Header:     resp.Header,
 	}, nil
 }
@@ -292,13 +292,11 @@ func (c *httpClient) signer(domain string) (signFunc, error) {
 	return signer, nil
 }
 
-func (c *httpClient) MapDomain(domain string, mapping string) {
+func (c *httpClient) MapHost(host string, mapping string) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	logger.Infof("Mapping domain %s to %s", domain, mapping)
-
-	c.mappings[domain] = mapping
+	c.mappings[host] = mapping
 }
 
 func (c *httpClient) HostMappings() map[string]string {
@@ -312,11 +310,9 @@ func (c *httpClient) resolveURL(url string) string {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
 
-	for domain, mapping := range c.mappings {
-		if strings.Contains(url, "//"+domain) {
-			logger.Infof("Mapping %s to %s", domain, mapping)
-
-			return strings.Replace(url, "//"+domain, "//"+mapping, 1)
+	for host, mapping := range c.mappings {
+		if strings.Contains(url, "//"+host) {
+			return strings.Replace(url, "//"+host, "//"+mapping, 1)
 		}
 	}
 

--- a/test/bdd/workerpool.go
+++ b/test/bdd/workerpool.go
@@ -40,7 +40,7 @@ type workerPoolOptions struct {
 
 type Opt func(*workerPoolOptions)
 
-func WithTaskDscription(desc string) Opt {
+func WithTaskDescription(desc string) Opt {
 	return func(options *workerPoolOptions) {
 		options.taskDescription = desc
 	}


### PR DESCRIPTION
Refactor BDD tests to remove hard-coded URLs for local host mappings, anchor origins. Also use variables in the feature files instead of repeating the entire URL many times.

closes #1420

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>