### PR TITLE
fix: Make VC issuer the same as author of anchor linkset

### DIFF
--- a/cmd/orb-server/startcmd/params_test.go
+++ b/cmd/orb-server/startcmd/params_test.go
@@ -208,8 +208,6 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 			"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
 			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption,
 			"--" + anchorCredentialDomainFlagName, "domain.com",
-			"--" + anchorCredentialIssuerFlagName, "issuer.com",
-			"--" + anchorCredentialURLFlagName, "peer.com",
 			"--" + LogLevelFlagName, log.ParseString(log.ERROR),
 		}
 
@@ -234,8 +232,6 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 			"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
 			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption,
 			"--" + anchorCredentialDomainFlagName, "domain.com",
-			"--" + anchorCredentialIssuerFlagName, "issuer.com",
-			"--" + anchorCredentialURLFlagName, "peer.com",
 			"--" + LogLevelFlagName, log.ParseString(log.ERROR),
 		}
 
@@ -261,8 +257,6 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 			"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
 			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption,
 			"--" + anchorCredentialDomainFlagName, "domain.com",
-			"--" + anchorCredentialIssuerFlagName, "issuer.com",
-			"--" + anchorCredentialURLFlagName, "peer.com",
 			"--" + LogLevelFlagName, log.ParseString(log.ERROR),
 		}
 
@@ -289,8 +283,6 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 			"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
 			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption,
 			"--" + anchorCredentialDomainFlagName, "domain.com",
-			"--" + anchorCredentialIssuerFlagName, "issuer.com",
-			"--" + anchorCredentialURLFlagName, "peer.com",
 			"--" + LogLevelFlagName, log.ParseString(log.ERROR),
 		}
 
@@ -316,8 +308,6 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 			"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
 			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption,
 			"--" + anchorCredentialDomainFlagName, "domain.com",
-			"--" + anchorCredentialIssuerFlagName, "issuer.com",
-			"--" + anchorCredentialURLFlagName, "peer.com",
 			"--" + LogLevelFlagName, log.ParseString(log.ERROR),
 		}
 
@@ -344,8 +334,6 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 			"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
 			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption,
 			"--" + anchorCredentialDomainFlagName, "domain.com",
-			"--" + anchorCredentialIssuerFlagName, "issuer.com",
-			"--" + anchorCredentialURLFlagName, "peer.com",
 			"--" + LogLevelFlagName, log.ParseString(log.ERROR),
 		}
 
@@ -370,8 +358,6 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 			"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
 			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption,
 			"--" + anchorCredentialDomainFlagName, "domain.com",
-			"--" + anchorCredentialIssuerFlagName, "issuer.com",
-			"--" + anchorCredentialURLFlagName, "peer.com",
 			"--" + LogLevelFlagName, log.ParseString(log.ERROR),
 		}
 
@@ -394,8 +380,6 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 			"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
 			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption,
 			"--" + anchorCredentialDomainFlagName, "domain.com",
-			"--" + anchorCredentialIssuerFlagName, "issuer.com",
-			"--" + anchorCredentialURLFlagName, "peer.com",
 			"--" + LogLevelFlagName, log.ParseString(log.ERROR),
 			"--" + httpSignaturesEnabledFlagName, "invalid bool",
 		}
@@ -420,8 +404,6 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 			"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
 			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption,
 			"--" + anchorCredentialDomainFlagName, "domain.com",
-			"--" + anchorCredentialIssuerFlagName, "issuer.com",
-			"--" + anchorCredentialURLFlagName, "peer.com",
 			"--" + LogLevelFlagName, log.ParseString(log.ERROR),
 			"--" + enableVCTFlagName, "invalid bool",
 		}
@@ -446,8 +428,6 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 			"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
 			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption,
 			"--" + anchorCredentialDomainFlagName, "domain.com",
-			"--" + anchorCredentialIssuerFlagName, "issuer.com",
-			"--" + anchorCredentialURLFlagName, "peer.com",
 			"--" + LogLevelFlagName, log.ParseString(log.ERROR),
 			"--" + enableDidDiscoveryFlagName, "invalid bool",
 		}
