### PR TITLE
feat: Added /loglevels REST endpoint

### DIFF
--- a/cmd/orb-server/startcmd/log.go
+++ b/cmd/orb-server/startcmd/log.go
@@ -6,7 +6,15 @@ SPDX-License-Identifier: Apache-2.0
 
 package startcmd
 
-import "github.com/trustbloc/logutil-go/pkg/log"
+import (
+	"io"
+	"net/http"
+
+	"github.com/trustbloc/logutil-go/pkg/log"
+	"github.com/trustbloc/sidetree-core-go/pkg/restapi/common"
+
+	logfields "github.com/trustbloc/orb/internal/pkg/log"
+)
 
 const (
 	// LogLevelFlagName is the flag name used for setting the default log level.
@@ -24,10 +32,16 @@ const (
 		"set with the following environment variable: " + LogLevelEnvKey
 )
 
-const logSpecErrorMsg = `Invalid log spec. It needs to be in the following format: "ModuleName1=Level1` +
-	`:ModuleName2=Level2:ModuleNameN=LevelN:AllOtherModuleDefaultLevel"
+const (
+	logSpecErrorMsg = `Invalid log spec. It needs to be in the following format: "ModuleName1=Level1` +
+		`:ModuleName2=Level2:ModuleNameN=LevelN:AllOtherModuleDefaultLevel"
 Valid log levels: critical,error,warn,info,debug
 Error: %s`
+
+	logSpecPath                 = "/loglevels"
+	internalServerErrorResponse = "Internal Server Error.\n"
+	badRequestResponse          = "Bad Request.\n"
+)
 
 // setLogLevels sets the log levels for individual modules as well as the default level.
 func setLogLevels(logger *log.Log, logSpec string) {
@@ -35,5 +49,101 @@ func setLogLevels(logger *log.Log, logSpec string) {
 		logger.Warn(logSpecErrorMsg, log.WithError(err))
 
 		log.SetDefaultLevel(log.INFO)
+	} else {
+		logger.Info("Successfully set log levels", logfields.WithLogSpec(log.GetSpec()))
+	}
+}
+
+// logSpecWriter is a REST handler that updates the default log level and/or log levels on specified modules.
+type logSpecWriter struct {
+	logger  *log.Log
+	readAll func(r io.Reader) ([]byte, error)
+}
+
+func newLogSpecWriter() *logSpecWriter {
+	return &logSpecWriter{
+		logger:  logger.With(logfields.WithServiceEndpoint(logSpecPath)),
+		readAll: io.ReadAll,
+	}
+}
+
+func (h *logSpecWriter) Method() string {
+	return http.MethodPost
+}
+
+func (h *logSpecWriter) Path() string {
+	return logSpecPath
+}
+
+func (h *logSpecWriter) Handler() common.HTTPRequestHandler {
+	return h.handlePost
+}
+
+func (h *logSpecWriter) handlePost(w http.ResponseWriter, req *http.Request) {
+	reqBytes, err := h.readAll(req.Body)
+	if err != nil {
+		h.logger.Error("Error reading request body", log.WithError(err))
+
+		writeResponse(h.logger, w, http.StatusInternalServerError, []byte(internalServerErrorResponse))
+
+		return
+	}
+
+	h.logger.Debug("Got request to update log levels", logfields.WithRequestBody(reqBytes))
+
+	request := string(reqBytes)
+
+	err = log.SetSpec(request)
+	if err != nil {
+		h.logger.Warn("Set logging spec error", logfields.WithLogSpec(request), log.WithError(err))
+
+		writeResponse(h.logger, w, http.StatusBadRequest, []byte(badRequestResponse))
+
+		return
+	}
+
+	h.logger.Info("Successfully updated log levels", logfields.WithLogSpec(log.GetSpec()))
+
+	writeResponse(h.logger, w, http.StatusOK, nil)
+}
+
+// logSpecReader is a REST handler that returns the logging spec in the format "module1=level1:module2=level2:defaultLevel".
+type logSpecReader struct {
+	logger *log.Log
+}
+
+func newLogSpecReader() *logSpecReader {
+	return &logSpecReader{
+		logger: logger.With(logfields.WithServiceEndpoint(logSpecPath)),
+	}
+}
+
+func (h *logSpecReader) Method() string {
+	return http.MethodGet
+}
+
+func (h *logSpecReader) Path() string {
+	return logSpecPath
+}
+
+func (h *logSpecReader) Handler() common.HTTPRequestHandler {
+	return h.handleGet
+}
+
+func (h *logSpecReader) handleGet(w http.ResponseWriter, _ *http.Request) {
+	writeResponse(h.logger, w, http.StatusOK, []byte(log.GetSpec()))
+}
+
+func writeResponse(logger *log.Log, w http.ResponseWriter, status int, body []byte) {
+	w.WriteHeader(status)
+
+	if len(body) > 0 {
+		if _, err := w.Write(body); err != nil {
+			logger.Warn("Unable to write response", log.WithError(err))
+
+			return
+		}
+
+		logger.Debug("Wrote response", log.WithResponse(body))
 	}
 }

