### PR TITLE
fix: Exit proof monitor loop on server shutdown

### DIFF
--- a/cmd/orb-server/startcmd/params_test.go
+++ b/cmd/orb-server/startcmd/params_test.go
@@ -748,6 +748,19 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 		require.Contains(t, err.Error(), "invalid value for vct-proof-monitoring-interval [xxx]")
 	})
 
+	t.Run("VCT proof monitoring max records", func(t *testing.T) {
+		restoreEnv := setEnv(t, vctProofMonitoringMaxRecordsEnvKey, "xxx")
+		defer restoreEnv()
+
+		startCmd := GetStartCmd()
+
+		startCmd.SetArgs(getTestArgs("localhost:8081", "local", "false", databaseTypeMemOption))
+
+		err := startCmd.Execute()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid value for vct-proof-monitoring-max-records [xxx]")
+	})
+
 	t.Run("VCT proof monitoring expiry period", func(t *testing.T) {
 		restoreEnv := setEnv(t, vctProofMonitoringExpiryPeriodEnvKey, "xxx")
 		defer restoreEnv()

--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -771,8 +771,10 @@ func startOrbServices(parameters *orbParameters) error {
 
 	apSigVerifier := getActivityPubVerifier(parameters, km, cr, apClient)
 
-	proofMonitoringSvc, err := proofmonitoring.New(storeProviders.provider, orbDocumentLoader, wfClient,
-		httpClient, taskMgr, parameters.vct.proofMonitoringInterval, parameters.requestTokens)
+	proofMonitoringSvc, err := proofmonitoring.New(storeProviders.provider, orbDocumentLoader, wfClient, httpClient, taskMgr,
+		proofmonitoring.WithMonitoringInterval(parameters.vct.proofMonitoringInterval),
+		proofmonitoring.WithRequestTokens(parameters.requestTokens),
+		proofmonitoring.WithMaxRecordsPerInterval(parameters.vct.proofMonitoringMaxRecords))
 	if err != nil {
 		return fmt.Errorf("new VCT monitoring service: %w", err)
 	}
@@ -1194,7 +1196,7 @@ func startOrbServices(parameters *orbParameters) error {
 	)
 
 	err = run(httpServer, activityPubService, opQueue, obsrv, batchWriter, taskMgr, apClient,
-		nodeInfoService, newMPLifecycleWrapper(mp), tracerProvider)
+		nodeInfoService, newMPLifecycleWrapper(mp), tracerProvider, proofMonitoringSvc)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/log/fields.go
+++ b/internal/pkg/log/fields.go
@@ -151,6 +151,7 @@ const (
 	FieldMaxActivitiesToSync      = "maxActivitiesToSync"
 	FieldNumActivitiesSynced      = "numActivitiesSynced"
 	FieldNextActivitySyncInterval = "nextActivitySyncInterval"
+	FieldMaxProofMonitorRecords   = "maxProofMonitorRecords"
 )
 
 // WithMessageID sets the message-id field.
@@ -902,6 +903,11 @@ func WithNumActivitiesSynced(value int) zap.Field {
 // WithNextActivitySyncInterval sets the nextActivitySyncInterval field.
 func WithNextActivitySyncInterval(value time.Duration) zap.Field {
 	return zap.Duration(FieldNextActivitySyncInterval, value)
+}
+
+// WithMaxProofMonitorRecords sets the maxProofMonitorRecords field.
+func WithMaxProofMonitorRecords(value int) zap.Field {
+	return zap.Int(FieldMaxProofMonitorRecords, value)
 }
 
 type jsonMarshaller struct {

--- a/internal/pkg/log/fields_test.go
+++ b/internal/pkg/log/fields_test.go
@@ -63,7 +63,7 @@ func TestStandardFields(t *testing.T) {
 			WithCreatedTime(now), WithWitnessURI(u1), WithWitnessURIs(u1, u2), WithWitnessPolicy("some policy"),
 			WithAnchorOrigin(u1.String()), WithOperationType("Create"), WithCoreIndex("1234"),
 			WithMaxOperationsToRepost(300), WithMaxActivitiesToSync(11), WithNextActivitySyncInterval(3*time.Second),
-			WithNumActivitiesSynced(123),
+			WithNumActivitiesSynced(123), WithMaxProofMonitorRecords(23),
 		)
 
 		t.Logf(stdOut.String())
@@ -123,6 +123,7 @@ func TestStandardFields(t *testing.T) {
 		require.Equal(t, 11, l.MaxActivitiesToSync)
 		require.Equal(t, "3s", l.NextActivitySyncInterval)
 		require.Equal(t, 123, l.NumActivitiesSynced)
+		require.Equal(t, 23, l.MaxProofMonitorRecords)
 	})
 
 	t.Run("json fields 2", func(t *testing.T) {
@@ -452,6 +453,7 @@ type logData struct {
 	MaxActivitiesToSync      int                 `json:"maxActivitiesToSync"`
 	NextActivitySyncInterval string              `json:"nextActivitySyncInterval"`
 	NumActivitiesSynced      int                 `json:"numActivitiesSynced"`
+	MaxProofMonitorRecords   int                 `json:"maxProofMonitorRecords"`
 }
 
 func unmarshalLogData(t *testing.T, b []byte) *logData {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -113,7 +113,7 @@ func TestCache_Get(t *testing.T) {
 			},
 			WithName("test-cache"),
 			WithMonitorInterval(10*time.Millisecond),
-			WithRefreshInterval(20*time.Millisecond),
+			WithRefreshInterval(25*time.Millisecond),
 			WithRetryBackoff(50*time.Millisecond),
 			WithMaxLoadAttempts(5),
 		)


### PR DESCRIPTION
Also limit the number of records to check per monitor interval.

closes #1563
closes #1570 
closes #1569 
