### PR TITLE
fix: Panic in HTTP subscriber Stop

### DIFF
--- a/cmd/orb-server/startcmd/params_test.go
+++ b/cmd/orb-server/startcmd/params_test.go
@@ -1040,9 +1040,7 @@ func TestStartCmdValidArgsEnvVar(t *testing.T) {
 		defer unsetEnvVars(t)
 
 		go func() {
-			err := startCmd.Execute()
-			require.Nil(t, err)
-			require.Equal(t, log.ERROR, log.GetLevel(""))
+			require.NoError(t, startCmd.Execute())
 		}()
 
 		require.NoError(t, backoff.Retry(func() error {
@@ -1060,9 +1058,7 @@ func TestStartCmdValidArgsEnvVar(t *testing.T) {
 		defer unsetEnvVars(t)
 
 		go func() {
-			err := startCmd.Execute()
-			require.Nil(t, err)
-			require.Equal(t, log.ERROR, log.GetLevel(""))
+			require.NoError(t, startCmd.Execute())
 		}()
 
 		require.NoError(t, backoff.Retry(func() error {
@@ -1080,9 +1076,7 @@ func TestStartCmdValidArgsEnvVar(t *testing.T) {
 		defer unsetEnvVars(t)
 
 		go func() {
-			err := startCmd.Execute()
-			require.Nil(t, err)
-			require.Equal(t, log.ERROR, log.GetLevel(""))
+			require.NoError(t, startCmd.Execute())
 		}()
 
 		require.NoError(t, backoff.Retry(func() error {


### PR DESCRIPTION
Added a publisher channel to handle publish requests in a separate Go proc. When the HTTP subscriber is stopped, the publisher listener safely shuts down the subscriber channel.

This commit also fixes the problem with varying code coverage in the unit tests.

closes #1463
closes #591

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>