--- a/cmd/orb-server/startcmd/log_test.go
+++ b/cmd/orb-server/startcmd/log_test.go
@@ -7,6 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 package startcmd
 
 import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -19,7 +24,7 @@ var testLogger = log.New(testLogModuleName)
 
 func TestSetLogLevel(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		resetLoggingLevels(t)
+		defer resetLoggingLevels(t)
 
 		setLogLevels(testLogger, "debug")
 
@@ -27,7 +32,7 @@ func TestSetLogLevel(t *testing.T) {
 	})
 
 	t.Run("Log spec -> Success", func(t *testing.T) {
-		resetLoggingLevels(t)
+		defer resetLoggingLevels(t)
 
 		setLogLevels(testLogger, "module1=debug:module2=error:warning")
 
@@ -37,12 +42,95 @@ func TestSetLogLevel(t *testing.T) {
 	})
 
 	t.Run("Invalid log level", func(t *testing.T) {
-		resetLoggingLevels(t)
+		defer resetLoggingLevels(t)
 
 		setLogLevels(testLogger, "mango")
 
 		// Should remain unchanged
 		require.Equal(t, log.INFO, log.GetLevel(""))
+	})
+}
+
+func TestLogSpec(t *testing.T) {
+	const logSpecURL = "https://example.com/services/logger"
+
+	t.Run("Success", func(t *testing.T) {
+		defer resetLoggingLevels(t)
+
+		const spec = "module3=WARN:ERROR"
+
+		hw := newLogSpecWriter()
+		require.NotNil(t, hw.Handler())
+		require.Equal(t, logSpecPath, hw.Path())
+		require.Equal(t, http.MethodPost, hw.Method())
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, logSpecURL, bytes.NewBuffer([]byte(spec)))
+
+		hw.handlePost(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusOK, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+
+		require.Equal(t, log.ERROR, log.GetLevel(""))
+		require.Equal(t, log.WARNING, log.GetLevel("module3"))
+
+		hr := newLogSpecReader()
+		require.NotNil(t, hr.Handler())
+		require.Equal(t, logSpecPath, hr.Path())
+		require.Equal(t, http.MethodGet, hr.Method())
+
+		rw = httptest.NewRecorder()
+		req = httptest.NewRequest(http.MethodGet, logSpecURL, http.NoBody)
+
+		hr.handleGet(rw, req)
+
+		result = rw.Result()
+		require.Equal(t, http.StatusOK, result.StatusCode)
+
+		respBytes, err := io.ReadAll(result.Body)
+		require.NoError(t, err)
+		require.NoError(t, result.Body.Close())
+
+		response := string(respBytes)
+
+		require.Contains(t, response, ":ERROR")
+		require.Contains(t, response, "module3=WARN")
+	})
+
+	t.Run("Invalid spec -> error", func(t *testing.T) {
+		h := newLogSpecWriter()
+		require.NotNil(t, h.Handler())
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, logSpecURL, bytes.NewBuffer([]byte("module2:INFO")))
+
+		h.handlePost(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusBadRequest, result.StatusCode)
+		require.NoError(t, result.Body.Close())
+	})
+
+	t.Run("Read request error", func(t *testing.T) {
+		errExpected := errors.New("injected read error")
+
+		h := newLogSpecWriter()
+		require.NotNil(t, h.Handler())
+
+		h.readAll = func(r io.Reader) ([]byte, error) {
+			return nil, errExpected
+		}
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, logSpecURL, bytes.NewBuffer([]byte(`INFO`)))
+
+		h.handlePost(rw, req)
+
+		result := rw.Result()
+		require.Equal(t, http.StatusInternalServerError, result.StatusCode)
+		require.NoError(t, result.Body.Close())
 	})
 }
 
