### PR TITLE
chore: Bump golangci-lint to v1.52

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ run:
   tests: true
   build-tags: [""]
   skip-dirs:  [""]
+  go: '1.19'
 
 output:
   format: colored-line-number
@@ -80,61 +81,60 @@ linters-settings:
     line-length: 140
   misspell:
     locale: US
+    ignore-words:
+      - marshaller
+      - marshalling
+      - unmarshalling
   nolintlint:
     allow-unused: false # report any unused nolint directives
     require-explanation: false # don't require an explanation for nolint directives
     require-specific: false # don't require nolint directives to be specific about which linter is being skipped
     machine: false # don't require //nolint instead of // nolint
     explain: false # don't require //nolint // my explanation instead of just //nolint
+  revive:
+    rules:
+      - name: exported
+        arguments:
+          - disableStutteringCheck
 
 linters:
-  disable-all: true
-  enable:
-    - bodyclose
-    - depguard
-    - dogsled
-    - dupl
-    - errcheck
-    - exportloopref
-    - funlen
-    - gochecknoinits
-    - goconst
-    - gocritic
-    - gocyclo
-    - goimports
-    - gomnd
-    - goprintffuncname
-    - gosec
-    - gosimple
-    - govet
-    - ineffassign
-    - lll
-    - nakedret
-    - noctx
-    - nolintlint
-    - staticcheck
-    - stylecheck
-    - typecheck
-    - unconvert
-    - unparam
-    - unused
-    - whitespace
-
-  # don't enable:
-  # - asciicheck
-  # - scopelint
-  # - gochecknoglobals
-  # - gocognit
-  # - godot
-  # - godox
-  # - goerr113
-  # - interfacer
-  # - maligned
-  # - nestif
-  # - prealloc
-  # - testpackage
-  # - revive
-  # - wsl
+  enable-all: true
+  disable:
+   - asciicheck
+   - gochecknoglobals
+   - gocognit
+   - godot
+   - godox
+   - goerr113
+   - prealloc
+   - testpackage
+   - wsl
+   - exhaustive
+   - exhaustruct
+   - gomoddirectives
+   - cyclop
+   - ireturn
+   - nonamedreturns
+   - paralleltest
+   - varnamelen
+   - wrapcheck
+   - tagliatelle
+   - maintidx
+   - gci
+   - containedctx
+   - forbidigo
+   - musttag
+   # The following linters are deprecated:
+   - scopelint
+   - varcheck
+   - deadcode
+   - exhaustivestruct
+   - maligned
+   - structcheck
+   - ifshort
+   - nosnakecase
+   - interfacer
+   - golint
 
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source
@@ -173,3 +173,7 @@ issues:
     -  at least one file in a package should have a package comment
     # Allow package logger variables (for now)
     - logger is a global variable
+
+  include:
+    - EXC0012  # EXC0012 revive: Annoying issue about not having a comment. The rare codebase has such comments
+    - EXC0014  # EXC0014 revive: Annoying issue about not having a comment. The rare codebase has such comments

