### PR TITLE
feat: Improved arm64 support, add missing docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,10 +115,12 @@ ifneq ($(strip $(DEV_IMAGES)),)
 	@docker rmi $(DEV_IMAGES) -f
 endif
 
+# TODO (#1479): frapsoft/openssl only has an amd64 version. While this does work under amd64 and arm64 Mac OS currently,
+#               we should add an arm64 version for systems that can only run arm64 code.
 .PHONY: generate-test-keys
 generate-test-keys:
 	@mkdir -p -p test/bdd/fixtures/keys/tls
-	@docker run -i --rm \
+	@docker run -i --platform linux/amd64 --rm \
 		-v $(abspath .):/opt/workspace/orb \
 		--entrypoint "/opt/workspace/orb/scripts/generate_test_keys.sh" \
 		frapsoft/openssl
@@ -137,6 +139,8 @@ extract-orb-cli-binaries:
 	@echo "Extract orb cli binaries"
 	@mkdir -p .build/extract;cd .build/dist/bin;tar -zxf orb-cli-linux-amd64.tar.gz;mv orb-cli-linux-amd64 ../../extract/
 	@mkdir -p .build/extract;cd .build/dist/bin;tar -zxf orb-cli-darwin-amd64.tar.gz;mv orb-cli-darwin-amd64 ../../extract/
+	@mkdir -p .build/extract;cd .build/dist/bin;tar -zxf orb-cli-linux-arm64.tar.gz;mv orb-cli-linux-arm64 ../../extract/
+	@mkdir -p .build/extract;cd .build/dist/bin;tar -zxf orb-cli-darwin-arm64.tar.gz;mv orb-cli-darwin-arm64 ../../extract/
 
 .PHONY: bdd-test-cas-local
 bdd-test-cas-local: generate-test-keys orb-docker orb-driver-docker build-orb-cli-binaries extract-orb-cli-binaries

--- a/README.md
+++ b/README.md
@@ -29,14 +29,24 @@ To run Orb outside of _make_, you can use _docker-compose_:
 2. `docker-compose up`
 This starts the Orb nodes and all dependent containers (wait for containers to start for about 15-20 seconds)
 
+## Tests
+
 A full set of integration tests is included, which demonstrate all the features of Orb, including adding followers/witnesses and
-creating/resolving sample DIDs. (These are located in ./test/bdd/features.) After Orb is started (using the instructions above) you may run the tests as follows:
+creating/resolving sample DIDs. (These are located in ./test/bdd/features.)
+
+### Prerequisites
+
+* [MongoDB Tools](https://www.mongodb.com/docs/database-tools/installation/installation), used by the _orb_domain_backup_and_restore_ test
+* The PostgreSQL Command Line Tools, which can be installed using the [PostgreSQL installer](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads). Note that you can install just them standalone without the PostgreSQL server, which isn't required since PostgreSQL is run via Docker for the BDD tests. The PostgreSQL Command Line Tools are used by the _vct_backup_and_restore_ test.
+* The PostgreSQL Command Line Tools added to your PATH.
+* The following entries in your `hosts` file: `127.0.0.1 orb.domain1.com` and '127.0.0.1 orb.vct'
+
+### Running BDD tests
+
+After Orb is started (using the instructions in the [Run](#run) section, above) you may run the tests as follows:
 1. `cd test/bdd`
 2. `DISABLE_COMPOSITION=true go test`
 
-(Note that _orb_domain_backup_and_restore_ test requires that
-[MongoDB Tools](https://www.mongodb.com/docs/database-tools/installation/installation/)
-is installed and _vct_backup_and_restore_ test requires that Command Line Tools, part of [PostgreSQL](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads) is installed.)
 
 You can run individual tests using the -run option, for example:
 

--- a/scripts/generate_test_keys.sh
+++ b/scripts/generate_test_keys.sh
@@ -10,7 +10,6 @@ set -e
 
 echo "Generating orb Test PKI"
 
-# TODO re-use the sandbox CA script https://github.com/trustbloc/orb/issues/131
 cd /opt/workspace/orb
 mkdir -p test/bdd/fixtures/keys/tls
 tmp=$(mktemp)

--- a/test/bdd/cli_steps.go
+++ b/test/bdd/cli_steps.go
@@ -640,7 +640,8 @@ func (e *Steps) execute(argsStr string) error {
 }
 
 func execCMD(args ...string) (string, error) {
-	cmd := exec.Command(fmt.Sprintf("../../.build/extract/orb-cli-%s-amd64", runtime.GOOS), args...) // nolint: gosec
+	path := fmt.Sprintf("../../.build/extract/orb-cli-%s-%s", runtime.GOOS, runtime.GOARCH)
+	cmd := exec.Command(path, args...) // nolint: gosec
 
 	var out bytes.Buffer
 


### PR DESCRIPTION
* BDD tests are no longer hardcoded to use the amd64 binary for CLI commands. They now select between amd64 and arm64 based on the running system's detected architecture.
* Updated the Makefile's extract-orb-cli-binaries target to extract the arm64 binaries (they were being built before but were never extracted).
* Resolved a warning from Docker that would get printed when running the generate-test-keys Makefile target on an arm64 system. The warning from Docker alerts you that the image for frapsoft/openssl is for amd64, which doesn't match the system you're on. To resolve the warning, you have to either use an image that matches the system architecture, or explicitly state the platform using the --platform flag. In this case, there is only an amd64 version of frapsoft/openssl, so I added the explicit flag to resolve the warning. I also added a TODO for us to find an arm64 alternative in the future (although the amd64 version of frapsoft/openssl does seem to work fine on arm64 Mac OS currently, presumably due to Apple's Rosetta translation layer or some other emulation layer).
* Updated the documentation for the BDD tests to indicate that some hosts file entries are required for some tests to function correctly and to add some clarification+extra detail regarding the PostgreSQL Command Line Tools.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>