### PR TITLE
feat: Convert ActivityPub subsystem to use structured logs

### DIFF
--- a/cmd/orb-server/startcmd/log.go
+++ b/cmd/orb-server/startcmd/log.go
@@ -35,7 +35,7 @@ Valid log levels: critical,error,warn,info,debug
 Error: %s`
 
 // setLogLevels sets the log levels for individual modules as well as the default level.
-func setLogLevels(logger log.Logger, logSpec string) {
+func setLogLevels(logger *log.Log, logSpec string) {
 	if err := log.SetSpec(logSpec); err != nil {
 		logger.Warnf(logSpecErrorMsg, err.Error())
 

--- a/internal/pkg/log/common.go
+++ b/internal/pkg/log/common.go
@@ -1,0 +1,26 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package log
+
+import "go.uber.org/zap"
+
+type loggerFunc func(msg string, fields ...zap.Field)
+
+// InvalidParameterValue outputs an 'invalid parameter' log to the given logger.
+func InvalidParameterValue(log loggerFunc, param string, err error) {
+	log("Invalid parameter value", WithParameter(param), WithError(err))
+}
+
+// CloseIterator outputs a 'close iterator' error log to the given logger.
+func CloseIterator(log loggerFunc, err error) {
+	log("Error closing iterator", WithError(err))
+}
+
+// CloseResponseBody outputs an 'close respojnse body' error log to the given logger.
+func CloseResponseBody(log loggerFunc, err error) {
+	log("Error closing response body", WithError(err))
+}

--- a/internal/pkg/log/fields.go
+++ b/internal/pkg/log/fields.go
@@ -1,0 +1,341 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package log
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// Log Fields.
+const (
+	FieldURI                 = "uri"
+	FieldSenderURL           = "sender"
+	FieldConfig              = "config"
+	FieldServiceName         = "service"
+	FieldServiceIRI          = "service-iri"
+	FieldServiceEndpoint     = "service-endpoint"
+	FieldActorID             = "actor-id"
+	FieldActivityType        = "activity-type"
+	FieldActivityID          = "activity-id"
+	FieldMessageID           = "message-id"
+	FieldPayload             = "payload"
+	FieldRequestURL          = "request-url"
+	FieldRequestHeaders      = "request-headers"
+	FieldRequestBody         = "request-body"
+	FieldResponse            = "response"
+	FieldSize                = "size"
+	FieldExpiration          = "expiration"
+	FieldTarget              = "target"
+	FieldQueue               = "queue"
+	FieldHTTPStatus          = "http-status"
+	FieldParameter           = "parameter"
+	FieldAcceptListType      = "accept-list-type"
+	FieldAcceptListAdditions = "accept-list-additions"
+	FieldAcceptListDeletions = "accept-list-deletions"
+	FieldReferenceType       = "reference-type"
+	FieldAnchorURI           = "anchor-uri"
+	FieldAnchorEventURI      = "anchor-event-uri"
+	FieldObjectIRI           = "object-iri"
+	FieldReferenceIRI        = "reference"
+	FieldKeyID               = "key-id"
+	FieldKeyType             = "key-type"
+	FieldKeyOwner            = "key-owner"
+	FieldCurrent             = "current"
+	FieldNext                = "next"
+	FieldTotalItems          = "total"
+	FieldType                = "type"
+	FieldQuery               = "query"
+)
+
+// WithError sets the error field.
+func WithError(err error) zap.Field {
+	return zap.Error(err)
+}
+
+// WithMessageID sets the message-id field.
+func WithMessageID(value string) zap.Field {
+	return zap.String(FieldMessageID, value)
+}
+
+// WithPayload sets the payload field.
+func WithPayload(value []byte) zap.Field {
+	return zap.String(FieldPayload, string(value))
+}
+
+// WithRequestURL sets the request-url field.
+func WithRequestURL(value fmt.Stringer) zap.Field {
+	return zap.Stringer(FieldRequestURL, value)
+}
+
+// WithRequestURLString sets the request-url field.
+func WithRequestURLString(value string) zap.Field {
+	return zap.String(FieldRequestURL, value)
+}
+
+// WithRequestHeaders sets the request-headers field.
+func WithRequestHeaders(value http.Header) zap.Field {
+	return zap.Object(FieldRequestHeaders, newHTTPHeaderMarshaller(value))
+}
+
+// WithRequestBody sets the request-body field.
+func WithRequestBody(value []byte) zap.Field {
+	return zap.String(FieldRequestBody, string(value))
+}
+
+// WithResponse sets the response field.
+func WithResponse(value []byte) zap.Field {
+	return zap.String(FieldResponse, string(value))
+}
+
+// WithServiceName sets the service field.
+func WithServiceName(value string) zap.Field {
+	return zap.String(FieldServiceName, value)
+}
+
+// WithServiceIRI sets the service-iri field.
+func WithServiceIRI(value fmt.Stringer) zap.Field {
+	return zap.Stringer(FieldServiceIRI, value)
+}
+
+// WithServiceEndpoint sets the service-endpoint field.
+func WithServiceEndpoint(value string) zap.Field {
+	return zap.String(FieldServiceEndpoint, value)
+}
+
+// WithActivityType sets the activity-type field.
+func WithActivityType(value string) zap.Field {
+	return zap.String(FieldActivityType, value)
+}
+
+// WithActivityID sets the activity-id field.
+func WithActivityID(value fmt.Stringer) zap.Field {
+	return zap.Stringer(FieldActivityID, value)
+}
+
+// WithActorIRI sets the actor-id field.
+func WithActorIRI(value fmt.Stringer) zap.Field {
+	return zap.Stringer(FieldActorID, value)
+}
+
+// WithActorID sets the actor-id field.
+func WithActorID(value string) zap.Field {
+	return zap.String(FieldActorID, value)
+}
+
+// WithConfig sets the config field. The value of the field is
+// encoded as JSON.
+func WithConfig(value interface{}) zap.Field {
+	return zap.Inline(newJSONMarshaller(FieldConfig, value))
+}
+
+// WithSize sets the size field.
+func WithSize(value int) zap.Field {
+	return zap.Int(FieldSize, value)
+}
+
+// WithExpiration sets the expiration field.
+func WithExpiration(value time.Duration) zap.Field {
+	return zap.Duration(FieldExpiration, value)
+}
+
+// WithTarget sets the target field.
+func WithTarget(value string) zap.Field {
+	return zap.String(FieldTarget, value)
+}
+
+// WithTargetIRI sets the target field.
+func WithTargetIRI(value fmt.Stringer) zap.Field {
+	return zap.Stringer(FieldTarget, value)
+}
+
+// WithQueue sets the queue field.
+func WithQueue(value string) zap.Field {
+	return zap.String(FieldQueue, value)
+}
+
+// WithHTTPStatus sets the http-status field.
+func WithHTTPStatus(value int) zap.Field {
+	return zap.Int(FieldHTTPStatus, value)
+}
+
+// WithParameter sets the parameter field.
+func WithParameter(value string) zap.Field {
+	return zap.String(FieldParameter, value)
+}
+
+// WithAcceptListType sets the accept-list-type field.
+func WithAcceptListType(value string) zap.Field {
+	return zap.String(FieldAcceptListType, value)
+}
+
+// WithAcceptListAdditions sets the accept-list-additions field.
+func WithAcceptListAdditions(value ...*url.URL) zap.Field {
+	return zap.Array(FieldAcceptListAdditions, newURLArrayMarshaller(value))
+}
+
+// WithAcceptListDeletions sets the accept-list-deletions field.
+func WithAcceptListDeletions(value ...*url.URL) zap.Field {
+	return zap.Array(FieldAcceptListDeletions, newURLArrayMarshaller(value))
+}
+
+// WithReferenceType sets the reference-type field.
+func WithReferenceType(value string) zap.Field {
+	return zap.String(FieldReferenceType, value)
+}
+
+// WithURI sets the uri field.
+func WithURI(value fmt.Stringer) zap.Field {
+	return zap.Stringer(FieldURI, value)
+}
+
+// WithSenderURL sets the sender field.
+func WithSenderURL(value fmt.Stringer) zap.Field {
+	return zap.Stringer(FieldSenderURL, value)
+}
+
+// WithAnchorEventURI sets the anchor-event-uri field.
+func WithAnchorEventURI(value fmt.Stringer) zap.Field {
+	return zap.Stringer(FieldAnchorEventURI, value)
+}
+
+// WithAnchorURI sets the anchor-uri field.
+func WithAnchorURI(value fmt.Stringer) zap.Field {
+	return zap.Stringer(FieldAnchorURI, value)
+}
+
+// WithObjectIRI sets the object-iri field.
+func WithObjectIRI(value fmt.Stringer) zap.Field {
+	return zap.Stringer(FieldObjectIRI, value)
+}
+
+// WithReferenceIRI sets the reference field.
+func WithReferenceIRI(value fmt.Stringer) zap.Field {
+	return zap.Stringer(FieldReferenceIRI, value)
+}
+
+// WithKeyID sets the key-id field.
+func WithKeyID(value string) zap.Field {
+	return zap.String(FieldKeyID, value)
+}
+
+// WithKeyIRI sets the key-id field.
+func WithKeyIRI(value fmt.Stringer) zap.Field {
+	return zap.Stringer(FieldKeyID, value)
+}
+
+// WithKeyOwnerIRI sets the key-owner field.
+func WithKeyOwnerIRI(value fmt.Stringer) zap.Field {
+	return zap.Stringer(FieldKeyOwner, value)
+}
+
+// WithKeyType sets the key-type field.
+func WithKeyType(value string) zap.Field {
+	return zap.String(FieldKeyType, value)
+}
+
+// WithCurrentIRI sets the current field.
+func WithCurrentIRI(value fmt.Stringer) zap.Field {
+	return zap.Stringer(FieldCurrent, value)
+}
+
+// WithNextIRI sets the next field.
+func WithNextIRI(value fmt.Stringer) zap.Field {
+	return zap.Stringer(FieldNext, value)
+}
+
+// WithTotal sets the total field.
+func WithTotal(value int) zap.Field {
+	return zap.Int(FieldTotalItems, value)
+}
+
+// WithType sets the type field.
+func WithType(value string) zap.Field {
+	return zap.String(FieldType, value)
+}
+
+// WithQuery sets the query field. The value of the field is
+// encoded as JSON.
+func WithQuery(value interface{}) zap.Field {
+	return zap.Inline(newJSONMarshaller(FieldQuery, value))
+}
+
+type jsonMarshaller struct {
+	key string
+	obj interface{}
+}
+
+func newJSONMarshaller(key string, value interface{}) *jsonMarshaller {
+	return &jsonMarshaller{key: key, obj: value}
+}
+
+func (m *jsonMarshaller) MarshalLogObject(e zapcore.ObjectEncoder) error {
+	b, err := json.Marshal(m.obj)
+	if err != nil {
+		return fmt.Errorf("marshal json: %w", err)
+	}
+
+	e.AddString(m.key, string(b))
+
+	return nil
+}
+
+type urlArrayMarshaller struct {
+	urls []*url.URL
+}
+
+func newURLArrayMarshaller(urls []*url.URL) *urlArrayMarshaller {
+	return &urlArrayMarshaller{urls: urls}
+}
+
+func (m *urlArrayMarshaller) MarshalLogArray(e zapcore.ArrayEncoder) error {
+	for _, u := range m.urls {
+		e.AppendString(u.String())
+	}
+
+	return nil
+}
+
+type httpHeaderMarshaller struct {
+	headers http.Header
+}
+
+func newHTTPHeaderMarshaller(headers http.Header) *httpHeaderMarshaller {
+	return &httpHeaderMarshaller{headers: headers}
+}
+
+func (m *httpHeaderMarshaller) MarshalLogObject(e zapcore.ObjectEncoder) error {
+	for k, values := range m.headers {
+		if err := e.AddArray(k, newStringArrayMarshaller(values)); err != nil {
+			return fmt.Errorf("marshal values: %w", err)
+		}
+	}
+
+	return nil
+}
+
+type stringArrayMarshaller struct {
+	values []string
+}
+
+func newStringArrayMarshaller(values []string) *stringArrayMarshaller {
+	return &stringArrayMarshaller{values: values}
+}
+
+func (m *stringArrayMarshaller) MarshalLogArray(e zapcore.ArrayEncoder) error {
+	for _, v := range m.values {
+		e.AppendString(v)
+	}
+
+	return nil
+}

--- a/internal/pkg/log/logger_test.go
+++ b/internal/pkg/log/logger_test.go
@@ -8,7 +8,12 @@ package log
 
 import (
 	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -324,6 +329,133 @@ func TestLogLevels(t *testing.T) {
 	require.False(t, mlevel.isEnabled("module-xyz-random-module", DEBUG))
 }
 
+func TestStructuredLogger(t *testing.T) {
+	const module = "test_module"
+
+	u1 := parseURL(t, "https://example1.com")
+	u2 := parseURL(t, "https://example2.com")
+	u3 := parseURL(t, "https://example3.com")
+
+	t.Run("console error", func(t *testing.T) {
+		stdErr := newMockWriter()
+
+		logger := NewStructured(module,
+			WithStdErr(stdErr),
+			WithFields(WithServiceName("myservice")),
+		)
+
+		logger.Error("Sample error", WithError(errors.New("some error")))
+
+		require.Contains(t, stdErr.Buffer.String(), `Sample error	{"service": "myservice", "error": "some error"}`)
+	})
+
+	t.Run("json error", func(t *testing.T) {
+		stdErr := newMockWriter()
+
+		logger := NewStructured(module,
+			WithStdErr(stdErr), WithEncoding(JSON),
+			WithFields(WithServiceName("myservice")),
+		)
+
+		logger.Error("Sample error", WithError(errors.New("some error")))
+
+		var l logData
+		require.NoError(t, json.Unmarshal(stdErr.Bytes(), &l))
+
+		require.Equal(t, "myservice", l.Service)
+		require.Equal(t, "test_module", l.Logger)
+		require.Equal(t, "Sample error", l.Msg)
+		require.Contains(t, l.Caller, "log/logger_test.go")
+		require.Equal(t, "some error", l.Error)
+		require.Equal(t, "error", l.Level)
+	})
+
+	t.Run("json fields 1", func(t *testing.T) {
+		stdOut := newMockWriter()
+
+		logger := NewStructured(module, WithStdOut(stdOut), WithEncoding(JSON))
+
+		logger.Info("Some message",
+			WithMessageID("msg1"), WithPayload([]byte(`{"field":"value"}`)),
+			WithActorIRI(u1), WithActivityID(u2), WithActivityType("Create"),
+			WithServiceIRI(parseURL(t, u2.String())), WithServiceName("service1"),
+			WithServiceEndpoint("/services/service1"),
+			WithSize(1234), WithExpiration(12*time.Second),
+			WithTargetIRI(u1), WithQueue("queue1"),
+			WithHTTPStatus(http.StatusNotFound), WithParameter("param1"),
+			WithReferenceType("followers"), WithURI(u2),
+			WithSenderURL(u1), WithAnchorURI(u3), WithAnchorEventURI(u3),
+			WithAcceptListType("follow"),
+			WithAcceptListAdditions(u1, u3),
+			WithAcceptListDeletions(u1),
+			WithRequestURL(u1), WithRequestBody([]byte(`request body`)), WithResponse([]byte(`response body`)),
+			WithRequestHeaders(map[string][]string{"key1": {"v1", "v2"}, "key2": {"v3"}}),
+		)
+
+		l := unmarshalLogData(t, stdOut.Bytes())
+
+		require.Equal(t, `Some message`, l.Msg)
+		require.Equal(t, `msg1`, l.MessageID)
+		require.Equal(t, `{"field":"value"}`, l.Payload)
+		require.Equal(t, u1.String(), l.ActorID)
+		require.Equal(t, u2.String(), l.ActivityID)
+		require.Equal(t, `Create`, l.ActivityType)
+		require.Equal(t, `service1`, l.Service)
+		require.Equal(t, `/services/service1`, l.ServiceEndpoint)
+		require.Equal(t, u2.String(), l.ServiceIri)
+		require.Equal(t, 1234, l.Size)
+		require.Equal(t, `12s`, l.Expiration)
+		require.Equal(t, u1.String(), l.Target)
+		require.Equal(t, `queue1`, l.Queue)
+		require.Equal(t, 404, l.HTTPStatus)
+		require.Equal(t, `param1`, l.Parameter)
+		require.Equal(t, `followers`, l.ReferenceType)
+		require.Equal(t, u2.String(), l.URI)
+		require.Equal(t, u3.String(), l.AnchorURI)
+		require.Equal(t, u3.String(), l.AnchorEventURI)
+		require.Equal(t, `follow`, l.AcceptListType)
+		require.Equal(t, []string{u1.String(), u3.String()}, l.AcceptListAdditions)
+		require.Equal(t, []string{u1.String()}, l.AcceptListDeletions)
+		require.Equal(t, u1.String(), l.RequestURL)
+		require.Equal(t, `request body`, l.RequestBody)
+		require.Equal(t, `response body`, l.Response)
+		require.Equal(t, map[string][]string{"key1": {"v1", "v2"}, "key2": {"v3"}}, l.RequestHeaders)
+	})
+
+	t.Run("json fields 2", func(t *testing.T) {
+		stdOut := newMockWriter()
+
+		logger := NewStructured(module, WithStdOut(stdOut), WithEncoding(JSON))
+
+		logger.Info("Some message",
+			WithActorID(u1.String()), WithTarget(u2.String()),
+			WithConfig(&mockConfig{Field1: "value1", Field2: 1234}),
+			WithRequestURLString(u1.String()),
+		)
+
+		l := unmarshalLogData(t, stdOut.Bytes())
+
+		require.Equal(t, `Some message`, l.Msg)
+		require.Equal(t, u1.String(), l.ActorID)
+		require.Equal(t, u2.String(), l.Target)
+		require.Equal(t, `{"Field1":"value1","Field2":1234}`, l.Config)
+		require.Equal(t, u1.String(), l.RequestURL)
+	})
+
+	t.Run("marshal error", func(t *testing.T) {
+		stdOut := newMockWriter()
+
+		logger := NewStructured(module, WithStdOut(stdOut), WithEncoding(JSON))
+
+		logger.Info("Some message", WithConfig(func() {}))
+
+		l := unmarshalLogData(t, stdOut.Bytes())
+
+		require.Equal(t, `Some message`, l.Msg)
+		require.Equal(t, `marshal json: json: unsupported type: func()`, l.Error)
+	})
+}
+
 func resetLoggingLevels() {
 	SetLevel("module1", INFO)
 	SetLevel("module2", INFO)
@@ -342,4 +474,65 @@ func verifyLevels(t *testing.T, module string, enabled, disabled []Level) {
 		require.False(t, levels.isEnabled(module, level),
 			"expected level [%s] to be disabled for module [%s]", level, module)
 	}
+}
+
+type mockConfig struct {
+	Field1 string
+	Field2 int
+}
+
+type logData struct {
+	Level  string `json:"level"`
+	Time   string `json:"time"`
+	Logger string `json:"logger"`
+	Caller string `json:"caller"`
+	Msg    string `json:"msg"`
+	Error  string `json:"error"`
+
+	MessageID           string              `json:"message-id"`
+	Payload             string              `json:"payload"`
+	ActorID             string              `json:"actor-id"`
+	ActivityID          string              `json:"activity-id"`
+	ActivityType        string              `json:"activity-type"`
+	ServiceIri          string              `json:"service-iri"`
+	Service             string              `json:"service"`
+	ServiceEndpoint     string              `json:"service-endpoint"`
+	Size                int                 `json:"size"`
+	Expiration          string              `json:"expiration"`
+	Target              string              `json:"target"`
+	Queue               string              `json:"queue"`
+	HTTPStatus          int                 `json:"http-status"`
+	Parameter           string              `json:"parameter"`
+	ReferenceType       string              `json:"reference-type"`
+	URI                 string              `json:"uri"`
+	Sender              string              `json:"sender"`
+	AnchorURI           string              `json:"anchor-uri"`
+	AnchorEventURI      string              `json:"anchor-event-uri"`
+	Config              string              `json:"config"`
+	AcceptListType      string              `json:"accept-list-type"`
+	AcceptListAdditions []string            `json:"accept-list-additions"`
+	AcceptListDeletions []string            `json:"accept-list-deletions"`
+	RequestURL          string              `json:"request-url"`
+	RequestHeaders      map[string][]string `json:"request-headers"`
+	RequestBody         string              `json:"request-body"`
+	Response            string              `json:"response"`
+}
+
+func unmarshalLogData(t *testing.T, b []byte) *logData {
+	t.Helper()
+
+	l := &logData{}
+
+	require.NoError(t, json.Unmarshal(b, l))
+
+	return l
+}
+
+func parseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+
+	return u
 }

--- a/pkg/activitypub/client/transport/transport.go
+++ b/pkg/activitypub/client/transport/transport.go
@@ -18,7 +18,7 @@ import (
 	apclientmocks "github.com/trustbloc/orb/pkg/activitypub/client/mocks"
 )
 
-var logger = log.New("activitypub_client")
+var logger = log.NewStructured("activitypub_client")
 
 const (
 	// AcceptHeader specifies the content type that the client is expecting.
@@ -139,9 +139,9 @@ func (t *Transport) Post(ctx context.Context, r *Request, payload []byte) (*http
 			return nil, fmt.Errorf("sign request: %w", err)
 		}
 
-		logger.Debugf("Signed HTTP POST to %s. Headers: %s", r.URL, req.Header)
+		logger.Debug("Signed HTTP POST", log.WithRequestURL(r.URL), log.WithRequestHeaders(req.Header))
 	} else {
-		logger.Debugf("HTTP signature is not required for HTTP POST to %s", r.URL)
+		logger.Debug("HTTP signature is not required for HTTP POST", log.WithRequestURL(r.URL))
 	}
 
 	return t.client.Do(req)
@@ -169,9 +169,9 @@ func (t *Transport) Get(ctx context.Context, r *Request) (*http.Response, error)
 			return nil, fmt.Errorf("sign request: %w", err)
 		}
 
-		logger.Debugf("Signed HTTP GET to %s. Headers: %s", r.URL, req.Header)
+		logger.Debug("Signed HTTP GET", log.WithRequestURL(r.URL), log.WithRequestHeaders(req.Header))
 	} else {
-		logger.Debugf("HTTP signature is not required for HTTP GET to %s", r.URL)
+		logger.Debug("HTTP signature is not required for HTTP GET", log.WithRequestURL(r.URL))
 	}
 
 	return t.client.Do(req)

--- a/pkg/activitypub/httpsig/algorithm.go
+++ b/pkg/activitypub/httpsig/algorithm.go
@@ -14,6 +14,8 @@ import (
 
 	ariesverifier "github.com/hyperledger/aries-framework-go/pkg/doc/signature/verifier"
 	httpsig "github.com/igor-pavlenko/httpsignatures-go"
+
+	"github.com/trustbloc/orb/internal/pkg/log"
 )
 
 const orbHTTPSigAlgorithm = "Sign"
@@ -59,17 +61,17 @@ func (a *SignatureHashAlgorithm) Algorithm() string {
 func (a *SignatureHashAlgorithm) Create(secret httpsig.Secret, data []byte) ([]byte, error) {
 	kh, err := a.KMS.Get(a.keyID)
 	if err != nil {
-		return nil, fmt.Errorf("get key handle: %w", err)
+		return nil, fmt.Errorf("get KMS key handle: %w", err)
 	}
 
-	logger.Debugf("Got key handle for key ID [%s]. Signing ...", secret.KeyID)
+	logger.Debug("Got key handle. Signing ...", log.WithKeyID(secret.KeyID))
 
 	sig, err := a.Crypto.Sign(data, kh)
 	if err != nil {
 		return nil, fmt.Errorf("sign data: %w", err)
 	}
 
-	logger.Debugf("... successfully signed data with keyID from KMS [%s]", a.keyID)
+	logger.Debug("... successfully signed data with KMS", log.WithKeyID(a.keyID))
 
 	return sig, nil
 }
@@ -81,7 +83,7 @@ func (a *SignatureHashAlgorithm) Verify(secret httpsig.Secret, data, signature [
 		return fmt.Errorf("resolve key %s: %w", secret.KeyID, err)
 	}
 
-	logger.Debugf("Got key %+v from keyID [%s]", pubKey, secret.KeyID)
+	logger.Debug("Got public key", log.WithKeyType(pubKey.Type), log.WithKeyID(secret.KeyID))
 
 	switch {
 	case strings.HasPrefix(pubKey.Type, "Ed25519"):
@@ -111,24 +113,22 @@ func NewKeyResolver(actorRetriever actorRetriever) *KeyResolver {
 func (r *KeyResolver) Resolve(keyID string) (*ariesverifier.PublicKey, error) {
 	keyIRI, err := url.Parse(keyID)
 	if err != nil {
-		logger.Errorf("Error parsing public key IRI [%s]: %s", keyID, err)
+		logger.Error("Error parsing public key", log.WithKeyID(keyID), log.WithError(err))
 
 		return nil, fmt.Errorf("parse key IRI [%s]: %w", keyID, err)
 	}
 
-	logger.Debugf("Retrieving public key for key IRI [%s]", keyIRI)
+	logger.Debug("Retrieving public key", log.WithKeyIRI(keyIRI))
 
 	pubKey, err := r.pubKeyRetriever.GetPublicKey(keyIRI)
 	if err != nil {
-		logger.Errorf("Error retrieving public key for IRI [%s]: %s", keyIRI, err)
+		logger.Error("Error retrieving public key", log.WithKeyIRI(keyIRI), log.WithError(err))
 
 		return nil, fmt.Errorf("retrieve public key for ID [%s]: %w", keyID, err)
 	}
 
-	block, rest := pem.Decode([]byte(pubKey.PublicKeyPem()))
+	block, _ := pem.Decode([]byte(pubKey.PublicKeyPem()))
 	if block == nil {
-		logger.Warnf("invalid public key: nil block. Rest: %s", rest)
-
 		return nil, fmt.Errorf("invalid public key for ID [%s]: nil block", keyID)
 	}
 

--- a/pkg/activitypub/httpsig/signer.go
+++ b/pkg/activitypub/httpsig/signer.go
@@ -16,7 +16,7 @@ import (
 	"github.com/trustbloc/orb/internal/pkg/log"
 )
 
-var logger = log.New("activitypub_httpsig")
+var logger = log.NewStructured("activitypub_httpsig")
 
 const (
 	dateHeader = "Date"
@@ -82,13 +82,14 @@ func NewSigner(cfg SignerConfig, cr crypto, km keyManager, keyID string) *Signer
 func (s *Signer) SignRequest(pubKeyID string, req *http.Request) error {
 	req.Header.Add(dateHeader, date())
 
-	logger.Debugf("Signing request for %s. Public key ID [%s]. Headers: %s", req.RequestURI, pubKeyID, req.Header)
+	logger.Debug("Signing request for %s. Public key ID [%s]. Headers: %s", log.WithRequestURLString(req.RequestURI),
+		log.WithKeyID(pubKeyID), log.WithRequestHeaders(req.Header))
 
 	if err := s.signer().Sign(pubKeyID, req); err != nil {
 		return fmt.Errorf("sign request with public key ID [%s]: %w", pubKeyID, err)
 	}
 
-	logger.Debugf("Signed request. Headers: %s", req.Header)
+	logger.Debug("Signed request.", log.WithRequestHeaders(req.Header))
 
 	return nil
 }

--- a/pkg/activitypub/resthandler/resthandler.go
+++ b/pkg/activitypub/resthandler/resthandler.go
@@ -23,7 +23,7 @@ import (
 	orberrors "github.com/trustbloc/orb/pkg/errors"
 )
 
-var logger = log.New("activitypub_resthandler")
+const loggerModule = "activitypub_resthandler"
 
 const (
 	// PublicKeysPath specifies the service's "keys" endpoint.
@@ -225,7 +225,7 @@ func (h *handler) paramAsInt(req *http.Request, param string) (int, bool) {
 
 	size, err := strconv.Atoi(values[0])
 	if err != nil {
-		logger.Debugf("Invalid value for parameter [%s]: %s", param, err)
+		log.InvalidParameterValue(h.logger.Error, param, err)
 
 		return 0, false
 	}
@@ -243,7 +243,7 @@ func (h *handler) paramAsBool(req *http.Request, param string) bool {
 
 	b, err := strconv.ParseBool(values[0])
 	if err != nil {
-		logger.Debugf("Invalid value for parameter [%s]: %s", param, err)
+		log.InvalidParameterValue(h.logger.Error, param, err)
 
 		return false
 	}

--- a/pkg/activitypub/service/acceptlist/acceptlist.go
+++ b/pkg/activitypub/service/acceptlist/acceptlist.go
@@ -19,7 +19,7 @@ import (
 	orberrors "github.com/trustbloc/orb/pkg/errors"
 )
 
-var logger = log.New("accept_list")
+var logger = log.NewStructured("accept_list")
 
 const acceptTypeTag = "acceptType"
 
@@ -83,7 +83,7 @@ func (m *Manager) Update(acceptType string, additions, deletions []*url.URL) err
 	}
 
 	if len(operations) == 0 {
-		logger.Debugf("No new additions or deletions for type [%s].", acceptType)
+		logger.Debug("No new additions or deletions for type.", log.WithAcceptListType(acceptType))
 
 		return nil
 	}
@@ -93,8 +93,9 @@ func (m *Manager) Update(acceptType string, additions, deletions []*url.URL) err
 		return orberrors.NewTransient(fmt.Errorf("batch update: %w", err))
 	}
 
-	logger.Debugf("Successfully updated the accept list [%s] - Additions: %s, Deletions: %s",
-		acceptType, additions, deletions)
+	logger.Debug("Successfully updated the accept list [%s] - Additions: %s, Deletions: %s",
+		log.WithAcceptListType(acceptType), log.WithAcceptListAdditions(additions...),
+		log.WithAcceptListDeletions(deletions...))
 
 	return nil
 }
@@ -176,14 +177,14 @@ func (m *Manager) next(it storage.Iterator, acceptListMap map[string]*spi.Accept
 
 	err = m.unmarshal(value, &cfg)
 	if err != nil {
-		logger.Warnf("Error unmarshalling accept-list config: %s. The item will be ignored.", err)
+		logger.Warn("Error unmarshalling accept-list config. The item will be ignored.", log.WithError(err))
 
 		return true, nil
 	}
 
 	uri, err := url.Parse(cfg.URI)
 	if err != nil {
-		logger.Warnf("Invalid URI [%s]: %s. The item will be ignored.", cfg.URI, err)
+		logger.Warn("Invalid target URI. The item will be ignored.", log.WithTarget(cfg.URI), log.WithError(err))
 
 		return true, nil
 	}

--- a/pkg/activitypub/service/activityhandler/acceptlistauthhandler.go
+++ b/pkg/activitypub/service/activityhandler/acceptlistauthhandler.go
@@ -10,8 +10,11 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/trustbloc/orb/internal/pkg/log"
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
 )
+
+var logger = log.NewStructured(loggerModule)
 
 const (
 	// FollowType defines the 'follow' accept list type.
@@ -47,12 +50,14 @@ func (h *AcceptListAuthHandler) AuthorizeActor(actor *vocab.ActorType) (bool, er
 	}
 
 	if contains(allowList, actor.ID().URL()) {
-		logger.Debugf("Actor [%s] is in the accept list for type [%s]", actor.ID(), h.allowType)
+		logger.Debug("Actor is in the accept list for the given type",
+			log.WithActorID(actor.ID().String()), log.WithAcceptListType(h.allowType))
 
 		return true, nil
 	}
 
-	logger.Debugf("Actor [%s] is NOT in the accept list for type [%s]", actor.ID(), h.allowType)
+	logger.Debug("Actor is NOT in the accept-list for the given type",
+		log.WithActorID(actor.ID().String()), log.WithAcceptListType(h.allowType))
 
 	return false, nil
 }

--- a/pkg/activitypub/service/outbox/outbox_test.go
+++ b/pkg/activitypub/service/outbox/outbox_test.go
@@ -148,7 +148,7 @@ func TestOutbox_Post(t *testing.T) {
 			func(w http.ResponseWriter, req *http.Request) {
 				collID := testutil.NewMockID(service2URL, resthandler.WitnessesPath)
 
-				if !paramAsBool(req, "page") {
+				if !paramAsBool(t, req, "page") {
 					handleMockCollection(t, collID, witnesses, w, req)
 				} else {
 					handleMockCollectionPage(t, collID, witnesses, w, req)
@@ -805,7 +805,9 @@ func (m *testHandler) Handler() common.HTTPRequestHandler {
 	return m.handler
 }
 
-func paramAsInt(req *http.Request, param string) (int, bool) {
+func paramAsInt(t *testing.T, req *http.Request, param string) (int, bool) {
+	t.Helper()
+
 	params := req.URL.Query()
 
 	values := params[param]
@@ -815,7 +817,7 @@ func paramAsInt(req *http.Request, param string) (int, bool) {
 
 	size, err := strconv.Atoi(values[0])
 	if err != nil {
-		logger.Debugf("Invalid value for parameter [%s]: %s", param, err)
+		t.Logf("Invalid value for parameter [%s]: %s", param, err)
 
 		return 0, false
 	}
@@ -823,7 +825,9 @@ func paramAsInt(req *http.Request, param string) (int, bool) {
 	return size, true
 }
 
-func paramAsBool(req *http.Request, param string) bool {
+func paramAsBool(t *testing.T, req *http.Request, param string) bool {
+	t.Helper()
+
 	params := req.URL.Query()
 
 	values := params[param]
@@ -833,7 +837,7 @@ func paramAsBool(req *http.Request, param string) bool {
 
 	b, err := strconv.ParseBool(values[0])
 	if err != nil {
-		logger.Debugf("Invalid value for parameter [%s]: %s", param, err)
+		t.Logf("Invalid value for parameter [%s]: %s", param, err)
 
 		return false
 	}
@@ -897,7 +901,7 @@ func handleMockCollectionPage(t *testing.T, collID *url.URL, uris []*url.URL,
 	w http.ResponseWriter, req *http.Request) {
 	t.Helper()
 
-	pageNum, ok := paramAsInt(req, "page-num")
+	pageNum, ok := paramAsInt(t, req, "page-num")
 	if !ok {
 		pageNum = 0
 	}

--- a/pkg/activitypub/store/spi/spi.go
+++ b/pkg/activitypub/store/spi/spi.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package spi
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 
@@ -133,6 +134,11 @@ type Criteria struct {
 	ActivityIRIs  []*url.URL
 }
 
+// MarshalJSON marshals the criteria into a logger-friendly format.
+func (c *Criteria) MarshalJSON() ([]byte, error) {
+	return json.Marshal(newLoggedCriteria(c))
+}
+
 // CriteriaOpt sets a Criteria option.
 type CriteriaOpt func(q *Criteria)
 
@@ -200,4 +206,22 @@ type ReferenceIterator interface {
 	Next() (*url.URL, error)
 	// Close closes the iterator.
 	Close() error
+}
+
+type loggedCriteria struct {
+	Types         []vocab.Type                 `json:"types,omitempty"`
+	ReferenceType ReferenceType                `json:"referenceType,omitempty"`
+	ObjectIRI     *vocab.URLProperty           `json:"objectIRI,omitempty"`
+	ReferenceIRI  *vocab.URLProperty           `json:"referenceIRI,omitempty"`
+	ActivityIRIs  *vocab.URLCollectionProperty `json:"activityIRIs,omitempty"`
+}
+
+func newLoggedCriteria(c *Criteria) *loggedCriteria {
+	return &loggedCriteria{
+		Types:         c.Types,
+		ReferenceType: c.ReferenceType,
+		ObjectIRI:     vocab.NewURLProperty(c.ObjectIRI),
+		ReferenceIRI:  vocab.NewURLProperty(c.ReferenceIRI),
+		ActivityIRIs:  vocab.NewURLCollectionProperty(c.ActivityIRIs...),
+	}
 }

--- a/pkg/activitypub/store/spi/spi_test.go
+++ b/pkg/activitypub/store/spi/spi_test.go
@@ -7,17 +7,33 @@ SPDX-License-Identifier: Apache-2.0
 package spi
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/trustbloc/orb/pkg/activitypub/vocab"
+	"github.com/trustbloc/orb/pkg/internal/testutil"
 )
 
 func TestCriteria(t *testing.T) {
-	c := NewCriteria(WithType(vocab.TypeCreate, vocab.TypeAnnounce))
+	c := NewCriteria(
+		WithType(vocab.TypeCreate, vocab.TypeAnnounce),
+		WithReferenceType(Inbox),
+		WithReferenceIRI(testutil.MustParseURL("https://example.com/ref")),
+		WithObjectIRI(testutil.MustParseURL("https://example.com/obj")),
+		WithActivityIRIs(
+			testutil.MustParseURL("https://example.com/activity1"),
+			testutil.MustParseURL("https://example.com/activity2"),
+		),
+	)
 	require.NotNil(t, c)
 	require.Len(t, c.Types, 2)
 	require.Equal(t, vocab.TypeCreate, c.Types[0])
 	require.Equal(t, vocab.TypeAnnounce, c.Types[1])
+
+	b, err := json.Marshal(c)
+	require.NoError(t, err)
+
+	t.Logf("%s", b)
 }

--- a/pkg/activitypub/vocab/objecttype.go
+++ b/pkg/activitypub/vocab/objecttype.go
@@ -241,6 +241,29 @@ func (u Urls) contains(v fmt.Stringer) bool {
 	return false
 }
 
+// String returns the string representation of the URL array.
+func (u Urls) String() string {
+	if len(u) == 0 {
+		return ""
+	}
+
+	if len(u) == 1 {
+		return u[0].String()
+	}
+
+	var s string
+
+	for _, iri := range u {
+		if s == "" {
+			s = "[" + iri.String()
+		} else {
+			s += "," + iri.String()
+		}
+	}
+
+	return s + "]"
+}
+
 // To returns a set of URLs to which the object should be sent.
 func (t *ObjectType) To() Urls {
 	if t == nil || t.object == nil || t.object.To == nil {

--- a/pkg/pubsub/wmlogger/mocks/logger.gen.go
+++ b/pkg/pubsub/wmlogger/mocks/logger.gen.go
@@ -4,378 +4,140 @@ package mocks
 import (
 	"sync"
 
-	"github.com/trustbloc/orb/internal/pkg/log"
+	"go.uber.org/zap/zapcore"
 )
 
 type Logger struct {
-	DebugfStub        func(string, ...interface{})
-	debugfMutex       sync.RWMutex
-	debugfArgsForCall []struct {
+	DebugStub        func(string, ...zapcore.Field)
+	debugMutex       sync.RWMutex
+	debugArgsForCall []struct {
 		arg1 string
-		arg2 []interface{}
+		arg2 []zapcore.Field
 	}
-	ErrorfStub        func(string, ...interface{})
-	errorfMutex       sync.RWMutex
-	errorfArgsForCall []struct {
+	ErrorStub        func(string, ...zapcore.Field)
+	errorMutex       sync.RWMutex
+	errorArgsForCall []struct {
 		arg1 string
-		arg2 []interface{}
+		arg2 []zapcore.Field
 	}
-	FatalfStub        func(string, ...interface{})
-	fatalfMutex       sync.RWMutex
-	fatalfArgsForCall []struct {
+	InfoStub        func(string, ...zapcore.Field)
+	infoMutex       sync.RWMutex
+	infoArgsForCall []struct {
 		arg1 string
-		arg2 []interface{}
-	}
-	InfofStub        func(string, ...interface{})
-	infofMutex       sync.RWMutex
-	infofArgsForCall []struct {
-		arg1 string
-		arg2 []interface{}
-	}
-	InfowStub        func(string, ...interface{})
-	infowMutex       sync.RWMutex
-	infowArgsForCall []struct {
-		arg1 string
-		arg2 []interface{}
-	}
-	IsEnabledForStub        func(log.Level) bool
-	isEnabledForMutex       sync.RWMutex
-	isEnabledForArgsForCall []struct {
-		arg1 log.Level
-	}
-	isEnabledForReturns struct {
-		result1 bool
-	}
-	isEnabledForReturnsOnCall map[int]struct {
-		result1 bool
-	}
-	PanicfStub        func(string, ...interface{})
-	panicfMutex       sync.RWMutex
-	panicfArgsForCall []struct {
-		arg1 string
-		arg2 []interface{}
-	}
-	WarnfStub        func(string, ...interface{})
-	warnfMutex       sync.RWMutex
-	warnfArgsForCall []struct {
-		arg1 string
-		arg2 []interface{}
+		arg2 []zapcore.Field
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *Logger) Debugf(arg1 string, arg2 ...interface{}) {
-	fake.debugfMutex.Lock()
-	fake.debugfArgsForCall = append(fake.debugfArgsForCall, struct {
+func (fake *Logger) Debug(arg1 string, arg2 ...zapcore.Field) {
+	fake.debugMutex.Lock()
+	fake.debugArgsForCall = append(fake.debugArgsForCall, struct {
 		arg1 string
-		arg2 []interface{}
+		arg2 []zapcore.Field
 	}{arg1, arg2})
-	stub := fake.DebugfStub
-	fake.recordInvocation("Debugf", []interface{}{arg1, arg2})
-	fake.debugfMutex.Unlock()
+	stub := fake.DebugStub
+	fake.recordInvocation("Debug", []interface{}{arg1, arg2})
+	fake.debugMutex.Unlock()
 	if stub != nil {
-		fake.DebugfStub(arg1, arg2...)
+		fake.DebugStub(arg1, arg2...)
 	}
 }
 
-func (fake *Logger) DebugfCallCount() int {
-	fake.debugfMutex.RLock()
-	defer fake.debugfMutex.RUnlock()
-	return len(fake.debugfArgsForCall)
+func (fake *Logger) DebugCallCount() int {
+	fake.debugMutex.RLock()
+	defer fake.debugMutex.RUnlock()
+	return len(fake.debugArgsForCall)
 }
 
-func (fake *Logger) DebugfCalls(stub func(string, ...interface{})) {
-	fake.debugfMutex.Lock()
-	defer fake.debugfMutex.Unlock()
-	fake.DebugfStub = stub
+func (fake *Logger) DebugCalls(stub func(string, ...zapcore.Field)) {
+	fake.debugMutex.Lock()
+	defer fake.debugMutex.Unlock()
+	fake.DebugStub = stub
 }
 
-func (fake *Logger) DebugfArgsForCall(i int) (string, []interface{}) {
-	fake.debugfMutex.RLock()
-	defer fake.debugfMutex.RUnlock()
-	argsForCall := fake.debugfArgsForCall[i]
+func (fake *Logger) DebugArgsForCall(i int) (string, []zapcore.Field) {
+	fake.debugMutex.RLock()
+	defer fake.debugMutex.RUnlock()
+	argsForCall := fake.debugArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *Logger) Errorf(arg1 string, arg2 ...interface{}) {
-	fake.errorfMutex.Lock()
-	fake.errorfArgsForCall = append(fake.errorfArgsForCall, struct {
+func (fake *Logger) Error(arg1 string, arg2 ...zapcore.Field) {
+	fake.errorMutex.Lock()
+	fake.errorArgsForCall = append(fake.errorArgsForCall, struct {
 		arg1 string
-		arg2 []interface{}
+		arg2 []zapcore.Field
 	}{arg1, arg2})
-	stub := fake.ErrorfStub
-	fake.recordInvocation("Errorf", []interface{}{arg1, arg2})
-	fake.errorfMutex.Unlock()
+	stub := fake.ErrorStub
+	fake.recordInvocation("Error", []interface{}{arg1, arg2})
+	fake.errorMutex.Unlock()
 	if stub != nil {
-		fake.ErrorfStub(arg1, arg2...)
+		fake.ErrorStub(arg1, arg2...)
 	}
 }
 
-func (fake *Logger) ErrorfCallCount() int {
-	fake.errorfMutex.RLock()
-	defer fake.errorfMutex.RUnlock()
-	return len(fake.errorfArgsForCall)
+func (fake *Logger) ErrorCallCount() int {
+	fake.errorMutex.RLock()
+	defer fake.errorMutex.RUnlock()
+	return len(fake.errorArgsForCall)
 }
 
-func (fake *Logger) ErrorfCalls(stub func(string, ...interface{})) {
-	fake.errorfMutex.Lock()
-	defer fake.errorfMutex.Unlock()
-	fake.ErrorfStub = stub
+func (fake *Logger) ErrorCalls(stub func(string, ...zapcore.Field)) {
+	fake.errorMutex.Lock()
+	defer fake.errorMutex.Unlock()
+	fake.ErrorStub = stub
 }
 
-func (fake *Logger) ErrorfArgsForCall(i int) (string, []interface{}) {
-	fake.errorfMutex.RLock()
-	defer fake.errorfMutex.RUnlock()
-	argsForCall := fake.errorfArgsForCall[i]
+func (fake *Logger) ErrorArgsForCall(i int) (string, []zapcore.Field) {
+	fake.errorMutex.RLock()
+	defer fake.errorMutex.RUnlock()
+	argsForCall := fake.errorArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *Logger) Fatalf(arg1 string, arg2 ...interface{}) {
-	fake.fatalfMutex.Lock()
-	fake.fatalfArgsForCall = append(fake.fatalfArgsForCall, struct {
+func (fake *Logger) Info(arg1 string, arg2 ...zapcore.Field) {
+	fake.infoMutex.Lock()
+	fake.infoArgsForCall = append(fake.infoArgsForCall, struct {
 		arg1 string
-		arg2 []interface{}
+		arg2 []zapcore.Field
 	}{arg1, arg2})
-	stub := fake.FatalfStub
-	fake.recordInvocation("Fatalf", []interface{}{arg1, arg2})
-	fake.fatalfMutex.Unlock()
+	stub := fake.InfoStub
+	fake.recordInvocation("Info", []interface{}{arg1, arg2})
+	fake.infoMutex.Unlock()
 	if stub != nil {
-		fake.FatalfStub(arg1, arg2...)
+		fake.InfoStub(arg1, arg2...)
 	}
 }
 
-func (fake *Logger) FatalfCallCount() int {
-	fake.fatalfMutex.RLock()
-	defer fake.fatalfMutex.RUnlock()
-	return len(fake.fatalfArgsForCall)
+func (fake *Logger) InfoCallCount() int {
+	fake.infoMutex.RLock()
+	defer fake.infoMutex.RUnlock()
+	return len(fake.infoArgsForCall)
 }
 
-func (fake *Logger) FatalfCalls(stub func(string, ...interface{})) {
-	fake.fatalfMutex.Lock()
-	defer fake.fatalfMutex.Unlock()
-	fake.FatalfStub = stub
+func (fake *Logger) InfoCalls(stub func(string, ...zapcore.Field)) {
+	fake.infoMutex.Lock()
+	defer fake.infoMutex.Unlock()
+	fake.InfoStub = stub
 }
 
-func (fake *Logger) FatalfArgsForCall(i int) (string, []interface{}) {
-	fake.fatalfMutex.RLock()
-	defer fake.fatalfMutex.RUnlock()
-	argsForCall := fake.fatalfArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *Logger) Infof(arg1 string, arg2 ...interface{}) {
-	fake.infofMutex.Lock()
-	fake.infofArgsForCall = append(fake.infofArgsForCall, struct {
-		arg1 string
-		arg2 []interface{}
-	}{arg1, arg2})
-	stub := fake.InfofStub
-	fake.recordInvocation("Infof", []interface{}{arg1, arg2})
-	fake.infofMutex.Unlock()
-	if stub != nil {
-		fake.InfofStub(arg1, arg2...)
-	}
-}
-
-func (fake *Logger) InfofCallCount() int {
-	fake.infofMutex.RLock()
-	defer fake.infofMutex.RUnlock()
-	return len(fake.infofArgsForCall)
-}
-
-func (fake *Logger) InfofCalls(stub func(string, ...interface{})) {
-	fake.infofMutex.Lock()
-	defer fake.infofMutex.Unlock()
-	fake.InfofStub = stub
-}
-
-func (fake *Logger) InfofArgsForCall(i int) (string, []interface{}) {
-	fake.infofMutex.RLock()
-	defer fake.infofMutex.RUnlock()
-	argsForCall := fake.infofArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *Logger) Infow(arg1 string, arg2 ...interface{}) {
-	fake.infowMutex.Lock()
-	fake.infowArgsForCall = append(fake.infowArgsForCall, struct {
-		arg1 string
-		arg2 []interface{}
-	}{arg1, arg2})
-	stub := fake.InfowStub
-	fake.recordInvocation("Infow", []interface{}{arg1, arg2})
-	fake.infowMutex.Unlock()
-	if stub != nil {
-		fake.InfowStub(arg1, arg2...)
-	}
-}
-
-func (fake *Logger) InfowCallCount() int {
-	fake.infowMutex.RLock()
-	defer fake.infowMutex.RUnlock()
-	return len(fake.infowArgsForCall)
-}
-
-func (fake *Logger) InfowCalls(stub func(string, ...interface{})) {
-	fake.infowMutex.Lock()
-	defer fake.infowMutex.Unlock()
-	fake.InfowStub = stub
-}
-
-func (fake *Logger) InfowArgsForCall(i int) (string, []interface{}) {
-	fake.infowMutex.RLock()
-	defer fake.infowMutex.RUnlock()
-	argsForCall := fake.infowArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *Logger) IsEnabled(arg1 log.Level) bool {
-	fake.isEnabledForMutex.Lock()
-	ret, specificReturn := fake.isEnabledForReturnsOnCall[len(fake.isEnabledForArgsForCall)]
-	fake.isEnabledForArgsForCall = append(fake.isEnabledForArgsForCall, struct {
-		arg1 log.Level
-	}{arg1})
-	stub := fake.IsEnabledForStub
-	fakeReturns := fake.isEnabledForReturns
-	fake.recordInvocation("IsEnabledFor", []interface{}{arg1})
-	fake.isEnabledForMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *Logger) IsEnabledForCallCount() int {
-	fake.isEnabledForMutex.RLock()
-	defer fake.isEnabledForMutex.RUnlock()
-	return len(fake.isEnabledForArgsForCall)
-}
-
-func (fake *Logger) IsEnabledForCalls(stub func(log.Level) bool) {
-	fake.isEnabledForMutex.Lock()
-	defer fake.isEnabledForMutex.Unlock()
-	fake.IsEnabledForStub = stub
-}
-
-func (fake *Logger) IsEnabledForArgsForCall(i int) log.Level {
-	fake.isEnabledForMutex.RLock()
-	defer fake.isEnabledForMutex.RUnlock()
-	argsForCall := fake.isEnabledForArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *Logger) IsEnabledForReturns(result1 bool) {
-	fake.isEnabledForMutex.Lock()
-	defer fake.isEnabledForMutex.Unlock()
-	fake.IsEnabledForStub = nil
-	fake.isEnabledForReturns = struct {
-		result1 bool
-	}{result1}
-}
-
-func (fake *Logger) IsEnabledForReturnsOnCall(i int, result1 bool) {
-	fake.isEnabledForMutex.Lock()
-	defer fake.isEnabledForMutex.Unlock()
-	fake.IsEnabledForStub = nil
-	if fake.isEnabledForReturnsOnCall == nil {
-		fake.isEnabledForReturnsOnCall = make(map[int]struct {
-			result1 bool
-		})
-	}
-	fake.isEnabledForReturnsOnCall[i] = struct {
-		result1 bool
-	}{result1}
-}
-
-func (fake *Logger) Panicf(arg1 string, arg2 ...interface{}) {
-	fake.panicfMutex.Lock()
-	fake.panicfArgsForCall = append(fake.panicfArgsForCall, struct {
-		arg1 string
-		arg2 []interface{}
-	}{arg1, arg2})
-	stub := fake.PanicfStub
-	fake.recordInvocation("Panicf", []interface{}{arg1, arg2})
-	fake.panicfMutex.Unlock()
-	if stub != nil {
-		fake.PanicfStub(arg1, arg2...)
-	}
-}
-
-func (fake *Logger) PanicfCallCount() int {
-	fake.panicfMutex.RLock()
-	defer fake.panicfMutex.RUnlock()
-	return len(fake.panicfArgsForCall)
-}
-
-func (fake *Logger) PanicfCalls(stub func(string, ...interface{})) {
-	fake.panicfMutex.Lock()
-	defer fake.panicfMutex.Unlock()
-	fake.PanicfStub = stub
-}
-
-func (fake *Logger) PanicfArgsForCall(i int) (string, []interface{}) {
-	fake.panicfMutex.RLock()
-	defer fake.panicfMutex.RUnlock()
-	argsForCall := fake.panicfArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *Logger) Warnf(arg1 string, arg2 ...interface{}) {
-	fake.warnfMutex.Lock()
-	fake.warnfArgsForCall = append(fake.warnfArgsForCall, struct {
-		arg1 string
-		arg2 []interface{}
-	}{arg1, arg2})
-	stub := fake.WarnfStub
-	fake.recordInvocation("Warnf", []interface{}{arg1, arg2})
-	fake.warnfMutex.Unlock()
-	if stub != nil {
-		fake.WarnfStub(arg1, arg2...)
-	}
-}
-
-func (fake *Logger) WarnfCallCount() int {
-	fake.warnfMutex.RLock()
-	defer fake.warnfMutex.RUnlock()
-	return len(fake.warnfArgsForCall)
-}
-
-func (fake *Logger) WarnfCalls(stub func(string, ...interface{})) {
-	fake.warnfMutex.Lock()
-	defer fake.warnfMutex.Unlock()
-	fake.WarnfStub = stub
-}
-
-func (fake *Logger) WarnfArgsForCall(i int) (string, []interface{}) {
-	fake.warnfMutex.RLock()
-	defer fake.warnfMutex.RUnlock()
-	argsForCall := fake.warnfArgsForCall[i]
+func (fake *Logger) InfoArgsForCall(i int) (string, []zapcore.Field) {
+	fake.infoMutex.RLock()
+	defer fake.infoMutex.RUnlock()
+	argsForCall := fake.infoArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *Logger) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.debugfMutex.RLock()
-	defer fake.debugfMutex.RUnlock()
-	fake.errorfMutex.RLock()
-	defer fake.errorfMutex.RUnlock()
-	fake.fatalfMutex.RLock()
-	defer fake.fatalfMutex.RUnlock()
-	fake.infofMutex.RLock()
-	defer fake.infofMutex.RUnlock()
-	fake.infowMutex.RLock()
-	defer fake.infowMutex.RUnlock()
-	fake.isEnabledForMutex.RLock()
-	defer fake.isEnabledForMutex.RUnlock()
-	fake.panicfMutex.RLock()
-	defer fake.panicfMutex.RUnlock()
-	fake.warnfMutex.RLock()
-	defer fake.warnfMutex.RUnlock()
+	fake.debugMutex.RLock()
+	defer fake.debugMutex.RUnlock()
+	fake.errorMutex.RLock()
+	defer fake.errorMutex.RUnlock()
+	fake.infoMutex.RLock()
+	defer fake.infoMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value
@@ -394,5 +156,3 @@ func (fake *Logger) recordInvocation(key string, args []interface{}) {
 	}
 	fake.invocations[key] = append(fake.invocations[key], args)
 }
-
-var _ log.Logger = new(Logger)

--- a/pkg/pubsub/wmlogger/wmlogger_test.go
+++ b/pkg/pubsub/wmlogger/wmlogger_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/trustbloc/orb/pkg/pubsub/wmlogger/mocks"
 )
 
-//go:generate counterfeiter -o ./mocks/logger.gen.go --fake-name Logger github.com/trustbloc/orb/internal/pkg/log.Logger
+//go:generate counterfeiter -o ./mocks/logger.gen.go --fake-name Logger . logger
 
 func TestNew(t *testing.T) {
 	logger := New()
@@ -46,9 +46,9 @@ func TestWMLogger(t *testing.T) {
 		logger.Debug("message", fields)
 		logger.Trace("message", nil)
 
-		require.Equal(t, 1, l.ErrorfCallCount())
-		require.Equal(t, 1, l.InfofCallCount())
-		require.Equal(t, 2, l.DebugfCallCount())
+		require.Equal(t, 1, l.ErrorCallCount())
+		require.Equal(t, 1, l.InfoCallCount())
+		require.Equal(t, 2, l.DebugCallCount())
 	})
 
 	t.Run("Info level", func(t *testing.T) {
@@ -64,9 +64,9 @@ func TestWMLogger(t *testing.T) {
 		logger.Debug("message", fields)
 		logger.Trace("message", nil)
 
-		require.Equal(t, 1, l.ErrorfCallCount())
-		require.Equal(t, 1, l.InfofCallCount())
-		require.Equal(t, 0, l.DebugfCallCount())
+		require.Equal(t, 1, l.ErrorCallCount())
+		require.Equal(t, 1, l.InfoCallCount())
+		require.Equal(t, 0, l.DebugCallCount())
 	})
 
 	t.Run("Warn level", func(t *testing.T) {
@@ -82,9 +82,9 @@ func TestWMLogger(t *testing.T) {
 		logger.Debug("message", fields)
 		logger.Trace("message", nil)
 
-		require.Equal(t, 1, l.ErrorfCallCount())
-		require.Equal(t, 0, l.InfofCallCount())
-		require.Equal(t, 0, l.DebugfCallCount())
+		require.Equal(t, 1, l.ErrorCallCount())
+		require.Equal(t, 0, l.InfoCallCount())
+		require.Equal(t, 0, l.DebugCallCount())
 	})
 
 	t.Run("Error level", func(t *testing.T) {
@@ -100,9 +100,9 @@ func TestWMLogger(t *testing.T) {
 		logger.Debug("message", fields)
 		logger.Trace("message", nil)
 
-		require.Equal(t, 1, l.ErrorfCallCount())
-		require.Equal(t, 0, l.InfofCallCount())
-		require.Equal(t, 0, l.DebugfCallCount())
+		require.Equal(t, 1, l.ErrorCallCount())
+		require.Equal(t, 0, l.InfoCallCount())
+		require.Equal(t, 0, l.DebugCallCount())
 	})
 
 	t.Run("With", func(t *testing.T) {
@@ -115,6 +115,6 @@ func TestWMLogger(t *testing.T) {
 
 		logger.Debug("message", fields)
 
-		require.Equal(t, 1, l.DebugfCallCount())
+		require.Equal(t, 1, l.DebugCallCount())
 	})
 }


### PR DESCRIPTION
The ActivityPub subsystem now uses key-value pairs for additional data (as opposed to embedding values into the log message).

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>