@@ -472,8 +452,6 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 			"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
 			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption,
 			"--" + anchorCredentialDomainFlagName, "domain.com",
-			"--" + anchorCredentialIssuerFlagName, "issuer.com",
-			"--" + anchorCredentialURLFlagName, "peer.com",
 			"--" + LogLevelFlagName, log.ParseString(log.ERROR),
 			"--" + enableUnpublishedOperationStoreFlagName, "invalid bool",
 		}
@@ -498,8 +476,6 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 			"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
 			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption,
 			"--" + anchorCredentialDomainFlagName, "domain.com",
-			"--" + anchorCredentialIssuerFlagName, "issuer.com",
-			"--" + anchorCredentialURLFlagName, "peer.com",
 			"--" + LogLevelFlagName, log.ParseString(log.ERROR),
 			"--" + resolveFromAnchorOriginFlagName, "invalid bool",
 		}
@@ -524,8 +500,6 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 			"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
 			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption,
 			"--" + anchorCredentialDomainFlagName, "domain.com",
-			"--" + anchorCredentialIssuerFlagName, "issuer.com",
-			"--" + anchorCredentialURLFlagName, "peer.com",
 			"--" + LogLevelFlagName, log.ParseString(log.ERROR),
 			"--" + verifyLatestFromAnchorOriginFlagName, "invalid bool",
 		}
@@ -550,8 +524,6 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 			"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
 			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption,
 			"--" + anchorCredentialDomainFlagName, "domain.com",
-			"--" + anchorCredentialIssuerFlagName, "issuer.com",
-			"--" + anchorCredentialURLFlagName, "peer.com",
 			"--" + LogLevelFlagName, log.ParseString(log.ERROR),
 			"--" + includeUnpublishedOperationsFlagName, "invalid bool",
 		}
@@ -576,8 +548,6 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 			"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
 			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption,
 			"--" + anchorCredentialDomainFlagName, "domain.com",
-			"--" + anchorCredentialIssuerFlagName, "issuer.com",
-			"--" + anchorCredentialURLFlagName, "peer.com",
 			"--" + LogLevelFlagName, log.ParseString(log.ERROR),
 			"--" + includePublishedOperationsFlagName, "invalid bool",
 		}
@@ -941,8 +911,6 @@ func TestStartCmdWithInvalidCIDVersion(t *testing.T) {
 		"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
 		"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption,
 		"--" + anchorCredentialDomainFlagName, "domain.com",
-		"--" + anchorCredentialIssuerFlagName, "issuer.com",
-		"--" + anchorCredentialURLFlagName, "peer.com",
 		"--" + LogLevelFlagName, log.ParseString(log.ERROR),
 	}
 	startCmd.SetArgs(args)
@@ -964,8 +932,6 @@ func TestStartCmdCreateKMSFailure(t *testing.T) {
 			"--" + databaseTypeFlagName, databaseTypeMemOption,
 			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeCouchDBOption,
 			"--" + anchorCredentialDomainFlagName, "domain.com",
-			"--" + anchorCredentialIssuerFlagName, "issuer.com",
-			"--" + anchorCredentialURLFlagName, "peer.com",
 			"--" + kmsSecretsDatabaseURLFlagName, "badURL",
 			"--" + kmsTypeFlagName, "local",
 		}
@@ -988,8 +954,6 @@ func TestStartCmdCreateKMSFailure(t *testing.T) {
 			"--" + databaseTypeFlagName, databaseTypeMemOption,
 			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeCouchDBOption,
 			"--" + anchorCredentialDomainFlagName, "domain.com",
-			"--" + anchorCredentialIssuerFlagName, "issuer.com",
-			"--" + anchorCredentialURLFlagName, "peer.com",
 			"--" + kmsSecretsDatabaseURLFlagName, "badURL",
 			"--" + kmsTypeFlagName, "wrong",
 		}
@@ -1010,8 +974,6 @@ func TestStartCmdCreateKMSFailure(t *testing.T) {
 			"--" + didNamespaceFlagName, "namespace",
 			"--" + databaseTypeFlagName, databaseTypeMemOption,
 			"--" + anchorCredentialDomainFlagName, "domain.com",
-			"--" + anchorCredentialIssuerFlagName, "issuer.com",
-			"--" + anchorCredentialURLFlagName, "peer.com",
 			"--" + kmsTypeFlagName, "web",
 		}
 		startCmd.SetArgs(args)
