### PR TITLE
fix: did:web resolver is not properly encoding port in DID

### DIFF
--- a/pkg/document/webresolver/resolvehandler.go
+++ b/pkg/document/webresolver/resolvehandler.go
@@ -81,7 +81,9 @@ func (r *ResolveHandler) ResolveDocument(id string) (*document.ResolutionResult,
 		return nil, orberrors.ErrContentNotFound
 	}
 
-	webDID := fmt.Sprintf("did:web:%s:scid:%s", r.domain.Host, id)
+	domainWithPort := strings.ReplaceAll(r.domain.Host, ":", "%3A")
+
+	webDID := fmt.Sprintf("did:web:%s:scid:%s", domainWithPort, id)
 
 	didWebDoc, err := diddoctransformer.WebDocumentFromOrbDocument(webDID, localResponse)
 	if err != nil {


### PR DESCRIPTION
If port is specified for domain (external endpoint) return proper port encoding e.g. did:web:example.com%3A3000:scid:suffix

Closes #1482

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>