### PR TITLE
chore: Add function GetEndpointNoCache

### DIFF
--- a/pkg/discovery/endpoint/client/client.go
+++ b/pkg/discovery/endpoint/client/client.go
@@ -167,6 +167,11 @@ func (cs *Client) GetEndpoint(domain string) (*models.Endpoint, error) {
 	return endpoint.(*models.Endpoint), nil //nolint:forcetypeassert
 }
 
+// GetEndpointNoCache fetches endpoints from domain bypassing the cache.
+func (cs *Client) GetEndpointNoCache(domain string) (*models.Endpoint, error) {
+	return cs.getEndpoint(domain)
+}
+
 // GetEndpointFromAnchorOrigin fetches endpoints from anchor origin, caching the value.
 func (cs *Client) GetEndpointFromAnchorOrigin(didURI string) (*models.Endpoint, error) {
 	return cs.getEndpointAnchorOrigin(didURI)

--- a/pkg/discovery/endpoint/client/client_test.go
+++ b/pkg/discovery/endpoint/client/client_test.go
@@ -373,6 +373,10 @@ func TestConfigService_GetEndpoint(t *testing.T) { //nolint: gocyclo,gocognit,cy
 		endpoint, err := cs.GetEndpoint("d1")
 		require.NoError(t, err)
 
+		endpoint2, err := cs.GetEndpointNoCache("d1")
+		require.NoError(t, err)
+		require.Equal(t, endpoint, endpoint2)
+
 		require.Equal(t, endpoint.ResolutionEndpoints, []string{"https://localhost/resolve1", "https://localhost/resolve2"})
 		require.Equal(t, endpoint.OperationEndpoints, []string{"https://localhost/op1", "https://localhost/op2"})
 		require.Equal(t, endpoint.MinResolvers, 2)


### PR DESCRIPTION
This function bypasses the cache when retrieving the sidetree endpoint for the domain.