@@ -1031,8 +993,6 @@ func TestStartCmdCreateKMSFailure(t *testing.T) {
 			"--" + didNamespaceFlagName, "namespace",
 			"--" + databaseTypeFlagName, databaseTypeMemOption,
 			"--" + anchorCredentialDomainFlagName, "domain.com",
-			"--" + anchorCredentialIssuerFlagName, "issuer.com",
-			"--" + anchorCredentialURLFlagName, "peer.com",
 			"--" + kmsEndpointFlagName, "https://vct.example.com",
 			"--" + kmsTypeFlagName, "web",
 		}
@@ -1727,12 +1687,6 @@ func setEnvVars(t *testing.T, databaseType, casType, replicateLocalCASToIPFS str
 	err = os.Setenv(kmsSecretsDatabaseTypeEnvKey, databaseTypeMemOption)
 	require.NoError(t, err)
 
-	err = os.Setenv(anchorCredentialIssuerEnvKey, "issuer")
-	require.NoError(t, err)
-
-	err = os.Setenv(anchorCredentialURLEnvKey, "peer")
-	require.NoError(t, err)
-
 	err = os.Setenv(anchorCredentialDomainEnvKey, "domain")
 	require.NoError(t, err)
 
@@ -1826,8 +1780,6 @@ func getTestArgs(ipfsURL, casType, localCASReplicateInIPFSEnabled, databaseType,
 		"--" + databaseTypeFlagName, databaseType,
 		"--" + kmsSecretsDatabaseTypeFlagName, databaseType,
 		"--" + anchorCredentialDomainFlagName, "domain.com",
-		"--" + anchorCredentialIssuerFlagName, "issuer.com",
-		"--" + anchorCredentialURLFlagName, "peer.com",
 		"--" + LogLevelFlagName, log.ParseString(log.ERROR),
 		"--" + localCASReplicateInIPFSFlagName, localCASReplicateInIPFSEnabled,
 		"--" + enableUnpublishedOperationStoreFlagName, "true",
@@ -1846,6 +1798,69 @@ func getTestArgs(ipfsURL, casType, localCASReplicateInIPFSEnabled, databaseType,
 	}
 
 	return args
+}
+
+func Test_getAPServiceParams(t *testing.T) {
+	t.Run("Default service ID", func(t *testing.T) {
+		apServiceParams, err := newAPServiceParams("", "https://orb.domain1.com", nil, false)
+		require.NoError(t, err)
+		require.Equal(t, "https://orb.domain1.com/services/orb", apServiceParams.serviceEndpoint().String())
+		require.Equal(t, "https://orb.domain1.com/services/orb", apServiceParams.serviceIRI().String())
+		require.Equal(t, "https://orb.domain1.com/services/orb/keys/main-key", apServiceParams.publicKeyIRI())
+	})
+
+	t.Run("HTTPS service ID -> success", func(t *testing.T) {
+		apServiceParams, err := newAPServiceParams("https://orb.domain1.com/services/anchor",
+			"https://orb.domain1.com", nil, false)
+		require.NoError(t, err)
+		require.Equal(t, "https://orb.domain1.com/services/anchor", apServiceParams.serviceEndpoint().String())
+		require.Equal(t, "https://orb.domain1.com/services/anchor", apServiceParams.serviceIRI().String())
+		require.Equal(t, "https://orb.domain1.com/services/anchor/keys/main-key", apServiceParams.publicKeyIRI())
+	})
+
+	t.Run("DID service ID -> success", func(t *testing.T) {
+		apServiceParams, err := newAPServiceParams("did:web:orb.domain1.com:services:anchor",
+			"https://orb.domain1.com", &kmsParameters{httpSignActiveKeyID: "123456"}, false)
+		require.NoError(t, err)
+		require.Equal(t, "https://orb.domain1.com/services/anchor", apServiceParams.serviceEndpoint().String())
+		require.Equal(t, "did:web:orb.domain1.com:services:anchor", apServiceParams.serviceIRI().String())
+		require.Equal(t, "did:web:orb.domain1.com:services:anchor#123456", apServiceParams.publicKeyIRI())
+	})
+
+	t.Run("DID service ID with dev-mode -> success", func(t *testing.T) {
+		apServiceParams, err := newAPServiceParams("did:web:orb.domain1.com:services:anchor",
+			"http://orb.domain1.com", &kmsParameters{httpSignActiveKeyID: "123456"}, true)
+		require.NoError(t, err)
+		require.Equal(t, "http://orb.domain1.com/services/anchor", apServiceParams.serviceEndpoint().String())
+		require.Equal(t, "did:web:orb.domain1.com:services:anchor", apServiceParams.serviceIRI().String())
+		require.Equal(t, "did:web:orb.domain1.com:services:anchor#123456", apServiceParams.publicKeyIRI())
+	})
+
+	t.Run("serviceID/external-endpoint protocol mismatch -> error", func(t *testing.T) {
+		_, err := newAPServiceParams("http://orb.domain1.com/services/anchor",
+			"https://orb.domain1.com", nil, false)
+		require.EqualError(t, err, "external endpoint [https://orb.domain1.com] and service ID [http://orb.domain1.com/services/anchor] must have the same protocol scheme (e.g. https)")
+	})
+
+	t.Run("serviceID/external-endpoint host mismatch -> error", func(t *testing.T) {
+		_, err := newAPServiceParams("did:web:orb.domain1.com:services:anchor",
+			"https://orb.domainx.com", &kmsParameters{httpSignActiveKeyID: "123456"}, false)
+		require.EqualError(t, err, "external endpoint [https://orb.domainx.com] and service ID [did:web:orb.domain1.com:services:anchor] must have the same host")
+	})
+
+	t.Run("Invalid DID format -> error", func(t *testing.T) {
+		_, err := newAPServiceParams("did:web",
+			"https://orb.domainx.com", &kmsParameters{httpSignActiveKeyID: "123456"}, false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid did")
+	})
+
+	t.Run("DID method not supported -> error", func(t *testing.T) {
+		_, err := newAPServiceParams("did:key:orb.domain1.com:services:anchor",
+			"https://orb.domainx.com", &kmsParameters{httpSignActiveKeyID: "123456"}, false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unsupported DID method [did:key]")
+	})
 }
 
 type mockStoreProvider struct {

--- a/test/bdd/fixtures/docker-compose-testver.yml
+++ b/test/bdd/fixtures/docker-compose-testver.yml
@@ -45,8 +45,6 @@ services:
       - MQ_PUBLISHER_POOL=50
       - MQ_MAX_CONNECTION_CHANNELS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN1}
-      - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain1.com
-      - ANCHOR_CREDENTIAL_URL=https://orb.domain1.com/vc
       # used in case that orb server signs anchor credential (there is no local witness log)
       - ANCHOR_CREDENTIAL_DOMAIN=https://orb.domain1.com
       - DATABASE_TYPE=mongodb
@@ -167,8 +165,6 @@ services:
       - MQ_PUBLISHER_POOL=25
       - MQ_MAX_CONNECTION_CHANNELS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN2}
-      - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain2.com
-      - ANCHOR_CREDENTIAL_URL=https://orb.domain2.com/vc
       # used in case that orb server signs anchor credential (there is no local witness log)
       - ANCHOR_CREDENTIAL_DOMAIN=https://orb.domain2.com
       - DATABASE_TYPE=mongodb
@@ -269,8 +265,6 @@ services:
       - MQ_PUBLISHER_POOL=25
       - MQ_MAX_CONNECTION_CHANNELS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN3}
-      - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain3.com
-      - ANCHOR_CREDENTIAL_URL=https://orb.domain3.com/vc
       # used in case that orb server signs anchor credential (there is no local witness log)
       - ANCHOR_CREDENTIAL_DOMAIN=https://orb.domain3.com
       - DATABASE_TYPE=mongodb
@@ -382,8 +376,6 @@ services:
       - MQ_PUBLISHER_POOL=25
       - MQ_MAX_CONNECTION_CHANNELS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN3}
