### PR TITLE
fix: Orb did:web endpoint for file did.json should return document 

### DIFF
--- a/pkg/discovery/endpoint/restapi/operations.go
+++ b/pkg/discovery/endpoint/restapi/operations.go
@@ -231,7 +231,7 @@ func (o *Operation) orbWebDIDHandler(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeResponse(rw, result)
+	writeResponse(rw, result.Document)
 }
 
 // webDIDHandler swagger:route Get /.well-known/did.json discovery wellKnownDIDReq


### PR DESCRIPTION
Orb did:web endpoint for file did.json should return document not resolution result

Closes #1447

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>