### PR TITLE
chore: Remove dependency on edge-core tlsutils

### DIFF
--- a/cmd/orb-cli/common/common.go
+++ b/cmd/orb-cli/common/common.go
@@ -33,7 +33,6 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 	"github.com/spf13/cobra"
 	"github.com/trustbloc/edge-core/pkg/log"
-	tlsutils "github.com/trustbloc/edge-core/pkg/utils/tls"
 	"github.com/trustbloc/sidetree-core-go/pkg/jws"
 	"github.com/trustbloc/sidetree-core-go/pkg/util/ecsigner"
 	"github.com/trustbloc/sidetree-core-go/pkg/util/edsigner"
@@ -41,6 +40,7 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/1_0/client"
 
 	"github.com/trustbloc/orb/internal/pkg/cmdutil"
+	"github.com/trustbloc/orb/internal/pkg/tlsutil"
 )
 
 var logger = log.New("orb-cli")
@@ -430,7 +430,7 @@ func getRootCAs(cmd *cobra.Command) (*x509.CertPool, error) {
 	tlsCACerts := cmdutil.GetUserSetOptionalVarFromArrayString(cmd, TLSCACertsFlagName,
 		TLSCACertsEnvKey)
 
-	return tlsutils.GetCertPool(tlsSystemCertPool, tlsCACerts)
+	return tlsutil.GetCertPool(tlsSystemCertPool, tlsCACerts)
 }
 
 func newAuthTokenHeader(cmd *cobra.Command) map[string]string {

--- a/cmd/orb-cli/createdidcmd/createdid.go
+++ b/cmd/orb-cli/createdidcmd/createdid.go
@@ -18,10 +18,10 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 	"github.com/hyperledger/aries-framework-go/pkg/kms/webkms"
 	"github.com/spf13/cobra"
-	tlsutils "github.com/trustbloc/edge-core/pkg/utils/tls"
 
 	"github.com/trustbloc/orb/cmd/orb-cli/common"
 	"github.com/trustbloc/orb/internal/pkg/cmdutil"
+	"github.com/trustbloc/orb/internal/pkg/tlsutil"
 )
 
 const (
@@ -303,7 +303,7 @@ func getRootCAs(cmd *cobra.Command) (*x509.CertPool, error) {
 	tlsCACerts := cmdutil.GetUserSetOptionalVarFromArrayString(cmd, tlsCACertsFlagName,
 		tlsCACertsEnvKey)
 
-	return tlsutils.GetCertPool(tlsSystemCertPool, tlsCACerts)
+	return tlsutil.GetCertPool(tlsSystemCertPool, tlsCACerts)
 }
 
 func createFlags(startCmd *cobra.Command) {

--- a/cmd/orb-cli/deactivatedidcmd/deactivatedid.go
+++ b/cmd/orb-cli/deactivatedidcmd/deactivatedid.go
@@ -21,10 +21,10 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 	"github.com/hyperledger/aries-framework-go/pkg/kms/webkms"
 	"github.com/spf13/cobra"
-	tlsutils "github.com/trustbloc/edge-core/pkg/utils/tls"
 
 	"github.com/trustbloc/orb/cmd/orb-cli/common"
 	"github.com/trustbloc/orb/internal/pkg/cmdutil"
+	"github.com/trustbloc/orb/internal/pkg/tlsutil"
 )
 
 const (
@@ -234,7 +234,7 @@ func getRootCAs(cmd *cobra.Command) (*x509.CertPool, error) {
 	tlsCACerts := cmdutil.GetUserSetOptionalVarFromArrayString(cmd, tlsCACertsFlagName,
 		tlsCACertsEnvKey)
 
-	return tlsutils.GetCertPool(tlsSystemCertPool, tlsCACerts)
+	return tlsutil.GetCertPool(tlsSystemCertPool, tlsCACerts)
 }
 
 func createFlags(startCmd *cobra.Command) {

--- a/cmd/orb-cli/ipfskeygencmd/keygen.go
+++ b/cmd/orb-cli/ipfskeygencmd/keygen.go
@@ -20,10 +20,10 @@ import (
 
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/spf13/cobra"
-	tlsutils "github.com/trustbloc/edge-core/pkg/utils/tls"
 
 	"github.com/trustbloc/orb/cmd/orb-cli/common"
 	"github.com/trustbloc/orb/internal/pkg/cmdutil"
+	"github.com/trustbloc/orb/internal/pkg/tlsutil"
 )
 
 const (
@@ -228,7 +228,7 @@ func getRootCAs(cmd *cobra.Command) (*x509.CertPool, error) {
 	tlsCACerts := cmdutil.GetUserSetOptionalVarFromArrayString(cmd, tlsCACertsFlagName,
 		tlsCACertsEnvKey)
 
-	return tlsutils.GetCertPool(tlsSystemCertPool, tlsCACerts)
+	return tlsutil.GetCertPool(tlsSystemCertPool, tlsCACerts)
 }
 
 func createFlags(startCmd *cobra.Command) {

--- a/cmd/orb-cli/ipnshostmetagencmd/ipnshostmetagencmd.go
+++ b/cmd/orb-cli/ipnshostmetagencmd/ipnshostmetagencmd.go
@@ -17,10 +17,10 @@ import (
 
 	shell "github.com/ipfs/go-ipfs-api"
 	"github.com/spf13/cobra"
-	tlsutils "github.com/trustbloc/edge-core/pkg/utils/tls"
 
 	"github.com/trustbloc/orb/cmd/orb-cli/common"
 	"github.com/trustbloc/orb/internal/pkg/cmdutil"
+	"github.com/trustbloc/orb/internal/pkg/tlsutil"
 	"github.com/trustbloc/orb/pkg/discovery/endpoint/restapi"
 )
 
@@ -194,7 +194,7 @@ func getRootCAs(cmd *cobra.Command) (*x509.CertPool, error) {
 	tlsCACerts := cmdutil.GetUserSetOptionalVarFromArrayString(cmd, tlsCACertsFlagName,
 		tlsCACertsEnvKey)
 
-	return tlsutils.GetCertPool(tlsSystemCertPool, tlsCACerts)
+	return tlsutil.GetCertPool(tlsSystemCertPool, tlsCACerts)
 }
 
 func createFlags(startCmd *cobra.Command) {

--- a/cmd/orb-cli/recoverdidcmd/recoverdid.go
+++ b/cmd/orb-cli/recoverdidcmd/recoverdid.go
@@ -22,10 +22,10 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 	"github.com/hyperledger/aries-framework-go/pkg/kms/webkms"
 	"github.com/spf13/cobra"
-	tlsutils "github.com/trustbloc/edge-core/pkg/utils/tls"
 
 	"github.com/trustbloc/orb/cmd/orb-cli/common"
 	"github.com/trustbloc/orb/internal/pkg/cmdutil"
+	"github.com/trustbloc/orb/internal/pkg/tlsutil"
 )
 
 const (
@@ -383,7 +383,7 @@ func getRootCAs(cmd *cobra.Command) (*x509.CertPool, error) {
 	tlsCACerts := cmdutil.GetUserSetOptionalVarFromArrayString(cmd, tlsCACertsFlagName,
 		tlsCACertsEnvKey)
 
-	return tlsutils.GetCertPool(tlsSystemCertPool, tlsCACerts)
+	return tlsutil.GetCertPool(tlsSystemCertPool, tlsCACerts)
 }
 
 func createFlags(startCmd *cobra.Command) {

--- a/cmd/orb-cli/resolvedidcmd/resolvedid.go
+++ b/cmd/orb-cli/resolvedidcmd/resolvedid.go
@@ -16,9 +16,9 @@ import (
 	"github.com/hyperledger/aries-framework-go-ext/component/vdr/orb"
 	vdrapi "github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdr"
 	"github.com/spf13/cobra"
-	tlsutils "github.com/trustbloc/edge-core/pkg/utils/tls"
 
 	"github.com/trustbloc/orb/internal/pkg/cmdutil"
+	"github.com/trustbloc/orb/internal/pkg/tlsutil"
 )
 
 const (
@@ -187,7 +187,7 @@ func getRootCAs(cmd *cobra.Command) (*x509.CertPool, error) {
 	tlsCACerts := cmdutil.GetUserSetOptionalVarFromArrayString(cmd, tlsCACertsFlagName,
 		tlsCACertsEnvKey)
 
-	return tlsutils.GetCertPool(tlsSystemCertPool, tlsCACerts)
+	return tlsutil.GetCertPool(tlsSystemCertPool, tlsCACerts)
 }
 
 func createFlags(startCmd *cobra.Command) {

--- a/cmd/orb-cli/updatedidcmd/updatedid.go
+++ b/cmd/orb-cli/updatedidcmd/updatedid.go
@@ -22,10 +22,10 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 	"github.com/hyperledger/aries-framework-go/pkg/kms/webkms"
 	"github.com/spf13/cobra"
-	tlsutils "github.com/trustbloc/edge-core/pkg/utils/tls"
 
 	"github.com/trustbloc/orb/cmd/orb-cli/common"
 	"github.com/trustbloc/orb/internal/pkg/cmdutil"
+	"github.com/trustbloc/orb/internal/pkg/tlsutil"
 )
 
 const (
@@ -338,7 +338,7 @@ func getRootCAs(cmd *cobra.Command) (*x509.CertPool, error) {
 	tlsCACerts := cmdutil.GetUserSetOptionalVarFromArrayString(cmd, tlsCACertsFlagName,
 		tlsCACertsEnvKey)
 
-	return tlsutils.GetCertPool(tlsSystemCertPool, tlsCACerts)
+	return tlsutil.GetCertPool(tlsSystemCertPool, tlsCACerts)
 }
 
 func createFlags(startCmd *cobra.Command) {

--- a/cmd/orb-driver/startcmd/start.go
+++ b/cmd/orb-driver/startcmd/start.go
@@ -18,10 +18,10 @@ import (
 	"github.com/hyperledger/aries-framework-go-ext/component/vdr/orb"
 	"github.com/spf13/cobra"
 	"github.com/trustbloc/edge-core/pkg/log"
-	tlsutils "github.com/trustbloc/edge-core/pkg/utils/tls"
 	restcommon "github.com/trustbloc/sidetree-core-go/pkg/restapi/common"
 
 	"github.com/trustbloc/orb/internal/pkg/cmdutil"
+	"github.com/trustbloc/orb/internal/pkg/tlsutil"
 	driverrest "github.com/trustbloc/orb/pkg/driver/restapi"
 	"github.com/trustbloc/orb/pkg/httpserver"
 )
@@ -221,7 +221,7 @@ func createFlags(startCmd *cobra.Command) {
 }
 
 func startDriver(parameters *parameters) error {
-	rootCAs, err := tlsutils.GetCertPool(parameters.tlsSystemCertPool, parameters.tlsCACerts)
+	rootCAs, err := tlsutil.GetCertPool(parameters.tlsSystemCertPool, parameters.tlsCACerts)
 	if err != nil {
 		return err
 	}

--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -57,7 +57,6 @@ import (
 	jsonld "github.com/piprate/json-gold/ld"
 	"github.com/spf13/cobra"
 	"github.com/trustbloc/edge-core/pkg/log"
-	tlsutils "github.com/trustbloc/edge-core/pkg/utils/tls"
 	awssvc "github.com/trustbloc/kms/pkg/aws"
 	casapi "github.com/trustbloc/sidetree-core-go/pkg/api/cas"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
@@ -70,6 +69,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 
 	"github.com/trustbloc/orb/internal/pkg/ldcontext"
+	"github.com/trustbloc/orb/internal/pkg/tlsutil"
 	"github.com/trustbloc/orb/pkg/activitypub/client"
 	"github.com/trustbloc/orb/pkg/activitypub/client/transport"
 	"github.com/trustbloc/orb/pkg/activitypub/httpsig"
@@ -495,7 +495,7 @@ func startOrbServices(parameters *orbParameters) error {
 		return fmt.Errorf("open store: %w", err)
 	}
 
-	rootCAs, err := tlsutils.GetCertPool(parameters.tlsParams.systemCertPool, parameters.tlsParams.caCerts)
+	rootCAs, err := tlsutil.GetCertPool(parameters.tlsParams.systemCertPool, parameters.tlsParams.caCerts)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/tlsutil/certpool.go
+++ b/internal/pkg/tlsutil/certpool.go
@@ -1,0 +1,163 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package tlsutil
+
+import (
+	"crypto/x509"
+	"sync"
+	"sync/atomic"
+
+	"github.com/trustbloc/edge-core/pkg/log"
+)
+
+var logger = log.New("tlsutil")
+
+// CertPool is a thread safe wrapper around the x509 standard library
+// cert pool implementation.
+// It optionally allows loading the system trust store.
+type CertPool struct {
+	certPool       *x509.CertPool
+	certs          []*x509.Certificate
+	certsByName    map[string][]int
+	lock           sync.RWMutex
+	dirty          int32
+	systemCertPool bool
+}
+
+// NewCertPool new CertPool implementation.
+func NewCertPool(useSystemCertPool bool) (*CertPool, error) {
+	c, err := loadSystemCertPool(useSystemCertPool)
+	if err != nil {
+		return nil, err
+	}
+
+	newCertPool := &CertPool{
+		certsByName:    make(map[string][]int),
+		certPool:       c,
+		systemCertPool: useSystemCertPool,
+	}
+
+	return newCertPool, nil
+}
+
+// Get returns certpool.
+// If there are any certs in cert queue added by any previous Add() call
+// it adds those certs to certpool before returning.
+func (c *CertPool) Get() (*x509.CertPool, error) {
+	// if dirty then add certs from queue to cert pool
+	if atomic.CompareAndSwapInt32(&c.dirty, 1, 0) {
+		// swap certpool if queue is dirty
+		err := c.swapCertPool()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	return c.certPool, nil
+}
+
+// Add adds given certs to cert pool queue, those certs will be added to certpool during subsequent Get() call.
+func (c *CertPool) Add(certs ...*x509.Certificate) {
+	if len(certs) == 0 {
+		return
+	}
+
+	// filter certs to be added, check if they already exist or duplicate
+	certsToBeAdded := c.filterCerts(certs...)
+
+	if len(certsToBeAdded) > 0 {
+		c.lock.Lock()
+		defer c.lock.Unlock()
+
+		for _, newCert := range certsToBeAdded {
+			// Store cert name index
+			name := string(newCert.RawSubject)
+			c.certsByName[name] = append(c.certsByName[name], len(c.certs))
+			// Store cert
+			c.certs = append(c.certs, newCert)
+		}
+
+		atomic.CompareAndSwapInt32(&c.dirty, 0, 1)
+	}
+}
+
+func (c *CertPool) swapCertPool() error {
+	newCertPool, err := loadSystemCertPool(c.systemCertPool)
+	if err != nil {
+		return err
+	}
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// add all new certs in queue to new cert pool
+	for _, cert := range c.certs {
+		newCertPool.AddCert(cert)
+	}
+
+	// swap old certpool with new one
+	c.certPool = newCertPool
+
+	return nil
+}
+
+// filterCerts remove certs from list if they already exist in pool or duplicate.
+func (c *CertPool) filterCerts(certs ...*x509.Certificate) []*x509.Certificate {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	filtered := []*x509.Certificate{}
+
+CertLoop:
+	for _, cert := range certs {
+		if cert == nil {
+			continue
+		}
+		possibilities := c.certsByName[string(cert.RawSubject)]
+		for _, p := range possibilities {
+			if c.certs[p].Equal(cert) {
+				continue CertLoop
+			}
+		}
+		filtered = append(filtered, cert)
+	}
+
+	// remove duplicate from list of certs being passed
+	return removeDuplicates(filtered...)
+}
+
+func removeDuplicates(certs ...*x509.Certificate) []*x509.Certificate {
+	encountered := map[*x509.Certificate]bool{}
+	result := []*x509.Certificate{}
+
+	for v := range certs {
+		if !encountered[certs[v]] {
+			encountered[certs[v]] = true
+
+			result = append(result, certs[v])
+		}
+	}
+
+	return result
+}
+
+func loadSystemCertPool(useSystemCertPool bool) (*x509.CertPool, error) {
+	if !useSystemCertPool {
+		return x509.NewCertPool(), nil
+	}
+
+	systemCertPool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Debugf("Loaded system cert pool of size: %d", len(systemCertPool.Subjects()))
+
+	return systemCertPool, nil
+}

--- a/internal/pkg/tlsutil/certpool_test.go
+++ b/internal/pkg/tlsutil/certpool_test.go
@@ -1,0 +1,427 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package tlsutil
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	tlsCaOrg1 = `-----BEGIN CERTIFICATE-----
+MIICSDCCAe+gAwIBAgIQVy95bDHyGiHPiW/hN7iCEzAKBggqhkjOPQQDAjB2MQsw
+CQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNU2FuIEZy
+YW5jaXNjbzEZMBcGA1UEChMQb3JnMS5leGFtcGxlLmNvbTEfMB0GA1UEAxMWdGxz
+Y2Eub3JnMS5leGFtcGxlLmNvbTAeFw0xODA3MjUxNDQxMjJaFw0yODA3MjIxNDQx
+MjJaMHYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQH
+Ew1TYW4gRnJhbmNpc2NvMRkwFwYDVQQKExBvcmcxLmV4YW1wbGUuY29tMR8wHQYD
+VQQDExZ0bHNjYS5vcmcxLmV4YW1wbGUuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0D
+AQcDQgAEMl8XK0Rpr514HXVut0MS/PX07l7gWeXGCQkl8T8LBuuSjGEkgSIuOwpf
+VqQv4TwXH0A8zIBrtxY2/W3/ERhhC6NfMF0wDgYDVR0PAQH/BAQDAgGmMA8GA1Ud
+JQQIMAYGBFUdJQAwDwYDVR0TAQH/BAUwAwEB/zApBgNVHQ4EIgQg+tqYPgAj39pQ
+2EH0hxR4SbPOmDRCmwiDsaVIj7tXIFYwCgYIKoZIzj0EAwIDRwAwRAIgUJVxM/57
+1WMfcy56D2zw6g9APP5Z3g+Qg/Y5cScstkgCIBj0JVuemNxiQWdXZ/Qhc6sh4m5d
+ngzYatfQtNv3/+4V
+-----END CERTIFICATE-----`
+
+	tlsCaOrg2 = `-----BEGIN CERTIFICATE-----
+MIICSDCCAe+gAwIBAgIQRAmchEVD9462610qy8BdfDAKBggqhkjOPQQDAjB2MQsw
+CQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNU2FuIEZy
+YW5jaXNjbzEZMBcGA1UEChMQb3JnMi5leGFtcGxlLmNvbTEfMB0GA1UEAxMWdGxz
+Y2Eub3JnMi5leGFtcGxlLmNvbTAeFw0xODA3MjUxNDQxMjJaFw0yODA3MjIxNDQx
+MjJaMHYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQH
+Ew1TYW4gRnJhbmNpc2NvMRkwFwYDVQQKExBvcmcyLmV4YW1wbGUuY29tMR8wHQYD
+VQQDExZ0bHNjYS5vcmcyLmV4YW1wbGUuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0D
+AQcDQgAErO2jmz8uCcrVAghsV0CqWCbp55apZ+4Sww01eYswbeNWsFkXLeUxoDYW
+24ClPai2+hXe8djlV/0J9dQN9Lb05aNfMF0wDgYDVR0PAQH/BAQDAgGmMA8GA1Ud
+JQQIMAYGBFUdJQAwDwYDVR0TAQH/BAUwAwEB/zApBgNVHQ4EIgQgV28IES/J0+fq
+SZlYwCgztWVcEH4gwOvZw3g3y5J194wwCgYIKoZIzj0EAwIDRwAwRAIgYEcFrfpI
+gd8ZaCY75B07c87C1FkMJqom3TrdyLbb39kCIHS9zZg6t/W/rmSG6rJlXxqS3RRh
+10Y4jiCH6so41N9w
+-----END CERTIFICATE-----`
+
+	tlsOrdererCert = `-----BEGIN CERTIFICATE-----
+MIICNjCCAdygAwIBAgIRAO47NS1d5RtzwWFIUwWpWT0wCgYIKoZIzj0EAwIwbDEL
+MAkGA1UEBhMCVVMxEzARBgNVBAgTCkNhbGlmb3JuaWExFjAUBgNVBAcTDVNhbiBG
+cmFuY2lzY28xFDASBgNVBAoTC2V4YW1wbGUuY29tMRowGAYDVQQDExF0bHNjYS5l
+eGFtcGxlLmNvbTAeFw0xODA3MjUxNDQxMjJaFw0yODA3MjIxNDQxMjJaMGwxCzAJ
+BgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1TYW4gRnJh
+bmNpc2NvMRQwEgYDVQQKEwtleGFtcGxlLmNvbTEaMBgGA1UEAxMRdGxzY2EuZXhh
+bXBsZS5jb20wWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQEQRujXijEID810f9Y
+09zBcqucKcz8G4nRgsbfuLZiLgy3Cq/TJsdgjAIvfqR56KtQaupS6tU8xPtLFIr5
+Vr6oo18wXTAOBgNVHQ8BAf8EBAMCAaYwDwYDVR0lBAgwBgYEVR0lADAPBgNVHRMB
+Af8EBTADAQH/MCkGA1UdDgQiBCCKGZZgFT855X2eDdYagwYvZB8rkWu7xMsRGvvm
+bworhDAKBggqhkjOPQQDAgNIADBFAiEAnmp7VjUxVbfrKRXfpW3X2O27doYxb1Z9
+xjm288m0ljoCID1CMTrMDZn8M/YYpPrw9WkS3n2clykUQeMxeMN8uUCj
+-----END CERTIFICATE-----`
+)
+
+func TestTLSCAConfigWithMultipleCerts(t *testing.T) {
+	// prepare 3 certs
+	certOrg1, err := getCertFromPEMBytes([]byte(tlsCaOrg1))
+	assert.Nil(t, err)
+	assert.NotNil(t, certOrg1)
+
+	certOrg2, err := getCertFromPEMBytes([]byte(tlsCaOrg2))
+	assert.Nil(t, err)
+	assert.NotNil(t, certOrg2)
+
+	certOrderer, err := getCertFromPEMBytes([]byte(tlsOrdererCert))
+	assert.Nil(t, err)
+	assert.NotNil(t, certOrderer)
+
+	// number of subjects in system cert pool
+	c, err := loadSystemCertPool(true)
+	assert.Nil(t, err)
+
+	numberOfSubjects := len(c.Subjects())
+
+	// create certpool instance
+	tlsCertPool, err := NewCertPool(true)
+	assert.Nil(t, err)
+
+	// empty cert pool with just system cert pool certs
+	pool, err := tlsCertPool.Get()
+	assert.Nil(t, err)
+	verifyCertPoolInstance(t, pool, tlsCertPool, 0, 0, 0, numberOfSubjects, 0)
+
+	// add 2 certs
+	tlsCertPool.Add(certOrderer, certOrg1)
+	verifyCertPoolInstance(t, pool, tlsCertPool, 0, 2, 2, numberOfSubjects, 1)
+	pool, err = tlsCertPool.Get()
+	assert.Nil(t, err)
+	verifyCertPoolInstance(t, pool, tlsCertPool, 2, 2, 2, numberOfSubjects, 0)
+
+	// add 1 existing cert, queue should be unchanged and dirty flag should be off
+	tlsCertPool.Add(certOrg1)
+	verifyCertPoolInstance(t, pool, tlsCertPool, 2, 2, 2, numberOfSubjects, 0)
+	pool, err = tlsCertPool.Get()
+	assert.Nil(t, err)
+	verifyCertPoolInstance(t, pool, tlsCertPool, 2, 2, 2, numberOfSubjects, 0)
+
+	// try again, add 1 existing cert, queue should be unchanged and dirty flag should be off
+	tlsCertPool.Add(certOrg1)
+	verifyCertPoolInstance(t, pool, tlsCertPool, 2, 2, 2, numberOfSubjects, 0)
+	pool, err = tlsCertPool.Get()
+	assert.Nil(t, err)
+	verifyCertPoolInstance(t, pool, tlsCertPool, 2, 2, 2, numberOfSubjects, 0)
+
+	// add 2 existing certs, queue should be unchanged and dirty flag should be off
+	tlsCertPool.Add(certOrderer, certOrg1)
+	verifyCertPoolInstance(t, pool, tlsCertPool, 2, 2, 2,
+		numberOfSubjects, 0)
+
+	pool, err = tlsCertPool.Get()
+	assert.Nil(t, err)
+	verifyCertPoolInstance(t, pool, tlsCertPool, 2, 2, 2,
+		numberOfSubjects, 0)
+
+	// add 3 certs, (2 existing + 1 new), queue should have one extra cert and dirty flag should be on
+	tlsCertPool.Add(certOrderer, certOrg1, certOrg2)
+	verifyCertPoolInstance(t, pool, tlsCertPool, 2, 3, 3,
+		numberOfSubjects, 1)
+
+	pool, err = tlsCertPool.Get()
+	assert.Nil(t, err)
+	verifyCertPoolInstance(t, pool, tlsCertPool, 3, 3, 3,
+		numberOfSubjects, 0)
+
+	// add all 3 existing certs, queue should be unchanged and dirty flag should be off
+	tlsCertPool.Add(certOrderer, certOrg1, certOrg2)
+	verifyCertPoolInstance(t, pool, tlsCertPool, 3, 3, 3,
+		numberOfSubjects, 0)
+
+	pool, err = tlsCertPool.Get()
+	assert.Nil(t, err)
+	verifyCertPoolInstance(t, pool, tlsCertPool, 3, 3, 3,
+		numberOfSubjects, 0)
+}
+
+func verifyCertPoolInstance(t *testing.T, pool *x509.CertPool, tlsCertPool *CertPool, numberOfCertsInPool,
+	numberOfCerts, numberOfCertsByName, numberOfSubjects int, dirty int32) {
+	t.Helper()
+
+	assert.NotNil(t, tlsCertPool)
+	assert.Equal(t, dirty, tlsCertPool.dirty)
+	assert.Equal(t, numberOfCerts, len(tlsCertPool.certs))
+	assert.Equal(t, numberOfCertsByName, len(tlsCertPool.certsByName))
+	assert.Equal(t, numberOfSubjects+numberOfCertsInPool, len(pool.Subjects()))
+}
+
+func TestAddingDuplicateCertsToPool(t *testing.T) {
+	// prepare 3 certs
+	certOrg1, err := getCertFromPEMBytes([]byte(tlsCaOrg1))
+	assert.Nil(t, err)
+	assert.NotNil(t, certOrg1)
+
+	certOrg2, err := getCertFromPEMBytes([]byte(tlsCaOrg2))
+	assert.Nil(t, err)
+	assert.NotNil(t, certOrg2)
+
+	certOrderer, err := getCertFromPEMBytes([]byte(tlsOrdererCert))
+	assert.Nil(t, err)
+	assert.NotNil(t, certOrderer)
+
+	// number of subjects in system cert pool
+	c, err := loadSystemCertPool(true)
+	assert.Nil(t, err)
+
+	numberOfSubjects := len(c.Subjects())
+
+	// create certpool instance
+	tlsCertPool, err := NewCertPool(true)
+	assert.Nil(t, err)
+
+	// empty cert pool with just system cert pool certs
+	pool, err := tlsCertPool.Get()
+	assert.Nil(t, err)
+	verifyCertPoolInstance(t, pool, tlsCertPool, 0, 0, 0, numberOfSubjects, 0)
+
+	// add multiple certs with duplicate
+	tlsCertPool.Add(certOrderer, certOrg1, certOrderer, certOrg1, certOrg1, certOrg1, certOrderer, certOrderer)
+	verifyCertPoolInstance(t, pool, tlsCertPool, 0, 2, 2, numberOfSubjects, 1)
+	pool, err = tlsCertPool.Get()
+	assert.Nil(t, err)
+	verifyCertPoolInstance(t, pool, tlsCertPool, 2, 2, 2, numberOfSubjects, 0)
+
+	// add multiple certs with duplicate
+	tlsCertPool.Add(certOrderer, certOrg1, certOrderer, certOrg1, certOrg2, certOrg2, certOrg2, certOrderer, certOrderer)
+	verifyCertPoolInstance(t, pool, tlsCertPool, 2, 3, 3, numberOfSubjects, 1)
+	pool, err = tlsCertPool.Get()
+	assert.Nil(t, err)
+	verifyCertPoolInstance(t, pool, tlsCertPool, 3, 3, 3, numberOfSubjects, 0)
+}
+
+func TestRemoveDuplicatesCerts(t *testing.T) {
+	// prepare 3 certs
+	certOrg1, err := getCertFromPEMBytes([]byte(tlsCaOrg1))
+	assert.Nil(t, err)
+	assert.NotNil(t, certOrg1)
+
+	certOrg2, err := getCertFromPEMBytes([]byte(tlsCaOrg2))
+	assert.Nil(t, err)
+	assert.NotNil(t, certOrg2)
+
+	certOrderer, err := getCertFromPEMBytes([]byte(tlsOrdererCert))
+	assert.Nil(t, err)
+	assert.NotNil(t, certOrderer)
+
+	certs := removeDuplicates(certOrg1, certOrg2, certOrg1, certOrg1, certOrg1, certOrg1, certOrderer)
+	assert.Equal(t, 3, len(certs))
+
+	var hasCertOrg1, hasCertOrg2, hasOrdCert bool
+
+	for _, c := range certs {
+		switch c.Subject.CommonName {
+		case "tlsca.org1.example.com":
+			hasCertOrg1 = true
+		case "tlsca.org2.example.com":
+			hasCertOrg2 = true
+		case "tlsca.example.com":
+			hasOrdCert = true
+		}
+	}
+
+	assert.True(t, hasCertOrg1)
+	assert.True(t, hasCertOrg2)
+	assert.True(t, hasOrdCert)
+}
+
+func TestTLSCAConfig(t *testing.T) {
+	goodCert := &x509.Certificate{
+		RawSubject: []byte("Good header"),
+		Raw:        []byte("Good cert"),
+	}
+
+	tlsCertPool, err := NewCertPool(true)
+	require.NoError(t, err)
+
+	tlsCertPool.Add(goodCert)
+	_, err = tlsCertPool.Get()
+	require.NoError(t, err)
+	assert.NotNil(t, tlsCertPool.certsByName)
+
+	originalLength := len(tlsCertPool.certs)
+	// try again with same cert
+	tlsCertPool.Add(goodCert)
+	_, err = tlsCertPool.Get()
+	assert.NoError(t, err, "TLS CA cert pool fetch failed")
+	assert.False(t, len(tlsCertPool.certs) > originalLength, "number of certs in cert list shouldn't accept duplicates")
+
+	// test with system cert pool disabled
+	tlsCertPool, err = NewCertPool(false)
+	require.NoError(t, err)
+
+	tlsCertPool.Add(goodCert)
+	cPool, err := tlsCertPool.Get()
+	require.NoError(t, err)
+	assert.Len(t, tlsCertPool.certs, 1)
+	assert.Len(t, cPool.Subjects(), 1)
+}
+
+func TestTLSCAPoolManyCerts(t *testing.T) {
+	size := 50
+	goodCert := &x509.Certificate{
+		RawSubject: []byte("Good header"),
+		Raw:        []byte("Good cert"),
+	}
+
+	tlsCertPool, err := NewCertPool(true)
+	require.NoError(t, err)
+
+	tlsCertPool.Add(goodCert)
+	_, err = tlsCertPool.Get()
+	require.NoError(t, err)
+
+	pool, err := tlsCertPool.Get()
+	assert.NoError(t, err)
+
+	originalLen := len(pool.Subjects())
+
+	certs := createNCerts(size)
+	tlsCertPool.Add(certs[0])
+	pool, err = tlsCertPool.Get()
+	assert.NoError(t, err)
+	assert.Len(t, pool.Subjects(), originalLen+1)
+
+	tlsCertPool.Add(certs...)
+	pool, err = tlsCertPool.Get()
+	assert.NoError(t, err)
+	assert.Len(t, pool.Subjects(), originalLen+size)
+}
+
+func TestConcurrent(t *testing.T) {
+	concurrency := 1000
+	certs := createNCerts(concurrency)
+
+	tlsCertPool, err := NewCertPool(false)
+	require.NoError(t, err)
+
+	systemCerts := len(tlsCertPool.certPool.Subjects())
+
+	writeDone := make(chan bool)
+	readDone := make(chan bool)
+
+	for i := 0; i < concurrency; i++ {
+		go func(c *x509.Certificate) {
+			tlsCertPool.Add(c)
+			_, errGet := tlsCertPool.Get()
+			assert.NoError(t, errGet)
+			writeDone <- true
+		}(certs[i])
+
+		go func() {
+			_, errGet := tlsCertPool.Get()
+			assert.NoError(t, errGet)
+			readDone <- true
+		}()
+	}
+
+	for i := 0; i < concurrency; i++ {
+		select {
+		case b := <-writeDone:
+			assert.True(t, b)
+		case <-time.After(time.Second * 10):
+			t.Fatalf("Timed out waiting for write %d", i)
+		}
+
+		select {
+		case b := <-readDone:
+			assert.True(t, b)
+		case <-time.After(time.Second * 10):
+			t.Fatalf("Timed out waiting for read %d", i)
+		}
+	}
+
+	certPool, err := tlsCertPool.Get()
+	assert.Len(t, tlsCertPool.certs, concurrency)
+	require.NoError(t, err)
+	assert.Len(t, certPool.Subjects(), concurrency+systemCerts)
+}
+
+func createNCerts(n int) []*x509.Certificate {
+	var certs []*x509.Certificate
+
+	for i := 0; i < n; i++ {
+		cert := &x509.Certificate{
+			RawSubject: []byte(strconv.Itoa(i)),
+			Raw:        []byte(strconv.Itoa(i)),
+		}
+		certs = append(certs, cert)
+	}
+
+	return certs
+}
+
+func BenchmarkTLSCertPool(b *testing.B) {
+	tlsCertPool, err := NewCertPool(true)
+	require.NoError(b, err)
+
+	for n := 0; n < b.N; n++ {
+		_, err := tlsCertPool.Get()
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkTLSCertPoolSameCert(b *testing.B) {
+	goodCert := &x509.Certificate{
+		RawSubject: []byte("Good header"),
+		Raw:        []byte("Good cert"),
+	}
+
+	tlsCertPool, err := NewCertPool(true)
+	require.NoError(b, err)
+
+	for n := 0; n < b.N; n++ {
+		tlsCertPool.Add(goodCert)
+		_, err = tlsCertPool.Get()
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkTLSCertPoolDifferentCert(b *testing.B) {
+	tlsCertPool, err := NewCertPool(true)
+	require.NoError(b, err)
+
+	certs := createNCerts(b.N)
+
+	for n := 0; n < b.N; n++ {
+		tlsCertPool.Add(certs[n])
+		_, err = tlsCertPool.Get()
+		require.NoError(b, err)
+	}
+}
+
+func getCertFromPEMBytes(pemCerts []byte) (*x509.Certificate, error) {
+	for len(pemCerts) > 0 {
+		var block *pem.Block
+		block, pemCerts = pem.Decode(pemCerts)
+
+		if block == nil {
+			break
+		}
+
+		if block.Type != "CERTIFICATE" || len(block.Headers) != 0 {
+			continue
+		}
+
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			continue
+		}
+
+		return cert, nil
+	}
+
+	return nil, errors.New("empty cert bytes provided")
+}

--- a/internal/pkg/tlsutil/tlsutil.go
+++ b/internal/pkg/tlsutil/tlsutil.go
@@ -1,0 +1,43 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package tlsutil
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"path"
+)
+
+// GetCertPool get cert pool.
+func GetCertPool(useSystemCertPool bool, tlsCACerts []string) (*x509.CertPool, error) {
+	certPool, err := NewCertPool(useSystemCertPool)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new cert pool: %w", err)
+	}
+
+	for _, v := range tlsCACerts {
+		bytes, errRead := ioutil.ReadFile(path.Clean(v))
+		if errRead != nil {
+			return nil, fmt.Errorf("failed to read cert: %w", errRead)
+		}
+
+		block, _ := pem.Decode(bytes)
+		if block == nil {
+			return nil, fmt.Errorf("failed to decode pem")
+		}
+
+		cert, errParse := x509.ParseCertificate(block.Bytes)
+		if errParse != nil {
+			return nil, fmt.Errorf("failed to parse cert: %w", errParse)
+		}
+
+		certPool.Add(cert)
+	}
+
+	return certPool.Get()
+}

--- a/internal/pkg/tlsutil/tlsutil_test.go
+++ b/internal/pkg/tlsutil/tlsutil_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package tlsutil_test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/orb/internal/pkg/tlsutil"
+)
+
+const (
+	tlsCaOrg1 = `-----BEGIN CERTIFICATE-----
+MIICSDCCAe+gAwIBAgIQVy95bDHyGiHPiW/hN7iCEzAKBggqhkjOPQQDAjB2MQsw
+CQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNU2FuIEZy
+YW5jaXNjbzEZMBcGA1UEChMQb3JnMS5leGFtcGxlLmNvbTEfMB0GA1UEAxMWdGxz
+Y2Eub3JnMS5leGFtcGxlLmNvbTAeFw0xODA3MjUxNDQxMjJaFw0yODA3MjIxNDQx
+MjJaMHYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQH
+Ew1TYW4gRnJhbmNpc2NvMRkwFwYDVQQKExBvcmcxLmV4YW1wbGUuY29tMR8wHQYD
+VQQDExZ0bHNjYS5vcmcxLmV4YW1wbGUuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0D
+AQcDQgAEMl8XK0Rpr514HXVut0MS/PX07l7gWeXGCQkl8T8LBuuSjGEkgSIuOwpf
+VqQv4TwXH0A8zIBrtxY2/W3/ERhhC6NfMF0wDgYDVR0PAQH/BAQDAgGmMA8GA1Ud
+JQQIMAYGBFUdJQAwDwYDVR0TAQH/BAUwAwEB/zApBgNVHQ4EIgQg+tqYPgAj39pQ
+2EH0hxR4SbPOmDRCmwiDsaVIj7tXIFYwCgYIKoZIzj0EAwIDRwAwRAIgUJVxM/57
+1WMfcy56D2zw6g9APP5Z3g+Qg/Y5cScstkgCIBj0JVuemNxiQWdXZ/Qhc6sh4m5d
+ngzYatfQtNv3/+4V
+-----END CERTIFICATE-----`
+)
+
+func TestGetCertPool(t *testing.T) {
+	t.Run("test wrong file path", func(t *testing.T) {
+		certPool, err := tlsutil.GetCertPool(false, []string{"wrongLocation"})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to read cert")
+		require.Nil(t, certPool)
+	})
+
+	t.Run("test error from decode pem", func(t *testing.T) {
+		file, err := ioutil.TempFile("", "file")
+		require.NoError(t, err)
+
+		_, err = file.Write([]byte("data"))
+		require.NoError(t, err)
+
+		defer func() { require.NoError(t, os.Remove(file.Name())) }()
+		certPool, err := tlsutil.GetCertPool(false, []string{file.Name()})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to decode pem")
+		require.Nil(t, certPool)
+	})
+
+	t.Run("test error from success", func(t *testing.T) {
+		file, err := ioutil.TempFile("", "file")
+		require.NoError(t, err)
+
+		_, err = file.Write([]byte(tlsCaOrg1))
+		require.NoError(t, err)
+
+		defer func() { require.NoError(t, os.Remove(file.Name())) }()
+		certPool, err := tlsutil.GetCertPool(false, []string{file.Name()})
+		require.NoError(t, err)
+		require.NotNil(t, certPool)
+	})
+}


### PR DESCRIPTION
Moved tlsutils functions to internal orb package.

closes #1493

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>