### PR TITLE
feat: did:web resolver should allow resolving DIDs that have different domain in DID if configured

### DIFF
--- a/cmd/orb-server/startcmd/params_test.go
+++ b/cmd/orb-server/startcmd/params_test.go
@@ -875,6 +875,19 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "allowed-origins-cache-expiration: invalid value [xxx]")
 	})
+
+	t.Run("allowed DID web domains", func(t *testing.T) {
+		restoreEnv := setEnv(t, allowedDIDWebDomainsEnvKey, ":domain.com")
+		defer restoreEnv()
+
+		startCmd := GetStartCmd()
+
+		startCmd.SetArgs(getTestArgs("localhost:8081", "local", "false", databaseTypeMemOption, ""))
+
+		err := startCmd.Execute()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "allowed-did-web-domains: parse \":domain.com\": missing protocol scheme")
+	})
 }
 
 func TestStartCmdWithBlankEnvVar(t *testing.T) {

--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -1205,7 +1205,14 @@ func startOrbServices(parameters *orbParameters) error {
 		logEndpoint = &noOpRetriever{}
 	}
 
-	webResolveHandler := webresolver.NewResolveHandler(u, parameters.didNamespace,
+	// current external endpoint is always allowed
+	allowedDIDWebDomains := []*url.URL{u}
+
+	if len(parameters.allowedDIDWebDomains) > 0 {
+		allowedDIDWebDomains = append(allowedDIDWebDomains, parameters.allowedDIDWebDomains...)
+	}
+
+	webResolveHandler := webresolver.NewResolveHandler(allowedDIDWebDomains, parameters.didNamespace,
 		unpublishedDIDLabel, orbResolveHandler, metrics.Get())
 
 	// create discovery rest api

--- a/pkg/discovery/endpoint/restapi/operations.go
+++ b/pkg/discovery/endpoint/restapi/operations.go
@@ -220,7 +220,9 @@ func (o *Operation) wellKnownHandler(rw http.ResponseWriter, r *http.Request) {
 func (o *Operation) orbWebDIDFileHandler(rw http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
 
-	result, err := o.webResolver.ResolveDocument(id)
+	did := fmt.Sprintf("did:web:%s:scid:%s", o.domainWithPort, id)
+
+	result, err := o.webResolver.ResolveDocument(did)
 	if err != nil {
 		if errors.Is(err, orberrors.ErrContentNotFound) {
 			logger.Debugf("web resource[%s] not found", id)

--- a/pkg/document/util/util.go
+++ b/pkg/document/util/util.go
@@ -49,17 +49,17 @@ func GetHint(id, namespace, suffix string) (string, error) {
 func BetweenStrings(value, first, second string) (string, error) {
 	posFirst := strings.Index(value, first)
 	if posFirst == -1 {
-		return "", fmt.Errorf("string '%s' doesn't contain first string '%s'", value, first)
+		return "", fmt.Errorf("string[%s] doesn't contain string[%s]", value, first)
 	}
 
 	posSecond := strings.Index(value, second)
 	if posSecond == -1 {
-		return "", fmt.Errorf("string '%s' doesn't contain second string '%s'", value, second)
+		return "", fmt.Errorf("string[%s] doesn't contain string[%s]", value, second)
 	}
 
 	posFirstAdjusted := posFirst + len(first)
 	if posFirstAdjusted >= posSecond {
-		return "", fmt.Errorf("second string '%s' is before first string '%s' in string '%s'", second, first, value)
+		return "", fmt.Errorf("second string[%s] is before first string[%s] in string[%s]", second, first, value)
 	}
 
 	return value[posFirstAdjusted:posSecond], nil

--- a/pkg/document/util/util_test.go
+++ b/pkg/document/util/util_test.go
@@ -41,14 +41,14 @@ func TestBetweenStrings(t *testing.T) {
 		str, err := BetweenStrings("did:orb:cid:suffix", "first", "suffix")
 		require.Error(t, err)
 		require.Empty(t, str)
-		require.Contains(t, err.Error(), "string 'did:orb:cid:suffix' doesn't contain first string 'first'")
+		require.Contains(t, err.Error(), "string[did:orb:cid:suffix] doesn't contain string[first]")
 	})
 
 	t.Run("error - doesn't contain second string", func(t *testing.T) {
 		str, err := BetweenStrings("did:orb:cid:suffix", "cid", "second")
 		require.Error(t, err)
 		require.Empty(t, str)
-		require.Contains(t, err.Error(), "string 'did:orb:cid:suffix' doesn't contain second string 'second'")
+		require.Contains(t, err.Error(), "string[did:orb:cid:suffix] doesn't contain string[second]")
 	})
 
 	t.Run("error - first string is after second string", func(t *testing.T) {
@@ -56,7 +56,7 @@ func TestBetweenStrings(t *testing.T) {
 		require.Error(t, err)
 		require.Empty(t, str)
 		require.Contains(t, err.Error(),
-			"second string 'did:orb' is before first string 'suffix' in string 'did:orb:cid:suffix'")
+			"second string[did:orb] is before first string[suffix] in string[did:orb:cid:suffix]")
 	})
 }
 

--- a/test/bdd/features/did-sidetree.feature
+++ b/test/bdd/features/did-sidetree.feature
@@ -424,12 +424,20 @@ Feature:
     Given the authorization bearer token for "GET" requests to path "/sidetree/v1/identifiers" is set to "READ_TOKEN"
     And the authorization bearer token for "POST" requests to path "/sidetree/v1/operations" is set to "ADMIN_TOKEN"
 
-    When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to create DID document
+    When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to create DID document and the suffix is saved to variable "didSuffix"
     Then check success response contains "#interimDID"
     Then we wait 2 seconds
 
     When client sends request to "https://orb.domain1.com/sidetree/v1/identifiers" to resolve DID document with interim did
     Then check success response contains "canonicalId"
+
+    # the domain1 is enabled by default, domain2 and domain3 are configured in allowed did:web domains
+    When an HTTP GET is sent to "https://orb.domain1.com/sidetree/v1/identifiers/did:web:orb.domain1.com:scid:${didSuffix}"
+    When an HTTP GET is sent to "https://orb.domain1.com/sidetree/v1/identifiers/did:web:orb.domain2.com:scid:${didSuffix}"
+    When an HTTP GET is sent to "https://orb.domain1.com/sidetree/v1/identifiers/did:web:orb.domain3.com:scid:${didSuffix}"
+
+    # the domain1 is enabled by default, domain2 and domain3 are configured; other.com will fail
+    When an HTTP GET is sent to "https://orb.domain3.com/sidetree/v1/identifiers/did:web:other.com:scid:${didSuffix}" and the returned status code is 500
 
     When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to add service endpoint with ID "newService" to DID document
     Then check for request success
@@ -481,7 +489,7 @@ Feature:
     When an HTTP GET is sent to "https://orb.domain3.com/scid/non-existent/did.json" and the returned status code is 404
 
     # test did:web document not found for identifiers endpoint
-    When an HTTP GET is sent to "https://orb.domain3.com/sidetree/v1/identifiers/did:web:other.com:scid:suffix" and the returned status code is 404
+    When an HTTP GET is sent to "https://orb.domain3.com/sidetree/v1/identifiers/did:web:other.com:scid:suffix" and the returned status code is 500
     When an HTTP GET is sent to "https://orb.domain3.com/sidetree/v1/identifiers/did:web:orb.domain3.com:scid:suffix" and the returned status code is 404
 
     # test invalid did method

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       - DID_NAMESPACE=did:orb
       - ALLOWED_ORIGINS=https://orb.domain1.com,https://orb.domain2.com,ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q
       - ALLOWED_ORIGINS_CACHE_EXPIRATION=1m
+      - ALLOWED_DID_WEB_DOMAINS=https://orb.domain2.com,https://orb.domain3.com
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
       - BATCH_WRITER_TIMEOUT=1000
       - CAS_TYPE=${CAS_TYPE}
@@ -185,6 +186,7 @@ services:
       - DID_NAMESPACE=did:orb
       - ALLOWED_ORIGINS=https://orb.domain1.com,https://orb.domain2.com,ipns://k51qzi5uqu5dgkmm1afrkmex5mzpu5r774jstpxjmro6mdsaullur27nfxle1q
       - ALLOWED_ORIGINS_CACHE_EXPIRATION=1m
+      - ALLOWED_DID_WEB_DOMAINS=https://orb.domain2.com,https://orb.domain3.com
       # BATCH_WRITER_TIMEOUT is max wait time in-between cutting batches (defined in milliseconds)
       - BATCH_WRITER_TIMEOUT=1000
       - CAS_TYPE=${CAS_TYPE}


### PR DESCRIPTION
Limit resolving did:web DIDs to current host domain plus configured additional domains.

Closes #1475

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>