### PR TITLE
fix: Don't process anchor if it has already been processed

### DIFF
--- a/pkg/activitypub/httpsig/signer.go
+++ b/pkg/activitypub/httpsig/signer.go
@@ -83,7 +83,7 @@ func NewSigner(cfg SignerConfig, cr crypto, km keyManager, keyID string) *Signer
 func (s *Signer) SignRequest(pubKeyID string, req *http.Request) error {
 	req.Header.Add(dateHeader, date())
 
-	logger.Debug("Signing request for %s. Public key ID [%s]. Headers: %s", logfields.WithRequestURLString(req.RequestURI),
+	logger.Debug("Signing request", logfields.WithRequestURLString(req.RequestURI),
 		logfields.WithKeyID(pubKeyID), logfields.WithRequestHeaders(req.Header))
 
 	if err := s.signer().Sign(pubKeyID, req); err != nil {

--- a/pkg/anchor/linkstore/linkstore_test.go
+++ b/pkg/anchor/linkstore/linkstore_test.go
@@ -153,6 +153,13 @@ func TestStore_GetLinks(t *testing.T) {
 	links, err = s.GetProcessedAndPendingLinks(hash2)
 	require.NoError(t, err)
 	require.Len(t, links, 2)
+
+	err = s.DeletePendingLinks(links)
+	require.NoError(t, err)
+
+	links, err = s.GetProcessedAndPendingLinks(hash2)
+	require.NoError(t, err)
+	require.Len(t, links, 1)
 }
 
 func TestStore_GetLinksError(t *testing.T) {

--- a/pkg/mocks/anchorlinkstore.gen.go
+++ b/pkg/mocks/anchorlinkstore.gen.go
@@ -18,6 +18,17 @@ type AnchorLinkStore struct {
 	deleteLinksReturnsOnCall map[int]struct {
 		result1 error
 	}
+	DeletePendingLinksStub        func([]*url.URL) error
+	deletePendingLinksMutex       sync.RWMutex
+	deletePendingLinksArgsForCall []struct {
+		arg1 []*url.URL
+	}
+	deletePendingLinksReturns struct {
+		result1 error
+	}
+	deletePendingLinksReturnsOnCall map[int]struct {
+		result1 error
+	}
 	GetLinksStub        func(string) ([]*url.URL, error)
 	getLinksMutex       sync.RWMutex
 	getLinksArgsForCall []struct {
@@ -108,6 +119,72 @@ func (fake *AnchorLinkStore) DeleteLinksReturnsOnCall(i int, result1 error) {
 		})
 	}
 	fake.deleteLinksReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *AnchorLinkStore) DeletePendingLinks(arg1 []*url.URL) error {
+	var arg1Copy []*url.URL
+	if arg1 != nil {
+		arg1Copy = make([]*url.URL, len(arg1))
+		copy(arg1Copy, arg1)
+	}
+	fake.deletePendingLinksMutex.Lock()
+	ret, specificReturn := fake.deletePendingLinksReturnsOnCall[len(fake.deletePendingLinksArgsForCall)]
+	fake.deletePendingLinksArgsForCall = append(fake.deletePendingLinksArgsForCall, struct {
+		arg1 []*url.URL
+	}{arg1Copy})
+	stub := fake.DeletePendingLinksStub
+	fakeReturns := fake.deletePendingLinksReturns
+	fake.recordInvocation("DeletePendingLinks", []interface{}{arg1Copy})
+	fake.deletePendingLinksMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *AnchorLinkStore) DeletePendingLinksCallCount() int {
+	fake.deletePendingLinksMutex.RLock()
+	defer fake.deletePendingLinksMutex.RUnlock()
+	return len(fake.deletePendingLinksArgsForCall)
+}
+
+func (fake *AnchorLinkStore) DeletePendingLinksCalls(stub func([]*url.URL) error) {
+	fake.deletePendingLinksMutex.Lock()
+	defer fake.deletePendingLinksMutex.Unlock()
+	fake.DeletePendingLinksStub = stub
+}
+
+func (fake *AnchorLinkStore) DeletePendingLinksArgsForCall(i int) []*url.URL {
+	fake.deletePendingLinksMutex.RLock()
+	defer fake.deletePendingLinksMutex.RUnlock()
+	argsForCall := fake.deletePendingLinksArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *AnchorLinkStore) DeletePendingLinksReturns(result1 error) {
+	fake.deletePendingLinksMutex.Lock()
+	defer fake.deletePendingLinksMutex.Unlock()
+	fake.DeletePendingLinksStub = nil
+	fake.deletePendingLinksReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *AnchorLinkStore) DeletePendingLinksReturnsOnCall(i int, result1 error) {
+	fake.deletePendingLinksMutex.Lock()
+	defer fake.deletePendingLinksMutex.Unlock()
+	fake.DeletePendingLinksStub = nil
+	if fake.deletePendingLinksReturnsOnCall == nil {
+		fake.deletePendingLinksReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.deletePendingLinksReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -247,6 +324,8 @@ func (fake *AnchorLinkStore) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.deleteLinksMutex.RLock()
 	defer fake.deleteLinksMutex.RUnlock()
+	fake.deletePendingLinksMutex.RLock()
+	defer fake.deletePendingLinksMutex.RUnlock()
 	fake.getLinksMutex.RLock()
 	defer fake.getLinksMutex.RUnlock()
 	fake.putLinksMutex.RLock()

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -55,6 +55,7 @@ type linkStore interface { //nolint:unused
 	PutLinks(links []*url.URL) error
 	GetLinks(anchorHash string) ([]*url.URL, error)
 	DeleteLinks(links []*url.URL) error
+	DeletePendingLinks(links []*url.URL) error
 }
 
 const casLink = "https://domain.com/cas"


### PR DESCRIPTION
Just before posting an anchor to the message queue, check if the anchor has already been processed. This greatly reduces the number of duplicate anchors sent to the queue and will improve overall performance.

closes #1565