-      - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain4.com
-      - ANCHOR_CREDENTIAL_URL=https://orb.domain4.com/vc
       # used in case that orb server signs anchor credential (there is no local witness log)
       - ANCHOR_CREDENTIAL_DOMAIN=https://orb.domain4.com
       - DATABASE_TYPE=mongodb

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -72,8 +72,6 @@ services:
       - MQ_PUBLISHER_CONFIRM_DELIVERY=true
       - MQ_MAX_CONNECTION_CHANNELS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN1}
-      - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain1.com
-      - ANCHOR_CREDENTIAL_URL=https://orb.domain1.com/vc
       # used in case that orb server signs anchor credential (there is no local witness log)
       - ANCHOR_CREDENTIAL_DOMAIN=https://orb.domain1.com
       - DATABASE_TYPE=mongodb
@@ -211,8 +209,6 @@ services:
       - MQ_PUBLISHER_POOL=50
       - MQ_MAX_CONNECTION_CHANNELS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN1}
-      - ANCHOR_CREDENTIAL_ISSUER=https://orb2.domain1.com
-      - ANCHOR_CREDENTIAL_URL=https://orb2.domain1.com/vc
       # used in case that orb server signs anchor credential (there is no local witness log)
       - ANCHOR_CREDENTIAL_DOMAIN=https://orb.domain1.com
       - DATABASE_TYPE=mongodb
