### PR TITLE
fix: Failed processing of batch can cause operation queue to grow uncontrollably

### DIFF
--- a/cmd/orb-cli/go.mod
+++ b/cmd/orb-cli/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/stretchr/testify v1.8.2
 	github.com/trustbloc/logutil-go v1.0.0-rc1
 	github.com/trustbloc/orb v1.0.0-rc3.0.20221110183921-dc5feded4796
-	github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230602183030-41b2f35eb5d1
+	github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230606202232-3c7387f972f6
 	github.com/trustbloc/vct v1.0.0-rc5
 )
 

--- a/cmd/orb-cli/go.sum
+++ b/cmd/orb-cli/go.sum
@@ -885,8 +885,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/trustbloc/logutil-go v1.0.0-rc1 h1:rRJbvgQfrlUfyej+mY0nuQJymGqjRW4oZEwKi544F4c=
 github.com/trustbloc/logutil-go v1.0.0-rc1/go.mod h1:JlxT0oZfNKgIlSNtgc001WEeDMxlnAvOM43gNm8DQVc=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230602183030-41b2f35eb5d1 h1:4CHuMxs1NRkxHMCQ6vbF/C88XhQzTeTkg11Gp27Yt5U=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230602183030-41b2f35eb5d1/go.mod h1:jdxAFuorlIwFOGVW6O455/lZqxg2mZkRHNTEolcZdDI=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230606202232-3c7387f972f6 h1:/jdm+7dHJSBT+o1F16QQrlUF7otmNwwxTYkOI5P6wdM=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230606202232-3c7387f972f6/go.mod h1:jdxAFuorlIwFOGVW6O455/lZqxg2mZkRHNTEolcZdDI=
 github.com/trustbloc/vct v1.0.0-rc5 h1:fBn5xFi+D+vtDFu/UncsqwwOIuFfy0KANe470GXriOw=
 github.com/trustbloc/vct v1.0.0-rc5/go.mod h1:TrS5PDqw6RPl4q1ISDys/aZZDZ7bglIXXBsvdBv48dM=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/cmd/orb-driver/go.mod
+++ b/cmd/orb-driver/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/square/go-jose/v3 v3.0.0-20200630053402-0a67ce9b0693 // indirect
 	github.com/teserakt-io/golang-ed25519 v0.0.0-20210104091850-3888c087a4c8 // indirect
-	github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230602183030-41b2f35eb5d1 // indirect
+	github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230606202232-3c7387f972f6 // indirect
 	github.com/trustbloc/vct v1.0.0-rc5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect

--- a/cmd/orb-driver/go.sum
+++ b/cmd/orb-driver/go.sum
@@ -869,8 +869,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/trustbloc/logutil-go v1.0.0-rc1 h1:rRJbvgQfrlUfyej+mY0nuQJymGqjRW4oZEwKi544F4c=
 github.com/trustbloc/logutil-go v1.0.0-rc1/go.mod h1:JlxT0oZfNKgIlSNtgc001WEeDMxlnAvOM43gNm8DQVc=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230602183030-41b2f35eb5d1 h1:4CHuMxs1NRkxHMCQ6vbF/C88XhQzTeTkg11Gp27Yt5U=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230602183030-41b2f35eb5d1/go.mod h1:jdxAFuorlIwFOGVW6O455/lZqxg2mZkRHNTEolcZdDI=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230606202232-3c7387f972f6 h1:/jdm+7dHJSBT+o1F16QQrlUF7otmNwwxTYkOI5P6wdM=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230606202232-3c7387f972f6/go.mod h1:jdxAFuorlIwFOGVW6O455/lZqxg2mZkRHNTEolcZdDI=
 github.com/trustbloc/vct v1.0.0-rc5 h1:fBn5xFi+D+vtDFu/UncsqwwOIuFfy0KANe470GXriOw=
 github.com/trustbloc/vct v1.0.0-rc5/go.mod h1:TrS5PDqw6RPl4q1ISDys/aZZDZ7bglIXXBsvdBv48dM=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/cmd/orb-server/go.mod
+++ b/cmd/orb-server/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/trustbloc/kms v0.1.9-0.20221024131747-f895f91207f1
 	github.com/trustbloc/logutil-go v1.0.0-rc1
 	github.com/trustbloc/orb v1.0.0-rc3.0.20221101120557-1cf1ce21c938
-	github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230602183030-41b2f35eb5d1
+	github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230606202232-3c7387f972f6
 	go.mongodb.org/mongo-driver v1.9.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.40.0
 	go.uber.org/zap v1.23.0

