### PR TITLE
fix: Stop monitoring anchor once witness list is exhausted

### DIFF
--- a/cmd/orb-server/startcmd/params.go
+++ b/cmd/orb-server/startcmd/params.go
@@ -221,7 +221,7 @@ const (
 	anchorStatusInProcessGracePeriodFlagName  = "anchor-status-in-process-grace-period"
 	anchorStatusInProcessGracePeriodEnvKey    = "ANCHOR_STATUS_IN_PROCESS_GRACE_PERIOD"
 	anchorStatusInProcessGracePeriodFlagUsage = "The period in which witnesses will not be re-selected for 'in-process' anchors." +
-		"Defaults to 1m if not set. " +
+		"Defaults to 30s if not set. " +
 		commonEnvVarUsageText + anchorStatusInProcessGracePeriodEnvKey
 
 	externalEndpointFlagName      = "external-endpoint"

--- a/pkg/activitypub/service/activityhandler/inboxhandler.go
+++ b/pkg/activitypub/service/activityhandler/inboxhandler.go
@@ -513,7 +513,8 @@ func (h *Inbox) HandleAnnounceActivity(ctx context.Context, source *url.URL, ann
 }
 
 func (h *Inbox) handleOfferActivity(ctx context.Context, offer *vocab.ActivityType) error {
-	h.logger.Debug("Handling 'Offer' activity", logfields.WithActivityID(offer.ID()))
+	h.logger.Info("Handling 'Offer' activity", logfields.WithActivityID(offer.ID()),
+		logfields.WithActorIRI(offer.Actor()))
 
 	anchorLink, err := h.validateAndUnmarshalOfferActivity(offer)
 	if err != nil {
@@ -570,7 +571,8 @@ func (h *Inbox) handleOfferActivity(ctx context.Context, offer *vocab.ActivityTy
 }
 
 func (h *Inbox) handleAcceptOfferActivity(ctx context.Context, accept, offer *vocab.ActivityType) error {
-	h.logger.Debug("Handling 'Accept' offer activity", logfields.WithActivityID(accept.ID()))
+	h.logger.Info("Handling 'Accept' offer activity", logfields.WithActivityID(accept.ID()),
+		logfields.WithActorIRI(accept.Actor()))
 
 	err := h.validateAcceptOfferActivity(accept)
 	if err != nil {

--- a/pkg/anchor/handler/proof/handler_test.go
+++ b/pkg/anchor/handler/proof/handler_test.go
@@ -615,7 +615,7 @@ func TestWitnessProofHandler(t *testing.T) {
 		err = proofHandler.HandleProof(context.Background(), witness1IRI, al.Anchor().String(), expiryTime, []byte(witnessProofJSONWebSignature))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), fmt.Sprintf(
-			"failed to change status to 'completed' for anchor [%s]: add status error", al.Anchor().String()))
+			"failed to change status to 'completed' for anchor [%s]", al.Anchor().String()))
 	})
 
 	t.Run("status already completed", func(t *testing.T) {
@@ -731,8 +731,7 @@ func TestWitnessProofHandler(t *testing.T) {
 		proofHandler := New(providers, ps, datauri.MediaTypeDataURIGzipBase64, defaultClockSkew)
 
 		err = proofHandler.HandleProof(context.Background(), witness1IRI, al.Anchor().String(), expiryTime, []byte(witnessProofJSONWebSignature))
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "status not found for anchor [hl:uEiABbKSeh3rb4MOjS1Era2_62bBPwP9EytPSg5tIkNYiSQ]")
+		require.NoError(t, err)
 	})
 
 	t.Run("error - store error", func(t *testing.T) {

--- a/pkg/anchor/witness/policy/inspector/inspector.go
+++ b/pkg/anchor/witness/policy/inspector/inspector.go
@@ -127,7 +127,7 @@ func (c *Inspector) postOfferActivity(ctx context.Context, anchorLink *linkset.L
 		return fmt.Errorf("failed to post additional offer for anchor[%s]: %w", anchorLink.Anchor(), err)
 	}
 
-	logger.Info("Created additional 'Offer' activity for anchor", logfields.WithAnchorURI(anchorLink.Anchor()),
+	logger.Info("Posted 'Offer' activity to additional witnesses", logfields.WithAnchorURI(anchorLink.Anchor()),
 		logfields.WithActivityID(activityID), logfields.WithWitnessURIs(witnessesIRI...))
 
 	return nil

--- a/pkg/anchor/witness/policy/selector/random/selector.go
+++ b/pkg/anchor/witness/policy/selector/random/selector.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/trustbloc/orb/pkg/anchor/witness/proof"
+	orberrors "github.com/trustbloc/orb/pkg/errors"
 )
 
 // New returns new random selector.
@@ -29,7 +30,8 @@ func (s *Selector) Select(witnesses []*proof.Witness, n int) ([]*proof.Witness, 
 	l := len(witnesses)
 
 	if n > l {
-		return nil, fmt.Errorf("unable to select %d witnesses from witness array of length %d", n, len(witnesses))
+		return nil, fmt.Errorf("unable to select %d witnesses from witness array of length %d: %w",
+			n, len(witnesses), orberrors.ErrWitnessesNotFound)
 	}
 
 	if n == l {

--- a/pkg/anchor/witness/policy/selector/random/selector_test.go
+++ b/pkg/anchor/witness/policy/selector/random/selector_test.go
@@ -7,11 +7,13 @@ SPDX-License-Identifier: Apache-2.0
 package random
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/trustbloc/orb/pkg/anchor/witness/proof"
+	orberrors "github.com/trustbloc/orb/pkg/errors"
 )
 
 func TestNew(t *testing.T) {
@@ -51,6 +53,7 @@ func TestSelect(t *testing.T) {
 		selected, err := s.Select(nil, 2)
 		require.Error(t, err)
 		require.Empty(t, selected)
+		require.True(t, errors.Is(err, orberrors.ErrWitnessesNotFound))
 		require.Contains(t, err.Error(), "unable to select 2 witnesses from witness array of length 0")
 	})
 }

--- a/pkg/anchor/writer/writer.go
+++ b/pkg/anchor/writer/writer.go
@@ -652,8 +652,8 @@ func (c *Writer) postOfferActivity(ctx context.Context, anchorLink *linkset.Link
 		return fmt.Errorf("store witnesses: %w", err)
 	}
 
-	logger.Debug("Created 'Offer' activity for anchor", logfields.WithAnchorURI(anchorLink.Anchor()),
-		logfields.WithActivityID(activityID))
+	logger.Info("Posted 'Offer' activity to witnesses", logfields.WithAnchorURI(anchorLink.Anchor()),
+		logfields.WithActivityID(activityID), logfields.WithWitnessURIs(selectedWitnessesIRIs...))
 
 	if len(selectedWitnessesIRIs) == 1 {
 		// The Offer was posted only to the public IRI. This means that it will be persisted

--- a/pkg/document/updatehandler/decorator/decorator.go
+++ b/pkg/document/updatehandler/decorator/decorator.go
@@ -77,7 +77,9 @@ type metricsProvider interface {
 }
 
 // Decorate will validate local state against anchor origin for update/recover/deactivate.
-func (d *OperationDecorator) Decorate(op *operation.Operation) (*operation.Operation, error) { //nolint:cyclop
+//
+//nolint:funlen
+func (d *OperationDecorator) Decorate(op *operation.Operation) (*operation.Operation, error) {
 	startTime := time.Now()
 
 	defer func() {
@@ -132,7 +134,8 @@ func (d *OperationDecorator) Decorate(op *operation.Operation) (*operation.Opera
 
 	anchorOriginResponse, err := d.resolveDocumentFromAnchorOrigin(ctx, canonicalID, localAnchorOrigin)
 	if err != nil {
-		logger.Debugc(ctx, "Failed to resolve document from anchor origin", logfields.WithDID(canonicalID), log.WithError(err))
+		logger.Warnc(ctx, "Failed to resolve document from anchor origin. The local document will be used.",
+			logfields.WithDID(canonicalID), log.WithError(err))
 
 		return op, nil
 	}

--- a/pkg/vct/logmonitoring/monitor.go
+++ b/pkg/vct/logmonitoring/monitor.go
@@ -480,7 +480,7 @@ func min(a, b uint64) uint64 {
 
 func (c *Client) verifySTHConsistency(logURL string, storedSTH, sth *command.GetSTHResponse, vctClient *vct.Client) error {
 	if storedSTH.TreeSize > 0 {
-		logger.Debug("Getting STH consistency for stored[%d] and latest[%d]",
+		logger.Debug("Getting STH consistency for stored and latest",
 			logfields.WithLogURLString(logURL), zap.Uint64("stored-size", storedSTH.TreeSize),
 			logfields.WithSizeUint64(sth.TreeSize))
 
@@ -489,7 +489,7 @@ func (c *Client) verifySTHConsistency(logURL string, storedSTH, sth *command.Get
 			return fmt.Errorf("get STH consistency: %w", err)
 		}
 
-		logger.Debug("Found %d consistencies in STH consistency response", logfields.WithLogURLString(logURL),
+		logger.Debug("Found consistencies in STH consistency response", logfields.WithLogURLString(logURL),
 			zap.Int("consistency-size", len(sthConsistency.Consistency)))
 
 		err = c.logVerifier.VerifyConsistencyProof(int64(storedSTH.TreeSize), int64(sth.TreeSize),


### PR DESCRIPTION
The anchor monitor process will remove all in-process anchor status records after all witnesses have been exhausted.

This commit also adds more information to existing logs (such as anchorUri) and changes the level from DEBUG to INFO for some of the important logs so that issues may be more easily debugged.