### PR TITLE
fix: Execute pooled MQ handler in separate Go routine

### DIFF
--- a/pkg/activitypub/service/inbox/inbox.go
+++ b/pkg/activitypub/service/inbox/inbox.go
@@ -185,7 +185,7 @@ func (h *Inbox) listen() {
 	for msg := range h.msgChannel {
 		h.logger.Debug("Got new message", logfields.WithMessageID(msg.UUID), logfields.WithData(msg.Payload))
 
-		h.handle(msg)
+		go h.handle(msg)
 	}
 
 	h.logger.Debug("Message listener stopped")

--- a/pkg/activitypub/service/outbox/outbox.go
+++ b/pkg/activitypub/service/outbox/outbox.go
@@ -173,7 +173,7 @@ func (h *Outbox) listen() {
 	for msg := range h.msgChan {
 		h.logger.Debug("Got new message", logfields.WithMessageID(msg.UUID), logfields.WithData(msg.Payload))
 
-		h.handle(msg)
+		go h.handle(msg)
 	}
 
 	h.logger.Debug("Message listener stopped")

--- a/pkg/context/opqueue/opqueue.go
+++ b/pkg/context/opqueue/opqueue.go
@@ -333,7 +333,7 @@ func (q *Queue) listen() {
 				return
 			}
 
-			q.handleMessage(msg)
+			go q.handleMessage(msg)
 
 		case <-ticker.C:
 			// Update the task time so that other instances don't think I'm down.

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -12,10 +12,6 @@ import (
 )
 
 var (
-	errTransientType = &transientError{}
-
-	errInvalidRequestType = &badRequestError{}
-
 	// ErrContentNotFound is used to indicate that content at a given address could not be found.
 	ErrContentNotFound = errors.New("content not found")
 
@@ -37,6 +33,8 @@ func NewTransientf(format string, a ...interface{}) error {
 
 // IsTransient returns true if the given error is a 'transient' error.
 func IsTransient(err error) bool {
+	errTransientType := &transientError{}
+
 	return errors.As(err, &errTransientType)
 }
 
@@ -53,6 +51,8 @@ func NewBadRequestf(format string, a ...interface{}) error {
 
 // IsBadRequest returns true if the given error is a 'bad request' error.
 func IsBadRequest(err error) bool {
+	errInvalidRequestType := &badRequestError{}
+
 	return errors.As(err, &errInvalidRequestType)
 }
 

--- a/pkg/observer/pubsub.go
+++ b/pkg/observer/pubsub.go
@@ -155,7 +155,7 @@ func (h *PubSub) listen() {
 			logger.Debug("Got new anchor credential message", logfields.WithMessageID(msg.UUID),
 				logfields.WithMetadata(msg.Metadata), logfields.WithData(msg.Payload))
 
-			h.handleAnchorCredentialMessage(msg)
+			go h.handleAnchorCredentialMessage(msg)
 
 		case msg, ok := <-h.didChan:
 			if !ok {
@@ -166,7 +166,7 @@ func (h *PubSub) listen() {
 
 			logger.Debug("Got new DID message", logfields.WithMessageID(msg.UUID), logfields.WithData(msg.Payload))
 
-			h.handleDIDMessage(msg)
+			go h.handleDIDMessage(msg)
 		}
 	}
 }


### PR DESCRIPTION
Handlers for pooled subscribers are each executed in a separate Go routine.

Also fixed a race condition in the errors util.

closes #1552