--- a/cmd/orb-server/go.sum
+++ b/cmd/orb-server/go.sum
@@ -938,8 +938,8 @@ github.com/trustbloc/kms v0.1.9-0.20221024131747-f895f91207f1 h1:u617zM5QPsAawgQ
 github.com/trustbloc/kms v0.1.9-0.20221024131747-f895f91207f1/go.mod h1:Vv+mv35QeUo5f+Llm/gsp6x4FgLkLH9dTp4dGK0+aQU=
 github.com/trustbloc/logutil-go v1.0.0-rc1 h1:rRJbvgQfrlUfyej+mY0nuQJymGqjRW4oZEwKi544F4c=
 github.com/trustbloc/logutil-go v1.0.0-rc1/go.mod h1:JlxT0oZfNKgIlSNtgc001WEeDMxlnAvOM43gNm8DQVc=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230602183030-41b2f35eb5d1 h1:4CHuMxs1NRkxHMCQ6vbF/C88XhQzTeTkg11Gp27Yt5U=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230602183030-41b2f35eb5d1/go.mod h1:jdxAFuorlIwFOGVW6O455/lZqxg2mZkRHNTEolcZdDI=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230606202232-3c7387f972f6 h1:/jdm+7dHJSBT+o1F16QQrlUF7otmNwwxTYkOI5P6wdM=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230606202232-3c7387f972f6/go.mod h1:jdxAFuorlIwFOGVW6O455/lZqxg2mZkRHNTEolcZdDI=
 github.com/trustbloc/vct v1.0.0-rc5 h1:fBn5xFi+D+vtDFu/UncsqwwOIuFfy0KANe470GXriOw=
 github.com/trustbloc/vct v1.0.0-rc5/go.mod h1:TrS5PDqw6RPl4q1ISDys/aZZDZ7bglIXXBsvdBv48dM=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/stretchr/testify v1.8.2
 	github.com/transparency-dev/merkle v0.0.0-20220208131541-728dc2de1344
 	github.com/trustbloc/logutil-go v1.0.0-rc1
-	github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230602183030-41b2f35eb5d1
+	github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230606202232-3c7387f972f6
 	github.com/trustbloc/vct v1.0.0-rc5
 	go.mongodb.org/mongo-driver v1.9.1
 	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.40.0

--- a/go.sum
+++ b/go.sum
@@ -954,8 +954,8 @@ github.com/transparency-dev/merkle v0.0.0-20220208131541-728dc2de1344 h1:KCEn2RI
 github.com/transparency-dev/merkle v0.0.0-20220208131541-728dc2de1344/go.mod h1:B8FIw5LTq6DaULoHsVFRzYIUDkl8yuSwCdZnOZGKL/A=
 github.com/trustbloc/logutil-go v1.0.0-rc1 h1:rRJbvgQfrlUfyej+mY0nuQJymGqjRW4oZEwKi544F4c=
 github.com/trustbloc/logutil-go v1.0.0-rc1/go.mod h1:JlxT0oZfNKgIlSNtgc001WEeDMxlnAvOM43gNm8DQVc=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230602183030-41b2f35eb5d1 h1:4CHuMxs1NRkxHMCQ6vbF/C88XhQzTeTkg11Gp27Yt5U=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230602183030-41b2f35eb5d1/go.mod h1:jdxAFuorlIwFOGVW6O455/lZqxg2mZkRHNTEolcZdDI=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230606202232-3c7387f972f6 h1:/jdm+7dHJSBT+o1F16QQrlUF7otmNwwxTYkOI5P6wdM=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230606202232-3c7387f972f6/go.mod h1:jdxAFuorlIwFOGVW6O455/lZqxg2mZkRHNTEolcZdDI=
 github.com/trustbloc/vct v1.0.0-rc5 h1:fBn5xFi+D+vtDFu/UncsqwwOIuFfy0KANe470GXriOw=
 github.com/trustbloc/vct v1.0.0-rc5/go.mod h1:TrS5PDqw6RPl4q1ISDys/aZZDZ7bglIXXBsvdBv48dM=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/pkg/context/opqueue/opqueue.go
+++ b/pkg/context/opqueue/opqueue.go
@@ -593,7 +593,7 @@ func (q *Queue) asQueuedOperations(opMsgs []*queuedOperation) []*operation.Queue
 	q.logger.Debug("Returning queued operations", logfields.WithTotal(len(opMsgs)))
 
 	for i, opMsg := range opMsgs {
-		q.logger.Debug("Adding operation.", logfields.WithMessageID(opMsg.ID),
+		q.logger.Debug("Adding operation.", logfields.WithOperationID(opMsg.ID),
 			logfields.WithSuffix(opMsg.Operation.UniqueSuffix))
 
 		ops[i] = opMsg.Operation

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/tidwall/gjson v1.7.4
 	github.com/trustbloc/orb v1.0.0-rc3.0.20221110183921-dc5feded4796
-	github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230602183030-41b2f35eb5d1
+	github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230606202232-3c7387f972f6
 )
 
 require (

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -1156,8 +1156,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/trustbloc/logutil-go v1.0.0-rc1 h1:rRJbvgQfrlUfyej+mY0nuQJymGqjRW4oZEwKi544F4c=
 github.com/trustbloc/logutil-go v1.0.0-rc1/go.mod h1:JlxT0oZfNKgIlSNtgc001WEeDMxlnAvOM43gNm8DQVc=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230602183030-41b2f35eb5d1 h1:4CHuMxs1NRkxHMCQ6vbF/C88XhQzTeTkg11Gp27Yt5U=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230602183030-41b2f35eb5d1/go.mod h1:jdxAFuorlIwFOGVW6O455/lZqxg2mZkRHNTEolcZdDI=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230606202232-3c7387f972f6 h1:/jdm+7dHJSBT+o1F16QQrlUF7otmNwwxTYkOI5P6wdM=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230606202232-3c7387f972f6/go.mod h1:jdxAFuorlIwFOGVW6O455/lZqxg2mZkRHNTEolcZdDI=
 github.com/trustbloc/vct v1.0.0-rc5 h1:fBn5xFi+D+vtDFu/UncsqwwOIuFfy0KANe470GXriOw=
 github.com/trustbloc/vct v1.0.0-rc5/go.mod h1:TrS5PDqw6RPl4q1ISDys/aZZDZ7bglIXXBsvdBv48dM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=


### PR DESCRIPTION
Updated to latest sidetree-core-go which fixes this issue.

See https://github.com/trustbloc/sidetree-core-go/issues/697 for details.

closes #1579