### PR TITLE
fix: Caller for common logs is always the common.go file

### DIFF
--- a/cmd/orb-cli/common/common.go
+++ b/cmd/orb-cli/common/common.go
@@ -43,7 +43,7 @@ import (
 	"github.com/trustbloc/orb/internal/pkg/tlsutil"
 )
 
-var logger = log.New("orb-cli")
+var logger = log.NewStructured("orb-cli")
 
 const (
 	// TLSSystemCertPoolFlagName defines the flag for the system certificate pool.
@@ -390,7 +390,7 @@ func SendHTTPRequest(cmd *cobra.Command, reqBytes []byte, method, endpointURL st
 
 func closeResponseBody(respBody io.Closer) {
 	if err := respBody.Close(); err != nil {
-		logger.Errorf("Failed to close response body: %v", err)
+		log.CloseResponseBodyError(logger, err)
 	}
 }
 

--- a/cmd/orb-cli/main.go
+++ b/cmd/orb-cli/main.go
@@ -28,7 +28,7 @@ import (
 	"github.com/trustbloc/orb/internal/pkg/log"
 )
 
-var logger = log.New("orb-cli")
+var logger = log.NewStructured("orb-cli")
 
 func main() {
 	rootCmd := &cobra.Command{
@@ -77,6 +77,6 @@ func main() {
 	rootCmd.AddCommand(allowedoriginscmd.GetCmd())
 
 	if err := rootCmd.Execute(); err != nil {
-		logger.Fatalf("Failed to run orb-cli: %s", err.Error())
+		logger.Fatal("Failed to run orb-cli", log.WithError(err))
 	}
 }

--- a/cmd/orb-driver/startcmd/start.go
+++ b/cmd/orb-driver/startcmd/start.go
@@ -73,7 +73,7 @@ const (
 	verifyTypeNone        = "none"
 )
 
-var logger = log.New("orb-driver")
+var logger = log.NewStructured("orb-driver")
 
 // HTTPServer represents an actual HTTP server implementation.
 type HTTPServer struct{}
@@ -84,7 +84,7 @@ func (s *HTTPServer) Start(srv *httpserver.Server) error {
 		return err
 	}
 
-	logger.Infof("started orb driver service")
+	logger.Info("started orb driver service")
 
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, syscall.SIGINT, syscall.SIGTERM)

--- a/cmd/orb-server/main.go
+++ b/cmd/orb-server/main.go
@@ -22,7 +22,7 @@ import (
 	"github.com/trustbloc/orb/internal/pkg/log"
 )
 
-var logger = log.New("orb-server")
+var logger = log.NewStructured("orb-server")
 
 func main() {
 	rootCmd := &cobra.Command{
@@ -35,6 +35,6 @@ func main() {
 	rootCmd.AddCommand(startcmd.GetStartCmd())
 
 	if err := rootCmd.Execute(); err != nil {
-		logger.Fatalf("Failed to run orb-rest: %s", err.Error())
+		logger.Fatal("Failed to run Orb server.", log.WithError(err))
 	}
 }

--- a/internal/pkg/log/common.go
+++ b/internal/pkg/log/common.go
@@ -8,34 +8,32 @@ package log
 
 import "go.uber.org/zap"
 
-type loggerFunc func(msg string, fields ...zap.Field)
-
 // InvalidParameterValue outputs an 'invalid parameter' log to the given logger.
-func InvalidParameterValue(log loggerFunc, param string, err error) {
-	log("Invalid parameter value", WithParameter(param), WithError(err))
+func InvalidParameterValue(log *StructuredLog, param string, err error) {
+	log.WithOptions(zap.AddCallerSkip(1)).Error("Invalid parameter value", WithParameter(param), WithError(err))
 }
 
 // CloseIteratorError outputs a 'close iterator' error log to the given logger.
-func CloseIteratorError(log loggerFunc, err error) {
-	log("Error closing iterator", WithError(err))
+func CloseIteratorError(log *StructuredLog, err error) {
+	log.WithOptions(zap.AddCallerSkip(1)).Warn("Error closing iterator", WithError(err))
 }
 
 // CloseResponseBodyError outputs a 'close response body' error log to the given logger.
-func CloseResponseBodyError(log loggerFunc, err error) {
-	log("Error closing response body", WithError(err))
+func CloseResponseBodyError(log *StructuredLog, err error) {
+	log.WithOptions(zap.AddCallerSkip(1)).Warn("Error closing response body", WithError(err))
 }
 
 // ReadRequestBodyError outputs a 'read response body' error log to the given logger.
-func ReadRequestBodyError(log loggerFunc, err error) {
-	log("Error reading response body", WithError(err))
+func ReadRequestBodyError(log *StructuredLog, err error) {
+	log.WithOptions(zap.AddCallerSkip(1)).Error("Error reading request body", WithError(err))
 }
 
 // WriteResponseBodyError outputs a 'write response body' error log to the given logger.
-func WriteResponseBodyError(log loggerFunc, err error) {
-	log("Error writing response body", WithError(err))
+func WriteResponseBodyError(log *StructuredLog, err error) {
+	log.WithOptions(zap.AddCallerSkip(1)).Error("Error writing response body", WithError(err))
 }
 
 // WroteResponse outputs a 'wrote response' log to the given logger.
-func WroteResponse(log loggerFunc, data []byte) {
-	log("Wrote response", WithResponse(data))
+func WroteResponse(log *StructuredLog, data []byte) {
+	log.WithOptions(zap.AddCallerSkip(1)).Debug("Wrote response", WithResponse(data))
 }

--- a/internal/pkg/log/common_test.go
+++ b/internal/pkg/log/common_test.go
@@ -24,7 +24,7 @@ func TestCommonLogs(t *testing.T) {
 			WithFields(WithServiceName("myservice")),
 		)
 
-		InvalidParameterValue(logger.Error, "param1", errors.New("invalid integer"))
+		InvalidParameterValue(logger, "param1", errors.New("invalid integer"))
 
 		t.Logf(stdErr.String())
 
@@ -32,6 +32,7 @@ func TestCommonLogs(t *testing.T) {
 		require.Contains(t, stdErr.Buffer.String(), `"service": "myservice"`)
 		require.Contains(t, stdErr.Buffer.String(), `"parameter": "param1"`)
 		require.Contains(t, stdErr.Buffer.String(), `"error": "invalid integer"`)
+		require.Contains(t, stdErr.Buffer.String(), "log/common_test.go")
 	})
 
 	t.Run("CloseIteratorError", func(t *testing.T) {
@@ -42,11 +43,12 @@ func TestCommonLogs(t *testing.T) {
 			WithFields(WithServiceName("myservice")),
 		)
 
-		CloseIteratorError(logger.Info, errors.New("iterator error"))
+		CloseIteratorError(logger, errors.New("iterator error"))
 
 		require.Contains(t, stdOut.Buffer.String(), `Error closing iterator`)
 		require.Contains(t, stdOut.Buffer.String(), `"service": "myservice"`)
 		require.Contains(t, stdOut.Buffer.String(), `"error": "iterator error"`)
+		require.Contains(t, stdOut.Buffer.String(), "log/common_test.go")
 	})
 
 	t.Run("CloseResponseBodyError", func(t *testing.T) {
@@ -57,29 +59,49 @@ func TestCommonLogs(t *testing.T) {
 			WithFields(WithServiceName("myservice")),
 		)
 
-		CloseResponseBodyError(logger.Info, errors.New("response body error"))
+		CloseResponseBodyError(logger, errors.New("response body error"))
 
 		require.Contains(t, stdOut.Buffer.String(), `Error closing response body`)
 		require.Contains(t, stdOut.Buffer.String(), `"service": "myservice"`)
 		require.Contains(t, stdOut.Buffer.String(), `"error": "response body error"`)
+		require.Contains(t, stdOut.Buffer.String(), "log/common_test.go")
 	})
 
 	t.Run("WriteResponseBodyError", func(t *testing.T) {
-		stdOut := newMockWriter()
+		stdErr := newMockWriter()
 
 		logger := NewStructured(module,
-			WithStdOut(stdOut),
+			WithStdErr(stdErr),
 			WithFields(WithServiceName("myservice")),
 		)
 
-		WriteResponseBodyError(logger.Info, errors.New("response body error"))
+		WriteResponseBodyError(logger, errors.New("response body error"))
 
-		require.Contains(t, stdOut.Buffer.String(), `Error writing response body`)
-		require.Contains(t, stdOut.Buffer.String(), `"service": "myservice"`)
-		require.Contains(t, stdOut.Buffer.String(), `"error": "response body error"`)
+		require.Contains(t, stdErr.Buffer.String(), `Error writing response body`)
+		require.Contains(t, stdErr.Buffer.String(), `"service": "myservice"`)
+		require.Contains(t, stdErr.Buffer.String(), `"error": "response body error"`)
+		require.Contains(t, stdErr.Buffer.String(), "log/common_test.go")
+	})
+
+	t.Run("ReadRequestBodyError", func(t *testing.T) {
+		stdErr := newMockWriter()
+
+		logger := NewStructured(module,
+			WithStdErr(stdErr),
+			WithFields(WithServiceName("myservice")),
+		)
+
+		ReadRequestBodyError(logger, errors.New("request body error"))
+
+		require.Contains(t, stdErr.Buffer.String(), `Error reading request body`)
+		require.Contains(t, stdErr.Buffer.String(), `"service": "myservice"`)
+		require.Contains(t, stdErr.Buffer.String(), `"error": "request body error"`)
+		require.Contains(t, stdErr.Buffer.String(), "log/common_test.go")
 	})
 
 	t.Run("WroteResponse", func(t *testing.T) {
+		SetLevel(module, DEBUG)
+
 		stdOut := newMockWriter()
 
 		logger := NewStructured(module,
@@ -87,10 +109,11 @@ func TestCommonLogs(t *testing.T) {
 			WithFields(WithServiceName("myservice")),
 		)
 
-		WroteResponse(logger.Info, []byte("some response"))
+		WroteResponse(logger, []byte("some response"))
 
 		require.Contains(t, stdOut.Buffer.String(), `Wrote response`)
 		require.Contains(t, stdOut.Buffer.String(), `"service": "myservice"`)
 		require.Contains(t, stdOut.Buffer.String(), `"response": "some response"`)
+		require.Contains(t, stdOut.Buffer.String(), "log/common_test.go")
 	})
 }

--- a/internal/pkg/log/fields.go
+++ b/internal/pkg/log/fields.go
@@ -143,6 +143,9 @@ const (
 	FieldIndex                  = "index"
 	FieldFromIndex              = "from-index"
 	FieldToIndex                = "to-index"
+	FieldSource                 = "source"
+	FieldAge                    = "age"
+	FieldMinAge                 = "min-age"
 )
 
 // WithError sets the error field.
@@ -855,6 +858,21 @@ func WithFromIndexUint64(value uint64) zap.Field {
 // WithToIndexUint64 sets the to-index field.
 func WithToIndexUint64(value uint64) zap.Field {
 	return zap.Uint64(FieldToIndex, value)
+}
+
+// WithSource sets the source field.
+func WithSource(value string) zap.Field {
+	return zap.String(FieldSource, value)
+}
+
+// WithAge sets the age field.
+func WithAge(value time.Duration) zap.Field {
+	return zap.Duration(FieldAge, value)
+}
+
+// WithMinAge sets the min-age field.
+func WithMinAge(value time.Duration) zap.Field {
+	return zap.Duration(FieldMinAge, value)
 }
 
 type jsonMarshaller struct {

--- a/internal/pkg/tlsutil/certpool.go
+++ b/internal/pkg/tlsutil/certpool.go
@@ -13,7 +13,7 @@ import (
 	"github.com/trustbloc/orb/internal/pkg/log"
 )
 
-var logger = log.New("tlsutil")
+var logger = log.NewStructured("tlsutil")
 
 // CertPool is a thread safe wrapper around the x509 standard library
 // cert pool implementation.
@@ -157,7 +157,7 @@ func loadSystemCertPool(useSystemCertPool bool) (*x509.CertPool, error) {
 		return nil, err
 	}
 
-	logger.Debugf("Loaded system cert pool of size: %d", len(systemCertPool.Subjects()))
+	logger.Debug("Loaded system cert pool", log.WithSize(len(systemCertPool.Subjects())))
 
 	return systemCertPool, nil
 }

--- a/pkg/activitypub/client/client.go
+++ b/pkg/activitypub/client/client.go
@@ -336,7 +336,7 @@ func (c *Client) get(iri *url.URL) ([]byte, error) {
 
 	defer func() {
 		if e := resp.Body.Close(); e != nil {
-			log.CloseResponseBodyError(logger.Warn, e)
+			log.CloseResponseBodyError(logger, e)
 		}
 	}()
 

--- a/pkg/activitypub/resthandler/activityhandler.go
+++ b/pkg/activitypub/resthandler/activityhandler.go
@@ -220,7 +220,7 @@ func (h *Activities) getActivities(objectIRI, id *url.URL,
 	defer func() {
 		err = it.Close()
 		if err != nil {
-			log.CloseIteratorError(h.logger.Error, err)
+			log.CloseIteratorError(h.logger, err)
 		}
 	}()
 
@@ -263,7 +263,7 @@ func (h *Activities) getPage(objectIRI, id *url.URL, refType spi.ReferenceType,
 	defer func() {
 		err = it.Close()
 		if err != nil {
-			log.CloseIteratorError(h.logger.Error, err)
+			log.CloseIteratorError(h.logger, err)
 		}
 	}()
 

--- a/pkg/activitypub/resthandler/authhandler.go
+++ b/pkg/activitypub/resthandler/authhandler.go
@@ -62,7 +62,7 @@ func NewAuthHandler(cfg *Config, endpoint, method string, s store.Store, verifie
 					return
 				}
 
-				log.WroteResponse(logger.Debug, body)
+				log.WroteResponse(logger, body)
 			}
 		},
 	}
@@ -156,7 +156,7 @@ func (h *AuthHandler) hasReference(refType store.ReferenceType, refIRI *url.URL)
 	defer func() {
 		err = it.Close()
 		if err != nil {
-			log.CloseIteratorError(h.logger.Error, err)
+			log.CloseIteratorError(h.logger, err)
 		}
 	}()
 

--- a/pkg/activitypub/resthandler/referencehandler.go
+++ b/pkg/activitypub/resthandler/referencehandler.go
@@ -184,7 +184,7 @@ func (h *Reference) getReference(id *url.URL) (interface{}, error) {
 	defer func() {
 		err = it.Close()
 		if err != nil {
-			log.CloseIteratorError(h.logger.Error, err)
+			log.CloseIteratorError(h.logger, err)
 		}
 	}()
 
@@ -225,7 +225,7 @@ func (h *Reference) getPage(id *url.URL, opts ...spi.QueryOpt) (interface{}, err
 	defer func() {
 		err = it.Close()
 		if err != nil {
-			log.CloseIteratorError(h.logger.Error, err)
+			log.CloseIteratorError(h.logger, err)
 		}
 	}()
 

--- a/pkg/activitypub/resthandler/resthandler.go
+++ b/pkg/activitypub/resthandler/resthandler.go
@@ -225,7 +225,7 @@ func (h *handler) paramAsInt(req *http.Request, param string) (int, bool) {
 
 	size, err := strconv.Atoi(values[0])
 	if err != nil {
-		log.InvalidParameterValue(h.logger.Error, param, err)
+		log.InvalidParameterValue(h.logger, param, err)
 
 		return 0, false
 	}
@@ -243,7 +243,7 @@ func (h *handler) paramAsBool(req *http.Request, param string) bool {
 
 	b, err := strconv.ParseBool(values[0])
 	if err != nil {
-		log.InvalidParameterValue(h.logger.Error, param, err)
+		log.InvalidParameterValue(h.logger, param, err)
 
 		return false
 	}

--- a/pkg/activitypub/service/activityhandler/inboxhandler.go
+++ b/pkg/activitypub/service/activityhandler/inboxhandler.go
@@ -447,7 +447,7 @@ func (h *Inbox) hasReference(objectIRI, refIRI *url.URL, refType store.Reference
 	defer func() {
 		err = it.Close()
 		if err != nil {
-			log.CloseIteratorError(h.logger.Error, err)
+			log.CloseIteratorError(h.logger, err)
 		}
 	}()
 

--- a/pkg/anchor/allowedorigins/allowedoriginsrest/allowedoriginshandler.go
+++ b/pkg/anchor/allowedorigins/allowedoriginsrest/allowedoriginshandler.go
@@ -154,12 +154,12 @@ func writeResponse(w http.ResponseWriter, status int, body []byte) {
 
 	if len(body) > 0 {
 		if _, err := w.Write(body); err != nil {
-			log.WriteResponseBodyError(logger.Warn, err)
+			log.WriteResponseBodyError(logger, err)
 
 			return
 		}
 
-		log.WroteResponse(logger.Debug, body)
+		log.WroteResponse(logger, body)
 	}
 }
 

--- a/pkg/anchor/anchorlinkset/vcresthandler/resthandler.go
+++ b/pkg/anchor/anchorlinkset/vcresthandler/resthandler.go
@@ -84,11 +84,11 @@ func writeResponse(w http.ResponseWriter, status int, body []byte) {
 
 	if len(body) > 0 {
 		if _, err := w.Write(body); err != nil {
-			log.WriteResponseBodyError(logger.Warn, err)
+			log.WriteResponseBodyError(logger, err)
 
 			return
 		}
 
-		log.WroteResponse(logger.Debug, body)
+		log.WroteResponse(logger, body)
 	}
 }

--- a/pkg/anchor/witness/policy/resthandler/configurator.go
+++ b/pkg/anchor/witness/policy/resthandler/configurator.go
@@ -103,11 +103,11 @@ func writeResponse(w http.ResponseWriter, status int, body []byte) {
 
 	if len(body) > 0 {
 		if _, err := w.Write(body); err != nil {
-			log.WriteResponseBodyError(logger.Warn, err)
+			log.WriteResponseBodyError(logger, err)
 
 			return
 		}
 
-		log.WroteResponse(logger.Debug, body)
+		log.WroteResponse(logger, body)
 	}
 }

--- a/pkg/anchor/writer/writer.go
+++ b/pkg/anchor/writer/writer.go
@@ -858,7 +858,7 @@ func (c *Writer) getSystemWitnessesIRI() ([]*url.URL, error) {
 	defer func() {
 		err = it.Close()
 		if err != nil {
-			log.CloseIteratorError(logger.Warn, err)
+			log.CloseIteratorError(logger, err)
 		}
 	}()
 

--- a/pkg/cas/resolver/resolver.go
+++ b/pkg/cas/resolver/resolver.go
@@ -371,7 +371,7 @@ func (w *WebCASResolver) GetDataViaWebCASEndpoint(webCASEndpoint *url.URL) ([]by
 	defer func() {
 		errClose := resp.Body.Close()
 		if errClose != nil {
-			log.CloseResponseBodyError(logger.Warn, err)
+			log.CloseResponseBodyError(logger, err)
 		}
 	}()
 

--- a/pkg/context/opqueue/opqueue.go
+++ b/pkg/context/opqueue/opqueue.go
@@ -473,7 +473,7 @@ func (q *Queue) monitorOtherServers() {
 	defer func() {
 		errClose := it.Close()
 		if errClose != nil {
-			log.CloseIteratorError(q.logger.Warn, err)
+			log.CloseIteratorError(q.logger, err)
 		}
 	}()
 
@@ -591,7 +591,7 @@ func (q *Queue) repostOperations(serverID string) error { //nolint:gocyclo,cyclo
 	defer func() {
 		errClose := it.Close()
 		if errClose != nil {
-			log.CloseIteratorError(q.logger.Warn, err)
+			log.CloseIteratorError(q.logger, err)
 		}
 	}()
 

--- a/pkg/discovery/endpoint/client/client.go
+++ b/pkg/discovery/endpoint/client/client.go
@@ -588,7 +588,7 @@ func (cs *Client) sendRequest(req []byte, method, endpointURL string, respObj in
 func closeResponseBody(respBody io.Closer) {
 	e := respBody.Close() // nolint: ifshort
 	if e != nil {
-		log.CloseResponseBodyError(logger.Warn, e)
+		log.CloseResponseBodyError(logger, e)
 	}
 }
 

--- a/pkg/discovery/endpoint/restapi/operations.go
+++ b/pkg/discovery/endpoint/restapi/operations.go
@@ -299,7 +299,7 @@ func (o *Operation) handleDIDWeb(did string, pubKeys []PublicKey, rw http.Respon
 	rw.WriteHeader(http.StatusOK)
 
 	if _, err = rw.Write(bytes); err != nil {
-		log.WriteResponseBodyError(logger.Error, err)
+		log.WriteResponseBodyError(logger, err)
 	}
 }
 
@@ -744,7 +744,7 @@ func writeResponse(rw http.ResponseWriter, v interface{}) {
 
 	err := json.NewEncoder(rw).Encode(v)
 	if err != nil {
-		log.WriteResponseBodyError(logger.Error, err)
+		log.WriteResponseBodyError(logger, err)
 	}
 }
 

--- a/pkg/document/remoteresolver/remoteresolver.go
+++ b/pkg/document/remoteresolver/remoteresolver.go
@@ -99,7 +99,7 @@ func (rr *Resolver) send(uri string) ([]byte, error) {
 
 	defer func() {
 		if errClose := resp.Body.Close(); errClose != nil {
-			log.CloseResponseBodyError(logger.Warn, errClose)
+			log.CloseResponseBodyError(logger, errClose)
 		}
 	}()
 

--- a/pkg/driver/restapi/operations.go
+++ b/pkg/driver/restapi/operations.go
@@ -74,7 +74,7 @@ func (o *Operation) resolveDIDHandler(rw http.ResponseWriter, req *http.Request)
 	rw.WriteHeader(http.StatusOK)
 
 	if _, err := rw.Write(bytes); err != nil {
-		log.WriteResponseBodyError(logger.Error, err)
+		log.WriteResponseBodyError(logger, err)
 	}
 }
 
@@ -83,7 +83,7 @@ func (o *Operation) writeErrorResponse(rw http.ResponseWriter, status int, msg s
 	rw.WriteHeader(status)
 
 	if _, err := rw.Write([]byte(msg)); err != nil {
-		log.WriteResponseBodyError(logger.Error, err)
+		log.WriteResponseBodyError(logger, err)
 	}
 }
 

--- a/pkg/httpserver/auth/authwrapper.go
+++ b/pkg/httpserver/auth/authwrapper.go
@@ -44,12 +44,12 @@ func NewHandlerWrapper(handler common.HTTPHandler, tm tokenManager) *HandlerWrap
 
 			if len(body) > 0 {
 				if _, err := w.Write(body); err != nil {
-					log.WriteResponseBodyError(logger.Error, err)
+					log.WriteResponseBodyError(logger, err)
 
 					return
 				}
 
-				log.WroteResponse(logger.Debug, body)
+				log.WroteResponse(logger, body)
 			}
 		},
 	}

--- a/pkg/httpserver/auth/signature/authwrapper.go
+++ b/pkg/httpserver/auth/signature/authwrapper.go
@@ -80,7 +80,7 @@ func (o *HandlerWrapper) handler(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusInternalServerError)
 
 		if _, errWrite := rw.Write([]byte("Internal Server Error.\n")); errWrite != nil {
-			log.WriteResponseBodyError(o.logger.Error, errWrite)
+			log.WriteResponseBodyError(o.logger, errWrite)
 		}
 
 		return
@@ -92,7 +92,7 @@ func (o *HandlerWrapper) handler(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusUnauthorized)
 
 		if _, errWrite := rw.Write([]byte("Unauthorized.\n")); errWrite != nil {
-			log.WriteResponseBodyError(o.logger.Error, errWrite)
+			log.WriteResponseBodyError(o.logger, errWrite)
 		}
 
 		return

--- a/pkg/nodeinfo/handler.go
+++ b/pkg/nodeinfo/handler.go
@@ -77,11 +77,11 @@ func (h *Handler) writeResponse(w http.ResponseWriter, status int, body []byte) 
 
 	if len(body) > 0 {
 		if _, err := w.Write(body); err != nil {
-			log.WriteResponseBodyError(logger.Error, err)
+			log.WriteResponseBodyError(logger, err)
 
 			return
 		}
 
-		log.WroteResponse(logger.Debug, body)
+		log.WroteResponse(logger, body)
 	}
 }

--- a/pkg/nodeinfo/service.go
+++ b/pkg/nodeinfo/service.go
@@ -154,7 +154,7 @@ func (r *Service) updateStatsUsingSingleTagQuery() error {
 	defer func() {
 		err = it.Close()
 		if err != nil {
-			log.CloseIteratorError(logger.Warn, err)
+			log.CloseIteratorError(logger, err)
 		}
 	}()
 

--- a/pkg/protocolversion/versions/test/v_test/factory/factory.go
+++ b/pkg/protocolversion/versions/test/v_test/factory/factory.go
@@ -33,7 +33,7 @@ import (
 	"github.com/trustbloc/orb/pkg/versions/1_0/txnprocessor"
 )
 
-var logger = log.New("protocol-v_test")
+var logger = log.NewStructured("protocol-v_test")
 
 // Factory implements test version of the Sidetree protocol.
 type Factory struct{}
@@ -117,7 +117,8 @@ func formatWebCASURI(uri, serviceURI string) (string, error) {
 	// A CAS URI can either be a CID or a hashlink.
 	hash, err := hashlink.GetResourceHashFromHashLink(uri)
 	if err != nil {
-		logger.Debugf("CAS URI [%s] is not a hashlink: %s. Assuming that it's a plain hash.", uri, err)
+		logger.Debug("CAS URI is not a hashlink. Assuming that it's a plain hash.",
+			log.WithURIString(uri), log.WithError(err))
 
 		hash = uri
 	}
@@ -131,7 +132,7 @@ func formatWebCASURI(uri, serviceURI string) (string, error) {
 	// The WebCAS URI will look like this: https:orb.domain1.com:<hash>.
 	casURI := fmt.Sprintf("%s:%s:%s", scheme, host, hash)
 
-	logger.Debugf("Adding alternate CAS URI: %s", casURI)
+	logger.Debug("Adding alternate CAS URI", log.WithURIString(casURI))
 
 	return casURI, nil
 }

--- a/pkg/resolver/resource/resolver.go
+++ b/pkg/resolver/resource/resolver.go
@@ -184,7 +184,7 @@ func (c *Resolver) getHostMetaDocumentViaHTTP(urlToGetHostMetaDocumentFrom strin
 	defer func() {
 		err = resp.Body.Close()
 		if err != nil {
-			log.CloseResponseBodyError(logger.Warn, err)
+			log.CloseResponseBodyError(logger, err)
 		}
 	}()
 

--- a/pkg/store/witness/witness.go
+++ b/pkg/store/witness/witness.go
@@ -120,7 +120,7 @@ func (s *Store) Delete(anchorID string) error {
 	defer func() {
 		err = iter.Close()
 		if err != nil {
-			log.CloseIteratorError(logger.Warn, err)
+			log.CloseIteratorError(logger, err)
 		}
 	}()
 
@@ -198,7 +198,7 @@ func (s *Store) getWitnesses(anchorID string) ([]*proof.Witness, error) {
 	defer func() {
 		err = iter.Close()
 		if err != nil {
-			log.CloseIteratorError(logger.Warn, err)
+			log.CloseIteratorError(logger, err)
 		}
 	}()
 
@@ -254,7 +254,7 @@ func (s *Store) getProofs(anchorID string) (proofs, error) {
 	defer func() {
 		err = iter.Close()
 		if err != nil {
-			log.CloseIteratorError(logger.Warn, err)
+			log.CloseIteratorError(logger, err)
 		}
 	}()
 
@@ -331,7 +331,7 @@ func (s *Store) UpdateWitnessSelection(anchorID string, witnesses []*url.URL, se
 
 	defer func() {
 		if e := iter.Close(); e != nil {
-			log.CloseIteratorError(logger.Warn, err)
+			log.CloseIteratorError(logger, err)
 		}
 	}()
 

--- a/pkg/vct/logmonitoring/resthandler/update.go
+++ b/pkg/vct/logmonitoring/resthandler/update.go
@@ -128,12 +128,12 @@ func writeResponse(logger *log.StructuredLog, w http.ResponseWriter, status int,
 
 	if len(body) > 0 {
 		if _, err := w.Write(body); err != nil {
-			log.WriteResponseBodyError(logger.Warn, err)
+			log.WriteResponseBodyError(logger, err)
 
 			return
 		}
 
-		log.WroteResponse(logger.Debug, body)
+		log.WroteResponse(logger, body)
 	}
 }
 

--- a/pkg/vct/proofmonitoring/monitoring.go
+++ b/pkg/vct/proofmonitoring/monitoring.go
@@ -173,7 +173,7 @@ func (c *Client) handleEntities() error { //nolint:funlen,gocyclo,cyclop
 
 	defer func() {
 		if e := records.Close(); e != nil {
-			log.CloseIteratorError(logger.Warn, e)
+			log.CloseIteratorError(logger, e)
 		}
 	}()
 

--- a/pkg/vct/resthandler/configurator.go
+++ b/pkg/vct/resthandler/configurator.go
@@ -72,7 +72,7 @@ func New(cfgStore storage.Store, lmStore logMonitorStore) *LogConfigurator {
 func (c *LogConfigurator) handle(w http.ResponseWriter, req *http.Request) {
 	logURLBytes, err := ioutil.ReadAll(req.Body)
 	if err != nil {
-		log.ReadRequestBodyError(c.logger.Error, err)
+		log.ReadRequestBodyError(c.logger, err)
 
 		writeResponse(c.logger, w, http.StatusBadRequest, []byte(badRequestResponse))
 
@@ -140,12 +140,12 @@ func writeResponse(logger *log.StructuredLog, w http.ResponseWriter, status int,
 
 	if len(body) > 0 {
 		if _, err := w.Write(body); err != nil {
-			log.WriteResponseBodyError(logger.Error, err)
+			log.WriteResponseBodyError(logger, err)
 
 			return
 		}
 
-		log.WroteResponse(logger.Debug, body)
+		log.WroteResponse(logger, body)
 	}
 }
 

--- a/pkg/webcas/webcas.go
+++ b/pkg/webcas/webcas.go
@@ -92,7 +92,7 @@ func (w *WebCAS) handler(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusInternalServerError)
 
 		if _, errWrite := rw.Write([]byte("Internal Server Error.\n")); errWrite != nil {
-			log.WriteResponseBodyError(w.logger.Error, errWrite)
+			log.WriteResponseBodyError(w.logger, errWrite)
 		}
 
 		return
@@ -104,7 +104,7 @@ func (w *WebCAS) handler(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusUnauthorized)
 
 		if _, errWrite := rw.Write([]byte("Unauthorized.\n")); errWrite != nil {
-			log.WriteResponseBodyError(w.logger.Error, errWrite)
+			log.WriteResponseBodyError(w.logger, errWrite)
 		}
 
 		return
@@ -121,7 +121,7 @@ func (w *WebCAS) handler(rw http.ResponseWriter, req *http.Request) {
 
 			_, errWrite := rw.Write([]byte(fmt.Sprintf("no content at %s was found: %s", cid, err.Error())))
 			if errWrite != nil {
-				log.WriteResponseBodyError(w.logger.Error, errWrite)
+				log.WriteResponseBodyError(w.logger, errWrite)
 			}
 
 			return
@@ -131,7 +131,7 @@ func (w *WebCAS) handler(rw http.ResponseWriter, req *http.Request) {
 
 		_, errWrite := rw.Write([]byte(fmt.Sprintf("failure while finding content at %s: %s", cid, err.Error())))
 		if errWrite != nil {
-			log.WriteResponseBodyError(w.logger.Error, errWrite)
+			log.WriteResponseBodyError(w.logger, errWrite)
 		}
 
 		return
@@ -139,6 +139,6 @@ func (w *WebCAS) handler(rw http.ResponseWriter, req *http.Request) {
 
 	_, err = rw.Write(content)
 	if err != nil {
-		log.WriteResponseBodyError(w.logger.Error, err)
+		log.WriteResponseBodyError(w.logger, err)
 	}
 }

--- a/pkg/webfinger/client/client.go
+++ b/pkg/webfinger/client/client.go
@@ -159,7 +159,7 @@ func (c *Client) resolveResource(domainWithScheme, resource string) (*restapi.JR
 	defer func() {
 		err = resp.Body.Close()
 		if err != nil {
-			log.CloseResponseBodyError(logger.Warn, err)
+			log.CloseResponseBodyError(logger, err)
 		}
 	}()
 


### PR DESCRIPTION
The caller log field was always set to common.log for the common log fields. This commit increases the caller skip for these logs.

Also, implemented structured logging for remaining packages.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>