### PR TITLE
chore: Convert subsystems to use structured logs

### DIFF
--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -1257,10 +1257,8 @@ func startOrbServices(parameters *orbParameters) error {
 			"See https://github.com/trustbloc/orb/issues/797 for more information.")
 	}
 
-	nodeInfoLogger := log.New("nodeinfo")
-
-	nodeInfoService := nodeinfo.NewService(parameters.apServiceParams.serviceEndpoint(), parameters.nodeInfoRefreshInterval,
-		apStore, usingMongoDB, nodeInfoLogger)
+	nodeInfoService := nodeinfo.NewService(parameters.apServiceParams.serviceEndpoint(),
+		parameters.nodeInfoRefreshInterval, apStore, usingMongoDB)
 
 	handlers := make([]restcommon.HTTPHandler, 0)
 
@@ -1304,8 +1302,8 @@ func startOrbServices(parameters *orbParameters) error {
 		auth.NewHandlerWrapper(logmonitorhandler.NewRetriever(logMonitorStore), authTokenManager),
 		auth.NewHandlerWrapper(vcthandler.New(configStore, logMonitorStore), authTokenManager),
 		auth.NewHandlerWrapper(vcthandler.NewRetriever(configStore), authTokenManager),
-		auth.NewHandlerWrapper(nodeinfo.NewHandler(nodeinfo.V2_0, nodeInfoService, nodeInfoLogger), authTokenManager),
-		auth.NewHandlerWrapper(nodeinfo.NewHandler(nodeinfo.V2_1, nodeInfoService, nodeInfoLogger), authTokenManager),
+		auth.NewHandlerWrapper(nodeinfo.NewHandler(nodeinfo.V2_0, nodeInfoService), authTokenManager),
+		auth.NewHandlerWrapper(nodeinfo.NewHandler(nodeinfo.V2_1, nodeInfoService), authTokenManager),
 		auth.NewHandlerWrapper(vcresthandler.New(vcStore), authTokenManager),
 		auth.NewHandlerWrapper(allowedoriginsrest.NewWriter(allowedOriginsStore), authTokenManager),
 		auth.NewHandlerWrapper(allowedoriginsrest.NewReader(allowedOriginsStore), authTokenManager),

--- a/internal/pkg/log/fields.go
+++ b/internal/pkg/log/fields.go
@@ -27,10 +27,12 @@ const (
 	FieldServiceIRI             = "service-iri"
 	FieldServiceEndpoint        = "service-endpoint"
 	FieldActorID                = "actor-id"
+	FieldOriginActorID          = "origin-actor-id"
 	FieldActivityType           = "activity-type"
 	FieldActivityID             = "activity-id"
 	FieldMessageID              = "message-id"
 	FieldData                   = "data"
+	FieldMetadata               = "metadata"
 	FieldRequestURL             = "request-url"
 	FieldRequestHeaders         = "request-headers"
 	FieldRequestBody            = "request-body"
@@ -38,8 +40,10 @@ const (
 	FieldSize                   = "size"
 	FieldCacheExpiration        = "cache-expiration"
 	FieldTarget                 = "target"
+	FieldTargets                = "targets"
 	FieldQueue                  = "queue"
 	FieldHTTPStatus             = "http-status"
+	FieldHTTPMethod             = "http-method"
 	FieldParameter              = "parameter"
 	FieldAcceptListType         = "accept-list-type"
 	FieldAdditions              = "additions"
@@ -60,10 +64,12 @@ const (
 	FieldType                   = "type"
 	FieldQuery                  = "query"
 	FieldSuffix                 = "suffix"
+	FieldSuffixes               = "suffixes"
 	FieldVerifiableCredential   = "vc"
 	FieldVerifiableCredentialID = "vc-id"
 	FieldHash                   = "hash"
 	FieldHashlink               = "hashlink"
+	FieldLocalHashlink          = "local-hashlink"
 	FieldParent                 = "parent"
 	FieldParents                = "parents"
 	FieldProof                  = "proof"
@@ -96,6 +102,7 @@ const (
 	FieldTaskOwnerID            = "task-owner-id"
 	FieldTimeSinceLastUpdate    = "time-since-last-update"
 	FieldGenesisTime            = "genesis-time"
+	FieldSidetreeProtocol       = "sidetree-protocol"
 	FieldDID                    = "did"
 	FieldHRef                   = "href"
 	FieldID                     = "id"
@@ -103,6 +110,12 @@ const (
 	FieldResolutionResult       = "resolution-result"
 	FieldResolutionModel        = "resolution-model"
 	FieldResolutionEndpoints    = "resolution-endpoints"
+	FieldAuthToken              = "auth-token"
+	FieldAuthTokens             = "auth-tokens" //nolint:gosec
+	FieldAddress                = "address"
+	FieldAttributedTo           = "attributed-to"
+	FieldAnchorLinkset          = "anchor-linkset"
+	FieldVersion                = "version"
 )
 
 // WithError sets the error field.
@@ -118,6 +131,11 @@ func WithMessageID(value string) zap.Field {
 // WithData sets the data field.
 func WithData(value []byte) zap.Field {
 	return zap.String(FieldData, string(value))
+}
+
+// WithMetadata sets the metadata field.
+func WithMetadata(value interface{}) zap.Field {
+	return zap.Inline(NewObjectMarshaller(FieldMetadata, value))
 }
 
 // WithRequestURL sets the request-url field.
@@ -180,6 +198,11 @@ func WithActorID(value string) zap.Field {
 	return zap.String(FieldActorID, value)
 }
 
+// WithOriginActorID sets the origin-actor-id field.
+func WithOriginActorID(value string) zap.Field {
+	return zap.String(FieldOriginActorID, value)
+}
+
 // WithConfig sets the config field. The value of the field is
 // encoded as JSON.
 func WithConfig(value interface{}) zap.Field {
@@ -206,6 +229,11 @@ func WithTargetIRI(value fmt.Stringer) zap.Field {
 	return zap.Stringer(FieldTarget, value)
 }
 
+// WithTargetIRIs sets the targets field.
+func WithTargetIRIs(value ...*url.URL) zap.Field {
+	return zap.Array(FieldTargets, NewURLArrayMarshaller(value))
+}
+
 // WithQueue sets the queue field.
 func WithQueue(value string) zap.Field {
 	return zap.String(FieldQueue, value)
@@ -214,6 +242,11 @@ func WithQueue(value string) zap.Field {
 // WithHTTPStatus sets the http-status field.
 func WithHTTPStatus(value int) zap.Field {
 	return zap.Int(FieldHTTPStatus, value)
+}
+
+// WithHTTPMethod sets the http-method field.
+func WithHTTPMethod(value string) zap.Field {
+	return zap.String(FieldHTTPMethod, value)
 }
 
 // WithParameter sets the parameter field.
@@ -352,6 +385,11 @@ func WithSuffix(value string) zap.Field {
 	return zap.String(FieldSuffix, value)
 }
 
+// WithSuffixes sets the suffixes field.
+func WithSuffixes(value ...string) zap.Field {
+	return zap.Array(FieldSuffixes, NewStringArrayMarshaller(value))
+}
+
 // WithVerifiableCredential sets the vc field.
 func WithVerifiableCredential(value []byte) zap.Field {
 	return zap.String(FieldVerifiableCredential, string(value))
@@ -370,6 +408,11 @@ func WithHash(value string) zap.Field {
 // WithHashlink sets the hashlink field.
 func WithHashlink(value string) zap.Field {
 	return zap.String(FieldHashlink, value)
+}
+
+// WithLocalHashlink sets the local-hashlink field.
+func WithLocalHashlink(value string) zap.Field {
+	return zap.String(FieldLocalHashlink, value)
 }
 
 // WithHashlinkURI sets the hashlink field.
@@ -557,6 +600,11 @@ func WithGenesisTime(value uint64) zap.Field {
 	return zap.Uint64(FieldGenesisTime, value)
 }
 
+// WithSidetreeProtocol sets the sidetree-protocol field.
+func WithSidetreeProtocol(value interface{}) zap.Field {
+	return zap.Inline(NewObjectMarshaller(FieldSidetreeProtocol, value))
+}
+
 // WithDID sets the did field.
 func WithDID(value string) zap.Field {
 	return zap.String(FieldDID, value)
@@ -590,6 +638,36 @@ func WithResolutionModel(value interface{}) zap.Field {
 // WithResolutionEndpoints sets the resolution-endpoints field.
 func WithResolutionEndpoints(value ...string) zap.Field {
 	return zap.Array(FieldResolutionEndpoints, NewStringArrayMarshaller(value))
+}
+
+// WithAuthToken sets the auth-token field.
+func WithAuthToken(value string) zap.Field {
+	return zap.String(FieldAuthToken, value)
+}
+
+// WithAuthTokens sets the auth-tokens field.
+func WithAuthTokens(value ...string) zap.Field {
+	return zap.Array(FieldAuthTokens, NewStringArrayMarshaller(value))
+}
+
+// WithAddress sets the address field.
+func WithAddress(value string) zap.Field {
+	return zap.String(FieldAddress, value)
+}
+
+// WithAttributedTo sets the attributed-to field.
+func WithAttributedTo(value string) zap.Field {
+	return zap.String(FieldAttributedTo, value)
+}
+
+// WithAnchorLinkset sets the anchor-linkset field.
+func WithAnchorLinkset(value []byte) zap.Field {
+	return zap.String(FieldAnchorLinkset, string(value))
+}
+
+// WithVersion sets the version field.
+func WithVersion(value string) zap.Field {
+	return zap.String(FieldVersion, value)
 }
 
 type jsonMarshaller struct {

--- a/pkg/anchor/handler/credential/handler.go
+++ b/pkg/anchor/handler/credential/handler.go
@@ -74,7 +74,7 @@ func New(anchorPublisher anchorPublisher, casResolver casResolver,
 // nolint:funlen,gocyclo,cyclop
 func (h *AnchorEventHandler) HandleAnchorEvent(actor, anchorRef, source *url.URL,
 	anchorEvent *vocab.AnchorEventType) error {
-	logger.Debug("Received request for anchor", log.WithActorIRI(actor), log.WithAnchorURI(anchorRef))
+	logger.Debug("Received request for anchor", log.WithActorIRI(actor), log.WithAnchorEventURI(anchorRef))
 
 	var anchorLinksetBytes []byte
 
@@ -120,7 +120,7 @@ func (h *AnchorEventHandler) HandleAnchorEvent(actor, anchorRef, source *url.URL
 		attributedTo = actor.String()
 	}
 
-	logger.Info("Processing anchor", log.WithAnchorURI(anchorRef))
+	logger.Info("Processing anchor", log.WithAnchorEventURI(anchorRef))
 
 	var alternateSources []string
 

--- a/pkg/context/protocol/client/client.go
+++ b/pkg/context/protocol/client/client.go
@@ -11,7 +11,6 @@ import (
 	"sort"
 
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
-	"go.uber.org/zap"
 
 	"github.com/trustbloc/orb/internal/pkg/log"
 )
@@ -81,11 +80,11 @@ func (c *Client) Get(genesisTime uint64) (protocol.Version, error) {
 		p := pv.Protocol()
 
 		logger.Debug("Checking protocol for genesis time...", log.WithGenesisTime(genesisTime),
-			zap.Inline(log.NewObjectMarshaller("sidetree-protocol", &p)))
+			log.WithSidetreeProtocol(&p))
 
 		if genesisTime == p.GenesisTime {
 			logger.Debug("Found protocol for version genesis time", log.WithGenesisTime(genesisTime),
-				zap.Inline(log.NewObjectMarshaller("sidetree-protocol", &p)))
+				log.WithSidetreeProtocol(&p))
 
 			return pv, nil
 		}

--- a/pkg/driver/restapi/operations.go
+++ b/pkg/driver/restapi/operations.go
@@ -21,7 +21,7 @@ const (
 	didLDJson          = "application/did+ld+json"
 )
 
-var logger = log.New("driver")
+var logger = log.NewStructured("driver")
 
 // Handler http handler for each controller API endpoint.
 type Handler interface {
@@ -74,7 +74,7 @@ func (o *Operation) resolveDIDHandler(rw http.ResponseWriter, req *http.Request)
 	rw.WriteHeader(http.StatusOK)
 
 	if _, err := rw.Write(bytes); err != nil {
-		logger.Errorf("Unable to send error message, %s", err)
+		log.WriteResponseBodyError(logger.Error, err)
 	}
 }
 
@@ -83,7 +83,7 @@ func (o *Operation) writeErrorResponse(rw http.ResponseWriter, status int, msg s
 	rw.WriteHeader(status)
 
 	if _, err := rw.Write([]byte(msg)); err != nil {
-		logger.Errorf("Unable to send error message, %s", err)
+		log.WriteResponseBodyError(logger.Error, err)
 	}
 }
 

--- a/pkg/nodeinfo/handler_test.go
+++ b/pkg/nodeinfo/handler_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestNewHandler(t *testing.T) {
 	t.Run("V2.0", func(t *testing.T) {
-		h := NewHandler(V2_0, &NodeInfoRetriever{}, nil)
+		h := NewHandler(V2_0, &NodeInfoRetriever{})
 		require.NotNil(t, h)
 		require.Equal(t, http.MethodGet, h.Method())
 		require.Equal(t, "/nodeinfo/2.0", h.Path())
@@ -30,7 +30,7 @@ func TestNewHandler(t *testing.T) {
 	})
 
 	t.Run("V2.1", func(t *testing.T) {
-		h := NewHandler(V2_1, &NodeInfoRetriever{}, nil)
+		h := NewHandler(V2_1, &NodeInfoRetriever{})
 		require.NotNil(t, h)
 		require.Equal(t, http.MethodGet, h.Method())
 		require.Equal(t, "/nodeinfo/2.1", h.Path())
@@ -91,7 +91,7 @@ func TestHandlerV2_1(t *testing.T) {
 
 func TestNewHandlerError(t *testing.T) {
 	t.Run("Marshal error", func(t *testing.T) {
-		h := NewHandler(V2_0, &NodeInfoRetriever{}, nil)
+		h := NewHandler(V2_0, &NodeInfoRetriever{})
 		require.NotNil(t, h)
 
 		errExpected := errors.New("injected marshal error")
@@ -124,7 +124,7 @@ func testHandler(t *testing.T, version Version, nodeInfo *NodeInfo, expected str
 	retriever := &NodeInfoRetriever{}
 	retriever.GetNodeInfoReturns(nodeInfo)
 
-	h := NewHandler(version, retriever, nil)
+	h := NewHandler(version, retriever)
 	require.NotNil(t, h)
 
 	rw := httptest.NewRecorder()

--- a/pkg/orbclient/aoprovider/anchororiginprovider.go
+++ b/pkg/orbclient/aoprovider/anchororiginprovider.go
@@ -30,7 +30,7 @@ import (
 	"github.com/trustbloc/orb/pkg/protocolversion/clientregistry"
 )
 
-var logger = log.New("orb-client")
+var logger = log.NewStructured("orb-client")
 
 const v1 = "1.0"
 
@@ -141,7 +141,7 @@ func (c *OrbClient) GetAnchorOrigin(cid, suffix string) (interface{}, error) {
 		return nil, fmt.Errorf("unable to read anchor[%s] from CAS: %w", cid, err)
 	}
 
-	logger.Debugf("read anchor[%s]: %s", cid, string(anchorLinksetBytes))
+	logger.Debug("Got anchor linkset", log.WithCID(cid), log.WithAnchorLinkset(anchorLinksetBytes))
 
 	anchorLinkset := &linkset.Linkset{}
 
@@ -215,7 +215,8 @@ func (c *OrbClient) getAnchoredOperation(anchor anchorinfo.AnchorInfo, anchorLin
 		CanonicalReference: anchor.Hashlink,
 	}
 
-	logger.Debugf("processing anchor[%s], core index[%s]", anchor.Hashlink, anchorPayload.CoreIndex)
+	logger.Debug("Processing anchor", log.WithAnchorEventURIString(anchor.Hashlink),
+		log.WithCoreIndex(anchorPayload.CoreIndex))
 
 	txnOps, err := v.OperationProvider().GetTxnOperations(&sidetreeTxn)
 	if err != nil {

--- a/pkg/orbclient/protocol/verprovider/versionprovider.go
+++ b/pkg/orbclient/protocol/verprovider/versionprovider.go
@@ -15,7 +15,7 @@ import (
 	"github.com/trustbloc/orb/internal/pkg/log"
 )
 
-var logger = log.New("client-version-provider")
+var logger = log.NewStructured("client-version-provider")
 
 // ClientVersionProvider implements client versions.
 type ClientVersionProvider struct {
@@ -75,16 +75,18 @@ func (c *ClientVersionProvider) Current() (protocol.Version, error) {
 
 // Get gets client version based on version time.
 func (c *ClientVersionProvider) Get(versionTime uint64) (protocol.Version, error) {
-	logger.Debugf("available client versions: %s", c.versions)
+	logger.Debug("Available client versions", log.WithTotal(len(c.versions)))
 
 	for i := len(c.versions) - 1; i >= 0; i-- {
 		cv := c.versions[i]
 		p := cv.Protocol()
 
-		logger.Debugf("checking client version for version genesis time %d: %+v", versionTime, p)
+		logger.Debug("Checking client version for version genesis time",
+			log.WithGenesisTime(versionTime), log.WithSidetreeProtocol(p))
 
 		if versionTime == p.GenesisTime {
-			logger.Debugf("found client version for version genesis time %d: %+v", versionTime, p)
+			logger.Debug("Found client version for version genesis time",
+				log.WithGenesisTime(versionTime), log.WithSidetreeProtocol(p))
 
 			return cv, nil
 		}

--- a/pkg/protocolversion/clientregistry/clientregistry.go
+++ b/pkg/protocolversion/clientregistry/clientregistry.go
@@ -18,7 +18,7 @@ import (
 	versioncommon "github.com/trustbloc/orb/pkg/protocolversion/common"
 )
 
-var logger = log.New("client-factory-registry")
+var logger = log.NewStructured("client-factory-registry")
 
 type factory interface {
 	Create(version string, casClient common.CASReader, sidetreeCfg *config.Sidetree) (protocol.Version, error)
@@ -32,7 +32,7 @@ type Registry struct {
 
 // New returns a new client version factory Registry.
 func New() *Registry {
-	logger.Debugf("Creating client version factory Registry")
+	logger.Debug("Creating client version factory Registry")
 
 	registry := &Registry{factories: make(map[string]factory)}
 
@@ -49,7 +49,7 @@ func (r *Registry) CreateClientVersion(version string, casClient common.CASReade
 		return nil, err
 	}
 
-	logger.Debugf("Creating client version [%s]", version)
+	logger.Debug("Creating client version", log.WithVersion(version))
 
 	return v.Create(version, casClient, sidetreeCfg)
 }
@@ -63,7 +63,7 @@ func (r *Registry) Register(version string, factory factory) {
 		panic(fmt.Errorf("client version factory [%s] already registered", version))
 	}
 
-	logger.Debugf("Registering client version factory [%s]", version)
+	logger.Debug("Registering client version factory", log.WithVersion(version))
 
 	r.factories[version] = factory
 }

--- a/pkg/protocolversion/factoryregistry/factoryregistry.go
+++ b/pkg/protocolversion/factoryregistry/factoryregistry.go
@@ -20,7 +20,7 @@ import (
 	versioncommon "github.com/trustbloc/orb/pkg/protocolversion/common"
 )
 
-var logger = log.New("factory-registry")
+var logger = log.NewStructured("factory-registry")
 
 type factory interface {
 	Create(version string, casClient cas.Client, casResolver ctxcommon.CASResolver, opStore ctxcommon.OperationStore,
@@ -35,7 +35,7 @@ type Registry struct {
 
 // New returns a new protocol version factory Registry.
 func New() *Registry {
-	logger.Infof("Creating protocol version factory Registry")
+	logger.Info("Creating protocol version factory Registry")
 
 	registry := &Registry{factories: make(map[string]factory)}
 
@@ -54,7 +54,7 @@ func (r *Registry) CreateProtocolVersion(version string, casClient cas.Client, c
 		return nil, err
 	}
 
-	logger.Infof("Creating protocol version [%s]", version)
+	logger.Info("Creating protocol version", log.WithVersion(version))
 
 	return v.Create(version, casClient, casResolver, opStore, provider, sidetreeCfg)
 }
@@ -68,7 +68,7 @@ func (r *Registry) Register(version string, factory factory) {
 		panic(fmt.Errorf("protocol version factory [%s] already registered", version))
 	}
 
-	logger.Infof("Registering protocol version factory [%s]", version)
+	logger.Info("Registering protocol version factory", log.WithVersion(version))
 
 	r.factories[version] = factory
 }

--- a/pkg/protocolversion/versions/v1_0/factory/factory.go
+++ b/pkg/protocolversion/versions/v1_0/factory/factory.go
@@ -33,7 +33,7 @@ import (
 	"github.com/trustbloc/orb/pkg/versions/1_0/txnprocessor"
 )
 
-var logger = log.New("protocol-v1_0")
+var logger = log.NewStructured("protocol-v1_0")
 
 // Factory implements version 0.1 of the Sidetree protocol.
 type Factory struct{}
@@ -117,7 +117,8 @@ func formatWebCASURI(uri, serviceURI string) (string, error) {
 	// A CAS URI can either be a CID or a hashlink.
 	hash, err := hashlink.GetResourceHashFromHashLink(uri)
 	if err != nil {
-		logger.Debugf("CAS URI [%s] is not a hashlink: %s. Assuming that it's a plain hash.", uri, err)
+		logger.Debug("CAS URI is not a hashlink. Assuming that it's a plain hash.",
+			log.WithURIString(uri), log.WithError(err))
 
 		hash = uri
 	}
@@ -131,7 +132,7 @@ func formatWebCASURI(uri, serviceURI string) (string, error) {
 	// The WebCAS URI will look like this: https:orb.domain1.com:<hash>.
 	casURI := fmt.Sprintf("%s:%s:%s", scheme, host, hash)
 
-	logger.Debugf("Adding alternate CAS URI: %s", casURI)
+	logger.Debug("Adding alternate CAS URI", log.WithURIString(casURI))
 
 	return casURI, nil
 }


### PR DESCRIPTION
Implemented structured logging for the following subsystems:

- context
- driver
- httpserver
- lifecycle
- nodeinfo
- observer
- orbclient
- protocolversion

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>