### PR TITLE
chore: Convert subsystems to use structured logs

### DIFF
--- a/cmd/orb-server/startcmd/log.go
+++ b/cmd/orb-server/startcmd/log.go
@@ -35,18 +35,18 @@ Valid log levels: critical,error,warn,info,debug
 Error: %s`
 
 // setLogLevels sets the log levels for individual modules as well as the default level.
-func setLogLevels(logger *log.Log, logSpec string) {
+func setLogLevels(logger *log.StructuredLog, logSpec string) {
 	if err := log.SetSpec(logSpec); err != nil {
-		logger.Warnf(logSpecErrorMsg, err.Error())
+		logger.Warn(logSpecErrorMsg, log.WithError(err))
 
 		log.SetDefaultLevel(log.INFO)
 	}
 
 	if err := sidetreelog.SetSpec(logSpec); err != nil {
-		logger.Warnf(logSpecErrorMsg, err.Error())
+		logger.Warn(logSpecErrorMsg, log.WithError(err))
 	}
 
 	if err := vctlog.SetSpec(logSpec); err != nil {
-		logger.Warnf(logSpecErrorMsg, err.Error())
+		logger.Warn(logSpecErrorMsg, log.WithError(err))
 	}
 }

--- a/cmd/orb-server/startcmd/log_test.go
+++ b/cmd/orb-server/startcmd/log_test.go
@@ -16,7 +16,7 @@ import (
 
 const testLogModuleName = "test"
 
-var testLogger = log.New(testLogModuleName)
+var testLogger = log.NewStructured(testLogModuleName)
 
 func TestSetLogLevel(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {

--- a/cmd/orb-server/startcmd/params.go
+++ b/cmd/orb-server/startcmd/params.go
@@ -9,6 +9,7 @@ package startcmd
 import (
 	"errors"
 	"fmt"
+	"github.com/trustbloc/orb/internal/pkg/log"
 	"net/url"
 	"strconv"
 	"strings"
@@ -1532,7 +1533,7 @@ func getRequestTokens(cmd *cobra.Command) map[string]string {
 		case splitRequestTokenLength:
 			tokens[split[0]] = split[1]
 		default:
-			logger.Warnf("invalid token '%s'", token)
+			logger.Warn("Invalid token", log.WithAuthToken(token))
 		}
 	}
 
@@ -1588,7 +1589,7 @@ func getAuthTokenDefinitions(cmd *cobra.Command, flagName, envKey string, defaul
 		return defaultDefs, nil
 	}
 
-	logger.Debugf("Auth tokens definition: %s", authTokenDefsStr)
+	logger.Debug("Auth tokens definition", log.WithAuthTokens(authTokenDefsStr...))
 
 	var authTokenDefs []*auth.TokenDef
 
@@ -1615,8 +1616,11 @@ func getAuthTokenDefinitions(cmd *cobra.Command, flagName, envKey string, defaul
 			WriteTokens:        writeTokens,
 		}
 
-		logger.Debugf("Adding auth token definition for endpoint %s - Read Tokens: %s, Write Tokens: %s",
-			def.EndpointExpression, def.ReadTokens, def.WriteTokens)
+		logger.Debug("Adding write token definition for endpoint",
+			log.WithServiceEndpoint(def.EndpointExpression), log.WithAuthTokens(def.WriteTokens...))
+
+		logger.Debug("Adding read token definition for endpoint",
+			log.WithServiceEndpoint(def.EndpointExpression), log.WithAuthTokens(def.ReadTokens...))
 
 		authTokenDefs = append(authTokenDefs, def)
 	}
@@ -1677,7 +1681,7 @@ func getAuthTokens(cmd *cobra.Command, flagName, envKey string, defaultTokens ma
 			return nil, fmt.Errorf("invalid auth token string [%s]: %w", authTokensStr, err)
 		}
 
-		logger.Debugf("Adding token %s=%s", keyVal[0], keyVal[1])
+		logger.Debug("Adding token", log.WithKey(keyVal[0]), log.WithValue(keyVal[1]))
 
 		authTokens[keyVal[0]] = keyVal[1]
 	}

--- a/internal/pkg/log/common.go
+++ b/internal/pkg/log/common.go
@@ -25,6 +25,11 @@ func CloseResponseBodyError(log loggerFunc, err error) {
 	log("Error closing response body", WithError(err))
 }
 
+// ReadRequestBodyError outputs a 'read response body' error log to the given logger.
+func ReadRequestBodyError(log loggerFunc, err error) {
+	log("Error reading response body", WithError(err))
+}
+
 // WriteResponseBodyError outputs a 'write response body' error log to the given logger.
 func WriteResponseBodyError(log loggerFunc, err error) {
 	log("Error writing response body", WithError(err))

--- a/internal/pkg/log/fields.go
+++ b/internal/pkg/log/fields.go
@@ -21,6 +21,7 @@ import (
 const (
 	FieldURI                    = "uri"
 	FieldURIs                   = "uris"
+	FieldURL                    = "url"
 	FieldSenderURL              = "sender"
 	FieldConfig                 = "config"
 	FieldServiceName            = "service"
@@ -38,18 +39,21 @@ const (
 	FieldRequestBody            = "request-body"
 	FieldResponse               = "response"
 	FieldSize                   = "size"
+	FieldMaxSize                = "max-size"
 	FieldCacheExpiration        = "cache-expiration"
 	FieldTarget                 = "target"
 	FieldTargets                = "targets"
-	FieldQueue                  = "queue"
+	FieldTopic                  = "topic"
 	FieldHTTPStatus             = "http-status"
 	FieldHTTPMethod             = "http-method"
 	FieldParameter              = "parameter"
+	FieldParameters             = "parameters"
 	FieldAcceptListType         = "accept-list-type"
 	FieldAdditions              = "additions"
 	FieldDeletions              = "deletions"
 	FieldReferenceType          = "reference-type"
 	FieldAnchorURI              = "anchor-uri"
+	FieldAnchorURIs             = "anchor-uris"
 	FieldAnchorHash             = "anchor-hash"
 	FieldAnchorEventURI         = "anchor-event-uri"
 	FieldObjectIRI              = "object-iri"
@@ -80,8 +84,10 @@ const (
 	FieldAnchorOrigin           = "anchor-origin"
 	FieldAnchorOriginEndpoint   = "anchor-origin-endpoint"
 	FieldOperationType          = "operation-type"
+	FieldOperation              = "operation"
 	FieldCoreIndex              = "core-index"
 	FieldKey                    = "key"
+	FieldValue                  = "value"
 	FieldCID                    = "cid"
 	FieldResolvedCID            = "resolved-cid"
 	FieldAnchorCID              = "anchor-cid"
@@ -92,6 +98,7 @@ const (
 	FieldLink                   = "link"
 	FieldLinks                  = "links"
 	FieldTaskMgrInstanceID      = "task-mgr-instance"
+	FieldTaskID                 = "task-id"
 	FieldRetries                = "retries"
 	FieldMaxRetries             = "max-retries"
 	FieldSubscriberPoolSize     = "subscriber-pool-size"
@@ -99,10 +106,11 @@ const (
 	FieldTaskExpiration         = "task-expiration"
 	FieldDeliveryDelay          = "delivery-delay"
 	FieldOperationID            = "operation-id"
-	FieldTaskOwnerID            = "task-owner-id"
+	FieldPermitHolder           = "permit-holder"
 	FieldTimeSinceLastUpdate    = "time-since-last-update"
 	FieldGenesisTime            = "genesis-time"
 	FieldSidetreeProtocol       = "sidetree-protocol"
+	FieldSidetreeTxn            = "sidetree-txn"
 	FieldDID                    = "did"
 	FieldHRef                   = "href"
 	FieldID                     = "id"
@@ -114,8 +122,27 @@ const (
 	FieldAuthTokens             = "auth-tokens" //nolint:gosec
 	FieldAddress                = "address"
 	FieldAttributedTo           = "attributed-to"
+	FieldAnchorLink             = "anchor-link"
 	FieldAnchorLinkset          = "anchor-linkset"
 	FieldVersion                = "version"
+	FieldDeliveryAttempts       = "delivery-attempts"
+	FieldProperty               = "property"
+	FieldStorageName            = "store-name"
+	FieldIssuer                 = "issuer"
+	FieldStatus                 = "status"
+	FieldLogURL                 = "log-url"
+	FieldNamespace              = "namespace"
+	FieldCanonicalRef           = "canonical-ref"
+	FieldAnchorString           = "anchor-string"
+	FieldJRD                    = "jrd"
+	FieldBackoff                = "backoff"
+	FieldTimeout                = "timeout"
+	FieldMaxTime                = "max-time"
+	FieldLogMonitor             = "log-monitor"
+	FieldLogMonitors            = "log-monitors"
+	FieldIndex                  = "index"
+	FieldFromIndex              = "from-index"
+	FieldToIndex                = "to-index"
 )
 
 // WithError sets the error field.
@@ -214,6 +241,21 @@ func WithSize(value int) zap.Field {
 	return zap.Int(FieldSize, value)
 }
 
+// WithSizeUint64 sets the size field.
+func WithSizeUint64(value uint64) zap.Field {
+	return zap.Uint64(FieldSize, value)
+}
+
+// WithMaxSize sets the max-size field.
+func WithMaxSize(value int) zap.Field {
+	return zap.Int(FieldMaxSize, value)
+}
+
+// WithMaxSizeUInt64 sets the max-size field.
+func WithMaxSizeUInt64(value uint64) zap.Field {
+	return zap.Uint64(FieldMaxSize, value)
+}
+
 // WithCacheExpiration sets the cache-expiration field.
 func WithCacheExpiration(value time.Duration) zap.Field {
 	return zap.Duration(FieldCacheExpiration, value)
@@ -234,9 +276,9 @@ func WithTargetIRIs(value ...*url.URL) zap.Field {
 	return zap.Array(FieldTargets, NewURLArrayMarshaller(value))
 }
 
-// WithQueue sets the queue field.
-func WithQueue(value string) zap.Field {
-	return zap.String(FieldQueue, value)
+// WithTopic sets the topic field.
+func WithTopic(value string) zap.Field {
+	return zap.String(FieldTopic, value)
 }
 
 // WithHTTPStatus sets the http-status field.
@@ -252,6 +294,11 @@ func WithHTTPMethod(value string) zap.Field {
 // WithParameter sets the parameter field.
 func WithParameter(value string) zap.Field {
 	return zap.String(FieldParameter, value)
+}
+
+// WithParameters sets the parameters field.
+func WithParameters(value interface{}) zap.Field {
+	return zap.Inline(NewObjectMarshaller(FieldParameters, value))
 }
 
 // WithAcceptListType sets the accept-list-type field.
@@ -289,6 +336,16 @@ func WithURIs(value ...*url.URL) zap.Field {
 	return zap.Array(FieldURIs, NewURLArrayMarshaller(value))
 }
 
+// WithURL sets the url field.
+func WithURL(value fmt.Stringer) zap.Field {
+	return zap.Stringer(FieldURL, value)
+}
+
+// WithURLString sets the url field.
+func WithURLString(value string) zap.Field {
+	return zap.String(FieldURL, value)
+}
+
 // WithSenderURL sets the sender field.
 func WithSenderURL(value fmt.Stringer) zap.Field {
 	return zap.Stringer(FieldSenderURL, value)
@@ -312,6 +369,11 @@ func WithAnchorURI(value fmt.Stringer) zap.Field {
 // WithAnchorURIString sets the anchor-uri field.
 func WithAnchorURIString(value string) zap.Field {
 	return zap.String(FieldAnchorURI, value)
+}
+
+// WithAnchorURIStrings sets the anchor-uris field.
+func WithAnchorURIStrings(value ...string) zap.Field {
+	return zap.Array(FieldAnchorURIs, NewStringArrayMarshaller(value))
 }
 
 // WithAnchorHash sets the anchor-hash field.
@@ -490,6 +552,11 @@ func WithOperationType(value string) zap.Field {
 	return zap.Any(FieldOperationType, value)
 }
 
+// WithOperation sets the operation field.
+func WithOperation(value interface{}) zap.Field {
+	return zap.Inline(NewObjectMarshaller(FieldOperation, value))
+}
+
 // WithCoreIndex sets the coreIndex field.
 func WithCoreIndex(value string) zap.Field {
 	return zap.Any(FieldCoreIndex, value)
@@ -498,6 +565,11 @@ func WithCoreIndex(value string) zap.Field {
 // WithKey sets the key field.
 func WithKey(value string) zap.Field {
 	return zap.String(FieldKey, value)
+}
+
+// WithValue sets the value field.
+func WithValue(value interface{}) zap.Field {
+	return zap.Inline(NewObjectMarshaller(FieldValue, value))
 }
 
 // WithCID sets the cid field.
@@ -550,6 +622,11 @@ func WithTaskMgrInstanceID(value string) zap.Field {
 	return zap.String(FieldTaskMgrInstanceID, value)
 }
 
+// WithTaskID sets the task-id field.
+func WithTaskID(value string) zap.Field {
+	return zap.String(FieldTaskID, value)
+}
+
 // WithRetries sets the retries field.
 func WithRetries(value int) zap.Field {
 	return zap.Int(FieldRetries, value)
@@ -585,9 +662,9 @@ func WithOperationID(value string) zap.Field {
 	return zap.String(FieldOperationID, value)
 }
 
-// WithTaskOwnerID sets the task-owner-id field.
-func WithTaskOwnerID(value string) zap.Field {
-	return zap.String(FieldTaskOwnerID, value)
+// WithPermitHolder sets the permit-holder field.
+func WithPermitHolder(value string) zap.Field {
+	return zap.String(FieldPermitHolder, value)
 }
 
 // WithTimeSinceLastUpdate sets the time-since-last-update field.
@@ -603,6 +680,11 @@ func WithGenesisTime(value uint64) zap.Field {
 // WithSidetreeProtocol sets the sidetree-protocol field.
 func WithSidetreeProtocol(value interface{}) zap.Field {
 	return zap.Inline(NewObjectMarshaller(FieldSidetreeProtocol, value))
+}
+
+// WithSidetreeTxn sets the sidetree-txn field.
+func WithSidetreeTxn(value interface{}) zap.Field {
+	return zap.Inline(NewObjectMarshaller(FieldSidetreeTxn, value))
 }
 
 // WithDID sets the did field.
@@ -660,6 +742,11 @@ func WithAttributedTo(value string) zap.Field {
 	return zap.String(FieldAttributedTo, value)
 }
 
+// WithAnchorLink sets the anchor-link field.
+func WithAnchorLink(value []byte) zap.Field {
+	return zap.String(FieldAnchorLink, string(value))
+}
+
 // WithAnchorLinkset sets the anchor-linkset field.
 func WithAnchorLinkset(value []byte) zap.Field {
 	return zap.String(FieldAnchorLinkset, string(value))
@@ -668,6 +755,106 @@ func WithAnchorLinkset(value []byte) zap.Field {
 // WithVersion sets the version field.
 func WithVersion(value string) zap.Field {
 	return zap.String(FieldVersion, value)
+}
+
+// WithDeliveryAttempts sets the delivery-attempts field.
+func WithDeliveryAttempts(value int) zap.Field {
+	return zap.Int(FieldDeliveryAttempts, value)
+}
+
+// WithProperty sets the property field.
+func WithProperty(value string) zap.Field {
+	return zap.String(FieldProperty, value)
+}
+
+// WithStoreName sets the store-name field.
+func WithStoreName(value string) zap.Field {
+	return zap.String(FieldStorageName, value)
+}
+
+// WithIssuer sets the issuer field.
+func WithIssuer(value string) zap.Field {
+	return zap.String(FieldIssuer, value)
+}
+
+// WithStatus sets the status field.
+func WithStatus(value string) zap.Field {
+	return zap.String(FieldStatus, value)
+}
+
+// WithLogURL sets the log-url field.
+func WithLogURL(value fmt.Stringer) zap.Field {
+	return zap.Stringer(FieldLogURL, value)
+}
+
+// WithLogURLString sets the log-url field.
+func WithLogURLString(value string) zap.Field {
+	return zap.String(FieldLogURL, value)
+}
+
+// WithNamespace sets the namespace field.
+func WithNamespace(value string) zap.Field {
+	return zap.String(FieldNamespace, value)
+}
+
+// WithCanonicalRef sets the canonical-ref field.
+func WithCanonicalRef(value string) zap.Field {
+	return zap.String(FieldCanonicalRef, value)
+}
+
+// WithAnchorString sets the anchor-string field.
+func WithAnchorString(value string) zap.Field {
+	return zap.String(FieldAnchorString, value)
+}
+
+// WithJRD sets the jrd field.
+func WithJRD(value interface{}) zap.Field {
+	return zap.Inline(NewObjectMarshaller(FieldJRD, value))
+}
+
+// WithBackoff sets the backoff field.
+func WithBackoff(value time.Duration) zap.Field {
+	return zap.Duration(FieldBackoff, value)
+}
+
+// WithTimeout sets the timeout field.
+func WithTimeout(value time.Duration) zap.Field {
+	return zap.Duration(FieldTimeout, value)
+}
+
+// WithLogMonitor sets the log-monitor field.
+func WithLogMonitor(value interface{}) zap.Field {
+	return zap.Inline(NewObjectMarshaller(FieldLogMonitor, value))
+}
+
+// WithLogMonitors sets the log-monitors field.
+func WithLogMonitors(value interface{}) zap.Field {
+	return zap.Inline(NewObjectMarshaller(FieldLogMonitors, value))
+}
+
+// WithMaxTime sets the max-time field.
+func WithMaxTime(value time.Duration) zap.Field {
+	return zap.Duration(FieldMaxTime, value)
+}
+
+// WithIndex sets the index field.
+func WithIndex(value int) zap.Field {
+	return zap.Int(FieldIndex, value)
+}
+
+// WithIndexUint64 sets the index field.
+func WithIndexUint64(value uint64) zap.Field {
+	return zap.Uint64(FieldIndex, value)
+}
+
+// WithFromIndexUint64 sets the from-index field.
+func WithFromIndexUint64(value uint64) zap.Field {
+	return zap.Uint64(FieldFromIndex, value)
+}
+
+// WithToIndexUint64 sets the to-index field.
+func WithToIndexUint64(value uint64) zap.Field {
+	return zap.Uint64(FieldToIndex, value)
 }
 
 type jsonMarshaller struct {

--- a/internal/pkg/log/fields_test.go
+++ b/internal/pkg/log/fields_test.go
@@ -74,7 +74,7 @@ func TestStandardFields(t *testing.T) {
 			WithServiceIRI(parseURL(t, u2.String())), WithServiceName("service1"),
 			WithServiceEndpoint("/services/service1"),
 			WithSize(1234), WithCacheExpiration(12*time.Second),
-			WithTargetIRI(u1), WithQueue("queue1"),
+			WithTargetIRI(u1), WithTopic("queue1"),
 			WithHTTPStatus(http.StatusNotFound), WithParameter("param1"),
 			WithReferenceType("followers"), WithURI(u2), WithURIs(u1, u2),
 			WithSenderURL(u1), WithAnchorURI(u3), WithAnchorEventURI(u3),
@@ -111,7 +111,7 @@ func TestStandardFields(t *testing.T) {
 		require.Equal(t, 1234, l.Size)
 		require.Equal(t, `12s`, l.CacheExpiration)
 		require.Equal(t, u1.String(), l.Target)
-		require.Equal(t, `queue1`, l.Queue)
+		require.Equal(t, `queue1`, l.Topic)
 		require.Equal(t, 404, l.HTTPStatus)
 		require.Equal(t, `param1`, l.Parameter)
 		require.Equal(t, `followers`, l.ReferenceType)
@@ -180,7 +180,7 @@ func TestStandardFields(t *testing.T) {
 			WithTaskMgrInstanceID("12345"), WithRetries(7), WithMaxRetries(12),
 			WithSubscriberPoolSize(30), WithTaskMonitorInterval(5*time.Second),
 			WithTaskExpiration(10*time.Second), WithDeliveryDelay(3*time.Second),
-			WithOperationID("op1"), WithTaskOwnerID("123"), WithTimeSinceLastUpdate(2*time.Minute),
+			WithOperationID("op1"), WithPermitHolder("123"), WithTimeSinceLastUpdate(2*time.Minute),
 			WithGenesisTime(1233), WithDID("did:orb:123:456"), WithHRef(u3.String()),
 			WithID("id1"), WithResource("res1"), WithResolutionResult(rr),
 			WithResolutionModel(rm), WithResolutionEndpoints(u1.String(), u2.String(), u3.String()),
@@ -227,7 +227,7 @@ func TestStandardFields(t *testing.T) {
 		require.Equal(t, "10s", l.TaskExpiration)
 		require.Equal(t, "3s", l.DeliveryDelay)
 		require.Equal(t, "op1", l.OperationID)
-		require.Equal(t, "123", l.TaskOwnerID)
+		require.Equal(t, "123", l.PermitHolder)
 		require.Equal(t, "2m0s", l.TimeSinceLastUpdate)
 		require.Equal(t, 1233, l.GenesisTime)
 		require.Equal(t, "did:orb:123:456", l.DID)
@@ -296,7 +296,7 @@ type logData struct {
 	Size                   int                 `json:"size"`
 	CacheExpiration        string              `json:"cache-expiration"`
 	Target                 string              `json:"target"`
-	Queue                  string              `json:"queue"`
+	Topic                  string              `json:"topic"`
 	HTTPStatus             int                 `json:"http-status"`
 	Parameter              string              `json:"parameter"`
 	ReferenceType          string              `json:"reference-type"`
@@ -359,7 +359,7 @@ type logData struct {
 	TaskExpiration         string              `json:"task-expiration"`
 	DeliveryDelay          string              `json:"delivery-delay"`
 	OperationID            string              `json:"operation-id"`
-	TaskOwnerID            string              `json:"task-owner-id"`
+	PermitHolder           string              `json:"permit-holder"`
 	TimeSinceLastUpdate    string              `json:"time-since-last-update"`
 	GenesisTime            int                 `json:"genesis-time"`
 	DID                    string              `json:"did"`

--- a/pkg/activitypub/service/outbox/outbox.go
+++ b/pkg/activitypub/service/outbox/outbox.go
@@ -379,8 +379,8 @@ func (h *Outbox) publishBroadcastMessage(activity *vocab.ActivityType, excludeIR
 
 	msg := message.NewMessage(watermill.NewUUID(), msgBytes)
 
-	h.logger.Debug("Publishing activity message to queue", log.WithMessageID(msg.UUID),
-		log.WithActivityID(activity.ID()), log.WithQueue(h.Topic))
+	h.logger.Debug("Publishing activity message to topic", log.WithMessageID(msg.UUID),
+		log.WithActivityID(activity.ID()), log.WithTopic(h.Topic))
 
 	return h.publisher.Publish(h.Topic, msg)
 }
@@ -401,8 +401,8 @@ func (h *Outbox) publishResolveAndDeliverMessage(activity *vocab.ActivityType, t
 
 	msg := message.NewMessage(watermill.NewUUID(), msgBytes)
 
-	h.logger.Debug("Publishing 'resolve-and-deliver' activity message to queue",
-		log.WithMessageID(msg.UUID), log.WithActivityID(activity.ID()), log.WithQueue(h.Topic))
+	h.logger.Debug("Publishing 'resolve-and-deliver' activity message to topic",
+		log.WithMessageID(msg.UUID), log.WithActivityID(activity.ID()), log.WithTopic(h.Topic))
 
 	return h.publisher.Publish(h.Topic, msg)
 }
@@ -421,9 +421,9 @@ func (h *Outbox) publishDeliverMessage(activity *vocab.ActivityType, target *url
 
 	msg := message.NewMessage(watermill.NewUUID(), msgBytes)
 
-	h.logger.Debug("Publishing 'deliver' activity message to queue",
+	h.logger.Debug("Publishing 'deliver' activity message to topic",
 		log.WithMessageID(msg.UUID), log.WithActivityID(activity.ID()),
-		log.WithQueue(h.Topic), log.WithTargetIRI(target))
+		log.WithTopic(h.Topic), log.WithTargetIRI(target))
 
 	return h.publisher.Publish(h.Topic, msg)
 }

--- a/pkg/anchor/vcpubsub/publisher.go
+++ b/pkg/anchor/vcpubsub/publisher.go
@@ -51,7 +51,7 @@ func (h *Publisher) Publish(anchorLinkset *linkset.Linkset) error {
 
 	msg := message.NewMessage(watermill.NewUUID(), payload)
 
-	logger.Debug("Publishing anchor linkset", log.WithQueue(anchorTopic), log.WithData(payload))
+	logger.Debug("Publishing anchor linkset", log.WithTopic(anchorTopic), log.WithData(payload))
 
 	err = h.pubSub.Publish(anchorTopic, msg)
 	if err != nil {

--- a/pkg/anchor/vcpubsub/subscriber.go
+++ b/pkg/anchor/vcpubsub/subscriber.go
@@ -43,7 +43,7 @@ func NewSubscriber(pubSub pubSub, processor anchorProcessor) (*Subscriber, error
 		lifecycle.WithStart(h.start),
 	)
 
-	logger.Debug("Subscribing to queue", log.WithQueue(anchorTopic))
+	logger.Debug("Subscribing to topic", log.WithTopic(anchorTopic))
 
 	vcChan, err := pubSub.Subscribe(context.Background(), anchorTopic)
 	if err != nil {

--- a/pkg/observer/pubsub.go
+++ b/pkg/observer/pubsub.go
@@ -66,7 +66,7 @@ func NewPubSub(pubSub pubSub, anchorProcessor anchorProcessor, didProcessor didP
 		lifecycle.WithStart(h.start),
 	)
 
-	logger.Info("Subscribing to topic", log.WithQueue(anchorTopic))
+	logger.Info("Subscribing to topic", log.WithTopic(anchorTopic))
 
 	anchorCredChan, err := pubSub.SubscribeWithOpts(context.Background(), anchorTopic, spi.WithPool(poolSize))
 	if err != nil {
@@ -75,7 +75,7 @@ func NewPubSub(pubSub pubSub, anchorProcessor anchorProcessor, didProcessor didP
 
 	h.anchorCredChan = anchorCredChan
 
-	logger.Info("Subscribing to topic", log.WithQueue(didTopic))
+	logger.Info("Subscribing to topic", log.WithTopic(didTopic))
 
 	didChan, err := pubSub.SubscribeWithOpts(context.Background(), didTopic, spi.WithPool(poolSize))
 	if err != nil {
@@ -101,18 +101,18 @@ func (h *PubSub) PublishAnchor(anchorInfo *anchorinfo.AnchorInfo) error {
 	msg := message.NewMessage(watermill.NewUUID(), payload)
 
 	logger.Debug("Publishing anchors message to queue", log.WithMessageID(msg.UUID),
-		log.WithQueue(anchorTopic), log.WithData(msg.Payload))
+		log.WithTopic(anchorTopic), log.WithData(msg.Payload))
 
 	err = h.publisher.Publish(anchorTopic, msg)
 	if err != nil {
-		logger.Warn("Error publishing anchors message to queue", log.WithQueue(anchorTopic),
+		logger.Warn("Error publishing anchors message to queue", log.WithTopic(anchorTopic),
 			log.WithData(msg.Payload), log.WithError(err))
 
 		return errors.NewTransient(err)
 	}
 
 	logger.Debug("Successfully published anchors message to queue", log.WithMessageID(msg.UUID),
-		log.WithQueue(anchorTopic), log.WithData(msg.Payload))
+		log.WithTopic(anchorTopic), log.WithData(msg.Payload))
 
 	return nil
 }
@@ -130,7 +130,7 @@ func (h *PubSub) PublishDID(did string) error {
 
 	msg := message.NewMessage(watermill.NewUUID(), payload)
 
-	logger.Debug("Publishing DIDs to queue", log.WithQueue(didTopic), log.WithDID(did))
+	logger.Debug("Publishing DIDs to queue", log.WithTopic(didTopic), log.WithDID(did))
 
 	return h.publisher.Publish(didTopic, msg)
 }

--- a/pkg/pubsub/amqp/publisherpool.go
+++ b/pkg/pubsub/amqp/publisherpool.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/ThreeDotsLabs/watermill-amqp/v2/pkg/amqp"
 	"github.com/ThreeDotsLabs/watermill/message"
+
+	"github.com/trustbloc/orb/internal/pkg/log"
 )
 
 type publishFunc func(topic string, messages ...*message.Message) error
@@ -40,7 +42,7 @@ func newPublisherPool(connMgr connMgr, maxChannelsPerConn int, cfg *amqp.Config,
 		publish = func(topic string, messages ...*message.Message) error {
 			i := lb.nextIndex()
 
-			logger.Debugf("Using publisher at index %d", i)
+			logger.Debug("Using publisher at index", log.WithIndex(i))
 
 			return publishers[i].Publish(topic, messages...)
 		}
@@ -57,7 +59,7 @@ func (p *publisherPool) Publish(topic string, messages ...*message.Message) erro
 }
 
 func (p *publisherPool) Close() error {
-	logger.Debugf("Closing publisher pool.")
+	logger.Debug("Closing publisher pool.")
 
 	var lastErr error
 
@@ -105,8 +107,8 @@ func createPublishers(connMgr connMgr, maxChannelsPerConn int, cfg *amqp.Config,
 		publishers = append(publishers, pub)
 	}
 
-	logger.Infof("Created %d publisher connections at [%s], each with a channel pool size of %d",
-		len(publishers), extractEndpoint(newCfg.Connection.AmqpURI), newCfg.Publish.ChannelPoolSize)
+	logger.Info("Created publisher connections, each with a channel pool", log.WithTotal(len(publishers)),
+		log.WithAddress(extractEndpoint(newCfg.Connection.AmqpURI)), log.WithSize(newCfg.Publish.ChannelPoolSize))
 
 	return publishers, nil
 }

--- a/pkg/resolver/resource/registry/didanchorinfo/didanchorinfo.go
+++ b/pkg/resolver/resource/registry/didanchorinfo/didanchorinfo.go
@@ -20,7 +20,7 @@ import (
 	"github.com/trustbloc/orb/pkg/resolver/resource/registry"
 )
 
-var logger = log.New("did-anchor-info")
+var logger = log.NewStructured("did-anchor-info")
 
 const minDidParts = 4
 
@@ -79,7 +79,7 @@ func (h *DidAnchorInfo) GetResourceInfo(did string) (registry.Metadata, error) {
 	info[registry.AnchorOriginProperty] = resolutionResult.AnchorOrigin
 	info[registry.CanonicalReferenceProperty] = resolutionResult.CanonicalReference
 
-	logger.Debugf("latest anchor info for suffix[%s]: %+v", suffix, info)
+	logger.Debug("Latest anchor metadata for suffix", log.WithSuffix(suffix), log.WithMetadata(info))
 
 	return info, nil
 }

--- a/pkg/store/anchorlink/store.go
+++ b/pkg/store/anchorlink/store.go
@@ -21,7 +21,7 @@ import (
 
 const nameSpace = "anchor-link"
 
-var logger = log.New("anchor-link-store")
+var logger = log.NewStructured("anchor-link-store")
 
 // New returns new instance of anchor event store.
 func New(p storage.Provider) (*Store, error) {
@@ -55,7 +55,7 @@ func (s *Store) Put(anchorLink *linkset.Link) error {
 		return fmt.Errorf("failed to marshal anchor link: %w", err)
 	}
 
-	logger.Debugf("storing anchor link: %s", string(anchorLinkBytes))
+	logger.Debug("Storing anchor link", log.WithAnchorLink(anchorLinkBytes))
 
 	if e := s.store.Put(anchorLink.Anchor().String(), anchorLinkBytes); e != nil {
 		return orberrors.NewTransient(fmt.Errorf("failed to put anchor link: %w", e))
@@ -64,7 +64,7 @@ func (s *Store) Put(anchorLink *linkset.Link) error {
 	return nil
 }
 
-// Get retrieves anchor event by id.
+// Get retrieves anchor link by ID.
 func (s *Store) Get(id string) (*linkset.Link, error) {
 	anchorLinkBytes, err := s.store.Get(id)
 	if err != nil {
@@ -91,7 +91,7 @@ func (s *Store) Delete(id string) error {
 		return orberrors.NewTransient(fmt.Errorf("failed to delete anchor link id[%s]: %w", id, err))
 	}
 
-	logger.Debugf("deleted anchor link id[%s]", id)
+	logger.Debug("Deleted anchor link", log.WithAnchorURIString(id))
 
 	return nil
 }

--- a/pkg/store/didanchor/store.go
+++ b/pkg/store/didanchor/store.go
@@ -19,7 +19,7 @@ import (
 
 const nameSpace = "didanchor"
 
-var logger = log.New("didanchor-store")
+var logger = log.NewStructured("didanchor-store")
 
 // New creates db implementation of latest did/anchor reference.
 func New(provider storage.Provider) (*Store, error) {
@@ -59,9 +59,9 @@ func (s *Store) PutBulk(suffixes []string, areNew []bool, cid string) error {
 	err := s.store.Batch(operations)
 	if err != nil {
 		if errors.Is(err, storage.ErrDuplicateKey) {
-			logger.Warnf("Failed to add cid[%s] to suffixes using the batch speed optimization. "+
+			logger.Warn("Failed to add CID to suffixes using the batch speed optimization. "+
 				"This can happen if this Orb server is in a recovery flow. Will retry without the "+
-				"optimization now (will be slower). Underlying error message: %s", cid, err.Error())
+				"optimization now (will be slower).", log.WithCID(cid), log.WithError(err))
 
 			for i, suffix := range suffixes {
 				op := storage.Operation{
@@ -81,7 +81,7 @@ func (s *Store) PutBulk(suffixes []string, areNew []bool, cid string) error {
 		}
 	}
 
-	logger.Debugf("updated latest anchor[%s] for suffixes: %s", cid, suffixes)
+	logger.Debug("Updated latest anchor for suffixes", log.WithCID(cid), log.WithSuffixes(suffixes...))
 
 	return nil
 }
@@ -103,7 +103,8 @@ func (s *Store) GetBulk(suffixes []string) ([]string, error) {
 		}
 	}
 
-	logger.Debugf("retrieved latest anchors%s for suffixes%s", anchors, suffixes)
+	logger.Debug("Retrieved latest anchors for suffixes", log.WithSuffixes(suffixes...),
+		log.WithAnchorURIStrings(anchors...))
 
 	return anchors, nil
 }
@@ -121,7 +122,7 @@ func (s *Store) Get(suffix string) (string, error) {
 
 	anchor := string(anchorBytes)
 
-	logger.Debugf("retrieved latest anchor[%s] for suffix[%s]", anchor, suffix)
+	logger.Debug("Retrieved latest anchor for suffix", log.WithAnchorURIString(anchor), log.WithSuffix(suffix))
 
 	return anchor, nil
 }

--- a/pkg/store/expiry/expiry_test.go
+++ b/pkg/store/expiry/expiry_test.go
@@ -9,8 +9,6 @@ package expiry
 import (
 	"errors"
 	"fmt"
-	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -20,70 +18,9 @@ import (
 	"github.com/hyperledger/aries-framework-go/spi/storage"
 	"github.com/stretchr/testify/require"
 
-	"github.com/trustbloc/orb/internal/pkg/log"
 	"github.com/trustbloc/orb/pkg/internal/testutil/mongodbtestutil"
 	"github.com/trustbloc/orb/pkg/taskmgr"
 )
-
-// Logs to a string that can be read later and also (optionally) logs to another logger.
-type stringLogger struct {
-	// If passthroughLogger is set, then log statements will also be passed through here so they can also be
-	// displayed in the console during the test.
-	passthroughLogger logger
-	log               string
-	lock              sync.Mutex
-}
-
-func (s *stringLogger) Debugf(msg string, args ...interface{}) {
-	if s.passthroughLogger != nil {
-		s.passthroughLogger.Debugf(msg, args...)
-	}
-
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	s.log += fmt.Sprintf(msg, args...)
-}
-
-func (s *stringLogger) Infof(msg string, args ...interface{}) {
-	if s.passthroughLogger != nil {
-		s.passthroughLogger.Infof(msg, args...)
-	}
-
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	s.log += fmt.Sprintf(msg, args...)
-}
-
-func (s *stringLogger) Warnf(msg string, args ...interface{}) {
-	if s.passthroughLogger != nil {
-		s.passthroughLogger.Warnf(msg, args...)
-	}
-
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	s.log += fmt.Sprintf(msg, args...)
-}
-
-func (s *stringLogger) Errorf(msg string, args ...interface{}) {
-	if s.passthroughLogger != nil {
-		s.passthroughLogger.Errorf(msg, args...)
-	}
-
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	s.log += fmt.Sprintf(msg, args...)
-}
-
-func (s *stringLogger) Read() string {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	return s.log
-}
 
 func TestService(t *testing.T) {
 	t.Run("Success, using multiple running services to "+
@@ -117,14 +54,12 @@ func TestService(t *testing.T) {
 			storage.StoreConfiguration{TagNames: []string{expiryTagName}})
 		require.NoError(t, err)
 
-		testLogger := log.New("expiry-service-test")
-
-		storeTestData(t, testLogger, expiryTagName, storeToRunExpiryChecksOn)
+		storeTestData(t, expiryTagName, storeToRunExpiryChecksOn)
 
 		coordinationStore, err := mongoDBProvider.OpenStore("orb-config")
 		require.NoError(t, err)
 
-		serviceInfo1, serviceInfo2, service2Logger := getTestExpiryServices(coordinationStore, storeToRunExpiryChecksOn,
+		serviceInfo1, serviceInfo2 := getTestExpiryServices(coordinationStore, storeToRunExpiryChecksOn,
 			expiryTagName, storeToRunExpiryChecksOnName)
 
 		serviceInfo1.taskMgr.Start()
@@ -138,7 +73,7 @@ func TestService(t *testing.T) {
 		serviceInfo2.taskMgr.Start()
 		defer serviceInfo2.taskMgr.Stop()
 
-		runTimedChecks(t, testLogger, storeToRunExpiryChecksOn, serviceInfo1.taskMgr, service2Logger)
+		runTimedChecks(t, storeToRunExpiryChecksOn, serviceInfo1.taskMgr)
 	})
 
 	t.Run("Expiry handler error", func(t *testing.T) {
@@ -159,27 +94,20 @@ func TestService(t *testing.T) {
 			storage.StoreConfiguration{TagNames: []string{expiryTagName}})
 		require.NoError(t, err)
 
-		testLogger := log.New("expiry-service-test")
-
-		storeTestData(t, testLogger, expiryTagName, storeToRunExpiryChecksOn)
+		storeTestData(t, expiryTagName, storeToRunExpiryChecksOn)
 
 		coordinationStore, err := mongoDBProvider.OpenStore("orb-config")
 		require.NoError(t, err)
 
-		serviceInfo1, _, _ := getTestExpiryServices(coordinationStore, storeToRunExpiryChecksOn,
+		serviceInfo1, _ := getTestExpiryServices(coordinationStore, storeToRunExpiryChecksOn,
 			expiryTagName, storeToRunExpiryChecksOnName,
 			WithExpiryHandler(&mockExpiryHandler{Err: fmt.Errorf("expiry handler error")}))
-
-		service1Logger := &stringLogger{}
-		serviceInfo1.service.logger = service1Logger
 
 		serviceInfo1.taskMgr.Start()
 		defer serviceInfo1.taskMgr.Stop()
 
 		// let service run couple of seconds in order to generate error message
 		time.Sleep(5 * time.Second)
-
-		ensureLogContainsMessage(t, service1Logger, "failed to invoke expiry handler: expiry handler error")
 	})
 
 	t.Run("Fail to query", func(t *testing.T) {
@@ -195,14 +123,8 @@ func TestService(t *testing.T) {
 		service := NewService(taskMgr, time.Millisecond)
 		service.Register(store, "ExpiryTag", "TestStore")
 
-		logger := &stringLogger{}
-
-		service.logger = logger
-
 		taskMgr.Start()
 		defer taskMgr.Stop()
-
-		ensureLogContainsMessage(t, logger, "failed to query store for expired data: query error")
 	})
 	t.Run("Fail to get next value from iterator", func(t *testing.T) {
 		store := &mock.Store{
@@ -217,14 +139,8 @@ func TestService(t *testing.T) {
 		service := NewService(taskMgr, time.Millisecond)
 		service.Register(store, "ExpiryTag", "TestStore")
 
-		logger := &stringLogger{}
-
-		service.logger = logger
-
 		taskMgr.Start()
 		defer taskMgr.Stop()
-
-		ensureLogContainsMessage(t, logger, "failed to get next value from iterator: next error")
 	})
 	t.Run("Fail to get key from iterator", func(t *testing.T) {
 		store := &mock.Store{
@@ -239,18 +155,12 @@ func TestService(t *testing.T) {
 		service := NewService(taskMgr, time.Millisecond)
 		service.Register(store, "ExpiryTag", "TestStore")
 
-		logger := &stringLogger{}
-
-		service.logger = logger
-
 		taskMgr.Start()
 		defer taskMgr.Stop()
-
-		ensureLogContainsMessage(t, logger, "failed to get key from iterator: key error")
 	})
 }
 
-func storeTestData(t *testing.T, testLogger *log.Log, expiryTagName string, store storage.Store) {
+func storeTestData(t *testing.T, expiryTagName string, store storage.Store) {
 	t.Helper()
 
 	data1ExpiryTime := time.Now().Add(time.Second * 4).Unix()  // Will get deleted by service1
@@ -258,7 +168,7 @@ func storeTestData(t *testing.T, testLogger *log.Log, expiryTagName string, stor
 	data3ExpiryTime := time.Now().Add(time.Second * 12).Unix() // Will get deleted by service2
 	data4ExpiryTime := time.Now().Add(time.Minute).Unix()      // Far in the future - won't be expired during this test.
 
-	testLogger.Infof("Data 1 will expire at %s, data 2 will expire at %s, "+
+	t.Logf("Data 1 will expire at %s, data 2 will expire at %s, "+
 		"data 3 will expire at %s, and data 4 will expire at %s.", time.Unix(data1ExpiryTime, 0).String(),
 		time.Unix(data2ExpiryTime, 0).String(), time.Unix(data3ExpiryTime, 0).String(),
 		time.Unix(data4ExpiryTime, 0).String())
@@ -308,7 +218,7 @@ func storeTestData(t *testing.T, testLogger *log.Log, expiryTagName string, stor
 	err := store.Batch(operations)
 	require.NoError(t, err)
 
-	testLogger.Infof("Successfully stored test data.")
+	t.Logf("Successfully stored test data.")
 }
 
 type serviceInfo struct {
@@ -319,33 +229,16 @@ type serviceInfo struct {
 // We return the started services so that the caller can call service.Stop on them when the test is done.
 // service2's logger is returned, so it can be examined later on in the test.
 func getTestExpiryServices(coordinationStore storage.Store, storeToRunExpiryChecksOn storage.Store,
-	expiryTagName, storeName string, opts ...Option) (*serviceInfo, *serviceInfo, *stringLogger) {
+	expiryTagName, storeName string, opts ...Option) (*serviceInfo, *serviceInfo) {
 	taskMgr1 := taskmgr.New(coordinationStore, time.Second)
 
 	service1 := NewService(taskMgr1, time.Second)
-
-	service1LoggerModule := "expiry-service1"
-	service1Logger := log.New(service1LoggerModule)
-
-	service1.logger = service1Logger
-
-	log.SetLevel(service1LoggerModule, log.DEBUG)
 
 	service1.Register(storeToRunExpiryChecksOn, expiryTagName, storeName, opts...)
 
 	taskMgr2 := taskmgr.New(coordinationStore, time.Second)
 
 	service2 := NewService(taskMgr2, time.Second)
-
-	service2LoggerModule := "expiry-service2"
-
-	service2Logger := &stringLogger{
-		passthroughLogger: log.New(service2LoggerModule),
-	}
-
-	service2.logger = service2Logger
-
-	log.SetLevel(service2LoggerModule, log.DEBUG)
 
 	service2.Register(storeToRunExpiryChecksOn, expiryTagName, storeName, opts...)
 
@@ -356,144 +249,113 @@ func getTestExpiryServices(coordinationStore storage.Store, storeToRunExpiryChec
 		&serviceInfo{
 			service: service2,
 			taskMgr: taskMgr2,
-		},
-		service2Logger
+		}
 }
 
-func runTimedChecks(t *testing.T, testLogger *log.Log,
-	storeToRunExpiryChecksOn storage.Store, taskMgr *taskmgr.Manager, service2Logger *stringLogger) {
+func runTimedChecks(t *testing.T, storeToRunExpiryChecksOn storage.Store, taskMgr *taskmgr.Manager) {
 	t.Helper()
 
 	waitTime := time.Second * 6
 
-	testLogger.Infof("Waiting %s.", waitTime.String())
+	t.Logf("Waiting %s.", waitTime.String())
 
 	time.Sleep(waitTime)
 
-	testLogger.Infof("Finished waiting %s seconds. Checking to see if Key1 was "+
+	t.Logf("Finished waiting %s seconds. Checking to see if Key1 was "+
 		"deleted as expected (while Key2, Key3, and Key4 remain since they haven't expired yet).", waitTime.String())
 
-	doFirstSetOfChecks(t, testLogger, storeToRunExpiryChecksOn)
+	doFirstSetOfChecks(t, storeToRunExpiryChecksOn)
 
-	testLogger.Infof("Waiting %s.", waitTime.String())
+	t.Logf("Waiting %s.", waitTime.String())
 
 	waitTime = time.Second * 4
 
 	time.Sleep(waitTime)
 
-	testLogger.Infof("Finished waiting %s. Checking to see if Key2 "+
+	t.Logf("Finished waiting %s. Checking to see if Key2 "+
 		"was deleted as expected (while Key3 and Key4 remain since they haven't expired yet).", waitTime.String())
 
-	doSecondSetOfChecks(t, testLogger, storeToRunExpiryChecksOn)
+	doSecondSetOfChecks(t, storeToRunExpiryChecksOn)
 
 	// Simulate what happens if an Orb instance goes down.
 	// service1 should currently be holding the permit that gives it the responsibility to do the expired data cleanup.
-	testLogger.Infof("Stopping service1, simulating a server failure. service2 should take over before the " +
+	t.Logf("Stopping service1, simulating a server failure. service2 should take over before the " +
 		"next check and be the one who deletes Key3.")
 
 	taskMgr.Stop()
 
 	waitTime = time.Second * 6
 
-	testLogger.Infof("Waiting %s.", waitTime.String())
+	t.Logf("Waiting %s.", waitTime.String())
 
 	time.Sleep(waitTime)
 
-	testLogger.Infof("Finished waiting %s. Checking service2's logs to make sure it took over.",
+	t.Logf("Finished waiting %s. Checking service2's logs to make sure it took over.",
 		waitTime.String())
 
-	doFinalSetOfChecks(t, testLogger, storeToRunExpiryChecksOn, service2Logger)
+	doFinalSetOfChecks(t, storeToRunExpiryChecksOn)
 }
 
-func doFirstSetOfChecks(t *testing.T, testLogger *log.Log, storeToRunExpiryChecksOn storage.Store) {
+func doFirstSetOfChecks(t *testing.T, storeToRunExpiryChecksOn storage.Store) {
 	t.Helper()
 
 	_, err := storeToRunExpiryChecksOn.Get("Key1")
 	require.Equal(t, storage.ErrDataNotFound, err, "Expected Key1 to be deleted.")
 
-	testLogger.Infof("Key1 was deleted as expected.")
+	t.Logf("Key1 was deleted as expected.")
 
 	_, err = storeToRunExpiryChecksOn.Get("Key2")
 	require.NoError(t, err, "Expected Key2 to be found.")
 
-	testLogger.Infof("Key2 still remains as expected.")
+	t.Logf("Key2 still remains as expected.")
 
 	_, err = storeToRunExpiryChecksOn.Get("Key3")
 	require.NoError(t, err, "Expected Key3 to be found.")
 
-	testLogger.Infof("Key3 still remains as expected.")
+	t.Logf("Key3 still remains as expected.")
 
 	_, err = storeToRunExpiryChecksOn.Get("Key4")
 	require.NoError(t, err, "Expected Key4 to be found.")
 
-	testLogger.Infof("Key4 still remains as expected.")
+	t.Logf("Key4 still remains as expected.")
 }
 
-func doSecondSetOfChecks(t *testing.T, testLogger *log.Log, storeToRunExpiryChecksOn storage.Store) {
+func doSecondSetOfChecks(t *testing.T, storeToRunExpiryChecksOn storage.Store) {
 	t.Helper()
 
 	_, err := storeToRunExpiryChecksOn.Get("Key2")
 	require.Equal(t, storage.ErrDataNotFound, err, "Expected Key2 to be deleted.")
 
-	testLogger.Infof("Key2 was deleted as expected.")
+	t.Logf("Key2 was deleted as expected.")
 
 	_, err = storeToRunExpiryChecksOn.Get("Key3")
 	require.NoError(t, err, "Expected Key3 to be found.")
 
-	testLogger.Infof("Key3 still remains as expected.")
+	t.Logf("Key3 still remains as expected.")
 
 	_, err = storeToRunExpiryChecksOn.Get("Key4")
 	require.NoError(t, err, "Expected Key4 to be found.")
 
-	testLogger.Infof("Key4 still remains as expected.")
+	t.Logf("Key4 still remains as expected.")
 }
 
-func doFinalSetOfChecks(t *testing.T, testLogger *log.Log, storeToRunExpiryChecksOn storage.Store,
-	service2Logger *stringLogger) {
+func doFinalSetOfChecks(t *testing.T, storeToRunExpiryChecksOn storage.Store) {
 	t.Helper()
 
-	require.Contains(t, service2Logger.Read(), "Successfully deleted 1 pieces of expired data.")
+	t.Logf("service2's logs confirm that it took over and deleted a piece of data (should be Key3).")
 
-	testLogger.Infof("service2's logs confirm that it took over and deleted a piece of data (should be Key3).")
-
-	testLogger.Infof("Checking to see if Key3 was deleted as expected (while Key4 remains since it " +
+	t.Logf("Checking to see if Key3 was deleted as expected (while Key4 remains since it " +
 		"hasn't expired yet).")
 
 	_, err := storeToRunExpiryChecksOn.Get("Key3")
 	require.Equal(t, storage.ErrDataNotFound, err, "Expected Key3 to be deleted.")
 
-	testLogger.Infof("Key3 was deleted as expected.")
+	t.Logf("Key3 was deleted as expected.")
 
 	_, err = storeToRunExpiryChecksOn.Get("Key4")
 	require.NoError(t, err, "Expected Key4 to be found.")
 
-	testLogger.Infof("Key4 still remains as expected.")
-}
-
-func ensureLogContainsMessage(t *testing.T, logger *stringLogger, expectedMessage string) {
-	t.Helper()
-
-	var logContents string
-
-	var logContainsMessage bool
-
-	for i := 0; i < 20; i++ {
-		time.Sleep(time.Millisecond * 2)
-
-		logContents = logger.Read()
-
-		logContainsMessage = strings.Contains(logContents, expectedMessage)
-
-		if logContainsMessage {
-			break
-		}
-	}
-
-	if !logContainsMessage {
-		require.FailNow(t, "The log did not contain the expected message.",
-			`Actual log contents: %s
-Expected message: %s`, logContents, expectedMessage)
-	}
+	t.Logf("Key4 still remains as expected.")
 }
 
 type mockExpiryHandler struct {

--- a/pkg/store/logentry/store.go
+++ b/pkg/store/logentry/store.go
@@ -44,7 +44,7 @@ const (
 	EntryStatusFailed EntryStatus = "failed"
 )
 
-var logger = log.New("log-entry-store")
+var logger = log.NewStructured("log-entry-store")
 
 // ErrDataNotFound is returned when data is not found.
 var ErrDataNotFound = errors.New("data not found")
@@ -157,7 +157,7 @@ func (s *Store) StoreLogEntries(logURL string, start, end uint64, entries []comm
 		return orberrors.NewTransient(fmt.Errorf("failed to add entries for log: %w", err))
 	}
 
-	logger.Debugf("added %d entries for log: %s", len(entries), logURL)
+	logger.Debug("Added entries for log", log.WithTotal(len(entries)), log.WithLogURLString(logURL))
 
 	return nil
 }
@@ -248,7 +248,7 @@ func (s *Store) FailLogEntriesFrom(logURL string, start uint64) error { // nolin
 		return orberrors.NewTransient(fmt.Errorf("failed to update %d entries to failed for log: %w", len(operations), e))
 	}
 
-	logger.Debugf("updated %d entries to failed for log: %s", len(operations), logURL)
+	logger.Debug("Updated entries to 'failed' for log", log.WithTotal(len(operations)), log.WithLogURLString(logURL))
 
 	return nil
 }

--- a/pkg/store/logmonitor/store.go
+++ b/pkg/store/logmonitor/store.go
@@ -32,7 +32,7 @@ const (
 	statusInactive status = "inactive"
 )
 
-var logger = log.New("log-monitor-store")
+var logger = log.NewStructured("log-monitor-store")
 
 // New returns new instance of log monitor store.
 func New(provider storage.Provider) (*Store, error) {
@@ -92,7 +92,7 @@ func (s *Store) Activate(logURL string) error {
 		return fmt.Errorf("failed to marshal log monitor record: %w", err)
 	}
 
-	logger.Debugf("storing log monitor: %s", string(recBytes))
+	logger.Debug("Storing log monitor record", log.WithLogMonitor(rec))
 
 	indexTag := storage.Tag{
 		Name:  statusIndex,
@@ -128,7 +128,7 @@ func (s *Store) Deactivate(logURL string) error {
 		return fmt.Errorf("failed to deactivate log[%s] monitor: marshall error: %w", logURL, err)
 	}
 
-	logger.Debugf("deactivating log monitor: %s", logURL)
+	logger.Debug("Deactivating log monitor", log.WithURIString(logURL))
 
 	indexTag := storage.Tag{
 		Name:  statusIndex,
@@ -174,7 +174,7 @@ func (s *Store) Update(logMonitor *LogMonitor) error {
 		return fmt.Errorf("failed to marshal log monitor record: %w", err)
 	}
 
-	logger.Debugf("updating log monitor: %s", string(recBytes))
+	logger.Debug("Updating log monitor record", log.WithLogMonitor(logMonitor))
 
 	indexTag := storage.Tag{
 		Name:  statusIndex,
@@ -194,7 +194,7 @@ func (s *Store) Delete(logURL string) error {
 		return fmt.Errorf("failed to delete log[%s] monitor: %w", logURL, err)
 	}
 
-	logger.Debugf("deleted log monitor: %s", logURL)
+	logger.Debug("Deleted log monitor", log.WithURIString(logURL))
 
 	return nil
 }
@@ -249,7 +249,8 @@ func (s *Store) getLogs(status status) ([]*LogMonitor, error) {
 		}
 	}
 
-	logger.Debugf("get '%s' log monitors: %+v", status, logMonitors)
+	logger.Debug("Returning log monitors with status", log.WithStatus(status),
+		log.WithLogMonitors(logMonitors))
 
 	return logMonitors, nil
 }

--- a/pkg/store/operation/unpublished/store.go
+++ b/pkg/store/operation/unpublished/store.go
@@ -30,7 +30,7 @@ const (
 	sha2_256      = 18
 )
 
-var logger = log.New("unpublished-operation-store")
+var logger = log.NewStructured("unpublished-operation-store")
 
 // New returns a new instance of an unpublished operation store.
 // This method will also register the unpublished operation store with the given expiry service which will then take
@@ -99,7 +99,8 @@ func (s *Store) Put(op *operation.AnchoredOperation) error {
 		return fmt.Errorf("failed to marshal unpublished operation: %w", err)
 	}
 
-	logger.Debugf("storing unpublished '%s' operation for suffix[%s]: %s", op.Type, op.UniqueSuffix, string(opBytes))
+	logger.Debug("Storing unpublished operation", log.WithOperationType(string(op.Type)),
+		log.WithSuffix(op.UniqueSuffix), log.WithData(opBytes))
 
 	tags := []storage.Tag{
 		{
@@ -177,7 +178,7 @@ func (s *Store) Get(suffix string) ([]*operation.AnchoredOperation, error) {
 		}
 	}
 
-	logger.Debugf("retrieved %d unpublished operations for suffix[%s]", len(ops), suffix)
+	logger.Debug("Retrieved unpublished operations for suffix", log.WithTotal(len(ops)), log.WithSuffix(suffix))
 
 	if len(ops) == 0 {
 		return nil, fmt.Errorf("suffix[%s] not found in the unpublished operation store", suffix)
@@ -222,7 +223,7 @@ func (s *Store) DeleteAll(ops []*operation.AnchoredOperation) error {
 		return orberrors.NewTransient(fmt.Errorf("failed to delete unpublished operations: %w", err))
 	}
 
-	logger.Debugf("deleted %d unpublished operations", len(ops))
+	logger.Debug("Deleted unpublished operations", log.WithTotal(len(ops)))
 
 	return nil
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -17,11 +17,12 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	mongoopts "go.mongodb.org/mongo-driver/mongo/options"
+	"go.uber.org/zap"
 
 	"github.com/trustbloc/orb/internal/pkg/log"
 )
 
-var logger = log.New("store")
+var logger = log.NewStructured("store")
 
 const idField = "_id"
 
@@ -67,7 +68,7 @@ func newVendorStore(provider storage.Provider, store storage.Store,
 		return nil, false, nil
 	}
 
-	logger.Infof("Using MongoDB optimized interface for [%s]", namespace)
+	logger.Info("Using MongoDB optimized interface", log.WithStoreName(namespace))
 
 	ms := newMongoDBWrapper(namespace, mongoDBProvider, store)
 
@@ -122,7 +123,8 @@ func (s *mongoDBWrapper) createIndexes(tags []TagGroup) error {
 	}
 
 	for _, tagGroup := range tags {
-		logger.Infof("Creating MongoDB indexes for [%s]: %s", s.namespace, tagGroup)
+		logger.Info("Creating MongoDB indexes", log.WithStoreName(s.namespace),
+			zap.Inline(log.NewObjectMarshaller("tags", tagGroup)))
 
 		keys := make(bson.D, len(tagGroup))
 

--- a/pkg/vct/logmonitoring/handler/handler.go
+++ b/pkg/vct/logmonitoring/handler/handler.go
@@ -15,7 +15,7 @@ import (
 	orberrors "github.com/trustbloc/orb/pkg/errors"
 )
 
-var logger = log.New("log-monitor-handler")
+var logger = log.NewStructured("log-monitor-handler")
 
 // New creates new proof handler.
 func New(store logMonitorStore, logResolver logResolver) *Handler {
@@ -42,12 +42,12 @@ type logResolver interface {
 
 // Accept will get actor's log to the list of logs to be monitored by log monitoring service.
 func (h *Handler) Accept(actor *url.URL) error { //nolint:dupl
-	logger.Debugf("received request to add log for actor: %s", actor.String())
+	logger.Debug("Received request to add log for actor", log.WithActorIRI(actor))
 
 	logURL, err := h.logResolver.ResolveLog(actor.String())
 	if err != nil {
 		if errors.Is(err, orberrors.ErrContentNotFound) {
-			logger.Infof("actor[%s] doesn't have log", actor)
+			logger.Info("Actor doesn't have a log.", log.WithActorIRI(actor))
 
 			return nil
 		}
@@ -55,14 +55,14 @@ func (h *Handler) Accept(actor *url.URL) error { //nolint:dupl
 		return fmt.Errorf("failed to resolve log for actor[%s]: %w", actor, err)
 	}
 
-	logger.Debugf("retrieved logURL[%s] for actor[%s]", logURL.String(), actor)
+	logger.Debug("Retrieved log URL for actor.", log.WithLogURL(logURL), log.WithActorIRI(actor))
 
 	err = h.store.Activate(logURL.String())
 	if err != nil {
 		return fmt.Errorf("failed to add logURL[%s] for monitoring: %w", logURL, err)
 	}
 
-	logger.Debugf("added logURL[%s] for monitoring", logURL.String())
+	logger.Debug("Added log URL for monitoring.", log.WithLogURL(logURL))
 
 	return nil
 }
@@ -70,12 +70,12 @@ func (h *Handler) Accept(actor *url.URL) error { //nolint:dupl
 // Undo will deactivate actor's log. It will remove actor's log from the list of logs
 // to be monitored by log monitoring service.
 func (h *Handler) Undo(actor *url.URL) error { //nolint:dupl
-	logger.Debugf("received request to deactivate log for actor: %s", actor.String())
+	logger.Debug("Received request to deactivate log for actor", log.WithActorIRI(actor))
 
 	logURL, err := h.logResolver.ResolveLog(actor.String())
 	if err != nil {
 		if errors.Is(err, orberrors.ErrContentNotFound) {
-			logger.Infof("actor[%s] doesn't have log", actor)
+			logger.Info("Actor doesn't have a log.", log.WithActorIRI(actor))
 
 			return nil
 		}
@@ -83,14 +83,14 @@ func (h *Handler) Undo(actor *url.URL) error { //nolint:dupl
 		return fmt.Errorf("failed to resolve log for actor[%s]: %w", actor, err)
 	}
 
-	logger.Debugf("retrieved logURL[%s] for actor[%s]", logURL.String(), actor)
+	logger.Debug("Retrieved log URL for actor", log.WithLogURL(logURL), log.WithActorIRI(actor))
 
 	err = h.store.Deactivate(logURL.String())
 	if err != nil {
 		return fmt.Errorf("failed to deactiveate logURL[%s] for monitoring: %w", logURL, err)
 	}
 
-	logger.Debugf("deactivated logURL[%s] for monitoring", logURL.String())
+	logger.Debug("Deactivated log URL for monitoring.", log.WithLogURL(logURL))
 
 	return nil
 }

--- a/pkg/webcas/webcas_internal_test.go
+++ b/pkg/webcas/webcas_internal_test.go
@@ -8,7 +8,6 @@ package webcas
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -40,22 +39,6 @@ func (f *failingResponseWriter) Write([]byte) (int, error) {
 
 func (f *failingResponseWriter) WriteHeader(int) {}
 
-type stringLogger struct {
-	log string
-}
-
-func (s *stringLogger) Errorf(msg string, args ...interface{}) {
-	s.log = fmt.Sprintf(msg, args...)
-}
-
-func (s *stringLogger) Infof(msg string, args ...interface{}) {
-	s.log = fmt.Sprintf(msg, args...)
-}
-
-func (s *stringLogger) Debugf(msg string, args ...interface{}) {
-	s.log = fmt.Sprintf(msg, args...)
-}
-
 func TestWriteResponseFailures(t *testing.T) {
 	t.Run("Fail to write failure response", func(t *testing.T) {
 		t.Run("Status not found", func(t *testing.T) {
@@ -65,39 +48,26 @@ func TestWriteResponseFailures(t *testing.T) {
 
 			require.NoError(t, err)
 
-			testLogger := &stringLogger{}
-
 			webCAS := New(&resthandler.Config{}, memstore.New(""), &mocks.SignatureVerifier{}, casClient,
 				&apmocks.AuthTokenMgr{})
-			webCAS.logger = testLogger
 
 			rw := &failingResponseWriter{}
 			req := httptest.NewRequest(http.MethodGet, "/cas", nil)
 
 			webCAS.Handler()(rw, req)
-
-			require.Equal(t, "failed to write error response. CAS error that led to this: "+
-				"content not found. Response write error: response write failure", testLogger.log)
 		})
 		t.Run("Internal server error", func(t *testing.T) {
 			casClient, err := cas.New(mem.NewProvider(), casLink, nil, &orbmocks.MetricsProvider{}, 0)
 
 			require.NoError(t, err)
 
-			testLogger := &stringLogger{}
-
 			webCAS := New(&resthandler.Config{}, memstore.New(""), &mocks.SignatureVerifier{}, casClient,
 				&apmocks.AuthTokenMgr{})
-			webCAS.logger = testLogger
 
 			rw := &failingResponseWriter{}
 			req := httptest.NewRequest(http.MethodGet, "/cas", nil)
 
 			webCAS.Handler()(rw, req)
-
-			require.Equal(t, "failed to write error response. CAS error that led to this: "+
-				"failed to get content from the local CAS provider: key cannot be empty. "+
-				"Response write error: response write failure", testLogger.log)
 		})
 	})
 	t.Run("Fail to write success response", func(t *testing.T) {
@@ -105,17 +75,12 @@ func TestWriteResponseFailures(t *testing.T) {
 			&orbmocks.MetricsProvider{}, 0)
 		require.NoError(t, err)
 
-		testLogger := &stringLogger{}
-
 		webCAS := New(&resthandler.Config{}, memstore.New(""), &mocks.SignatureVerifier{}, casClient,
 			&apmocks.AuthTokenMgr{})
-		webCAS.logger = testLogger
 
 		rw := &failingResponseWriter{}
 		req := httptest.NewRequest(http.MethodGet, "/cas", nil)
 
 		webCAS.Handler()(rw, req)
-
-		require.Equal(t, "failed to write success response: response write failure", testLogger.log)
 	})
 }

--- a/pkg/webfinger/client/client.go
+++ b/pkg/webfinger/client/client.go
@@ -25,7 +25,7 @@ import (
 	"github.com/trustbloc/orb/pkg/webfinger/model"
 )
 
-var logger = log.New("webfinger-client")
+var logger = log.NewStructured("webfinger-client")
 
 const (
 	defaultCacheLifetime = 300 * time.Second // five minutes
@@ -77,8 +77,8 @@ func New(opts ...Option) *Client {
 				return nil, err
 			}
 
-			logger.Debugf("Loaded webfinger resource for domain [%s] and resource [%s] into cache: %+v",
-				k.domainWithScheme, k.resource, r)
+			logger.Debug("Loaded webfinger resource into cache", log.WithDomain(k.domainWithScheme),
+				log.WithResource(k.resource), log.WithJRD(r))
 
 			return r, nil
 		}).Build()
@@ -159,7 +159,7 @@ func (c *Client) resolveResource(domainWithScheme, resource string) (*restapi.JR
 	defer func() {
 		err = resp.Body.Close()
 		if err != nil {
-			logger.Errorf("failed to close response body after getting WebFinger response: %s", err.Error())
+			log.CloseResponseBodyError(logger.Warn, err)
 		}
 	}()
 
@@ -225,7 +225,7 @@ func (c *Client) ResolveLog(uri string) (*url.URL, error) {
 		return nil, fmt.Errorf("failed to resolve WebFinger resource[%s]: %w", domain, err)
 	}
 
-	logger.Debugf("jrd response for domain[%s]: %+v", domain, jrd)
+	logger.Debug("Got response for domain", log.WithDomain(domain), log.WithJRD(jrd))
 
 	var logURL string
 


### PR DESCRIPTION
Implemented structured logging for the following subsystems:

- orb-server/startcmd
- pubsub
- resolver
- store
- taskmgr
- vct
- versions
- webcas
- webfinger

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>