### PR TITLE
feat: Implement maintenance mode (configurable)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,8 +90,8 @@ jobs:
           name: logs-cas-ipfs
           path: test/bdd/docker-compose.log
 
-  bddTest-protocol-versions:
-    name: BDD test protocol versions
+  bddTest-versions-maintenance:
+    name: BDD test protocol versions, maintenance mode
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -103,17 +103,17 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - name: Run bdd test protocol versions
+      - name: Run bdd test protocol versions, maintenance mode
         timeout-minutes: 60
         run: |
           echo '127.0.0.1 orb.domain1.com' | sudo tee -a /etc/hosts
           echo '127.0.0.1 orb.vct' | sudo tee -a /etc/hosts
-          make bdd-test-protocol-versions
+          make bdd-test-versions-maintenance
 
       - uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: logs-protocol-versions
+          name: logs-versions-maintenance
           path: test/bdd/docker-compose.log
 
   checks:

--- a/Makefile
+++ b/Makefile
@@ -150,9 +150,9 @@ bdd-test-cas-local: generate-test-keys orb-docker orb-driver-docker build-orb-cl
 bdd-test-cas-ipfs: generate-test-keys orb-docker orb-driver-docker build-orb-cli-binaries extract-orb-cli-binaries
 	@scripts/integration_cas_ipfs.sh
 
-.PHONY: bdd-test-protocol-versions
-bdd-test-protocol-versions: generate-test-keys orb-docker orb-test-docker
-	@scripts/integration_protocol_versions.sh
+.PHONY: bdd-test-versions-maintenance
+bdd-test-versions-maintenance: generate-test-keys orb-docker orb-test-docker
+	@scripts/integration_versions_maintenance.sh
 
 .PHONY: clean
 clean:

