### PR TITLE
fix: Panic in auth handler for DELETE and PUT methods

### DIFF
--- a/pkg/httpserver/auth/tokenverifier.go
+++ b/pkg/httpserver/auth/tokenverifier.go
@@ -178,7 +178,7 @@ func (m *TokenManager) RequiredAuthTokens(endpoint, method string) ([]string, er
 		switch method {
 		case http.MethodGet:
 			tokens = def.readTokens
-		case http.MethodPost:
+		case http.MethodPost, http.MethodPut, http.MethodDelete:
 			tokens = def.writeTokens
 		default:
 			return nil, fmt.Errorf("unsupported HTTP method [%s]", method)

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -97,7 +97,7 @@ services:
       # - The client requires a 'read' or 'admin' token in order to view the outbox's contents
       # - The client requires an 'admin' token in order to post to the outbox
       # - The client requires a 'read' or 'admin' token in order to perform a GET on any endpoint starting with /services/orb/
-      - ORB_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/acceptlist|admin&read|admin,/allowedorigins|admin&read|admin,/services/orb/.*|read&admin,/transactions|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin,/log-monitor||admin,/log||admin,/policy||admin
+      - ORB_AUTH_TOKENS_DEF=/nodeinfo/2.0,/nodeinfo/2.1,/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/acceptlist|admin&read|admin,/services/orb/.*|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin,/log-monitor||admin,/log||admin,/vc|read&admin,/allowedorigins|admin&read|admin,/policy|read&admin|admin
       # ORB_AUTH_TOKENS specifies the actual values of the tokens defined in ORB_AUTH_TOKENS_DEF.
       - ORB_AUTH_TOKENS=admin=ADMIN_TOKEN,read=READ_TOKEN
       # FOLLOW_AUTH_POLICY indicates whether a 'Follow' request is automatically accepted by this service (accept-all policy)
@@ -235,7 +235,7 @@ services:
       # - The client requires a 'read' or 'admin' token in order to view the outbox's contents
       # - The client requires an 'admin' token in order to post to the outbox
       # - The client requires a 'read' or 'admin' token in order to perform a GET on any endpoint starting with /services/orb/
-      - ORB_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/acceptlist|admin&read|admin,/allowedorigins|admin&read|admin,/services/orb/.*|read&admin,/transactions|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin,/log-monitor||admin,/log||admin,/policy||admin
+      - ORB_AUTH_TOKENS_DEF=/nodeinfo/2.0,/nodeinfo/2.1,/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/acceptlist|admin&read|admin,/services/orb/.*|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin,/log-monitor||admin,/log||admin,/vc|read&admin,/allowedorigins|admin&read|admin,/policy|read&admin|admin
       # ORB_AUTH_TOKENS specifies the actual values of the tokens defined in ORB_AUTH_TOKENS_DEF.
       - ORB_AUTH_TOKENS=admin=ADMIN_TOKEN,read=READ_TOKEN
       # FOLLOW_AUTH_POLICY indicates whether a 'Follow' request is automatically accepted by this service (accept-all policy)
@@ -375,7 +375,7 @@ services:
       # - The client requires a 'read' or 'admin' token in order to view the outbox's contents
       # - The client requires an 'admin' token in order to post to the outbox
       # - The client requires a 'read' or 'admin' token in order to perform a GET on any endpoint starting with /services/orb/
-      - ORB_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/.*|read&admin,/transactions|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin,/log-monitor||admin,/log||admin,/policy||admin
+      - ORB_AUTH_TOKENS_DEF=/nodeinfo/2.0,/nodeinfo/2.1,/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/acceptlist|admin&read|admin,/services/orb/.*|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin,/log-monitor||admin,/log||admin,/vc|read&admin,/allowedorigins|admin&read|admin,/policy|read&admin|admin
       # ORB_AUTH_TOKENS specifies the actual values of the tokens defined in ORB_AUTH_TOKENS_DEF.
       - ORB_AUTH_TOKENS=admin=ADMIN_TOKEN,read=READ_TOKEN
       # FOLLOW_AUTH_POLICY indicates whether a 'Follow' request is automatically accepted by this service (accept-all policy)
@@ -480,7 +480,7 @@ services:
       # - The client requires a 'read' or 'admin' token in order to view the outbox's contents
       # - The client requires an 'admin' token in order to post to the outbox
       # - The client requires a 'read' or 'admin' token in order to perform a GET on any endpoint starting with /services/orb/
-      - ORB_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/.*|read&admin,/transactions|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin,/log-monitor||admin,/log||admin,/policy||admin
+      - ORB_AUTH_TOKENS_DEF=/nodeinfo/2.0,/nodeinfo/2.1,/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/acceptlist|admin&read|admin,/services/orb/.*|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin,/log-monitor||admin,/log||admin,/vc|read&admin,/allowedorigins|admin&read|admin,/policy|read&admin|admin
       # ORB_AUTH_TOKENS specifies the actual values of the tokens defined in ORB_AUTH_TOKENS_DEF.
       - ORB_AUTH_TOKENS=admin=ADMIN_TOKEN,read=READ_TOKEN
       # FOLLOW_AUTH_POLICY indicates whether a 'Follow' request is automatically accepted by this service (accept-all policy)
@@ -595,7 +595,7 @@ services:
       # ORB_CLIENT_AUTH_TOKENS_DEF follows the same rules as ORB_AUTH_TOKENS_DEF but is used by the Orb client transport to
       # determine whether an HTTP signature is required for an outbound HTTP request. If not specified then it is assumed
       # to be the same as ORB_AUTH_TOKENS_DEF.
-      - ORB_CLIENT_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/acceptlist|admin&read|admin,/allowedorigins|admin&read|admin,/services/orb/.*|read&admin,/transactions|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin
+      - ORB_CLIENT_AUTH_TOKENS_DEF=/nodeinfo/2.0,/nodeinfo/2.1,/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/acceptlist|admin&read|admin,/services/orb/.*|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin,/log-monitor||admin,/log||admin,/vc|read&admin,/allowedorigins|admin&read|admin,/policy|read&admin|admin
       # ORB_CLIENT_AUTH_TOKENS specifies the actual values of the tokens defined in ORB_CLIENT_AUTH_TOKENS_DEF. If not specified
       # then it is assumed to be the same as ORB_AUTH_TOKENS.
       - ORB_CLIENT_AUTH_TOKENS=admin=ADMIN_TOKEN,read=READ_TOKEN
@@ -717,7 +717,7 @@ services:
       # - The client requires a 'read' or 'admin' token in order to view the outbox's contents
       # - The client requires an 'admin' token in order to post to the outbox
       # - The client requires a 'read' or 'admin' token in order to perform a GET on any endpoint starting with /services/orb/
-      - ORB_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/acceptlist|admin&read|admin,/allowedorigins|admin&read|admin,/services/orb/.*|read&admin,/transactions|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin,/log-monitor||admin,/log||admin,/policy||admin
+      - ORB_AUTH_TOKENS_DEF=/nodeinfo/2.0,/nodeinfo/2.1,/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/acceptlist|admin&read|admin,/services/orb/.*|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin,/log-monitor||admin,/log||admin,/vc|read&admin,/allowedorigins|admin&read|admin,/policy|read&admin|admin
       # ORB_AUTH_TOKENS specifies the actual values of the tokens defined in ORB_AUTH_TOKENS_DEF.
       - ORB_AUTH_TOKENS=admin=ADMIN_TOKEN,read=READ_TOKEN
       # FOLLOW_AUTH_POLICY indicates whether a 'Follow' request is automatically accepted by this service (accept-all policy)
@@ -829,7 +829,7 @@ services:
       # ORB_CLIENT_AUTH_TOKENS_DEF follows the same rules as ORB_AUTH_TOKENS_DEF but is used by the Orb client transport to
       # determine whether an HTTP signature is required for an outbound HTTP request. If not specified then it is assumed
       # to be the same as ORB_AUTH_TOKENS_DEF.
-      - ORB_CLIENT_AUTH_TOKENS_DEF=/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/acceptlist|admin&read|admin,/allowedorigins|admin&read|admin,/services/orb/.*|read&admin,/transactions|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin
+      - ORB_CLIENT_AUTH_TOKENS_DEF=/nodeinfo/2.0,/nodeinfo/2.1,/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/acceptlist|admin&read|admin,/services/orb/.*|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin,/log-monitor||admin,/log||admin,/vc|read&admin,/allowedorigins|admin&read|admin,/policy|read&admin|admin
       # ORB_CLIENT_AUTH_TOKENS specifies the actual values of the tokens defined in ORB_CLIENT_AUTH_TOKENS_DEF. If not specified
       # then it is assumed to be the same as ORB_AUTH_TOKENS.
       - ORB_CLIENT_AUTH_TOKENS=admin=ADMIN_TOKEN,read=READ_TOKEN


### PR DESCRIPTION
Also cleaned up the auth token definition in the BDD test to remove invalid endpoint.

closes #1523

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>