@@ -352,8 +348,6 @@ services:
       - MQ_PUBLISHER_POOL=25
       - MQ_MAX_CONNECTION_CHANNELS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN2}
-      - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain2.com
-      - ANCHOR_CREDENTIAL_URL=https://orb.domain2.com/vc
       # used in case that orb server signs anchor credential (there is no local witness log)
       - ANCHOR_CREDENTIAL_DOMAIN=https://orb.domain2.com
       - DATABASE_TYPE=mongodb
@@ -458,8 +452,6 @@ services:
       - MQ_PUBLISHER_POOL=25
       - MQ_MAX_CONNECTION_CHANNELS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN2}
-      - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain2.com
-      - ANCHOR_CREDENTIAL_URL=https://orb.domain2.com/vc
       # used in case that orb server signs anchor credential (there is no local witness log)
       - ANCHOR_CREDENTIAL_DOMAIN=https://orb.domain2.com
       - DATABASE_TYPE=mongodb
@@ -562,8 +554,6 @@ services:
       - MQ_PUBLISHER_POOL=25
       - MQ_MAX_CONNECTION_CHANNELS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN3}
-      - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain3.com
-      - ANCHOR_CREDENTIAL_URL=https://orb.domain3.com/vc
       # used in case that orb server signs anchor credential (there is no local witness log)
       - ANCHOR_CREDENTIAL_DOMAIN=https://orb.domain3.com
       - DATABASE_TYPE=mongodb
@@ -684,8 +674,6 @@ services:
       - MQ_PUBLISHER_POOL=25
       - MQ_MAX_CONNECTION_CHANNELS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN4}
-      - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain4.com
-      - ANCHOR_CREDENTIAL_URL=https://orb.domain4.com/vc
       # used in case that orb server signs anchor credential (there is no local witness log)
       - ANCHOR_CREDENTIAL_DOMAIN=https://orb.domain4.com
       - DATABASE_TYPE=mongodb
@@ -805,8 +793,6 @@ services:
       - MQ_PUBLISHER_POOL=25
       - MQ_MAX_CONNECTION_CHANNELS=1500
       - CID_VERSION=${CID_VERSION_DOMAIN4}
-      - ANCHOR_CREDENTIAL_ISSUER=https://orb.domain5.com
-      - ANCHOR_CREDENTIAL_URL=https://orb.domain5.com/vc
       # used in case that orb server signs anchor credential (there is no local witness log)
       - ANCHOR_CREDENTIAL_DOMAIN=https://orb.domain5.com
       - DATABASE_TYPE=mongodb


### PR DESCRIPTION
The issuer in the anchor credential (VC) is now always the same as the author of the anchor linkset. So if the auther is a DID then the issuer will be set to the same DID.

This commit also removes the startup parameters, anchor-credential-issuer and anchor-credential-url since they are redundant and can also lead to misconfiguration.

closes #1488

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>