--- a/cmd/orb-server/startcmd/params.go
+++ b/cmd/orb-server/startcmd/params.go
@@ -531,6 +531,11 @@ const (
 	devModeEnabledUsage    = `Set to "true" to enable dev mode. ` +
 		commonEnvVarUsageText + devModeEnabledEnvKey
 
+	maintenanceModeEnabledFlagName = "enable-maintenance-mode"
+	maintenanceModeEnabledEnvKey   = "MAINTENANCE_MODE_ENABLED"
+	maintenanceModeEnabledUsage    = `Set to "true" to enable maintenance mode. ` +
+		commonEnvVarUsageText + maintenanceModeEnabledEnvKey
+
 	nodeInfoRefreshIntervalFlagName      = "nodeinfo-refresh-interval"
 	nodeInfoRefreshIntervalFlagShorthand = "R"
 	nodeInfoRefreshIntervalEnvKey        = "NODEINFO_REFRESH_INTERVAL"
@@ -736,6 +741,7 @@ type orbParameters struct {
 	clientAuthTokens                        map[string]string
 	activityPubPageSize                     int
 	enableDevMode                           bool
+	enableMaintenanceMode                   bool
 	enableVCT                               bool
 	nodeInfoRefreshInterval                 time.Duration
 	ipfsTimeout                             time.Duration
@@ -891,7 +897,7 @@ func supportedKmsType(kmsType kmsMode) bool {
 	return true
 }
 
-//nolint: funlen
+// nolint: funlen
 func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 	hostURL, err := cmdutil.GetUserSetVarFromString(cmd, hostURLFlagName, hostURLEnvKey, false)
 	if err != nil {
@@ -1112,6 +1118,18 @@ func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 		}
 
 		enableDevMode = enable
+	}
+
+	enableMaintenanceModeStr := cmdutil.GetUserSetOptionalVarFromString(cmd, maintenanceModeEnabledFlagName, maintenanceModeEnabledEnvKey)
+
+	enableMaintenanceMode := defaultMaintenanceModeEnabled
+	if enableMaintenanceModeStr != "" {
+		enable, parseErr := strconv.ParseBool(enableMaintenanceModeStr)
+		if parseErr != nil {
+			return nil, fmt.Errorf("invalid value for %s: %s", maintenanceModeEnabledFlagName, parseErr)
+		}
+
+		enableMaintenanceMode = enable
 	}
 
 	enableUnpublishedOperationStoreStr, err := cmdutil.GetUserSetVarFromString(cmd, enableUnpublishedOperationStoreFlagName, enableUnpublishedOperationStoreEnvKey, true)
@@ -1523,6 +1541,7 @@ func getOrbParameters(cmd *cobra.Command) (*orbParameters, error) {
 		clientAuthTokens:                        clientAuthTokens,
 		activityPubPageSize:                     activityPubPageSize,
 		enableDevMode:                           enableDevMode,
+		enableMaintenanceMode:                   enableMaintenanceMode,
 		enableVCT:                               enableVCT,
 		nodeInfoRefreshInterval:                 nodeInfoRefreshInterval,
 		ipfsTimeout:                             ipfsTimeout,
@@ -2270,6 +2289,7 @@ func createFlags(startCmd *cobra.Command) {
 	startCmd.Flags().StringArrayP(clientAuthTokensFlagName, "", nil, clientAuthTokensFlagUsage)
 	startCmd.Flags().StringP(activityPubPageSizeFlagName, activityPubPageSizeFlagShorthand, "", activityPubPageSizeFlagUsage)
 	startCmd.Flags().String(devModeEnabledFlagName, "false", devModeEnabledUsage)
+	startCmd.Flags().String(maintenanceModeEnabledFlagName, "false", maintenanceModeEnabledUsage)
 	startCmd.Flags().String(enableVCTFlagName, "false", enableVCTFlagUsage)
 	startCmd.Flags().StringP(nodeInfoRefreshIntervalFlagName, nodeInfoRefreshIntervalFlagShorthand, "", nodeInfoRefreshIntervalFlagUsage)
 	startCmd.Flags().StringP(ipfsTimeoutFlagName, ipfsTimeoutFlagShorthand, "", ipfsTimeoutFlagUsage)

--- a/cmd/orb-server/startcmd/params_test.go
+++ b/cmd/orb-server/startcmd/params_test.go
@@ -576,6 +576,31 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 		require.Contains(t, err.Error(), "invalid value for include-published-operations-in-metadata")
 	})
 
+	t.Run("test invalid enable-maintenance-mode", func(t *testing.T) {
+		startCmd := GetStartCmd()
+
+		args := []string{
+			"--" + hostURLFlagName, "localhost:8247",
+			"--" + metricsProviderFlagName, "prometheus",
+			"--" + promHttpUrlFlagName, "localhost:8248",
+			"--" + externalEndpointFlagName, "orb.example.com",
+			"--" + casTypeFlagName, "ipfs",
+			"--" + ipfsURLFlagName, "localhost:8081",
+			"--" + didNamespaceFlagName, "namespace", "--" + databaseTypeFlagName, databaseTypeMemOption,
+			"--" + kmsSecretsDatabaseTypeFlagName, databaseTypeMemOption,
+			"--" + anchorCredentialDomainFlagName, "domain.com",
+			"--" + LogLevelFlagName, log.ERROR.String(),
+			"--" + maintenanceModeEnabledFlagName, "invalid bool",
+		}
+
+		startCmd.SetArgs(args)
+
+		err := startCmd.Execute()
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid value for enable-maintenance-mode")
+	})
+
 	t.Run("Invalid ActivityPub page size", func(t *testing.T) {
 		restoreEnv := setEnv(t, activityPubPageSizeEnvKey, "-125")
 		defer restoreEnv()
@@ -1725,6 +1750,9 @@ func setEnvVars(t *testing.T, databaseType, casType, replicateLocalCASToIPFS str
 
 	err = os.Setenv(kmsSecretsDatabaseTypeFlagName, "mem")
 	require.NoError(t, err)
+
+	err = os.Setenv(maintenanceModeEnabledEnvKey, "false")
+	require.NoError(t, err)
 }
 
 func unsetEnvVars(t *testing.T) {
@@ -1813,6 +1841,7 @@ func getTestArgs(ipfsURL, casType, localCASReplicateInIPFSEnabled, databaseType,
 		"--" + sidetreeProtocolVersionsFlagName, "1.0",
 		"--" + currentSidetreeProtocolVersionFlagName, "1.0",
 		"--" + kmsTypeFlagName, "local",
+		"--" + maintenanceModeEnabledFlagName, "false",
 	}
 
 	if databaseURL != "" {

--- a/pkg/httpserver/maintenance/mode.go
+++ b/pkg/httpserver/maintenance/mode.go
@@ -1,0 +1,58 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package maintenance
+
+import (
+	"net/http"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/restapi/common"
+
+	"github.com/trustbloc/orb/internal/pkg/log"
+)
+
+const loggerModule = "maintenance"
+
+const serviceUnavailableResponse = "Service Unavailable.\n"
+
+// HandlerWrapper wraps an existing HTTP handler and call to handler endpoint returns 503 (Service Unavailable).
+// If authorized then the wrapped handler is invoked.
+type HandlerWrapper struct {
+	common.HTTPHandler
+
+	writeResponse func(w http.ResponseWriter, status int, body []byte)
+	logger        *log.Log
+}
+
+// NewMaintenanceWrapper will return service unavailable for handler that was passed in.
+func NewMaintenanceWrapper(handler common.HTTPHandler) *HandlerWrapper {
+	logger := log.New(loggerModule, log.WithFields(log.WithServiceEndpoint(handler.Path())))
+
+	return &HandlerWrapper{
+		HTTPHandler: handler,
+		logger:      logger,
+		writeResponse: func(w http.ResponseWriter, status int, body []byte) {
+			w.WriteHeader(status)
+
+			if len(body) > 0 {
+				if _, err := w.Write(body); err != nil {
+					log.WriteResponseBodyError(logger, err)
+
+					return
+				}
+
+				log.WroteResponse(logger, body)
+			}
+		},
+	}
+}
+
+// Handler returns the 'wrapper' handler.
+func (h *HandlerWrapper) Handler() common.HTTPRequestHandler {
+	return func(w http.ResponseWriter, req *http.Request) {
+		h.writeResponse(w, http.StatusServiceUnavailable, []byte(serviceUnavailableResponse))
+	}
+}

--- a/pkg/httpserver/maintenance/mode_test.go
+++ b/pkg/httpserver/maintenance/mode_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package maintenance
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/sidetree-core-go/pkg/restapi/common"
+)
+
+func TestHandlerWrapper(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		const path = "/services/orb/inbox"
+
+		w := NewMaintenanceWrapper(&mockHTTPHandler{
+			path:   path,
+			method: http.MethodPost,
+		})
+		require.NotNil(t, w)
+
+		require.Equal(t, path, w.Path())
+		require.Equal(t, http.MethodPost, w.Method())
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/services/orb/inbox", nil)
+
+		w.Handler()(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusServiceUnavailable, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+	})
+}
+
+type mockHTTPHandler struct {
+	path   string
+	method string
+}
+
+func (m *mockHTTPHandler) Path() string {
+	return m.path
+}
+
+func (m *mockHTTPHandler) Method() string {
+	return m.method
+}
+
+func (m *mockHTTPHandler) Handler() common.HTTPRequestHandler {
+	return func(writer http.ResponseWriter, request *http.Request) {}
+}

--- a/scripts/integration_versions_maintenance.sh
+++ b/scripts/integration_versions_maintenance.sh
@@ -18,9 +18,10 @@ export PGUSER=postgres
 export PGPASSWORD=password
 export DOCKER_COMPOSE_FILE=docker-compose-testver.yml
 export VERSION_TEST=true
+export MAINTENANCE_MODE=false
 
 cd test/bdd
-go test -tags "testver" -run sidetree_protocol_versions -count=1 -v -cover . -p 1 -timeout=30m -race
+go test -tags "testver" -run versions_maintenance -count=1 -v -cover . -p 1 -timeout=30m -race
 
 cd $PWD
 

--- a/test/bdd/fixtures/docker-compose-testver.yml
+++ b/test/bdd/fixtures/docker-compose-testver.yml
@@ -16,8 +16,8 @@ services:
       - ORB_KMS_TYPE=web
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
       - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:watermill=INFO:DEBUG
-      - ORB_VCT_URL=http://orb.vct:8077/maple2020
       - ORB_HOST_URL=172.20.0.23:443
+      - VCT_ENABLED=true
       # ORB_EXTERNAL_ENDPOINT is the endpoint that external clients use to invoke services. This endpoint is used
       # to generate IDs of anchor credentials and ActivityPub objects and should be resolvable by external
       # clients. This endpoint does not (typically) target a single node in the cluster but instead, a load
@@ -111,6 +111,7 @@ services:
       - WITNESS_POLICY_CACHE_EXPIRATION=10s
       - ANCHOR_DATA_URI_MEDIA_TYPE=application/gzip;base64
       - INCLUDE_PUBLISHED_OPERATIONS_IN_METADATA=true
+      - MAINTENANCE_MODE_ENABLED=${MAINTENANCE_MODE}
 
     ports:
       - 48326:443
@@ -237,7 +238,7 @@ services:
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
       - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:watermill=INFO:DEBUG
       - ORB_HOST_URL=172.20.0.6:443
-      - ORB_VCT_URL=http://orb.vct:8077/maple2020
+      - VCT_ENABLED=true
       # ORB_EXTERNAL_ENDPOINT is the endpoint that external clients use to invoke services. This endpoint is used
       # to generate IDs of anchor credentials and ActivityPub objects and should be resolvable by external
       # clients. This endpoint does not (typically) target a single node in the cluster but instead, a load
@@ -348,7 +349,6 @@ services:
       - ORB_KMS_ENDPOINT=http://orb.kms:7878
       - LOG_LEVEL=metrics=INFO:nodeinfo=WARNING:activitypub_store=INFO:expiry-service=INFO:task-manager=INFO:watermill=INFO:DEBUG
       - ORB_HOST_URL=172.20.0.7:443
-      - ORB_VCT_URL=http://orb.vct:8077/maple2020
       # ORB_EXTERNAL_ENDPOINT is the endpoint that external clients use to invoke services. This endpoint is used
       # to generate IDs of anchor credentials and ActivityPub objects and should be resolvable by external
       # clients. This endpoint does not (typically) target a single node in the cluster but instead, a load


### PR DESCRIPTION
Add maintenance mode flag to server startup parameters.

In case that maintenance mode is set:
-- disable Sidetree operations and identifiers endpoints 
-- disable Activity Pub inbox endpoint
-- return 200 (or some special status) for health-check

Closes #1527

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>