### PR TITLE
fix: Exit anchor status monitoring loop on shutdown

### DIFF
--- a/cmd/orb-server/startcmd/params_test.go
+++ b/cmd/orb-server/startcmd/params_test.go
@@ -839,6 +839,19 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 		require.Contains(t, err.Error(), "invalid value for anchor-status-monitoring-interval [xxx]")
 	})
 
+	t.Run("anchor status max records", func(t *testing.T) {
+		restoreEnv := setEnv(t, anchorStatusMaxRecordsEnvKey, "xxx")
+		defer restoreEnv()
+
+		startCmd := GetStartCmd()
+
+		startCmd.SetArgs(getTestArgs("localhost:8081", "local", "false", databaseTypeMemOption))
+
+		err := startCmd.Execute()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid value for anchor-status-max-records [xxx]")
+	})
+
 	t.Run("anchor status in-process grace period", func(t *testing.T) {
 		restoreEnv := setEnv(t, anchorStatusInProcessGracePeriodEnvKey, "xxx")
 		defer restoreEnv()

--- a/internal/pkg/log/fields.go
+++ b/internal/pkg/log/fields.go
@@ -151,7 +151,7 @@ const (
 	FieldMaxActivitiesToSync      = "maxActivitiesToSync"
 	FieldNumActivitiesSynced      = "numActivitiesSynced"
 	FieldNextActivitySyncInterval = "nextActivitySyncInterval"
-	FieldMaxProofMonitorRecords   = "maxProofMonitorRecords"
+	FieldRecordsProcessed         = "recordsProcessed"
 )
 
 // WithMessageID sets the message-id field.
@@ -905,9 +905,9 @@ func WithNextActivitySyncInterval(value time.Duration) zap.Field {
 	return zap.Duration(FieldNextActivitySyncInterval, value)
 }
 
-// WithMaxProofMonitorRecords sets the maxProofMonitorRecords field.
-func WithMaxProofMonitorRecords(value int) zap.Field {
-	return zap.Int(FieldMaxProofMonitorRecords, value)
+// WithRecordsProcessed sets the recordsProcessed field.
+func WithRecordsProcessed(value int) zap.Field {
+	return zap.Int(FieldRecordsProcessed, value)
 }
 
 type jsonMarshaller struct {

--- a/internal/pkg/log/fields_test.go
+++ b/internal/pkg/log/fields_test.go
@@ -63,7 +63,7 @@ func TestStandardFields(t *testing.T) {
 			WithCreatedTime(now), WithWitnessURI(u1), WithWitnessURIs(u1, u2), WithWitnessPolicy("some policy"),
 			WithAnchorOrigin(u1.String()), WithOperationType("Create"), WithCoreIndex("1234"),
 			WithMaxOperationsToRepost(300), WithMaxActivitiesToSync(11), WithNextActivitySyncInterval(3*time.Second),
-			WithNumActivitiesSynced(123), WithMaxProofMonitorRecords(23),
+			WithNumActivitiesSynced(123), WithRecordsProcessed(23),
 		)
 
 		t.Logf(stdOut.String())
@@ -123,7 +123,7 @@ func TestStandardFields(t *testing.T) {
 		require.Equal(t, 11, l.MaxActivitiesToSync)
 		require.Equal(t, "3s", l.NextActivitySyncInterval)
 		require.Equal(t, 123, l.NumActivitiesSynced)
-		require.Equal(t, 23, l.MaxProofMonitorRecords)
+		require.Equal(t, 23, l.RecordsProcessed)
 	})
 
 	t.Run("json fields 2", func(t *testing.T) {
@@ -453,7 +453,7 @@ type logData struct {
 	MaxActivitiesToSync      int                 `json:"maxActivitiesToSync"`
 	NextActivitySyncInterval string              `json:"nextActivitySyncInterval"`
 	NumActivitiesSynced      int                 `json:"numActivitiesSynced"`
-	MaxProofMonitorRecords   int                 `json:"maxProofMonitorRecords"`
+	RecordsProcessed         int                 `json:"recordsProcessed"`
 }
 
 func unmarshalLogData(t *testing.T, b []byte) *logData {

--- a/pkg/anchor/handler/proof/handler_test.go
+++ b/pkg/anchor/handler/proof/handler_test.go
@@ -86,7 +86,7 @@ func TestWitnessProofHandler(t *testing.T) {
 		err = aeStore.Put(al)
 		require.NoError(t, err)
 
-		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
+		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetTaskMgr(t), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
 		err = statusStore.AddStatus(al.Anchor().String(), proofapi.AnchorIndexStatusInProcess)
@@ -131,7 +131,7 @@ func TestWitnessProofHandler(t *testing.T) {
 		err = aeStore.Put(al)
 		require.NoError(t, err)
 
-		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
+		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetTaskMgr(t), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
 		err = statusStore.AddStatus(al.Anchor().String(), proofapi.AnchorIndexStatusInProcess)
@@ -181,7 +181,7 @@ func TestWitnessProofHandler(t *testing.T) {
 		err = aeStore.Put(al)
 		require.NoError(t, err)
 
-		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
+		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetTaskMgr(t), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
 		err = statusStore.AddStatus(al.Anchor().String(), proofapi.AnchorIndexStatusInProcess)
@@ -231,7 +231,7 @@ func TestWitnessProofHandler(t *testing.T) {
 		err = aeStore.Put(al)
 		require.NoError(t, err)
 
-		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
+		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetTaskMgr(t), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
 		err = statusStore.AddStatus(al.Anchor().String(), proofapi.AnchorIndexStatusCompleted)
@@ -265,7 +265,7 @@ func TestWitnessProofHandler(t *testing.T) {
 		err = aeStore.Put(al)
 		require.NoError(t, err)
 
-		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
+		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetTaskMgr(t), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
 		err = statusStore.AddStatus(al.Anchor().String(), proofapi.AnchorIndexStatusInProcess)
@@ -314,7 +314,7 @@ func TestWitnessProofHandler(t *testing.T) {
 		err = aeStore.Put(al)
 		require.NoError(t, err)
 
-		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
+		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetTaskMgr(t), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
 		err = statusStore.AddStatus(al.Anchor().String(), proofapi.AnchorIndexStatusCompleted)
@@ -349,7 +349,7 @@ func TestWitnessProofHandler(t *testing.T) {
 		err = aeStore.Put(al)
 		require.NoError(t, err)
 
-		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
+		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetTaskMgr(t), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
 		err = statusStore.AddStatus(al.Anchor().String(), proofapi.AnchorIndexStatusInProcess)
@@ -408,7 +408,7 @@ func TestWitnessProofHandler(t *testing.T) {
 		err = aeStore.Put(al)
 		require.NoError(t, err)
 
-		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
+		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetTaskMgr(t), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
 		err = statusStore.AddStatus(al.Anchor().String(), proofapi.AnchorIndexStatusInProcess)
@@ -459,7 +459,7 @@ func TestWitnessProofHandler(t *testing.T) {
 		err = aeStore.Put(al)
 		require.NoError(t, err)
 
-		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
+		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetTaskMgr(t), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
 		err = statusStore.AddStatus(al.Anchor().String(), proofapi.AnchorIndexStatusInProcess)
@@ -678,7 +678,7 @@ func TestWitnessProofHandler(t *testing.T) {
 		err = aeStore.Put(al)
 		require.NoError(t, err)
 
-		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
+		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetTaskMgr(t), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
 		err = statusStore.AddStatus(al.Anchor().String(), proofapi.AnchorIndexStatusInProcess)
@@ -715,7 +715,7 @@ func TestWitnessProofHandler(t *testing.T) {
 		err = aeStore.Put(al)
 		require.NoError(t, err)
 
-		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
+		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetTaskMgr(t), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
 		providers := &Providers{
@@ -744,7 +744,7 @@ func TestWitnessProofHandler(t *testing.T) {
 		aeStore, err := anchorlinkstore.New(provider)
 		require.NoError(t, err)
 
-		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
+		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetTaskMgr(t), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
 		err = statusStore.AddStatus(anchorID, proofapi.AnchorIndexStatusInProcess)
@@ -779,7 +779,7 @@ func TestWitnessProofHandler(t *testing.T) {
 		err = aeStore.Put(al)
 		require.NoError(t, err)
 
-		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
+		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetTaskMgr(t), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
 		err = statusStore.AddStatus(al.Anchor().String(), proofapi.AnchorIndexStatusInProcess)
@@ -815,7 +815,7 @@ func TestWitnessProofHandler(t *testing.T) {
 		err = aeStore.Put(al)
 		require.NoError(t, err)
 
-		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
+		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetTaskMgr(t), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
 		err = statusStore.AddStatus(al.Anchor().String(), proofapi.AnchorIndexStatusInProcess)
@@ -842,7 +842,7 @@ func TestWitnessProofHandler(t *testing.T) {
 		aeStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
-		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
+		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetTaskMgr(t), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
 		err = statusStore.AddStatus(anchorID, proofapi.AnchorIndexStatusInProcess)

--- a/pkg/anchor/writer/writer_test.go
+++ b/pkg/anchor/writer/writer_test.go
@@ -156,7 +156,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
-		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
+		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetTaskMgr(t), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
 		providers := &Providers{
@@ -210,7 +210,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
-		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
+		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetTaskMgr(t), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
 		providers := &Providers{
@@ -266,7 +266,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
-		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
+		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetTaskMgr(t), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
 		providers := &Providers{
@@ -323,7 +323,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 
 		wit := &mockWitness{proofBytes: []byte(`{"proof": {"domain":"domain","created": "2021-02-23T19:36:07Z"}}`)}
 
-		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
+		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetTaskMgr(t), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
 		providers := &Providers{
@@ -523,7 +523,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
-		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
+		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetTaskMgr(t), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
 		providers := &Providers{
@@ -800,7 +800,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
-		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
+		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetTaskMgr(t), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
 		providers := &Providers{
@@ -856,7 +856,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
-		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
+		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetTaskMgr(t), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
 		providers := &Providers{
@@ -904,7 +904,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
-		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
+		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetTaskMgr(t), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
 		activityStore := memstore.New("")
@@ -976,7 +976,7 @@ func TestWriter_WriteAnchor(t *testing.T) {
 		anchorEventStore, err := anchorlinkstore.New(mem.NewProvider())
 		require.NoError(t, err)
 
-		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
+		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetTaskMgr(t), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
 		activityStore := memstore.New("")
@@ -1369,7 +1369,7 @@ func TestWriter_postOfferActivity(t *testing.T) {
 	require.NotNil(t, anchorLink)
 
 	t.Run("success", func(t *testing.T) {
-		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
+		statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetTaskMgr(t), testutil.GetExpiryService(t), time.Minute)
 		require.NoError(t, err)
 
 		providers := &Providers{
@@ -1436,7 +1436,7 @@ func TestWriter_postOfferActivity(t *testing.T) {
 				errors.New("injected WebFinger client error"))
 			wfClientWithErr.HasSupportedLedgerTypeReturnsOnCall(4, true, nil)
 
-			statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetExpiryService(t), time.Minute)
+			statusStore, err := anchorstatus.New(mem.NewProvider(), testutil.GetTaskMgr(t), testutil.GetExpiryService(t), time.Minute)
 			require.NoError(t, err)
 
 			providers := &Providers{

--- a/pkg/internal/testutil/testutil.go
+++ b/pkg/internal/testutil/testutil.go
@@ -118,9 +118,8 @@ func GetLoader(t *testing.T) *ld.DocumentLoader {
 	return documentLoader
 }
 
-// GetExpiryService returns test expiry service object. For most tests, the expiry service used doesn't really matter
-// this object is just needed to ensure that no nil pointer errors happen when initializing the store.
-func GetExpiryService(t *testing.T) *expiry.Service {
+// GetTaskMgr returns a test task manager service.
+func GetTaskMgr(t *testing.T) *taskmgr.Manager {
 	t.Helper()
 
 	const checkInterval = 500 * time.Millisecond
@@ -128,7 +127,13 @@ func GetExpiryService(t *testing.T) *expiry.Service {
 	coordinationStore, err := mem.NewProvider().OpenStore("coordination")
 	require.NoError(t, err)
 
-	taskMgr := taskmgr.New(coordinationStore, checkInterval)
+	return taskmgr.New(coordinationStore, checkInterval)
+}
 
-	return expiry.NewService(taskMgr, time.Second)
+// GetExpiryService returns test expiry service object. For most tests, the expiry service used doesn't really matter
+// this object is just needed to ensure that no nil pointer errors happen when initializing the store.
+func GetExpiryService(t *testing.T) *expiry.Service {
+	t.Helper()
+
+	return expiry.NewService(GetTaskMgr(t), time.Second)
 }

--- a/scripts/check_lint.sh
+++ b/scripts/check_lint.sh
@@ -17,10 +17,10 @@ if [ ! $(command -v ${DOCKER_CMD}) ]; then
 fi
 
 echo "Linting pkg"
-${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 10m
 echo "Linting orb-server"
-${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/cmd/orb-server ${GOLANGCI_LINT_IMAGE} golangci-lint run -c ../../.golangci.yml --timeout 5m
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/cmd/orb-server ${GOLANGCI_LINT_IMAGE} golangci-lint run -c ../../.golangci.yml --timeout 10m
 echo "Linting orb-cli"
-${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/cmd/orb-cli ${GOLANGCI_LINT_IMAGE} golangci-lint run -c ../../.golangci.yml --timeout 5m
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/cmd/orb-cli ${GOLANGCI_LINT_IMAGE} golangci-lint run -c ../../.golangci.yml --timeout 10m
 echo "Linting orb-driver"
-${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/cmd/orb-driver ${GOLANGCI_LINT_IMAGE} golangci-lint run -c ../../.golangci.yml --timeout 5m
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/cmd/orb-driver ${GOLANGCI_LINT_IMAGE} golangci-lint run -c ../../.golangci.yml --timeout 10m


### PR DESCRIPTION
Also, updated witness proof monitor to accelerate the next task time if it is known that more records need to be processed.

closes #1572