@@ -52,4 +140,5 @@ func resetLoggingLevels(t *testing.T) {
 	log.SetDefaultLevel(log.INFO)
 	log.SetLevel("module1", log.INFO)
 	log.SetLevel("module2", log.INFO)
+	log.SetLevel("module3", log.INFO)
 }

--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -1319,6 +1319,8 @@ func startOrbServices(parameters *orbParameters) error {
 		auth.NewHandlerWrapper(vcresthandler.New(vcStore), authTokenManager),
 		auth.NewHandlerWrapper(allowedoriginsrest.NewWriter(allowedOriginsStore), authTokenManager),
 		auth.NewHandlerWrapper(allowedoriginsrest.NewReader(allowedOriginsStore), authTokenManager),
+		auth.NewHandlerWrapper(newLogSpecWriter(), authTokenManager),
+		auth.NewHandlerWrapper(newLogSpecReader(), authTokenManager),
 	)
 
 	handlers = append(handlers,

--- a/internal/pkg/log/fields.go
+++ b/internal/pkg/log/fields.go
@@ -144,7 +144,7 @@ const (
 	FieldSource                 = "source"
 	FieldAge                    = "age"
 	FieldMinAge                 = "minAge"
-	FieldDuration               = "duration"
+	FieldLogSpec                = "logSpec"
 )
 
 // WithMessageID sets the message-id field.
@@ -854,9 +854,8 @@ func WithMinAge(value time.Duration) zap.Field {
 	return zap.Duration(FieldMinAge, value)
 }
 
-// WithDuration sets the duration field.
-func WithDuration(value time.Duration) zap.Field {
-	return zap.Duration(FieldDuration, value)
+func WithLogSpec(value string) zap.Field {
+	return zap.String(FieldLogSpec, value)
 }
 
 type jsonMarshaller struct {

--- a/internal/pkg/log/fields_test.go
+++ b/internal/pkg/log/fields_test.go
@@ -283,12 +283,15 @@ func TestStandardFields(t *testing.T) {
 	})
 
 	t.Run("json fields 4", func(t *testing.T) {
+		const logSpec = "module1=DEBUG:INFO"
+
 		stdOut := newMockWriter()
 
 		logger := log.New(module, log.WithStdOut(stdOut), log.WithEncoding(log.JSON))
 
 		logger.Info("Some message",
 			WithMaxSizeUInt64(30), WithURLString(u1.String()), WithLogURLString(u3.String()), WithIndexUint64(7),
+			WithLogSpec(logSpec),
 		)
 
 		l := unmarshalLogData(t, stdOut.Bytes())
@@ -297,6 +300,7 @@ func TestStandardFields(t *testing.T) {
 		require.Equal(t, u1.String(), l.URL)
 		require.Equal(t, u3.String(), l.LogURL)
 		require.Equal(t, 7, l.Index)
+		require.Equal(t, logSpec, l.LogSpec)
 	})
 }
 
@@ -437,6 +441,7 @@ type logData struct {
 	Source                 string              `json:"source"`
 	Age                    string              `json:"age"`
 	MinAge                 string              `json:"minAge"`
+	LogSpec                string              `json:"logSpec"`
 }
 
 func unmarshalLogData(t *testing.T, b []byte) *logData {

--- a/test/bdd/features/loglevels.feature
+++ b/test/bdd/features/loglevels.feature
@@ -1,0 +1,29 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+@all
+@loglevels
+Feature: Log Levels
+  Background: Setup
+    Given host "orb.domain1.com" is mapped to "localhost:48326"
+    And host "orb2.domain1.com" is mapped to "localhost:48526"
+    And the authorization bearer token for "POST" requests to path "/loglevels" is set to "ADMIN_TOKEN"
+
+  @loglevels_put_and_get
+  Scenario: Tests the /loglevels endpoint
+    When an HTTP GET is sent to "https://orb.domain1.com/loglevels"
+    Then the response is saved to variable "originalLogLevels"
+
+    When an HTTP POST is sent to "https://orb.domain1.com/loglevels" with content "xxx" of type "text/plain" and the returned status code is 400
+
+    Given an HTTP POST is sent to "https://orb.domain1.com/loglevels" with content "test-module1=ERROR:test-module2=WARN:INFO" of type "text/plain"
+    When an HTTP GET is sent to "https://orb.domain1.com/loglevels"
+    Then the response contains ":INFO"
+    And the response contains "test-module1=ERROR"
+    And the response contains "test-module2=WARN"
+
+    # Restore the log levels
+    Given an HTTP POST is sent to "https://orb.domain1.com/loglevels" with content "${originalLogLevels}" of type "text/plain"

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -97,7 +97,7 @@ services:
       # - The client requires a 'read' or 'admin' token in order to view the outbox's contents
       # - The client requires an 'admin' token in order to post to the outbox
       # - The client requires a 'read' or 'admin' token in order to perform a GET on any endpoint starting with /services/orb/
-      - ORB_AUTH_TOKENS_DEF=/nodeinfo/2.0,/nodeinfo/2.1,/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/acceptlist|admin&read|admin,/services/orb/.*|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin,/log-monitor||admin,/log||admin,/vc|read&admin,/allowedorigins|admin&read|admin,/policy|read&admin|admin
+      - ORB_AUTH_TOKENS_DEF=/nodeinfo/2.0,/nodeinfo/2.1,/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/acceptlist|admin&read|admin,/services/orb/.*|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin,/log-monitor||admin,/log||admin,/vc|read&admin,/allowedorigins|admin&read|admin,/policy|read&admin|admin,/loglevels||admin
       # ORB_AUTH_TOKENS specifies the actual values of the tokens defined in ORB_AUTH_TOKENS_DEF.
       - ORB_AUTH_TOKENS=admin=ADMIN_TOKEN,read=READ_TOKEN
       # FOLLOW_AUTH_POLICY indicates whether a 'Follow' request is automatically accepted by this service (accept-all policy)
@@ -375,7 +375,7 @@ services:
       # - The client requires a 'read' or 'admin' token in order to view the outbox's contents
       # - The client requires an 'admin' token in order to post to the outbox
       # - The client requires a 'read' or 'admin' token in order to perform a GET on any endpoint starting with /services/orb/
-      - ORB_AUTH_TOKENS_DEF=/nodeinfo/2.0,/nodeinfo/2.1,/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/acceptlist|admin&read|admin,/services/orb/.*|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin,/log-monitor||admin,/log||admin,/vc|read&admin,/allowedorigins|admin&read|admin,/policy|read&admin|admin
+      - ORB_AUTH_TOKENS_DEF=/nodeinfo/2.0,/nodeinfo/2.1,/services/orb/keys,/services/orb/outbox|admin&read|admin,/services/orb/inbox|admin&read|admin,/services/orb/acceptlist|admin&read|admin,/services/orb/.*|read&admin,/sidetree/.*/identifiers|read&admin,/sidetree/.*/operations|read&admin|admin,/cas|read&admin,/log-monitor||admin,/log||admin,/vc|read&admin,/allowedorigins|admin&read|admin,/policy|read&admin|admin,/loglevels||admin
       # ORB_AUTH_TOKENS specifies the actual values of the tokens defined in ORB_AUTH_TOKENS_DEF.
       - ORB_AUTH_TOKENS=admin=ADMIN_TOKEN,read=READ_TOKEN
       # FOLLOW_AUTH_POLICY indicates whether a 'Follow' request is automatically accepted by this service (accept-all policy)


### PR DESCRIPTION
The /loglevels endpoints allows you to update the logging levels dynamically and retrieve the current levels.