--- a/cmd/orb-cli/common/activitypubclient.go
+++ b/cmd/orb-cli/common/activitypubclient.go
@@ -131,7 +131,8 @@ type requestSender func(req []byte, method, endpointURL string) ([]byte, error)
 type targetOverrideFunc func(targetURI string) string
 
 func newAPCollIterator(cmd *cobra.Command, collURI string, sendRequest requestSender,
-	getTargetOverride targetOverrideFunc) (*ActivityPubCollectionIterator, error) {
+	getTargetOverride targetOverrideFunc,
+) (*ActivityPubCollectionIterator, error) {
 	resp, err := sendRequest(nil, http.MethodGet, getTargetOverride(collURI))
 	if err != nil {
 		return nil, fmt.Errorf("failed to send http request: %w", err)

--- a/cmd/orb-cli/common/common.go
+++ b/cmd/orb-cli/common/common.go
@@ -179,7 +179,8 @@ func ParsePrivateKey(der []byte) (crypto.PrivateKey, error) {
 
 // GetPublicKeyFromKMS get publickey from kms.
 func GetPublicKeyFromKMS(cmd *cobra.Command, keyIDFlagName, keyIDEnvKey string,
-	webKmsClient kms.KeyManager) (interface{}, error) {
+	webKmsClient kms.KeyManager,
+) (interface{}, error) {
 	keyID, err := cmdutil.GetUserSetVarFromString(cmd, keyIDFlagName,
 		keyIDEnvKey, false)
 	if err != nil {
@@ -222,7 +223,8 @@ func GetPublicKeyFromKMS(cmd *cobra.Command, keyIDFlagName, keyIDEnvKey string,
 
 // GetKey get key.
 func GetKey(cmd *cobra.Command, keyFlagName, keyEnvKey, keyFileFlagName, keyFileEnvKey string,
-	password []byte, privateKey bool) (interface{}, error) {
+	password []byte, privateKey bool,
+) (interface{}, error) {
 	keyString := cmdutil.GetUserSetOptionalVarFromString(cmd, keyFlagName,
 		keyEnvKey)
 
@@ -335,7 +337,8 @@ func GetServices(serviceFilePath string) ([]docdid.Service, error) {
 
 // SendRequest send http request.
 func SendRequest(httpClient *http.Client, req []byte, headers map[string]string, method,
-	endpointURL string) ([]byte, error) {
+	endpointURL string,
+) ([]byte, error) {
 	var httpReq *http.Request
 
 	var err error
@@ -446,7 +449,8 @@ func newAuthTokenHeader(cmd *cobra.Command) map[string]string {
 
 // GetDuration get duration.
 func GetDuration(cmd *cobra.Command, flagName, envKey string,
-	defaultDuration time.Duration) (time.Duration, error) {
+	defaultDuration time.Duration,
+) (time.Duration, error) {
 	timeoutStr, err := cmdutil.GetUserSetVarFromString(cmd, flagName, envKey, true)
 	if err != nil {
 		return -1, err
@@ -489,7 +493,8 @@ var headerAlgorithm = map[string]string{
 
 // NewSigner return new signer.
 func NewSigner(signingkey crypto.PrivateKey, signingKeyID string, webKmsCryptoClient webcrypto.Crypto,
-	signingKeyPK crypto.PublicKey) *Signer {
+	signingKeyPK crypto.PublicKey,
+) *Signer {
 	if webKmsCryptoClient == nil {
 		switch key := signingkey.(type) {
 		case *ecdsa.PrivateKey:

--- a/cmd/orb-cli/common/common_test.go
+++ b/cmd/orb-cli/common/common_test.go
@@ -468,7 +468,7 @@ func TestGetVDRPublicKeys(t *testing.T) {
 		file, err := os.CreateTemp("", "*.json")
 		require.NoError(t, err)
 
-		_, err = file.WriteString(fmt.Sprintf(publicKeyData, jwk1File.Name(), jwk2File.Name()))
+		_, err = fmt.Fprintf(file, publicKeyData, jwk1File.Name(), jwk2File.Name())
 		require.NoError(t, err)
 
 		defer func() {
@@ -515,7 +515,7 @@ func TestGetVDRPublicKeys(t *testing.T) {
 		file, err := os.CreateTemp("", "*.json")
 		require.NoError(t, err)
 
-		_, err = file.WriteString(fmt.Sprintf(publicKeyData, jwk1File.Name(), jwk2File.Name()))
+		_, err = fmt.Fprintf(file, publicKeyData, jwk1File.Name(), jwk2File.Name())
 		require.NoError(t, err)
 
 		defer func() {

--- a/cmd/orb-cli/createdidcmd/createdid.go
+++ b/cmd/orb-cli/createdidcmd/createdid.go
@@ -266,9 +266,7 @@ func getServices(cmd *cobra.Command) ([]did.Service, error) {
 			return nil, fmt.Errorf("failed to get services from file %w", err)
 		}
 
-		for i := range services {
-			svc = append(svc, services[i])
-		}
+		svc = append(svc, services...)
 	}
 
 	return svc, nil

--- a/cmd/orb-cli/createdidcmd/createdid_test.go
+++ b/cmd/orb-cli/createdidcmd/createdid_test.go
@@ -194,7 +194,7 @@ func TestCreateDID(t *testing.T) {
 	publicKeyFile, err := os.CreateTemp("", "*.json")
 	require.NoError(t, err)
 
-	_, err = publicKeyFile.WriteString(fmt.Sprintf(publickeyData, jwk1File.Name(), jwk2File.Name()))
+	_, err = fmt.Fprintf(publicKeyFile, publickeyData, jwk1File.Name(), jwk2File.Name())
 	require.NoError(t, err)
 
 	defer func() { require.NoError(t, os.Remove(publicKeyFile.Name())) }()

--- a/cmd/orb-cli/ipnshostmetauploadcmd/ipnshostmetauploadcmd.go
+++ b/cmd/orb-cli/ipnshostmetauploadcmd/ipnshostmetauploadcmd.go
@@ -43,6 +43,7 @@ const (
 	timeout = 240
 )
 
+//nolint:musttag
 type object struct {
 	Hash string
 }

--- a/cmd/orb-cli/main_test.go
+++ b/cmd/orb-cli/main_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-// Correct behaviour is for main to finish with exit code 0.
+// Correct behavior is for main to finish with exit code 0.
 // This test fails otherwise. However, this can't be checked by the unit test framework. The *testing.T argument is
 // only there so that this test gets picked up by the framework but otherwise we don't need it.
 func TestWithoutUserAgs(_ *testing.T) {

--- a/cmd/orb-cli/recoverdidcmd/recoverdid.go
+++ b/cmd/orb-cli/recoverdidcmd/recoverdid.go
@@ -346,9 +346,7 @@ func getServices(cmd *cobra.Command) ([]ariesdid.Service, error) {
 			return nil, fmt.Errorf("failed to get services from file %w", err)
 		}
 
-		for i := range services {
-			svc = append(svc, services[i])
-		}
+		svc = append(svc, services...)
 	}
 
 	return svc, nil

--- a/cmd/orb-cli/recoverdidcmd/recoverdid_test.go
+++ b/cmd/orb-cli/recoverdidcmd/recoverdid_test.go
@@ -153,7 +153,7 @@ func TestRecoverDID(t *testing.T) {
 	publicKeyFile, err := os.CreateTemp("", "*.json")
 	require.NoError(t, err)
 
-	_, err = publicKeyFile.WriteString(fmt.Sprintf(publickeyData, jwk1File.Name(), jwk2File.Name()))
+	_, err = fmt.Fprintf(publicKeyFile, publickeyData, jwk1File.Name(), jwk2File.Name())
 	require.NoError(t, err)
 
 	defer func() { require.NoError(t, os.Remove(publicKeyFile.Name())) }()

--- a/cmd/orb-cli/updatedidcmd/updatedid.go
+++ b/cmd/orb-cli/updatedidcmd/updatedid.go
@@ -301,9 +301,7 @@ func getServices(cmd *cobra.Command) ([]ariesdid.Service, error) {
 			return nil, fmt.Errorf("failed to get services from file %w", err)
 		}
 
-		for i := range services {
-			svc = append(svc, services[i])
-		}
+		svc = append(svc, services...)
 	}
 
 	return svc, nil

--- a/cmd/orb-cli/updatedidcmd/updatedid_test.go
+++ b/cmd/orb-cli/updatedidcmd/updatedid_test.go
@@ -243,7 +243,7 @@ func TestUpdateDID(t *testing.T) {
 	file, err := os.CreateTemp("", "*.json")
 	require.NoError(t, err)
 
-	_, err = file.WriteString(fmt.Sprintf(publickeyData, jwk1File.Name(), jwk2File.Name()))
+	_, err = fmt.Fprintf(file, publickeyData, jwk1File.Name(), jwk2File.Name())
 	require.NoError(t, err)
 
 	defer func() { require.NoError(t, os.Remove(file.Name())) }()

--- a/cmd/orb-cli/vctcmd/verifycmd.go
+++ b/cmd/orb-cli/vctcmd/verifycmd.go
@@ -213,7 +213,8 @@ func getVerifyArgs(cmd *cobra.Command) (casURL, anchorHash, authToken string, ve
 }
 
 func getVC(cmd *cobra.Command, anchorHash, casURL string, docLoader jsonld.DocumentLoader,
-	verbose bool) (*verifiable.Credential, error) {
+	verbose bool,
+) (*verifiable.Credential, error) {
 	anchorLinksetBytes, err := common.SendHTTPRequest(cmd, nil, http.MethodGet,
 		fmt.Sprintf("%s/%s", casURL, anchorHash))
 	if err != nil {
@@ -304,7 +305,7 @@ func getVCParameters(proof verifiable.Proof) (domain string, created time.Time, 
 		return "", time.Time{}, fmt.Errorf("parse 'created': %w", err)
 	}
 
-	return d.(string), createdTime, nil
+	return d.(string), createdTime, nil //nolint:forcetypeassert
 }
 
 type ldStoreProvider struct {

--- a/cmd/orb-cli/vctcmd/verifycmd_test.go
+++ b/cmd/orb-cli/vctcmd/verifycmd_test.go
@@ -222,7 +222,8 @@ func (m *mockVCTClient) GetSTH(ctx context.Context) (*command.GetSTHResponse, er
 }
 
 func (m *mockVCTClient) GetProofByHash(ctx context.Context, hash string,
-	treeSize uint64) (*command.GetProofByHashResponse, error) {
+	treeSize uint64,
+) (*command.GetProofByHashResponse, error) {
 	return m.getProofByHashResponse, m.getProofByHashErr
 }
 

--- a/cmd/orb-driver/main_test.go
+++ b/cmd/orb-driver/main_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-// Correct behaviour is for main to finish with exit code 0.
+// Correct behavior is for main to finish with exit code 0.
 // This test fails otherwise. However, this can't be checked by the unit test framework. The *testing.T argument is
 // only there so that this test gets picked up by the framework but otherwise we don't need it.
 func TestWithoutUserAgs(_ *testing.T) {

--- a/internal/pkg/log/fields_test.go
+++ b/internal/pkg/log/fields_test.go
@@ -305,8 +305,8 @@ func TestStandardFields(t *testing.T) {
 }
 
 type mockObject struct {
-	Field1 string
-	Field2 int
+	Field1 string `json:"field1"`
+	Field2 int    `json:"field2"`
 }
 
 type logData struct {

--- a/internal/pkg/tlsutil/certpool_test.go
+++ b/internal/pkg/tlsutil/certpool_test.go
@@ -148,7 +148,8 @@ func TestTLSCAConfigWithMultipleCerts(t *testing.T) {
 }
 
 func verifyCertPoolInstance(t *testing.T, pool *x509.CertPool, tlsCertPool *CertPool, numberOfCertsInPool,
-	numberOfCerts, numberOfCertsByName, numberOfSubjects int, dirty int32) {
+	numberOfCerts, numberOfCertsByName, numberOfSubjects int, dirty int32,
+) {
 	t.Helper()
 
 	assert.NotNil(t, tlsCertPool)

--- a/pkg/activitypub/client/client.go
+++ b/pkg/activitypub/client/client.go
@@ -525,8 +525,10 @@ type activityIterator struct {
 	appendActivity appendFunc
 }
 
-func newActivityIterator(ctx context.Context, items []*vocab.ActivityType, currentPage, nextPage *url.URL, totalItems int,
-	get getFunc, getNext getNextIRIFunc, appendActivity appendFunc) *activityIterator {
+func newActivityIterator(ctx context.Context,
+	items []*vocab.ActivityType, currentPage, nextPage *url.URL, totalItems int,
+	get getFunc, getNext getNextIRIFunc, appendActivity appendFunc,
+) *activityIterator {
 	return &activityIterator{
 		ctx:            ctx,
 		currentItems:   items,
@@ -640,8 +642,10 @@ func (it *activityIterator) getNextPage() error {
 	return nil
 }
 
-func newForwardActivityIterator(ctx context.Context, items []*vocab.ActivityType, currentPage, nextPage *url.URL,
-	totalItems int, retrieve getFunc) *activityIterator {
+func newForwardActivityIterator(ctx context.Context,
+	items []*vocab.ActivityType, currentPage, nextPage *url.URL,
+	totalItems int, retrieve getFunc,
+) *activityIterator {
 	return newActivityIterator(ctx, items, currentPage, nextPage, totalItems, retrieve,
 		func(next, _ *url.URL) *url.URL {
 			return next
@@ -652,8 +656,10 @@ func newForwardActivityIterator(ctx context.Context, items []*vocab.ActivityType
 	)
 }
 
-func newReverseActivityIterator(ctx context.Context, items []*vocab.ActivityType, currentPage, nextPage *url.URL,
-	totalItems int, retrieve getFunc) *activityIterator {
+func newReverseActivityIterator(ctx context.Context,
+	items []*vocab.ActivityType, currentPage, nextPage *url.URL,
+	totalItems int, retrieve getFunc,
+) *activityIterator {
 	return newActivityIterator(ctx, reverseSort(items), currentPage, nextPage, totalItems, retrieve,
 		func(_, prev *url.URL) *url.URL {
 			return prev
@@ -665,8 +671,9 @@ func newReverseActivityIterator(ctx context.Context, items []*vocab.ActivityType
 	)
 }
 
-func unmarshalCollection(respBytes []byte) (items []*vocab.ObjectProperty, firstPage, lastPage *url.URL,
-	totalCount int, err error) {
+func unmarshalCollection(respBytes []byte) (items []*vocab.ObjectProperty, firstPage,
+	lastPage *url.URL, totalCount int, err error,
+) {
 	obj := &vocab.ObjectType{}
 
 	if err := json.Unmarshal(respBytes, &obj); err != nil {

--- a/pkg/activitypub/resthandler/activityhandler.go
+++ b/pkg/activitypub/resthandler/activityhandler.go
@@ -23,7 +23,8 @@ import (
 
 // NewActivity returns a new 'activities/{id}' REST handler that retrieves a single activity by ID.
 func NewActivity(cfg *Config, activityStore spi.Store, verifier signatureVerifier,
-	sortOrder spi.SortOrder, tm authTokenManager) *Activity {
+	sortOrder spi.SortOrder, tm authTokenManager,
+) *Activity {
 	h := &Activity{}
 
 	h.handler = newHandler(ActivitiesPath, cfg, activityStore, h.handle, verifier, sortOrder, tm)
@@ -33,7 +34,8 @@ func NewActivity(cfg *Config, activityStore spi.Store, verifier signatureVerifie
 
 // NewOutbox returns a new 'outbox' REST handler that retrieves a service's outbox.
 func NewOutbox(cfg *Config, activityStore spi.Store, verifier signatureVerifier,
-	sortOrder spi.SortOrder, tm authTokenManager) *ReadOutbox {
+	sortOrder spi.SortOrder, tm authTokenManager,
+) *ReadOutbox {
 	h := &ReadOutbox{
 		Activities: &Activities{
 			getObjectIRI: getObjectIRI(cfg.ObjectIRI),
@@ -50,7 +52,8 @@ func NewOutbox(cfg *Config, activityStore spi.Store, verifier signatureVerifier,
 
 // NewInbox returns a new 'inbox' REST handler that retrieves a service's inbox.
 func NewInbox(cfg *Config, activityStore spi.Store, verifier signatureVerifier,
-	sortOrder spi.SortOrder, tm authTokenManager) *Activities {
+	sortOrder spi.SortOrder, tm authTokenManager,
+) *Activities {
 	return NewActivities(InboxPath, spi.Inbox, cfg, activityStore,
 		getObjectIRI(cfg.ObjectIRI),
 		func(*url.URL, *http.Request) (*url.URL, error) {
@@ -61,14 +64,16 @@ func NewInbox(cfg *Config, activityStore spi.Store, verifier signatureVerifier,
 
 // NewShares returns a new 'shares' REST handler that retrieves an object's 'Announce' activities.
 func NewShares(cfg *Config, activityStore spi.Store, verifier signatureVerifier,
-	sortOrder spi.SortOrder, tm authTokenManager) *Activities {
+	sortOrder spi.SortOrder, tm authTokenManager,
+) *Activities {
 	return NewActivities(fmt.Sprintf("%s/{id}", SharesPath), spi.Share, cfg, activityStore,
 		getObjectIRIFromIDParam, getIDFromParam(cfg.ServiceEndpointURL, SharesPath), verifier, sortOrder, tm)
 }
 
 // NewLikes returns a new 'likes' REST handler that retrieves an object's 'Like' activities.
 func NewLikes(cfg *Config, activityStore spi.Store, verifier signatureVerifier,
-	sortOrder spi.SortOrder, tm authTokenManager) *Activities {
+	sortOrder spi.SortOrder, tm authTokenManager,
+) *Activities {
 	return NewActivities(fmt.Sprintf("%s/{id}", LikesPath), spi.Like, cfg, activityStore,
 		getObjectIRIFromIDParam, getIDFromParam(cfg.ServiceEndpointURL, LikesPath), verifier, sortOrder, tm)
 }
@@ -89,7 +94,8 @@ type Activities struct {
 // NewActivities returns a new activities REST handler.
 func NewActivities(path string, refType spi.ReferenceType, cfg *Config, activityStore spi.Store,
 	getObjectIRI getObjectIRIFunc, getID getIDFunc, verifier signatureVerifier,
-	sortOrder spi.SortOrder, tm authTokenManager) *Activities {
+	sortOrder spi.SortOrder, tm authTokenManager,
+) *Activities {
 	h := &Activities{
 		refType:      refType,
 		getID:        getID,
@@ -142,7 +148,8 @@ func (h *Activities) handleActivityRefsOfType(w http.ResponseWriter, req *http.R
 }
 
 func (h *Activities) handleActivities(rw http.ResponseWriter, _ *http.Request, objectIRI, id *url.URL,
-	refType spi.ReferenceType) {
+	refType spi.ReferenceType,
+) {
 	activities, err := h.getActivities(objectIRI, id, refType)
 	if err != nil {
 		h.logger.Error("Error retrieving references of the given type",
@@ -167,7 +174,8 @@ func (h *Activities) handleActivities(rw http.ResponseWriter, _ *http.Request, o
 }
 
 func (h *Activities) handleActivitiesPage(rw http.ResponseWriter, req *http.Request, objectIRI, id *url.URL,
-	refType spi.ReferenceType) {
+	refType spi.ReferenceType,
+) {
 	var page *vocab.OrderedCollectionPageType
 
 	var err error
@@ -209,7 +217,8 @@ func (h *Activities) handleActivitiesPage(rw http.ResponseWriter, req *http.Requ
 }
 
 func (h *Activities) getActivities(objectIRI, id *url.URL,
-	refType spi.ReferenceType) (*vocab.OrderedCollectionType, error) {
+	refType spi.ReferenceType,
+) (*vocab.OrderedCollectionType, error) {
 	it, err := h.activityStore.QueryReferences(refType,
 		spi.NewCriteria(
 			spi.WithObjectIRI(objectIRI),
@@ -251,7 +260,8 @@ func (h *Activities) getActivities(objectIRI, id *url.URL,
 }
 
 func (h *Activities) getPage(objectIRI, id *url.URL, refType spi.ReferenceType,
-	opts ...spi.QueryOpt) (*vocab.OrderedCollectionPageType, error) {
+	opts ...spi.QueryOpt,
+) (*vocab.OrderedCollectionPageType, error) {
 	it, err := h.activityStore.QueryActivities(
 		spi.NewCriteria(
 			spi.WithReferenceType(refType),

--- a/pkg/activitypub/resthandler/authhandler.go
+++ b/pkg/activitypub/resthandler/authhandler.go
@@ -41,7 +41,8 @@ type authTokenManager interface {
 
 // NewAuthHandler returns a new authorization handler.
 func NewAuthHandler(cfg *Config, endpoint, method string, s store.Store, verifier signatureVerifier,
-	tm authTokenManager, authorizeActor authorizeActorFunc) *AuthHandler {
+	tm authTokenManager, authorizeActor authorizeActorFunc,
+) *AuthHandler {
 	ep := fmt.Sprintf("%s%s", cfg.BasePath, endpoint)
 
 	logger := log.New(loggerModule, log.WithFields(logfields.WithServiceEndpoint(ep)))

--- a/pkg/activitypub/resthandler/openapi.go
+++ b/pkg/activitypub/resthandler/openapi.go
@@ -334,7 +334,7 @@ type outboxPostResp struct { //nolint: unused
 //
 //	200: outboxPostResp
 //
-//nolint: lll,goimports
+//nolint:lll
 func outboxPostRequest() { //nolint: unused
 }
 
@@ -365,7 +365,7 @@ type likesGetResp struct { //nolint: unused
 //
 // 200: likesGetResp
 //
-//nolint: lll,goimports
+//nolint:lll
 func likesGetRequest() { //nolint: unused
 }
 

--- a/pkg/activitypub/resthandler/referencehandler.go
+++ b/pkg/activitypub/resthandler/referencehandler.go
@@ -70,7 +70,8 @@ type Reference struct {
 // NewReference returns a new reference REST handler.
 func NewReference(path string, refType spi.ReferenceType, sortOrder spi.SortOrder, ordered bool,
 	cfg *Config, activityStore spi.Store, getID getIDFunc,
-	verifier signatureVerifier, tm authTokenManager) *Reference {
+	verifier signatureVerifier, tm authTokenManager,
+) *Reference {
 	h := &Reference{
 		refType:              refType,
 		createCollection:     createCollection(ordered),

--- a/pkg/activitypub/resthandler/resthandler.go
+++ b/pkg/activitypub/resthandler/resthandler.go
@@ -88,7 +88,8 @@ type handler struct {
 }
 
 func newHandler(endpoint string, cfg *Config, s spi.Store, rh common.HTTPRequestHandler,
-	verifier signatureVerifier, sortOrder spi.SortOrder, tm authTokenManager, params ...string) *handler {
+	verifier signatureVerifier, sortOrder spi.SortOrder, tm authTokenManager, params ...string,
+) *handler {
 	h := &handler{
 		Config:  cfg,
 		params:  paramsBuilder(params).build(),
@@ -176,7 +177,8 @@ func (h *handler) getCurrentPrevNext(totalItems int, options *spi.QueryOptions) 
 }
 
 func (h *handler) getIDPrevNextURL(objectIRI fmt.Stringer, totalItems int,
-	options *spi.QueryOptions) (*url.URL, *url.URL, *url.URL, error) {
+	options *spi.QueryOptions,
+) (*url.URL, *url.URL, *url.URL, error) {
 	current, prev, next := h.getCurrentPrevNext(totalItems, options)
 
 	var err error

--- a/pkg/activitypub/resthandler/serviceshandler.go
+++ b/pkg/activitypub/resthandler/serviceshandler.go
@@ -30,7 +30,8 @@ type Services struct {
 
 // NewServices returns a new 'services' REST handler.
 func NewServices(cfg *Config, activityStore spi.Store, publicKey *vocab.PublicKeyType,
-	tm authTokenManager) *Services {
+	tm authTokenManager,
+) *Services {
 	h := &Services{
 		publicKey: publicKey,
 	}
@@ -42,7 +43,8 @@ func NewServices(cfg *Config, activityStore spi.Store, publicKey *vocab.PublicKe
 
 // NewPublicKeys returns a new public keys REST handler.
 func NewPublicKeys(cfg *Config, activityStore spi.Store, publicKey *vocab.PublicKeyType,
-	tm authTokenManager) *Services {
+	tm authTokenManager,
+) *Services {
 	h := &Services{
 		publicKey: publicKey,
 	}

--- a/pkg/activitypub/service/activityhandler/activityhandler.go
+++ b/pkg/activitypub/service/activityhandler/activityhandler.go
@@ -72,7 +72,8 @@ type handler struct {
 }
 
 func newHandler(cfg *Config, s store.Store, activityPubClient activityPubClient,
-	undoFollow, undoInviteWitness, undoLike undoFunc) *handler {
+	undoFollow, undoInviteWitness, undoLike undoFunc,
+) *handler {
 	if cfg.BufferSize == 0 {
 		cfg.BufferSize = defaultBufferSize
 	}

--- a/pkg/activitypub/service/activityhandler/activityhandler_test.go
+++ b/pkg/activitypub/service/activityhandler/activityhandler_test.go
@@ -3187,7 +3187,8 @@ func (l *mockActivitySubscriber) Activity(iri fmt.Stringer) *vocab.ActivityType 
 type stopFunc func()
 
 func startInboxOutboxWithMocks(t *testing.T, inboxServiceIRI,
-	outboxServiceIRI *url.URL) (*Inbox, *Outbox, *mockActivitySubscriber, *mockActivitySubscriber, stopFunc) {
+	outboxServiceIRI *url.URL,
+) (*Inbox, *Outbox, *mockActivitySubscriber, *mockActivitySubscriber, stopFunc) {
 	t.Helper()
 
 	inboxCfg := &Config{

--- a/pkg/activitypub/service/activityhandler/outboxhandler.go
+++ b/pkg/activitypub/service/activityhandler/outboxhandler.go
@@ -122,8 +122,7 @@ func (h *handler) handleCreateActivity(ctx context.Context, create *vocab.Activi
 	return nil
 }
 
-func (h *Outbox) undoAddReference(activity *vocab.ActivityType, refType store.ReferenceType,
-	getTargetIRI func() *url.URL) error {
+func (h *Outbox) undoAddReference(activity *vocab.ActivityType, refType store.ReferenceType, getTargetIRI func() *url.URL) error {
 	if activity.Actor().String() != h.ServiceIRI.String() {
 		return fmt.Errorf("this service is not the actor for the 'Undo'")
 	}

--- a/pkg/activitypub/service/anchorsynctask/activitysynctask.go
+++ b/pkg/activitypub/service/anchorsynctask/activitysynctask.go
@@ -73,7 +73,8 @@ type task struct {
 
 // Register registers the anchor event synchronization task.
 func Register(cfg Config, taskMgr taskManager, apClient activityPubClient, apStore store.Store,
-	storageProvider storage.Provider, handlerFactory func() spi.InboxHandler) error {
+	storageProvider storage.Provider, handlerFactory func() spi.InboxHandler,
+) error {
 	interval := cfg.Interval
 
 	if interval == 0 {
@@ -102,7 +103,8 @@ func Register(cfg Config, taskMgr taskManager, apClient activityPubClient, apSto
 
 func newTask(serviceIRI *url.URL, apClient activityPubClient, apStore store.Store,
 	storageProvider storage.Provider, minActivityAge time.Duration,
-	handlerFactory func() spi.InboxHandler) (*task, error) {
+	handlerFactory func() spi.InboxHandler,
+) (*task, error) {
 	s, err := newSyncStore(storageProvider)
 	if err != nil {
 		return nil, fmt.Errorf("create new run store: %w", err)
@@ -343,7 +345,8 @@ func (m *task) getServices(refType store.ReferenceType) ([]*url.URL, error) {
 }
 
 func (m *task) getNewActivities(serviceIRI *url.URL, src activitySource) (client.ActivityIterator,
-	*url.URL, int, error) {
+	*url.URL, int, error,
+) {
 	page, index, err := m.getLastSyncedPage(serviceIRI, src)
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("get last synced page: %w", err)

--- a/pkg/activitypub/service/inbox/inbox.go
+++ b/pkg/activitypub/service/inbox/inbox.go
@@ -83,7 +83,8 @@ type Inbox struct {
 
 // New returns a new ActivityPub inbox.
 func New(cnfg *Config, s store.Store, pubSub pubSub, activityHandler service.ActivityHandler,
-	sigVerifier signatureVerifier, tm authTokenManager, metrics metricsProvider) (*Inbox, error) {
+	sigVerifier signatureVerifier, tm authTokenManager, metrics metricsProvider,
+) (*Inbox, error) {
 	cfg := populateConfigDefaults(cnfg)
 
 	h := &Inbox{

--- a/pkg/activitypub/service/mocks/mockanchoreventackhandler.go
+++ b/pkg/activitypub/service/mocks/mockanchoreventackhandler.go
@@ -31,8 +31,7 @@ func (m *AnchorEventAcknowledgementHandler) WithError(err error) *AnchorEventAck
 }
 
 // AnchorEventAcknowledged handles the acknowledgement of a successful anchor event processed from an Orb server.
-func (m *AnchorEventAcknowledgementHandler) AnchorEventAcknowledged(actor, anchorRef *url.URL,
-	additionalAnchorRefs []*url.URL) error {
+func (m *AnchorEventAcknowledgementHandler) AnchorEventAcknowledged(_, anchorRef *url.URL, _ []*url.URL) error {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
@@ -42,8 +41,7 @@ func (m *AnchorEventAcknowledgementHandler) AnchorEventAcknowledged(actor, ancho
 }
 
 // UndoAnchorEventAcknowledgement undoes the acknowledgement of an anchor event processed from an Orb server.
-func (m *AnchorEventAcknowledgementHandler) UndoAnchorEventAcknowledgement(actor, anchorRef *url.URL,
-	additionalAnchorRefs []*url.URL) error {
+func (m *AnchorEventAcknowledgementHandler) UndoAnchorEventAcknowledgement(_, anchorRef *url.URL, _ []*url.URL) error {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 

--- a/pkg/activitypub/service/mocks/mockpubsub.go
+++ b/pkg/activitypub/service/mocks/mockpubsub.go
@@ -80,8 +80,7 @@ func (m *MockPubSub) Subscribe(_ context.Context, topic string) (<-chan *message
 }
 
 // SubscribeWithOpts subscribes to the given topic.
-func (m *MockPubSub) SubscribeWithOpts(ctx context.Context,
-	topic string, _ ...spi.Option) (<-chan *message.Message, error) {
+func (m *MockPubSub) SubscribeWithOpts(ctx context.Context, topic string, _ ...spi.Option) (<-chan *message.Message, error) {
 	return m.Subscribe(ctx, topic)
 }
 

--- a/pkg/activitypub/service/outbox/outbox.go
+++ b/pkg/activitypub/service/outbox/outbox.go
@@ -111,7 +111,8 @@ type metricsProvider interface {
 
 // New returns a new ActivityPub Outbox.
 func New(cnfg *Config, s store.Store, pubSub pubSub, t httpTransport, activityHandler service.ActivityHandler,
-	apClient activityPubClient, resourceResolver resourceResolver, metrics metricsProvider) (*Outbox, error) {
+	apClient activityPubClient, resourceResolver resourceResolver, metrics metricsProvider,
+) (*Outbox, error) {
 	cfg := populateConfigDefaults(cnfg)
 
 	logger := log.New(loggerModule, log.WithFields(logfields.WithServiceName(cfg.ServiceName)))
@@ -409,8 +410,9 @@ func (h *Outbox) publishBroadcastMessage(ctx context.Context, activity *vocab.Ac
 	return h.publisher.Publish(h.Topic, msg)
 }
 
-func (h *Outbox) publishResolveAndDeliverMessage(ctx context.Context, activity *vocab.ActivityType, targetIRI *url.URL,
-	excludeIRIs []*url.URL) error {
+func (h *Outbox) publishResolveAndDeliverMessage(ctx context.Context,
+	activity *vocab.ActivityType, targetIRI *url.URL, excludeIRIs []*url.URL,
+) error {
 	activityMsg := &activityMessage{
 		Type:        resolveAndDeliverType,
 		Activity:    activity,
@@ -635,8 +637,7 @@ func (h *Outbox) loadReferences(refType store.ReferenceType) ([]*url.URL, error)
 
 // resolveIRIs resolves each of the given IRIs using the given resolve function. The requests are performed
 // in parallel, up to a maximum concurrent requests specified by parameter, MaxConcurrentRequests.
-func (h *Outbox) resolveIRIs(toIRIs []*url.URL,
-	resolve func(iri *url.URL) []*resolveIRIResponse) []*resolveIRIResponse {
+func (h *Outbox) resolveIRIs(toIRIs []*url.URL, resolve func(iri *url.URL) []*resolveIRIResponse) []*resolveIRIResponse {
 	var wg sync.WaitGroup
 
 	var responses []*resolveIRIResponse

--- a/pkg/activitypub/service/outbox/outbox_test.go
+++ b/pkg/activitypub/service/outbox/outbox_test.go
@@ -896,8 +896,7 @@ func handleMockCollection(t *testing.T, collID *url.URL, uris []*url.URL, w http
 	require.NoError(t, err)
 }
 
-func handleMockCollectionPage(t *testing.T, collID *url.URL, uris []*url.URL,
-	w http.ResponseWriter, req *http.Request) {
+func handleMockCollectionPage(t *testing.T, collID *url.URL, uris []*url.URL, w http.ResponseWriter, req *http.Request) {
 	t.Helper()
 
 	pageNum, ok := paramAsInt(t, req, "page-num")

--- a/pkg/activitypub/service/service.go
+++ b/pkg/activitypub/service/service.go
@@ -102,7 +102,8 @@ type metricsProvider interface {
 // New returns a new ActivityPub service.
 func New(cfg *Config, activityStore store.Store, t httpTransport, sigVerifier signatureVerifier,
 	pubSub PubSub, activityPubClient activityPubClient, resourceResolver resourceResolver,
-	tm authTokenManager, m metricsProvider, handlerOpts ...spi.HandlerOpt) (*Service, error) {
+	tm authTokenManager, m metricsProvider, handlerOpts ...spi.HandlerOpt,
+) (*Service, error) {
 	outboxHandler := activityhandler.NewOutbox(
 		&activityhandler.Config{
 			ServiceName:        cfg.ServicePath + resthandler.OutboxPath,

--- a/pkg/activitypub/service/service_test.go
+++ b/pkg/activitypub/service/service_test.go
@@ -922,8 +922,7 @@ type mockProviders struct {
 	undoFollowHandler     *mocks.UndoFollowHandler
 }
 
-func newServiceWithMocks(t *testing.T, endpoint string,
-	serviceIRI *url.URL) (*Service, spi.Store, *vocab.PublicKeyType, *mockProviders) {
+func newServiceWithMocks(t *testing.T, endpoint string, serviceIRI *url.URL) (*Service, spi.Store, *vocab.PublicKeyType, *mockProviders) {
 	t.Helper()
 
 	const kmsKey1 = "123456"

--- a/pkg/activitypub/store/ariesstore/ariesstore.go
+++ b/pkg/activitypub/store/ariesstore/ariesstore.go
@@ -133,8 +133,9 @@ type activityRef struct {
 }
 
 // AddReference adds the reference of the given type to the given object.
-func (s *Provider) AddReference(referenceType spi.ReferenceType, objectIRI *url.URL, referenceIRI *url.URL,
-	refMetaDataOpts ...spi.RefMetadataOpt) error {
+func (s *Provider) AddReference(referenceType spi.ReferenceType, objectIRI *url.URL,
+	referenceIRI *url.URL, refMetaDataOpts ...spi.RefMetadataOpt,
+) error {
 	s.logger.Debug("Adding reference", logfields.WithReferenceType(string(referenceType)),
 		logfields.WithObjectIRI(objectIRI), logfields.WithReferenceIRI(referenceIRI))
 
@@ -185,8 +186,9 @@ func (s *Provider) DeleteReference(referenceType spi.ReferenceType, objectIRI, r
 }
 
 // QueryReferences returns the list of references of the given type according to the given query.
-func (s *Provider) QueryReferences(referenceType spi.ReferenceType, query *spi.Criteria,
-	opts ...spi.QueryOpt) (spi.ReferenceIterator, error) {
+func (s *Provider) QueryReferences(referenceType spi.ReferenceType,
+	query *spi.Criteria, opts ...spi.QueryOpt,
+) (spi.ReferenceIterator, error) {
 	s.logger.Debug("Querying references", logfields.WithReferenceType(string(referenceType)), logfields.WithQuery(query))
 
 	if query.ObjectIRI == nil {
@@ -239,8 +241,9 @@ func (s *Provider) QueryReferences(referenceType spi.ReferenceType, query *spi.C
 	return memstore.NewReferenceIterator([]*url.URL{ref.IRI.URL()}, 1), nil
 }
 
-func (s *Provider) queryActivitiesByRef(refType spi.ReferenceType, query *spi.Criteria,
-	opts ...spi.QueryOpt) (spi.ActivityIterator, error) {
+func (s *Provider) queryActivitiesByRef(refType spi.ReferenceType,
+	query *spi.Criteria, opts ...spi.QueryOpt,
+) (spi.ActivityIterator, error) {
 	iterator, err := s.QueryReferences(refType, query, opts...)
 	if err != nil {
 		return nil, err

--- a/pkg/activitypub/store/ariesstore/ariesstore_test.go
+++ b/pkg/activitypub/store/ariesstore/ariesstore_test.go
@@ -424,8 +424,7 @@ func TestStore_Reference_Failures(t *testing.T) {
 // expectedActivities is with respect to the query's page settings.
 // Since Iterator.TotalItems' count is not affected by page settings, expectedTotalItems must be passed in explicitly.
 // It can't be determined by looking at the length of expectedActivities.
-func checkActivityQueryResultsInOrder(t *testing.T, it spi.ActivityIterator, expectedTotalItems int,
-	expectedActivities ...*url.URL) {
+func checkActivityQueryResultsInOrder(t *testing.T, it spi.ActivityIterator, expectedTotalItems int, expectedActivities ...*url.URL) {
 	t.Helper()
 
 	require.NotNil(t, it)
@@ -450,8 +449,7 @@ func checkActivityQueryResultsInOrder(t *testing.T, it spi.ActivityIterator, exp
 // expectedIRIs is with respect to the query's page settings.
 // Since Iterator.TotalItems' count is not affected by page settings, expectedTotalItems must be passed in explicitly.
 // It can't be determined by looking at the length of expectedIRIs.
-func checkReferenceQueryResultsInOrder(t *testing.T, it spi.ReferenceIterator, expectedTotalItems int,
-	expectedIRIs ...*url.URL) {
+func checkReferenceQueryResultsInOrder(t *testing.T, it spi.ReferenceIterator, expectedTotalItems int, expectedIRIs ...*url.URL) {
 	t.Helper()
 
 	require.NotNil(t, it)

--- a/pkg/activitypub/store/memstore/memstore.go
+++ b/pkg/activitypub/store/memstore/memstore.go
@@ -78,8 +78,7 @@ func (s *Store) QueryActivities(query *spi.Criteria, opts ...spi.QueryOpt) (spi.
 }
 
 // AddReference adds the reference of the given type to the given object.
-func (s *Store) AddReference(referenceType spi.ReferenceType, objectIRI *url.URL, referenceIRI *url.URL,
-	refMetaDataOpts ...spi.RefMetadataOpt) error {
+func (s *Store) AddReference(referenceType spi.ReferenceType, objectIRI, referenceIRI *url.URL, _ ...spi.RefMetadataOpt) error {
 	s.logger.Debug("Adding reference to object", logfields.WithReferenceType(string(referenceType)),
 		logfields.WithObjectIRI(objectIRI), logfields.WithReferenceIRI(referenceIRI))
 
@@ -111,15 +110,13 @@ func (s *Store) DeleteReference(referenceType spi.ReferenceType, objectIRI, refe
 }
 
 // QueryReferences returns the list of references of the given type according to the given query.
-func (s *Store) QueryReferences(refType spi.ReferenceType,
-	query *spi.Criteria, opts ...spi.QueryOpt) (spi.ReferenceIterator, error) {
+func (s *Store) QueryReferences(refType spi.ReferenceType, query *spi.Criteria, opts ...spi.QueryOpt) (spi.ReferenceIterator, error) {
 	s.logger.Debug("Querying references", logfields.WithReferenceType(string(refType)), logfields.WithQuery(query))
 
 	return s.referenceStores[refType].query(query, opts...)
 }
 
-func (s *Store) queryActivitiesByRef(refType spi.ReferenceType, query *spi.Criteria,
-	opts ...spi.QueryOpt) (spi.ActivityIterator, error) {
+func (s *Store) queryActivitiesByRef(refType spi.ReferenceType, query *spi.Criteria, opts ...spi.QueryOpt) (spi.ActivityIterator, error) {
 	it, err := s.QueryReferences(refType, query, opts...)
 	if err != nil {
 		return nil, err

--- a/pkg/activitypub/store/spi/spi.go
+++ b/pkg/activitypub/store/spi/spi.go
@@ -126,6 +126,8 @@ func WithActivityType(activityType vocab.Type) RefMetadataOpt {
 }
 
 // Criteria holds the search criteria for a query.
+//
+//nolint:musttag
 type Criteria struct {
 	Types         []vocab.Type
 	ReferenceType ReferenceType

--- a/pkg/activitypub/vocab/util.go
+++ b/pkg/activitypub/vocab/util.go
@@ -71,7 +71,7 @@ func UnmarshalFromDoc(doc Document, obj interface{}) error {
 	return nil
 }
 
-// MarshalJSON marshals the given objects (merging them into one document) and returns the marshalled JSON result.
+// MarshalJSON marshals the given objects (merging them into one document) and returns the marshaled JSON result.
 func MarshalJSON(o interface{}, others ...interface{}) ([]byte, error) {
 	doc, err := MarshalToDoc(o)
 	if err != nil {

--- a/pkg/anchor/anchorlinkset/anchorlinkset.go
+++ b/pkg/anchor/anchorlinkset/anchorlinkset.go
@@ -52,8 +52,9 @@ type generatorRegistry interface {
 // BuildAnchorLink builds an anchor Link from the given payload.
 //
 //nolint:cyclop
-func (b *Builder) BuildAnchorLink(payload *subject.Payload, dataURIMediaType datauri.MediaType,
-	buildVC VCBuilder) (anchorLink *linkset.Link, vcBytes []byte, err error) {
+func (b *Builder) BuildAnchorLink(payload *subject.Payload,
+	dataURIMediaType datauri.MediaType, buildVC VCBuilder,
+) (anchorLink *linkset.Link, vcBytes []byte, err error) {
 	contentObj, err := b.buildContentObject(payload)
 	if err != nil {
 		return nil, nil, fmt.Errorf("build content object: %w", err)

--- a/pkg/anchor/anchorlinkset/generator/didorbgenerator/didorbgenerator.go
+++ b/pkg/anchor/anchorlinkset/generator/didorbgenerator/didorbgenerator.go
@@ -200,8 +200,7 @@ func newItem(value *subject.SuffixAnchor) (*linkset.Item, error) {
 }
 
 // CreatePayload creates a payload from the given document.
-func (g *Generator) CreatePayload(doc vocab.Document, coreIndexURI *url.URL,
-	anchors []*url.URL) (*subject.Payload, error) {
+func (g *Generator) CreatePayload(doc vocab.Document, coreIndexURI *url.URL, anchors []*url.URL) (*subject.Payload, error) {
 	anchorLinkset := &linkset.Linkset{}
 
 	err := vocab.UnmarshalFromDoc(doc, anchorLinkset)

--- a/pkg/anchor/anchorlinkset/generator/didorbtestgenerator/didorbtestgenerator.go
+++ b/pkg/anchor/anchorlinkset/generator/didorbtestgenerator/didorbtestgenerator.go
@@ -63,8 +63,7 @@ func (g *Generator) CreateContentObject(payload *subject.Payload) (vocab.Documen
 }
 
 // CreatePayload creates a payload from the given anchor event.
-func (g *Generator) CreatePayload(doc vocab.Document, coreIndexURI *url.URL,
-	anchors []*url.URL) (*subject.Payload, error) {
+func (g *Generator) CreatePayload(doc vocab.Document, coreIndexURI *url.URL, anchors []*url.URL) (*subject.Payload, error) {
 	return g.orbGenerator.CreatePayload(doc, coreIndexURI, anchors)
 }
 

--- a/pkg/anchor/builder/builder.go
+++ b/pkg/anchor/builder/builder.go
@@ -62,8 +62,7 @@ type CredentialSubject struct {
 }
 
 // Build will create and sign anchor credential.
-func (b *Builder) Build(profile *url.URL, anchorHashlink, coreIndexHashlink string,
-	context []string) (*verifiable.Credential, error) {
+func (b *Builder) Build(profile *url.URL, anchorHashlink, coreIndexHashlink string, context []string) (*verifiable.Credential, error) {
 	id := b.params.URL + "/" + uuid.New().String()
 
 	now := &util.TimeWrapper{Time: time.Now()}

--- a/pkg/anchor/handler/credential/handler.go
+++ b/pkg/anchor/handler/credential/handler.go
@@ -63,7 +63,8 @@ type anchorPublisher interface {
 func New(anchorPublisher anchorPublisher, casResolver casResolver,
 	documentLoader ld.DocumentLoader,
 	maxDelay time.Duration, anchorLinkStore anchorLinkStore,
-	registry generatorRegistry) *AnchorEventHandler {
+	registry generatorRegistry,
+) *AnchorEventHandler {
 	return &AnchorEventHandler{
 		anchorPublisher:   anchorPublisher,
 		maxDelay:          maxDelay,
@@ -80,7 +81,8 @@ func New(anchorPublisher anchorPublisher, casResolver casResolver,
 //
 //nolint:cyclop
 func (h *AnchorEventHandler) HandleAnchorEvent(ctx context.Context, actor, anchorRef, source *url.URL,
-	anchorEvent *vocab.AnchorEventType) error {
+	anchorEvent *vocab.AnchorEventType,
+) error {
 	logger.Debug("Received request for anchor", logfields.WithActorIRI(actor), logfields.WithAnchorEventURI(anchorRef))
 
 	var anchorLinksetBytes []byte
@@ -217,7 +219,7 @@ func (h *AnchorEventHandler) ensureParentAnchorsAreProcessed(ctx context.Context
 // getUnprocessedParentAnchors returns all unprocessed ancestors (parents, grandparents, etc.) of the given
 // anchor event, sorted by oldest to newest.
 //
-//nolint: cyclop,goimports
+//nolint:cyclop
 func (h *AnchorEventHandler) getUnprocessedParentAnchors(hl string, anchorLink *linkset.Link) (anchorInfoSlice, error) {
 	logger.Debug("Getting unprocessed parents of anchor", logfields.WithAnchorURIString(hl))
 

--- a/pkg/anchor/handler/credential/handler_test.go
+++ b/pkg/anchor/handler/credential/handler_test.go
@@ -357,8 +357,7 @@ func TestAnchorEventHandler_processAnchorEvent(t *testing.T) {
 	})
 }
 
-func newAnchorEventHandler(t *testing.T,
-	client extendedcasclient.Client) *AnchorEventHandler {
+func newAnchorEventHandler(t *testing.T, client extendedcasclient.Client) *AnchorEventHandler {
 	t.Helper()
 
 	casResolver := casresolver.New(client, nil,

--- a/pkg/anchor/handler/proof/handler.go
+++ b/pkg/anchor/handler/proof/handler.go
@@ -47,8 +47,7 @@ type metricsProvider interface {
 }
 
 // New creates new proof handler.
-func New(providers *Providers, pubSub pubSub, dataURIMediaType datauri.MediaType,
-	maxClockSkew time.Duration) *WitnessProofHandler {
+func New(providers *Providers, pubSub pubSub, dataURIMediaType datauri.MediaType, maxClockSkew time.Duration) *WitnessProofHandler {
 	return &WitnessProofHandler{
 		Providers:        providers,
 		publisher:        vcpubsub.NewPublisher(pubSub),
@@ -182,8 +181,8 @@ func getCreatedTime(wp vct.Proof) (time.Time, error) {
 	return createdTime, nil
 }
 
-func (h *WitnessProofHandler) handleWitnessPolicy(ctx context.Context, anchorLink *linkset.Link,
-	vc *verifiable.Credential) error { //nolint:cyclop
+//nolint:cyclop
+func (h *WitnessProofHandler) handleWitnessPolicy(ctx context.Context, anchorLink *linkset.Link, vc *verifiable.Credential) error {
 	anchorID := anchorLink.Anchor().String()
 
 	logger.Debug("Handling witness policy for anchor link", logfields.WithAnchorURIString(anchorID))

--- a/pkg/anchor/util/util.go
+++ b/pkg/anchor/util/util.go
@@ -17,8 +17,7 @@ import (
 )
 
 // VerifiableCredentialFromAnchorLink validates the AnchorEvent and returns the embedded verifiable credential.
-func VerifiableCredentialFromAnchorLink(anchorLink *linkset.Link,
-	opts ...verifiable.CredentialOpt) (*verifiable.Credential, error) {
+func VerifiableCredentialFromAnchorLink(anchorLink *linkset.Link, opts ...verifiable.CredentialOpt) (*verifiable.Credential, error) {
 	if err := anchorLink.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid anchor link: %w", err)
 	}

--- a/pkg/anchor/witness/policy/policy.go
+++ b/pkg/anchor/witness/policy/policy.go
@@ -203,8 +203,11 @@ func (wp *WitnessPolicy) Select(witnesses []*proof.Witness, exclude ...*proof.Wi
 }
 
 // selects min number of batch and system witnesses that are required to fulfill witness policy.
-func (wp *WitnessPolicy) selectBatchAndSystemWitnesses(witnesses []*proof.Witness, //nolint: cyclop
-	cfg *config.WitnessPolicyConfig, exclude ...*proof.Witness) ([]*proof.Witness, []*proof.Witness, error) {
+//
+//nolint:cyclop
+func (wp *WitnessPolicy) selectBatchAndSystemWitnesses(witnesses []*proof.Witness,
+	cfg *config.WitnessPolicyConfig, exclude ...*proof.Witness,
+) ([]*proof.Witness, []*proof.Witness, error) {
 	logger.Debug("Selecting minimum number of batch and system witnesses based on policy",
 		withPolicyConfigField(cfg), withWitnessesField(witnesses))
 
@@ -285,8 +288,9 @@ func isExcluded(witness *proof.Witness, excluded ...*proof.Witness) bool {
 	return false
 }
 
-func (wp *WitnessPolicy) selectMinWitnesses(eligible []*proof.Witness,
-	minNumber, minPercent, totalWitnesses int, preferred ...*proof.Witness) ([]*proof.Witness, error) {
+func (wp *WitnessPolicy) selectMinWitnesses(eligible []*proof.Witness, minNumber, minPercent,
+	totalWitnesses int, preferred ...*proof.Witness,
+) ([]*proof.Witness, error) {
 	var selected []*proof.Witness
 	selected = append(selected, preferred...)
 

--- a/pkg/anchor/writer/writer.go
+++ b/pkg/anchor/writer/writer.go
@@ -192,7 +192,8 @@ func New(namespace string, apServiceIRI, apServiceEndpointURL, casURL *url.URL, 
 	providers *Providers, anchorPublisher anchorPublisher, pubSub pubSub,
 	maxWitnessDelay time.Duration, signWithLocalWitness bool,
 	resourceResolver *resourceresolver.Resolver,
-	metrics metricsProvider) (*Writer, error) {
+	metrics metricsProvider,
+) (*Writer, error) {
 	w := &Writer{
 		Providers:            providers,
 		anchorPublisher:      anchorPublisher,
@@ -220,7 +221,8 @@ func New(namespace string, apServiceIRI, apServiceEndpointURL, casURL *url.URL, 
 
 // WriteAnchor writes Sidetree anchor string to Orb anchor.
 func (c *Writer) WriteAnchor(anchor string, attachments []*protocol.AnchorDocument,
-	refs []*operation.Reference, version uint64) error {
+	refs []*operation.Reference, version uint64,
+) error {
 	startTime := time.Now()
 
 	defer func() { c.metrics.WriteAnchorTime(time.Since(startTime)) }()
@@ -283,7 +285,8 @@ func (c *Writer) WriteAnchor(anchor string, attachments []*protocol.AnchorDocume
 }
 
 func (c *Writer) buildAnchorLink(payload *subject.Payload,
-	witnesses []string) (anchorLink *linkset.Link, vcBytes []byte, err error) {
+	witnesses []string,
+) (anchorLink *linkset.Link, vcBytes []byte, err error) {
 	return c.AnchorLinkBuilder.BuildAnchorLink(payload, c.dataURIMediaType,
 		func(anchorHashlink, coreIndexHashlink string) (*verifiable.Credential, error) {
 			buildCredStartTime := time.Now()
@@ -766,7 +769,8 @@ func (c *Writer) Read(_ int) (bool, *txnapi.SidetreeTxn) {
 }
 
 func (c *Writer) getWitnesses(batchOpsWitnesses []string) (selectedWitnessesIRI []*url.URL,
-	witnesses []*proof.Witness, err error) {
+	witnesses []*proof.Witness, err error,
+) {
 	batchWitnesses, err := c.getBatchWitnesses(batchOpsWitnesses)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/anchor/writer/writer_test.go
+++ b/pkg/anchor/writer/writer_test.go
@@ -1776,7 +1776,8 @@ type mockTxnBuilder struct {
 }
 
 func (m *mockTxnBuilder) Build(profile *url.URL, anchorHashlink, coreIndexHashlink string,
-	_ []string) (*verifiable.Credential, error) {
+	_ []string,
+) (*verifiable.Credential, error) {
 	if m.Err != nil {
 		return nil, m.Err
 	}
@@ -1815,8 +1816,7 @@ type mockOpProcessor struct {
 	Map map[string]*protocol.ResolutionModel
 }
 
-func (m *mockOpProcessor) Resolve(uniqueSuffix string,
-	_ ...document.ResolutionOption) (*protocol.ResolutionModel, error) {
+func (m *mockOpProcessor) Resolve(uniqueSuffix string, _ ...document.ResolutionOption) (*protocol.ResolutionModel, error) {
 	if m.Err != nil {
 		return nil, m.Err
 	}
@@ -1885,8 +1885,7 @@ type mockActivityStore struct {
 	Err error
 }
 
-func (a *mockActivityStore) QueryReferences(refType spi.ReferenceType, query *spi.Criteria,
-	opts ...spi.QueryOpt) (spi.ReferenceIterator, error) {
+func (a *mockActivityStore) QueryReferences(spi.ReferenceType, *spi.Criteria, ...spi.QueryOpt) (spi.ReferenceIterator, error) {
 	if a.Err != nil {
 		return nil, a.Err
 	}

--- a/pkg/cas/ipfs/ipfs.go
+++ b/pkg/cas/ipfs/ipfs.go
@@ -56,16 +56,14 @@ type Client struct {
 
 // New creates cas client.
 // If no CID version is specified, then v1 will be used by default.
-func New(url string, timeout time.Duration, cacheSize int, metrics metricsProvider,
-	opts ...extendedcasclient.CIDFormatOption) *Client {
+func New(url string, timeout time.Duration, cacheSize int, metrics metricsProvider, opts ...extendedcasclient.CIDFormatOption) *Client {
 	ipfs := shell.NewShell(url)
 	ipfs.SetTimeout(timeout)
 
 	return newClient(ipfs, cacheSize, metrics, opts...)
 }
 
-func newClient(ipfs ipfsClient, cacheSize int, metrics metricsProvider,
-	opts ...extendedcasclient.CIDFormatOption) *Client {
+func newClient(ipfs ipfsClient, cacheSize int, metrics metricsProvider, opts ...extendedcasclient.CIDFormatOption) *Client {
 	if cacheSize == 0 {
 		cacheSize = defaultCacheSize
 	}
@@ -256,8 +254,7 @@ func (m *Client) getCIDFromHash(hash string) (string, error) {
 	return cid, nil
 }
 
-func getOptions(opts []extendedcasclient.CIDFormatOption) (
-	extendedcasclient.CIDFormatOptions, error) {
+func getOptions(opts []extendedcasclient.CIDFormatOption) (extendedcasclient.CIDFormatOptions, error) {
 	options := extendedcasclient.CIDFormatOptions{CIDVersion: 1}
 
 	for _, option := range opts {

--- a/pkg/cas/resolver/resolver.go
+++ b/pkg/cas/resolver/resolver.go
@@ -62,8 +62,7 @@ type ipfsReader interface {
 
 // New returns a new Resolver.
 // ipfsReader is optional. If not provided (is nil), CIDs with IPFS hints won't be resolvable.
-func New(casClient extendedcasclient.Client, ipfsReader ipfsReader, webCASResolver WebCASResolver,
-	metrics metricsProvider) *Resolver {
+func New(casClient extendedcasclient.Client, ipfsReader ipfsReader, webCASResolver WebCASResolver, metrics metricsProvider) *Resolver {
 	return &Resolver{
 		localCAS:       casClient,
 		ipfsReader:     ipfsReader,
@@ -334,8 +333,7 @@ type WebCASResolver struct {
 }
 
 // NewWebCASResolver returns a new WebCASResolver.
-func NewWebCASResolver(httpClient httpClient, webFingerClient *webfingerclient.Client,
-	webFingerURIScheme string) WebCASResolver {
+func NewWebCASResolver(httpClient httpClient, webFingerClient *webfingerclient.Client, webFingerURIScheme string) WebCASResolver {
 	return WebCASResolver{
 		httpClient: httpClient, webFingerClient: webFingerClient, webFingerURIScheme: webFingerURIScheme,
 	}

--- a/pkg/discovery/endpoint/client/client.go
+++ b/pkg/discovery/endpoint/client/client.go
@@ -299,8 +299,7 @@ func (cs *Client) loadDomainForDID(id string) (string, error) {
 	return "", fmt.Errorf("service endpoint not found in DID document for did [%s]", id)
 }
 
-func (cs *Client) populateAnchorResolutionEndpoint(
-	jrd *restapi.JRD) (*models.Endpoint, error) {
+func (cs *Client) populateAnchorResolutionEndpoint(jrd *restapi.JRD) (*models.Endpoint, error) {
 	endpoint := &models.Endpoint{}
 
 	min, ok := jrd.Properties[minResolvers].(float64)

--- a/pkg/discovery/endpoint/restapi/operations.go
+++ b/pkg/discovery/endpoint/restapi/operations.go
@@ -261,8 +261,10 @@ func (o *Operation) serviceWebDIDHandler(rw http.ResponseWriter, r *http.Request
 	o.handleDIDWeb(o.serviceID.String(), o.httpSignPubKeys, rw, false, true)
 }
 
-func (o *Operation) handleDIDWeb(did string, pubKeys []PublicKey, rw http.ResponseWriter,
-	includeVerificationRelationships, includeService bool) {
+func (o *Operation) handleDIDWeb(
+	did string, pubKeys []PublicKey, rw http.ResponseWriter,
+	includeVerificationRelationships, includeService bool,
+) {
 	rawDoc := &ariesdid.Doc{ID: did}
 
 	for _, key := range pubKeys {
@@ -305,8 +307,7 @@ func (o *Operation) handleDIDWeb(did string, pubKeys []PublicKey, rw http.Respon
 }
 
 //nolint:cyclop
-func populateVerificationMethod(rawDoc *ariesdid.Doc, did string, key PublicKey,
-	includeVerificationRelationships bool) error {
+func populateVerificationMethod(rawDoc *ariesdid.Doc, did string, key PublicKey, includeVerificationRelationships bool) error {
 	var vm *ariesdid.VerificationMethod
 
 	switch {

--- a/pkg/discovery/endpoint/restapi/operations_test.go
+++ b/pkg/discovery/endpoint/restapi/operations_test.go
@@ -895,8 +895,10 @@ func TestWellKnownNodeInfo(t *testing.T) {
 }
 
 //nolint:unparam
-func serveHTTP(t *testing.T, handler common.HTTPRequestHandler, method, path string,
-	req []byte, urlVars map[string]string, includeAcceptHeader bool) *httptest.ResponseRecorder {
+func serveHTTP(t *testing.T,
+	handler common.HTTPRequestHandler, method, path string,
+	req []byte, urlVars map[string]string, includeAcceptHeader bool,
+) *httptest.ResponseRecorder {
 	t.Helper()
 
 	httpReq, err := http.NewRequest(

--- a/pkg/document/remoteresolver/remoteresolver.go
+++ b/pkg/document/remoteresolver/remoteresolver.go
@@ -44,8 +44,9 @@ func New(httpClient httpClient) *Resolver {
 }
 
 // ResolveDocumentFromResolutionEndpoints resolved document from resolution endpoints.
-func (rr *Resolver) ResolveDocumentFromResolutionEndpoints(ctx context.Context, id string,
-	endpoints []string) (*document.ResolutionResult, error) {
+func (rr *Resolver) ResolveDocumentFromResolutionEndpoints(ctx context.Context,
+	id string, endpoints []string,
+) (*document.ResolutionResult, error) {
 	if len(endpoints) == 0 {
 		return nil, fmt.Errorf("must provide at least one remote resolver endpoint in order to retrieve data")
 	}

--- a/pkg/document/resolvehandler/resolvehandler.go
+++ b/pkg/document/resolvehandler/resolvehandler.go
@@ -114,7 +114,8 @@ func WithUnpublishedDIDLabel(label string) Option {
 // NewResolveHandler returns a new document resolve handler.
 func NewResolveHandler(namespace string, resolver coreResolver, discovery discoveryService,
 	domain string, endpointClient endpointClient, remoteResolver remoteResolver,
-	anchorGraph common.AnchorGraph, metrics metricsProvider, opts ...Option) *ResolveHandler {
+	anchorGraph common.AnchorGraph, metrics metricsProvider, opts ...Option,
+) *ResolveHandler {
 	rh := &ResolveHandler{
 		namespace:        namespace,
 		coreResolver:     resolver,
@@ -160,9 +161,9 @@ func (r *ResolveHandler) ResolveDocument(id string, opts ...document.ResolutionO
 }
 
 //nolint:funlen,cyclop
-func (r *ResolveHandler) resolveDocumentFromAnchorOriginAndCombineWithLocal(
-	ctx context.Context, id string, localResponse *document.ResolutionResult,
-	opts ...document.ResolutionOption) *document.ResolutionResult {
+func (r *ResolveHandler) resolveDocumentFromAnchorOriginAndCombineWithLocal(ctx context.Context, id string,
+	localResponse *document.ResolutionResult, opts ...document.ResolutionOption,
+) *document.ResolutionResult {
 	localAnchorOrigin, err := util.GetAnchorOrigin(localResponse.DocumentMetadata)
 	if err != nil {
 		logger.Debug(
@@ -292,8 +293,7 @@ func getOperations(id string, metadata document.Metadata) ([]*operation.Anchored
 	return unpublishedOps, publishedOps
 }
 
-func getAdditionalPublishedOps(id string, localOps,
-	anchorOps []*operation.AnchoredOperation) []*operation.AnchoredOperation {
+func getAdditionalPublishedOps(id string, localOps, anchorOps []*operation.AnchoredOperation) []*operation.AnchoredOperation {
 	if len(anchorOps) == 0 {
 		logger.Debug("Nothing to check since anchor origin published operations are not provided.",
 			logfields.WithDID(id))
@@ -433,7 +433,8 @@ func (r *ResolveHandler) getAnchorOriginEndpoint(anchorOrigin string) (*models.E
 }
 
 func (r *ResolveHandler) resolveDocumentLocally(ctx context.Context, id string,
-	opts ...document.ResolutionOption) (*document.ResolutionResult, error) {
+	opts ...document.ResolutionOption,
+) (*document.ResolutionResult, error) {
 	resolveDocumentLocallyStartTime := time.Now()
 
 	defer func() {

--- a/pkg/document/updatehandler/decorator/decorator.go
+++ b/pkg/document/updatehandler/decorator/decorator.go
@@ -27,8 +27,9 @@ import (
 var logger = log.New("operation-decorator")
 
 // New creates operation decorator that will verify that local domain has latest operations from anchor origin.
-func New(namespace, domain string, processor operationProcessor,
-	endpointClient endpointClient, remoteResolver remoteResolver, metrics metricsProvider) *OperationDecorator {
+func New(namespace, domain string, processor operationProcessor, endpointClient endpointClient,
+	remoteResolver remoteResolver, metrics metricsProvider,
+) *OperationDecorator {
 	od := &OperationDecorator{
 		namespace:      namespace,
 		domain:         domain,
@@ -179,8 +180,9 @@ func (d *OperationDecorator) Decorate(op *operation.Operation) (*operation.Opera
 	return op, nil
 }
 
-func (d *OperationDecorator) resolveDocumentFromAnchorOrigin(ctx context.Context, id,
-	anchorOrigin string) (*document.ResolutionResult, error) {
+func (d *OperationDecorator) resolveDocumentFromAnchorOrigin(ctx context.Context,
+	id, anchorOrigin string,
+) (*document.ResolutionResult, error) {
 	endpoint, err := d.endpointClient.GetEndpoint(anchorOrigin)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get endpoint from anchor origin domain[%s]: %w", id, err)

--- a/pkg/document/webresolver/resolvehandler.go
+++ b/pkg/document/webresolver/resolvehandler.go
@@ -45,8 +45,9 @@ type metricsProvider interface {
 }
 
 // NewResolveHandler returns a new document resolve handler.
-func NewResolveHandler(domains []*url.URL, orbPrefix, orbUnpublishedLabel string, resolver orbResolver,
-	metrics metricsProvider) *ResolveHandler {
+func NewResolveHandler(domains []*url.URL, orbPrefix, orbUnpublishedLabel string,
+	resolver orbResolver, metrics metricsProvider,
+) *ResolveHandler {
 	allowedDomains := make(map[string]bool)
 
 	for _, domain := range domains {

--- a/pkg/driver/restapi/operations_test.go
+++ b/pkg/driver/restapi/operations_test.go
@@ -76,7 +76,8 @@ func TestDIDResolve(t *testing.T) {
 }
 
 func serveHTTP(t *testing.T, handler common.HTTPRequestHandler, method, path string,
-	req []byte, urlVars map[string]string) *httptest.ResponseRecorder {
+	req []byte, urlVars map[string]string,
+) *httptest.ResponseRecorder {
 	t.Helper()
 
 	httpReq, err := http.NewRequest(

--- a/pkg/httpserver/auth/signature/authwrapper.go
+++ b/pkg/httpserver/auth/signature/authwrapper.go
@@ -39,7 +39,8 @@ type authTokenManager interface {
 
 // NewHandlerWrapper returns a new 'authenticated' handler. It verifies both tokens and signatures before proceeding.
 func NewHandlerWrapper(handler common.HTTPHandler, authCfg *resthandler.Config, s spi.Store,
-	verifier signatureVerifier, tm authTokenManager) *HandlerWrapper {
+	verifier signatureVerifier, tm authTokenManager,
+) *HandlerWrapper {
 	logger := log.New(loggerModule, log.WithFields(logfields.WithServiceEndpoint(handler.Path())))
 
 	ah := &HandlerWrapper{

--- a/pkg/internal/aptestutil/aptestutil.go
+++ b/pkg/internal/aptestutil/aptestutil.go
@@ -103,8 +103,7 @@ func NewMockOrderedCollection(id, first, last *url.URL, totalItems int) *vocab.O
 }
 
 // NewMockCollectionPage returns a mock 'CollectionPage' with the given ID and items.
-func NewMockCollectionPage(id, next, prev, collID *url.URL, totalItems int,
-	items ...*vocab.ObjectProperty) *vocab.CollectionPageType {
+func NewMockCollectionPage(id, next, prev, collID *url.URL, totalItems int, items ...*vocab.ObjectProperty) *vocab.CollectionPageType {
 	return vocab.NewCollectionPage(items,
 		vocab.WithContext(vocab.ContextActivityStreams),
 		vocab.WithID(id),
@@ -116,8 +115,9 @@ func NewMockCollectionPage(id, next, prev, collID *url.URL, totalItems int,
 }
 
 // NewMockOrderedCollectionPage returns a mock 'OrderedCollectionPage' with the given ID and items.
-func NewMockOrderedCollectionPage(id, next, prev, collID *url.URL, totalItems int,
-	items ...*vocab.ObjectProperty) *vocab.OrderedCollectionPageType {
+func NewMockOrderedCollectionPage(id, next, prev, collID *url.URL,
+	totalItems int, items ...*vocab.ObjectProperty,
+) *vocab.OrderedCollectionPageType {
 	return vocab.NewOrderedCollectionPage(items,
 		vocab.WithContext(vocab.ContextActivityStreams),
 		vocab.WithID(id),
@@ -310,7 +310,7 @@ func NewActivityID(id fmt.Stringer) *url.URL {
 	return testutil.NewMockID(id, uuid.New().String())
 }
 
-//nolint: gosec,goimports
+//nolint:gosec
 const verifiableCred = `{
   "@context": [
     "https://www.w3.org/2018/credentials/v1",

--- a/pkg/mocks/operationstore.go
+++ b/pkg/mocks/operationstore.go
@@ -47,7 +47,8 @@ func (m *MockOperationStore) Put(ops []*operation.AnchoredOperation) error {
 	defer m.mutex.Unlock()
 
 	for _, op := range ops {
-		fmt.Printf("Putting operation type[%s], suffix[%s], txtime[%d], txnum[%d], pg[%d], buffer: %s\n", op.Type, op.UniqueSuffix, op.TransactionTime, op.TransactionNumber, op.ProtocolVersion, string(op.OperationRequest)) //nolint:lll
+		fmt.Printf("Putting operation type[%s], suffix[%s], txtime[%d], txnum[%d], pg[%d], buffer: %s\n",
+			op.Type, op.UniqueSuffix, op.TransactionTime, op.TransactionNumber, op.ProtocolVersion, string(op.OperationRequest))
 		m.operations[op.UniqueSuffix] = append(m.operations[op.UniqueSuffix], op)
 	}
 

--- a/pkg/nodeinfo/openapi.go
+++ b/pkg/nodeinfo/openapi.go
@@ -51,6 +51,6 @@ type nodeInfo21Resp struct { //nolint: unused
 //
 // 200: nodeInfo21Resp
 //
-//nolint: lll,goimports
+//nolint:lll
 func (h *Handler) nodeInfo21GetReq() { //nolint: unused
 }

--- a/pkg/nodeinfo/service.go
+++ b/pkg/nodeinfo/service.go
@@ -50,8 +50,7 @@ type Service struct {
 // If this Orb server uses a storage provider that can do queries using 2 tags, then we can take advantage of a
 // feature in the underlying Aries storage provider to update the stats more efficiently.
 // If logger is nil, then a default will be used.
-func NewService(serviceIRI *url.URL, refreshInterval time.Duration, apStore apstore.Store,
-	multipleTagQueryCapable bool) *Service {
+func NewService(serviceIRI *url.URL, refreshInterval time.Duration, apStore apstore.Store, multipleTagQueryCapable bool) *Service {
 	r := &Service{
 		apStore:                 apStore,
 		serviceIRI:              serviceIRI,

--- a/pkg/observability/loglevels/loglevels.go
+++ b/pkg/observability/loglevels/loglevels.go
@@ -38,14 +38,17 @@ func NewWriteHandler() *WriteHandler {
 	}
 }
 
+// Method returns the HTTP method.
 func (h *WriteHandler) Method() string {
 	return http.MethodPost
 }
 
+// Path returns the HTTP path.
 func (h *WriteHandler) Path() string {
 	return logLevelsPath
 }
 
+// Handler returns the HTTP handler.
 func (h *WriteHandler) Handler() common.HTTPRequestHandler {
 	return h.handlePost
 }
@@ -90,14 +93,17 @@ func NewReadHandler() *ReadHandler {
 	}
 }
 
+// Method returns the HTTP methods.
 func (h *ReadHandler) Method() string {
 	return http.MethodGet
 }
 
+// Path returns the HTTP path.
 func (h *ReadHandler) Path() string {
 	return logLevelsPath
 }
 
+// Handler returns the HTTP handler.
 func (h *ReadHandler) Handler() common.HTTPRequestHandler {
 	return h.handleGet
 }

--- a/pkg/observability/loglevels/loglevels_test.go
+++ b/pkg/observability/loglevels/loglevels_test.go
@@ -22,7 +22,13 @@ func TestLogLevels(t *testing.T) {
 	const logSpecURL = "https://example.com/services/logger"
 
 	t.Run("Success", func(t *testing.T) {
-		defer resetLoggingLevels(t)
+		defer func() {
+			log.SetDefaultLevel(log.INFO)
+
+			log.SetLevel("module1", log.INFO)
+			log.SetLevel("module2", log.INFO)
+			log.SetLevel("module3", log.INFO)
+		}()
 
 		const spec = "module3=WARN:ERROR"
 
@@ -99,13 +105,4 @@ func TestLogLevels(t *testing.T) {
 		require.Equal(t, http.StatusInternalServerError, result.StatusCode)
 		require.NoError(t, result.Body.Close())
 	})
-}
-
-func resetLoggingLevels(t *testing.T) {
-	t.Helper()
-
-	log.SetDefaultLevel(log.INFO)
-	log.SetLevel("module1", log.INFO)
-	log.SetLevel("module2", log.INFO)
-	log.SetLevel("module3", log.INFO)
 }

--- a/pkg/observability/metrics/noop/provider.go
+++ b/pkg/observability/metrics/noop/provider.go
@@ -13,8 +13,7 @@ import (
 )
 
 // Provider implements a no-op metrics provider.
-type Provider struct {
-}
+type Provider struct{}
 
 // NewProvider creates new instance of Prometheus Metrics Provider.
 func NewProvider() *Provider {

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -307,8 +307,10 @@ func getDidParts(did string) (cid, suffix string, err error) {
 }
 
 //nolint:funlen,cyclop
-func (o *Observer) processAnchor(ctx context.Context, anchor *anchorinfo.AnchorInfo,
-	anchorLink *linkset.Link, suffixes ...string) error {
+func (o *Observer) processAnchor(ctx context.Context,
+	anchor *anchorinfo.AnchorInfo, anchorLink *linkset.Link,
+	suffixes ...string,
+) error {
 	logger.Debug("Processing anchor", logfields.WithAnchorEventURIString(anchor.Hashlink),
 		logfields.WithAttributedTo(anchor.AttributedTo), logfields.WithSuffixes(suffixes...))
 

--- a/pkg/observer/pubsub.go
+++ b/pkg/observer/pubsub.go
@@ -53,8 +53,7 @@ type PubSub struct {
 }
 
 // NewPubSub returns a new publisher/subscriber.
-func NewPubSub(pubSub pubSub, anchorProcessor anchorProcessor, didProcessor didProcessor,
-	poolSize int) (*PubSub, error) {
+func NewPubSub(pubSub pubSub, anchorProcessor anchorProcessor, didProcessor didProcessor, poolSize int) (*PubSub, error) {
 	h := &PubSub{
 		publisher:      pubSub,
 		processAnchors: anchorProcessor,

--- a/pkg/orbclient/doctransformer/transformer_test.go
+++ b/pkg/orbclient/doctransformer/transformer_test.go
@@ -44,7 +44,7 @@ func TestWebDocumentFromOrbDocument(t *testing.T) {
 		responseBytes, err := json.Marshal(response)
 		require.NoError(t, err)
 
-		fmt.Println(string(responseBytes))
+		fmt.Printf("%s", string(responseBytes))
 	})
 
 	t.Run("success - unpublished did (orb unpublished ID added to also known as)", func(t *testing.T) {
@@ -67,7 +67,7 @@ func TestWebDocumentFromOrbDocument(t *testing.T) {
 		responseBytes, err := json.Marshal(response)
 		require.NoError(t, err)
 
-		fmt.Println(string(responseBytes))
+		fmt.Printf("%s", string(responseBytes))
 	})
 
 	t.Run("success - published did but domain not in alsoKnownAs (orb canonical ID added to also known as)", func(t *testing.T) {

--- a/pkg/orbclient/resolutionverifier/resolutionverifier.go
+++ b/pkg/orbclient/resolutionverifier/resolutionverifier.go
@@ -171,8 +171,7 @@ func (r *ResolutionVerifier) Verify(input *document.ResolutionResult) error {
 	return nil
 }
 
-func (r *ResolutionVerifier) resolveDocument(id string,
-	ops ...*operation.AnchoredOperation) (*document.ResolutionResult, error) {
+func (r *ResolutionVerifier) resolveDocument(id string, ops ...*operation.AnchoredOperation) (*document.ResolutionResult, error) {
 	pv, err := r.protocol.Current()
 	if err != nil {
 		return nil, err

--- a/pkg/protocolversion/clientregistry/clientregistry.go
+++ b/pkg/protocolversion/clientregistry/clientregistry.go
@@ -43,8 +43,7 @@ func New() *Registry {
 }
 
 // CreateClientVersion creates a new client version using the given version and providers.
-func (r *Registry) CreateClientVersion(version string, casClient common.CASReader,
-	sidetreeCfg *config.Sidetree) (protocol.Version, error) {
+func (r *Registry) CreateClientVersion(version string, casClient common.CASReader, sidetreeCfg *config.Sidetree) (protocol.Version, error) {
 	v, err := r.resolveFactory(version)
 	if err != nil {
 		return nil, err

--- a/pkg/protocolversion/versions/test/v_test/client/client.go
+++ b/pkg/protocolversion/versions/test/v_test/client/client.go
@@ -33,8 +33,7 @@ func New() *Factory {
 }
 
 // Create returns a test client version.
-func (v *Factory) Create(version string, casClient common.CASReader,
-	sidetreeCfg *config.Sidetree) (protocol.Version, error) {
+func (v *Factory) Create(version string, casClient common.CASReader, sidetreeCfg *config.Sidetree) (protocol.Version, error) {
 	p := protocolcfg.GetProtocolConfig()
 
 	var parserOpts []operationparser.Option

--- a/pkg/protocolversion/versions/v1_0/client/client.go
+++ b/pkg/protocolversion/versions/v1_0/client/client.go
@@ -33,8 +33,7 @@ func New() *Factory {
 }
 
 // Create returns a 1.0 client version.
-func (v *Factory) Create(version string, casClient common.CASReader,
-	sidetreeCfg *config.Sidetree) (protocol.Version, error) {
+func (v *Factory) Create(version string, casClient common.CASReader, sidetreeCfg *config.Sidetree) (protocol.Version, error) {
 	p := protocolcfg.GetProtocolConfig()
 
 	var parserOpts []operationparser.Option

--- a/pkg/protocolversion/versions/v1_0/factory/factory.go
+++ b/pkg/protocolversion/versions/v1_0/factory/factory.go
@@ -45,9 +45,9 @@ func New() *Factory {
 }
 
 // Create creates a new protocol version.
-func (v *Factory) Create(version string, casClient cas.Client, casResolver ctxcommon.CASResolver,
-	opStore ctxcommon.OperationStore, provider storage.Provider,
-	sidetreeCfg *config.Sidetree, metrics metricsProvider.Metrics) (protocol.Version, error) {
+func (v *Factory) Create(version string, casClient cas.Client, casResolver ctxcommon.CASResolver, opStore ctxcommon.OperationStore,
+	_ storage.Provider, sidetreeCfg *config.Sidetree, metrics metricsProvider.Metrics,
+) (protocol.Version, error) {
 	p := protocolcfg.GetProtocolConfig()
 
 	opParser := operationparser.New(p,

--- a/pkg/pubsub/amqp/amqppubsub.go
+++ b/pkg/pubsub/amqp/amqppubsub.go
@@ -184,8 +184,7 @@ func (p *PubSub) IsConnected() bool {
 
 // SubscribeWithOpts subscribes to a topic using the given options, and returns the Go channel over which messages
 // are sent. The returned channel will be closed when Close() is called on this struct.
-func (p *PubSub) SubscribeWithOpts(ctx context.Context, topic string,
-	opts ...spi.Option) (<-chan *message.Message, error) {
+func (p *PubSub) SubscribeWithOpts(ctx context.Context, topic string, opts ...spi.Option) (<-chan *message.Message, error) {
 	if p.State() != lifecycle.StateStarted {
 		return nil, lifecycle.ErrNotStarted
 	}

--- a/pkg/pubsub/amqp/pooledsubscriber.go
+++ b/pkg/pubsub/amqp/pooledsubscriber.go
@@ -26,8 +26,7 @@ type pooledSubscriber struct {
 	logger      *log.Log
 }
 
-func newPooledSubscriber(ctx context.Context, size int, subscriber subscriber,
-	topic string) (*pooledSubscriber, error) {
+func newPooledSubscriber(ctx context.Context, size int, subscriber subscriber, topic string) (*pooledSubscriber, error) {
 	l := log.New(loggerModule, log.WithFields(log.WithTopic(topic)))
 
 	p := &pooledSubscriber{

--- a/pkg/pubsub/amqp/publisherpool.go
+++ b/pkg/pubsub/amqp/publisherpool.go
@@ -25,8 +25,9 @@ type publisherPool struct {
 	publish    publishFunc
 }
 
-func newPublisherPool(connMgr connMgr, maxChannelsPerConn int, cfg *amqp.Config,
-	createPublisher createPublisherFunc) (*publisherPool, error) {
+func newPublisherPool(connMgr connMgr, maxChannelsPerConn int,
+	cfg *amqp.Config, createPublisher createPublisherFunc,
+) (*publisherPool, error) {
 	publishers, err := createPublishers(connMgr, maxChannelsPerConn, cfg, createPublisher)
 	if err != nil {
 		return nil, fmt.Errorf("create publishers: %w", err)
@@ -72,8 +73,7 @@ func (p *publisherPool) Close() error {
 	return lastErr
 }
 
-func createPublishers(connMgr connMgr, maxChannelsPerConn int, cfg *amqp.Config,
-	createPublisher createPublisherFunc) ([]publisher, error) {
+func createPublishers(connMgr connMgr, maxChannelsPerConn int, cfg *amqp.Config, createPublisher createPublisherFunc) ([]publisher, error) {
 	var numPublishers int
 
 	if cfg.Publish.ChannelPoolSize == 0 {

--- a/pkg/store/anchorstatus/store.go
+++ b/pkg/store/anchorstatus/store.go
@@ -68,8 +68,7 @@ func (s *noopPolicyHandler) CheckPolicy(_ string) error {
 }
 
 // New creates new anchor event status store.
-func New(provider storage.Provider, expiryService *expiry.Service, maxWitnessDelay time.Duration,
-	opts ...Option) (*Store, error) {
+func New(provider storage.Provider, expiryService *expiry.Service, maxWitnessDelay time.Duration, opts ...Option) (*Store, error) {
 	s, err := store.Open(provider, namespace,
 		store.NewTagGroup(anchorIDTagName, statusTagName),
 		store.NewTagGroup(expiryTimeTagName),
@@ -139,8 +138,7 @@ func (s *Store) AddStatus(anchorID string, status proof.AnchorIndexStatus) error
 	return nil
 }
 
-func (s *Store) getAnchorStatusWithTags(anchorID string,
-	status proof.AnchorIndexStatus) (*anchorStatus, []storage.Tag) {
+func (s *Store) getAnchorStatusWithTags(anchorID string, status proof.AnchorIndexStatus) (*anchorStatus, []storage.Tag) {
 	anchorIDEncoded := base64.RawURLEncoding.EncodeToString([]byte(anchorID))
 
 	indexTag := storage.Tag{

--- a/pkg/store/cas/cas.go
+++ b/pkg/store/cas/cas.go
@@ -25,6 +25,7 @@ import (
 var logger = log.New("cas-store")
 
 const (
+	dbName           = "cas"
 	defaultCacheSize = 1000
 	casType          = "local"
 )
@@ -50,8 +51,9 @@ type CAS struct {
 // Reads are always done on only the passed in provider.
 // If no CID version is specified, then v1 will be used by default.
 func New(provider ariesstorage.Provider, casLink string, ipfsClient *ipfs.Client, metrics metricsProvider,
-	cacheSize int, opts ...extendedcasclient.CIDFormatOption) (*CAS, error) {
-	cas, err := provider.OpenStore("cas")
+	cacheSize int, opts ...extendedcasclient.CIDFormatOption,
+) (*CAS, error) {
+	cas, err := provider.OpenStore(dbName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open store in underlying storage provider: %w", err)
 	}

--- a/pkg/store/expiry/expiry_test.go
+++ b/pkg/store/expiry/expiry_test.go
@@ -229,7 +229,8 @@ type serviceInfo struct {
 // We return the started services so that the caller can call service.Stop on them when the test is done.
 // service2's logger is returned, so it can be examined later on in the test.
 func getTestExpiryServices(coordinationStore storage.Store, storeToRunExpiryChecksOn storage.Store,
-	expiryTagName, storeName string, opts ...Option) (*serviceInfo, *serviceInfo) {
+	expiryTagName, storeName string, opts ...Option,
+) (*serviceInfo, *serviceInfo) {
 	taskMgr1 := taskmgr.New(coordinationStore, time.Second)
 
 	service1 := NewService(taskMgr1, time.Second)

--- a/pkg/store/operation/unpublished/store.go
+++ b/pkg/store/operation/unpublished/store.go
@@ -39,7 +39,8 @@ var logger = log.New("unpublished-operation-store")
 // unpublishedOperationLifespan defines how long unpublished operations can stay in the store before being flagged
 // for deletion.
 func New(provider storage.Provider, unpublishedOperationLifespan time.Duration,
-	expiryService *expiry.Service, metrics metricsProvider) (*Store, error) {
+	expiryService *expiry.Service, metrics metricsProvider,
+) (*Store, error) {
 	s, err := store.Open(provider, nameSpace,
 		store.NewTagGroup(index),
 		store.NewTagGroup(expiryTagName),

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -61,8 +61,7 @@ func NewTagGroup(tags ...string) TagGroup {
 	return tags
 }
 
-func newVendorStore(provider storage.Provider, store storage.Store,
-	namespace string, tagGroups []TagGroup) (storage.Store, bool, error) {
+func newVendorStore(provider storage.Provider, store storage.Store, namespace string, tagGroups []TagGroup) (storage.Store, bool, error) {
 	// Currently, only MongoDB is supported.
 	mongoDBProvider, ok := provider.(mongoDBProvider)
 	if !ok {

--- a/pkg/store/wrapper/store.go
+++ b/pkg/store/wrapper/store.go
@@ -167,8 +167,7 @@ func (store *MongoDBStoreWrapper) GetBulkAsRawMap(keys ...string) ([]map[string]
 // QueryCustom queries for data using the MongoDB find command. The given filter and options are passed directly to the
 // driver. Intended for use alongside the Provider.CreateCustomIndex, Store.PutAsJSON, and
 // Iterator.ValueAsRawMap methods.
-func (store *MongoDBStoreWrapper) QueryCustom(filter interface{},
-	options ...*mongoopts.FindOptions) (mongodb.Iterator, error) {
+func (store *MongoDBStoreWrapper) QueryCustom(filter interface{}, options ...*mongoopts.FindOptions) (mongodb.Iterator, error) {
 	start := time.Now()
 	defer func() { store.m.DBQueryTime(store.dbType, time.Since(start)) }()
 
@@ -176,7 +175,6 @@ func (store *MongoDBStoreWrapper) QueryCustom(filter interface{},
 }
 
 // CreateMongoDBFindOptions converts the given storage options to MongoDB options.
-func (store *MongoDBStoreWrapper) CreateMongoDBFindOptions(options []storage.QueryOption,
-	isJSONQuery bool) *mongoopts.FindOptions {
+func (store *MongoDBStoreWrapper) CreateMongoDBFindOptions(options []storage.QueryOption, isJSONQuery bool) *mongoopts.FindOptions {
 	return store.ms.CreateMongoDBFindOptions(options, isJSONQuery)
 }

--- a/pkg/vcsigner/signer.go
+++ b/pkg/vcsigner/signer.go
@@ -240,8 +240,7 @@ type kmsSigner struct {
 	metrics   metricsProvider
 }
 
-func newKMSSigner(keyManager keyManager, c crypto, verificationMethod string,
-	metrics metricsProvider) (*kmsSigner, error) {
+func newKMSSigner(keyManager keyManager, c crypto, verificationMethod string, metrics metricsProvider) (*kmsSigner, error) {
 	// verification will contain did key ID
 	keyID, err := getKeyIDFromVerificationMethod(verificationMethod)
 	if err != nil {

--- a/pkg/vct/logmonitoring/monitor.go
+++ b/pkg/vct/logmonitoring/monitor.go
@@ -306,7 +306,8 @@ func (c *Client) processLogInconsistency(logURL string, vctClient *vct.Client, s
 }
 
 func (c *Client) getDiscrepancyIndexAndAdditionalLogEntries(logURL string,
-	vctClient *vct.Client, treeSize uint64) (int64, []*command.LeafEntry, error) {
+	vctClient *vct.Client, treeSize uint64,
+) (int64, []*command.LeafEntry, error) {
 	var allDifferentLogEntries []*command.LeafEntry
 
 	curEnd := int64(treeSize)
@@ -421,8 +422,7 @@ func (c *Client) verifySTHTree(logURL string, sth *command.GetSTHResponse, vctCl
 	return nil
 }
 
-func (c *Client) getLogEntries(logURL string, vctClient *vct.Client,
-	start, end uint64, store bool) ([]*command.LeafEntry, error) {
+func (c *Client) getLogEntries(logURL string, vctClient *vct.Client, start, end uint64, store bool) ([]*command.LeafEntry, error) {
 	var allEntries []*command.LeafEntry
 
 	attempts := int(end) / c.maxGetEntriesRange
@@ -456,8 +456,7 @@ func (c *Client) getLogEntries(logURL string, vctClient *vct.Client,
 	return allEntries, nil
 }
 
-func (c *Client) getAllEntries(logURL string, vctClient *vct.Client,
-	treeSize uint64) ([]*command.LeafEntry, error) {
+func (c *Client) getAllEntries(logURL string, vctClient *vct.Client, treeSize uint64) ([]*command.LeafEntry, error) {
 	return c.getLogEntries(logURL, vctClient, 0, treeSize-1, true)
 }
 

--- a/pkg/vct/proofmonitoring/monitoring.go
+++ b/pkg/vct/proofmonitoring/monitoring.go
@@ -64,8 +64,8 @@ type taskManager interface {
 
 // New returns monitoring client.
 func New(provider storage.Provider, documentLoader ld.DocumentLoader, wfClient webfingerClient,
-	httpClient httpClient, taskMgr taskManager, interval time.Duration,
-	requestTokens map[string]string) (*Client, error) {
+	httpClient httpClient, taskMgr taskManager, interval time.Duration, requestTokens map[string]string,
+) (*Client, error) {
 	s, err := store.Open(provider, storeName,
 		store.NewTagGroup(tagStatus),
 	)

--- a/pkg/versions/1_0/operationparser/validators/anchororigin/validator.go
+++ b/pkg/versions/1_0/operationparser/validators/anchororigin/validator.go
@@ -56,7 +56,7 @@ func (v *Validator) Validate(obj interface{}) error {
 
 	switch t := obj.(type) {
 	case string:
-		val = obj.(string)
+		val = obj.(string) //nolint:forcetypeassert
 	default:
 		return fmt.Errorf("anchor origin type not supported %T", t)
 	}

--- a/pkg/webcas/webcas.go
+++ b/pkg/webcas/webcas.go
@@ -63,7 +63,8 @@ type authTokenManager interface {
 // New returns a new WebCAS, which contains a REST handler that implements WebCAS as defined in
 // https://trustbloc.github.io/did-method-orb/#webcas.
 func New(authCfg *resthandler.Config, s spi.Store, verifier signatureVerifier,
-	casClient casapi.Client, tm authTokenManager) *WebCAS {
+	casClient casapi.Client, tm authTokenManager,
+) *WebCAS {
 	h := &WebCAS{
 		casClient: casClient,
 	}

--- a/scripts/check_lint.sh
+++ b/scripts/check_lint.sh
@@ -10,12 +10,15 @@ set -e
 echo "Running $0"
 
 DOCKER_CMD=${DOCKER_CMD:-docker}
-GOLANGCI_LINT_IMAGE="golangci/golangci-lint:v1.50.0"
+GOLANGCI_LINT_IMAGE="golangci/golangci-lint:v1.52"
 
 if [ ! $(command -v ${DOCKER_CMD}) ]; then
     exit 0
 fi
 
+echo "Linting pkg"
 ${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m
+echo "Linting orb-cli"
 ${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/cmd/orb-cli ${GOLANGCI_LINT_IMAGE} golangci-lint run -c ../../.golangci.yml --timeout 5m
+echo "Linting orb-driver"
 ${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/cmd/orb-driver ${GOLANGCI_LINT_IMAGE} golangci-lint run -c ../../.golangci.yml --timeout 5m


### PR DESCRIPTION
Updated golangci-lint to v1.52 and also changed the linter config such that all linters are initially enabled and selected linters are disabled. This ensures that linters are not overlooked.

Code changes were required to resolve problems detected by the newly enabled linters.