### PR TITLE
fix: Ensure update operations are processed after create operations a…

### DIFF
--- a/cmd/orb-cli/go.mod
+++ b/cmd/orb-cli/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/stretchr/testify v1.8.2
 	github.com/trustbloc/logutil-go v1.0.0-rc1
 	github.com/trustbloc/orb v1.0.0-rc7
-	github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230609191801-793cbea60692
+	github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230622210745-a1b968a815f7
 	github.com/trustbloc/vct v1.0.0-rc5
 )
 

--- a/cmd/orb-cli/go.sum
+++ b/cmd/orb-cli/go.sum
@@ -885,8 +885,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/trustbloc/logutil-go v1.0.0-rc1 h1:rRJbvgQfrlUfyej+mY0nuQJymGqjRW4oZEwKi544F4c=
 github.com/trustbloc/logutil-go v1.0.0-rc1/go.mod h1:JlxT0oZfNKgIlSNtgc001WEeDMxlnAvOM43gNm8DQVc=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230609191801-793cbea60692 h1:8J/lEaFqWfGugvt5u/d5l9OvJoZZpE2XU3bR/U6iKjM=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230609191801-793cbea60692/go.mod h1:jdxAFuorlIwFOGVW6O455/lZqxg2mZkRHNTEolcZdDI=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230622210745-a1b968a815f7 h1:v4Ok2o8bUjTGsS9Vebc0k2DSS2XJWzCVuYOrAA+YFeE=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230622210745-a1b968a815f7/go.mod h1:jdxAFuorlIwFOGVW6O455/lZqxg2mZkRHNTEolcZdDI=
 github.com/trustbloc/vct v1.0.0-rc5 h1:fBn5xFi+D+vtDFu/UncsqwwOIuFfy0KANe470GXriOw=
 github.com/trustbloc/vct v1.0.0-rc5/go.mod h1:TrS5PDqw6RPl4q1ISDys/aZZDZ7bglIXXBsvdBv48dM=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/cmd/orb-driver/go.mod
+++ b/cmd/orb-driver/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/square/go-jose/v3 v3.0.0-20200630053402-0a67ce9b0693 // indirect
 	github.com/teserakt-io/golang-ed25519 v0.0.0-20210104091850-3888c087a4c8 // indirect
-	github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230609191801-793cbea60692 // indirect
+	github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230622210745-a1b968a815f7 // indirect
 	github.com/trustbloc/vct v1.0.0-rc5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect

--- a/cmd/orb-driver/go.sum
+++ b/cmd/orb-driver/go.sum
@@ -869,8 +869,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/trustbloc/logutil-go v1.0.0-rc1 h1:rRJbvgQfrlUfyej+mY0nuQJymGqjRW4oZEwKi544F4c=
 github.com/trustbloc/logutil-go v1.0.0-rc1/go.mod h1:JlxT0oZfNKgIlSNtgc001WEeDMxlnAvOM43gNm8DQVc=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230609191801-793cbea60692 h1:8J/lEaFqWfGugvt5u/d5l9OvJoZZpE2XU3bR/U6iKjM=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230609191801-793cbea60692/go.mod h1:jdxAFuorlIwFOGVW6O455/lZqxg2mZkRHNTEolcZdDI=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230622210745-a1b968a815f7 h1:v4Ok2o8bUjTGsS9Vebc0k2DSS2XJWzCVuYOrAA+YFeE=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230622210745-a1b968a815f7/go.mod h1:jdxAFuorlIwFOGVW6O455/lZqxg2mZkRHNTEolcZdDI=
 github.com/trustbloc/vct v1.0.0-rc5 h1:fBn5xFi+D+vtDFu/UncsqwwOIuFfy0KANe470GXriOw=
 github.com/trustbloc/vct v1.0.0-rc5/go.mod h1:TrS5PDqw6RPl4q1ISDys/aZZDZ7bglIXXBsvdBv48dM=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/cmd/orb-server/go.mod
+++ b/cmd/orb-server/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/trustbloc/kms v0.1.9-0.20221024131747-f895f91207f1
 	github.com/trustbloc/logutil-go v1.0.0-rc1
 	github.com/trustbloc/orb v1.0.0-rc3.0.20221101120557-1cf1ce21c938
-	github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230609191801-793cbea60692
+	github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230622210745-a1b968a815f7
 	go.mongodb.org/mongo-driver v1.9.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.40.0
 	go.uber.org/zap v1.23.0

--- a/cmd/orb-server/go.sum
+++ b/cmd/orb-server/go.sum
@@ -938,8 +938,8 @@ github.com/trustbloc/kms v0.1.9-0.20221024131747-f895f91207f1 h1:u617zM5QPsAawgQ
 github.com/trustbloc/kms v0.1.9-0.20221024131747-f895f91207f1/go.mod h1:Vv+mv35QeUo5f+Llm/gsp6x4FgLkLH9dTp4dGK0+aQU=
 github.com/trustbloc/logutil-go v1.0.0-rc1 h1:rRJbvgQfrlUfyej+mY0nuQJymGqjRW4oZEwKi544F4c=
 github.com/trustbloc/logutil-go v1.0.0-rc1/go.mod h1:JlxT0oZfNKgIlSNtgc001WEeDMxlnAvOM43gNm8DQVc=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230609191801-793cbea60692 h1:8J/lEaFqWfGugvt5u/d5l9OvJoZZpE2XU3bR/U6iKjM=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230609191801-793cbea60692/go.mod h1:jdxAFuorlIwFOGVW6O455/lZqxg2mZkRHNTEolcZdDI=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230622210745-a1b968a815f7 h1:v4Ok2o8bUjTGsS9Vebc0k2DSS2XJWzCVuYOrAA+YFeE=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230622210745-a1b968a815f7/go.mod h1:jdxAFuorlIwFOGVW6O455/lZqxg2mZkRHNTEolcZdDI=
 github.com/trustbloc/vct v1.0.0-rc5 h1:fBn5xFi+D+vtDFu/UncsqwwOIuFfy0KANe470GXriOw=
 github.com/trustbloc/vct v1.0.0-rc5/go.mod h1:TrS5PDqw6RPl4q1ISDys/aZZDZ7bglIXXBsvdBv48dM=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/cmd/orb-server/startcmd/params_test.go
+++ b/cmd/orb-server/startcmd/params_test.go
@@ -1448,12 +1448,16 @@ func TestGetOpQueueParameters(t *testing.T) {
 		restoreTaskExpirationEnv := setEnv(t, opQueueTaskExpirationEnvKey, "33s")
 		restoreMaxOperationsToRepostEnv := setEnv(t, opQueueMaxOperationsToRepostEnvKey, "750")
 		restoreOperationLifespanEnv := setEnv(t, opQueueOperationLifespanEnvKey, "60s")
+		restoreMaxContiguousOperationsWithErrEnv := setEnv(t, opQueueMaxContiguousOperationsWithErrEnvKey, "12")
+		restoreMaxContiguousOperationsWithoutErrEnv := setEnv(t, opQueueMaxContiguousOperationsWithoutErrEnvKey, "13")
 
 		defer func() {
 			restoreTaskExpirationEnv()
 			restoreTaskMonitorIntervalEnv()
 			restoreMaxOperationsToRepostEnv()
 			restoreOperationLifespanEnv()
+			restoreMaxContiguousOperationsWithErrEnv()
+			restoreMaxContiguousOperationsWithoutErrEnv()
 		}()
 
 		cmd := getTestCmd(t)
@@ -1477,6 +1481,8 @@ func TestGetOpQueueParameters(t *testing.T) {
 		require.Equal(t, float64(2.5), opQueueParams.RetriesMultiplier)
 		require.Equal(t, 750, opQueueParams.MaxOperationsToRepost)
 		require.Equal(t, 60*time.Second, opQueueParams.OperationLifeSpan)
+		require.Equal(t, 12, opQueueParams.MaxContiguousWithError)
+		require.Equal(t, 13, opQueueParams.MaxContiguousWithoutError)
 	})
 
 	t.Run("Not specified -> default value", func(t *testing.T) {
@@ -1488,6 +1494,8 @@ func TestGetOpQueueParameters(t *testing.T) {
 		require.Equal(t, opQueueDefaultTaskExpiration, opQueueParams.TaskExpiration)
 		require.Equal(t, opQueueDefaultMaxOperationsToRepost, opQueueParams.MaxOperationsToRepost)
 		require.Equal(t, opQueueDefaultOperationLifespan, opQueueParams.OperationLifeSpan)
+		require.Equal(t, opQueueDefaultMaxContiguousOperationsWithErr, opQueueParams.MaxContiguousWithError)
+		require.Equal(t, opQueueDefaultMaxContiguousOperationsWithoutErr, opQueueParams.MaxContiguousWithoutError)
 	})
 
 	t.Run("Invalid task monitor interval value -> error", func(t *testing.T) {

--- a/cmd/orb-server/startcmd/start.go
+++ b/cmd/orb-server/startcmd/start.go
@@ -967,7 +967,7 @@ func startOrbServices(parameters *orbParameters) error {
 		return fmt.Errorf("failed to create writer: %s", err.Error())
 	}
 
-	opQueue, err := opqueue.New(*parameters.opQueueParams, pubSub, storeProviders.provider,
+	opQueue, err := opqueue.New(parameters.opQueueParams, pubSub, storeProviders.provider,
 		taskMgr, expiryService, metrics)
 	if err != nil {
 		return fmt.Errorf("failed to create operation queue: %s", err.Error())
@@ -996,17 +996,15 @@ func startOrbServices(parameters *orbParameters) error {
 			parameters.unpublishedOperations.operationTypes))
 	}
 
-	if parameters.verifyLatestFromAnchorOrigin {
-		operationDecorator := decorator.New(parameters.sidetree.didNamespace,
-			parameters.http.externalEndpoint,
-			opProcessor,
-			endpointClient,
-			remoteresolver.New(httpTransport),
-			metrics,
-		)
+	operationDecorator := decorator.New(parameters.sidetree.didNamespace,
+		parameters.http.externalEndpoint,
+		opProcessor,
+		endpointClient,
+		remoteresolver.New(httpTransport),
+		parameters.verifyLatestFromAnchorOrigin,
+		metrics)
 
-		didDocHandlerOpts = append(didDocHandlerOpts, dochandler.WithOperationDecorator(operationDecorator))
-	}
+	didDocHandlerOpts = append(didDocHandlerOpts, dochandler.WithOperationDecorator(operationDecorator))
 
 	didDocHandler := dochandler.New(
 		parameters.sidetree.didNamespace,

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/stretchr/testify v1.8.2
 	github.com/transparency-dev/merkle v0.0.0-20220208131541-728dc2de1344
 	github.com/trustbloc/logutil-go v1.0.0-rc1
-	github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230609191801-793cbea60692
+	github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230622210745-a1b968a815f7
 	github.com/trustbloc/vct v1.0.0-rc5
 	go.mongodb.org/mongo-driver v1.9.1
 	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.40.0

--- a/go.sum
+++ b/go.sum
@@ -954,8 +954,8 @@ github.com/transparency-dev/merkle v0.0.0-20220208131541-728dc2de1344 h1:KCEn2RI
 github.com/transparency-dev/merkle v0.0.0-20220208131541-728dc2de1344/go.mod h1:B8FIw5LTq6DaULoHsVFRzYIUDkl8yuSwCdZnOZGKL/A=
 github.com/trustbloc/logutil-go v1.0.0-rc1 h1:rRJbvgQfrlUfyej+mY0nuQJymGqjRW4oZEwKi544F4c=
 github.com/trustbloc/logutil-go v1.0.0-rc1/go.mod h1:JlxT0oZfNKgIlSNtgc001WEeDMxlnAvOM43gNm8DQVc=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230609191801-793cbea60692 h1:8J/lEaFqWfGugvt5u/d5l9OvJoZZpE2XU3bR/U6iKjM=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230609191801-793cbea60692/go.mod h1:jdxAFuorlIwFOGVW6O455/lZqxg2mZkRHNTEolcZdDI=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230622210745-a1b968a815f7 h1:v4Ok2o8bUjTGsS9Vebc0k2DSS2XJWzCVuYOrAA+YFeE=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230622210745-a1b968a815f7/go.mod h1:jdxAFuorlIwFOGVW6O455/lZqxg2mZkRHNTEolcZdDI=
 github.com/trustbloc/vct v1.0.0-rc5 h1:fBn5xFi+D+vtDFu/UncsqwwOIuFfy0KANe470GXriOw=
 github.com/trustbloc/vct v1.0.0-rc5/go.mod h1:TrS5PDqw6RPl4q1ISDys/aZZDZ7bglIXXBsvdBv48dM=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/pkg/anchor/multierror/multierror.go
+++ b/pkg/anchor/multierror/multierror.go
@@ -1,0 +1,45 @@
+/*
+   Copyright SecureKey Technologies Inc.
+
+   This file contains software code that is the intellectual property of SecureKey.
+   SecureKey reserves all rights in the code and you may not use it without
+	 written permission from SecureKey.
+*/
+
+package multierror
+
+// Error contains multiple errors mapped by unique suffix.
+type Error struct {
+	errors map[string]error
+}
+
+// New returns a new multi-error which contains a map of errors whose key is the unique DID suffix.
+func New() *Error {
+	return &Error{
+		errors: make(map[string]error),
+	}
+}
+
+// Error implements the error interface.
+func (e *Error) Error() string {
+	// Return an arbitrary error.
+	for _, err := range e.errors {
+		return err.Error()
+	}
+
+	return ""
+}
+
+// Errors returns the map of suffix errors.
+func (e *Error) Errors() map[string]error {
+	if e == nil {
+		return nil
+	}
+
+	return e.errors
+}
+
+// Set sets the error for the given suffix.
+func (e *Error) Set(suffix string, err error) {
+	e.errors[suffix] = err
+}

--- a/pkg/anchor/multierror/multierror_test.go
+++ b/pkg/anchor/multierror/multierror_test.go
@@ -1,0 +1,36 @@
+/*
+   Copyright SecureKey Technologies Inc.
+
+   This file contains software code that is the intellectual property of SecureKey.
+   SecureKey reserves all rights in the code and you may not use it without
+	 written permission from SecureKey.
+*/
+
+package multierror
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestError(t *testing.T) {
+	var err0 *Error
+	require.Empty(t, err0.Errors())
+
+	err1 := New()
+	require.NotNil(t, err1)
+	require.Empty(t, err1.Error())
+
+	err1.Set("1111", errors.New("injected error1"))
+	err1.Set("2222", errors.New("injected error2"))
+
+	err := fmt.Errorf("got some error with cause: %w", err1)
+
+	var mErr *Error
+	require.True(t, errors.As(err, &mErr))
+	require.NotNil(t, mErr)
+	require.Len(t, mErr.Errors(), 2)
+}

--- a/pkg/document/updatehandler/decorator/decorator_test.go
+++ b/pkg/document/updatehandler/decorator/decorator_test.go
@@ -33,7 +33,7 @@ const (
 func TestNew(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		handler := New(namespace, domain, &mocks.OperationProcessor{},
-			&mocks.EndpointClient{}, &mocks.RemoteResolver{}, &orbmocks.MetricsProvider{})
+			&mocks.EndpointClient{}, &mocks.RemoteResolver{}, true, &orbmocks.MetricsProvider{})
 		require.NotNil(t, handler)
 	})
 }
@@ -77,7 +77,7 @@ func TestOperationDecorator_Decorate(t *testing.T) {
 				DocumentMetadata: docMetadata,
 			}, nil)
 
-		handler := New(namespace, domain, processor, endpointClient, remoteResolver, &orbmocks.MetricsProvider{})
+		handler := New(namespace, domain, processor, endpointClient, remoteResolver, true, &orbmocks.MetricsProvider{})
 		require.NotNil(t, handler)
 
 		op, err := handler.Decorate(&operation.Operation{Type: operation.TypeUpdate, UniqueSuffix: suffix})
@@ -120,7 +120,7 @@ func TestOperationDecorator_Decorate(t *testing.T) {
 				DocumentMetadata: docMetadata,
 			}, nil)
 
-		handler := New(namespace, domain, processor, endpointClient, remoteResolver, &orbmocks.MetricsProvider{})
+		handler := New(namespace, domain, processor, endpointClient, remoteResolver, true, &orbmocks.MetricsProvider{})
 		require.NotNil(t, handler)
 
 		op, err := handler.Decorate(&operation.Operation{Type: operation.TypeUpdate, UniqueSuffix: suffix})
@@ -159,7 +159,7 @@ func TestOperationDecorator_Decorate(t *testing.T) {
 		remoteResolver := &mocks.RemoteResolver{}
 		remoteResolver.ResolveDocumentFromResolutionEndpointsReturns(nil, fmt.Errorf("remote resolver error"))
 
-		handler := New(namespace, domain, processor, endpointClient, remoteResolver, &orbmocks.MetricsProvider{})
+		handler := New(namespace, domain, processor, endpointClient, remoteResolver, true, &orbmocks.MetricsProvider{})
 		require.NotNil(t, handler)
 
 		op, err := handler.Decorate(&operation.Operation{
@@ -174,7 +174,7 @@ func TestOperationDecorator_Decorate(t *testing.T) {
 
 	t.Run("success - create operations", func(t *testing.T) {
 		handler := New(namespace, domain, &mocks.OperationProcessor{},
-			&mocks.EndpointClient{}, &mocks.RemoteResolver{}, &orbmocks.MetricsProvider{})
+			&mocks.EndpointClient{}, &mocks.RemoteResolver{}, true, &orbmocks.MetricsProvider{})
 		require.NotNil(t, handler)
 
 		op, err := handler.Decorate(&operation.Operation{Type: operation.TypeCreate, UniqueSuffix: suffix})
@@ -193,7 +193,7 @@ func TestOperationDecorator_Decorate(t *testing.T) {
 
 		endpointClient := &mocks.EndpointClient{}
 
-		handler := New(namespace, domain, processor, endpointClient, &mocks.RemoteResolver{}, &orbmocks.MetricsProvider{})
+		handler := New(namespace, domain, processor, endpointClient, &mocks.RemoteResolver{}, true, &orbmocks.MetricsProvider{})
 		require.NotNil(t, handler)
 
 		op, err := handler.Decorate(&operation.Operation{Type: operation.TypeUpdate, UniqueSuffix: suffix})
@@ -238,7 +238,7 @@ func TestOperationDecorator_Decorate(t *testing.T) {
 				DocumentMetadata: docMetadata,
 			}, nil)
 
-		handler := New(namespace, domain, processor, endpointClient, remoteResolver, &orbmocks.MetricsProvider{})
+		handler := New(namespace, domain, processor, endpointClient, remoteResolver, true, &orbmocks.MetricsProvider{})
 		require.NotNil(t, handler)
 
 		op, err := handler.Decorate(&operation.Operation{Type: operation.TypeUpdate, UniqueSuffix: suffix})
@@ -284,7 +284,7 @@ func TestOperationDecorator_Decorate(t *testing.T) {
 				DocumentMetadata: docMetadata,
 			}, nil)
 
-		handler := New(namespace, domain, processor, endpointClient, remoteResolver, &orbmocks.MetricsProvider{})
+		handler := New(namespace, domain, processor, endpointClient, remoteResolver, true, &orbmocks.MetricsProvider{})
 		require.NotNil(t, handler)
 
 		op, err := handler.Decorate(&operation.Operation{Type: operation.TypeUpdate, UniqueSuffix: suffix})
@@ -306,7 +306,7 @@ func TestOperationDecorator_Decorate(t *testing.T) {
 		endpointClient := &mocks.EndpointClient{}
 		endpointClient.GetEndpointReturns(nil, fmt.Errorf("endpoint client error"))
 
-		handler := New(namespace, domain, processor, endpointClient, &mocks.RemoteResolver{}, &orbmocks.MetricsProvider{})
+		handler := New(namespace, domain, processor, endpointClient, &mocks.RemoteResolver{}, true, &orbmocks.MetricsProvider{})
 		require.NotNil(t, handler)
 
 		op, err := handler.Decorate(&operation.Operation{Type: operation.TypeUpdate, UniqueSuffix: suffix})
@@ -319,7 +319,7 @@ func TestOperationDecorator_Decorate(t *testing.T) {
 		processor.ResolveReturns(nil, fmt.Errorf("operation processor error"))
 
 		handler := New(namespace, domain, processor, &mocks.EndpointClient{},
-			&mocks.RemoteResolver{}, &orbmocks.MetricsProvider{})
+			&mocks.RemoteResolver{}, true, &orbmocks.MetricsProvider{})
 		require.NotNil(t, handler)
 
 		op, err := handler.Decorate(&operation.Operation{UniqueSuffix: suffix})
@@ -337,7 +337,7 @@ func TestOperationDecorator_Decorate(t *testing.T) {
 		processor.ResolveReturns(rm, nil)
 
 		handler := New(namespace, domain, processor, &mocks.EndpointClient{},
-			&mocks.RemoteResolver{}, &orbmocks.MetricsProvider{})
+			&mocks.RemoteResolver{}, true, &orbmocks.MetricsProvider{})
 		require.NotNil(t, handler)
 
 		op, err := handler.Decorate(&operation.Operation{UniqueSuffix: suffix})
@@ -383,7 +383,7 @@ func TestOperationDecorator_Decorate(t *testing.T) {
 				DocumentMetadata: docMetadata,
 			}, nil)
 
-		handler := New(namespace, domain, processor, endpointClient, remoteResolver, &orbmocks.MetricsProvider{})
+		handler := New(namespace, domain, processor, endpointClient, remoteResolver, true, &orbmocks.MetricsProvider{})
 		require.NotNil(t, handler)
 
 		op, err := handler.Decorate(&operation.Operation{UniqueSuffix: suffix})
@@ -428,7 +428,7 @@ func TestOperationDecorator_Decorate(t *testing.T) {
 				DocumentMetadata: docMetadata,
 			}, nil)
 
-		handler := New(namespace, domain, processor, endpointClient, remoteResolver, &orbmocks.MetricsProvider{})
+		handler := New(namespace, domain, processor, endpointClient, remoteResolver, true, &orbmocks.MetricsProvider{})
 		require.NotNil(t, handler)
 
 		op, err := handler.Decorate(&operation.Operation{UniqueSuffix: "suffix"})
@@ -470,7 +470,7 @@ func TestOperationDecorator_Decorate(t *testing.T) {
 				DocumentMetadata: docMetadata,
 			}, nil)
 
-		handler := New(namespace, domain, processor, endpointClient, remoteResolver, &orbmocks.MetricsProvider{})
+		handler := New(namespace, domain, processor, endpointClient, remoteResolver, true, &orbmocks.MetricsProvider{})
 		require.NotNil(t, handler)
 
 		op, err := handler.Decorate(&operation.Operation{UniqueSuffix: "suffix"})
@@ -508,7 +508,7 @@ func TestOperationDecorator_Decorate(t *testing.T) {
 				DocumentMetadata: docMetadata,
 			}, nil)
 
-		handler := New(namespace, domain, processor, endpointClient, remoteResolver, &orbmocks.MetricsProvider{})
+		handler := New(namespace, domain, processor, endpointClient, remoteResolver, true, &orbmocks.MetricsProvider{})
 		require.NotNil(t, handler)
 
 		op, err := handler.Decorate(&operation.Operation{UniqueSuffix: "suffix"})

--- a/pkg/pubsub/amqp/amqppubsub.go
+++ b/pkg/pubsub/amqp/amqppubsub.go
@@ -459,7 +459,7 @@ func (p *PubSub) redeliver(msg *message.Message, queue string, redeliveryAttempt
 			return fmt.Errorf("publish message to queue [%s]: %w", queue, err)
 		}
 
-		logger.Info("Successfully posted message for redelivery", logfields.WithMessageID(msg.UUID),
+		logger.Debug("Successfully posted message for redelivery", logfields.WithMessageID(msg.UUID),
 			log.WithTopic(queue), logfields.WithDeliveryAttempts(redeliveryAttempts))
 
 		return nil

--- a/test/bdd/features/did-orb.feature
+++ b/test/bdd/features/did-orb.feature
@@ -552,6 +552,12 @@ Feature:
 
     Then client verifies resolved document
 
+  @orb_concurrent_create_update_unpublished
+  Scenario: Concurrent create/update unpublished
+    When client sends request to "https://orb.domain1.com/sidetree/v1/operations" to create 200 DID documents and update them with key ID "newkey_1_1" using 1 concurrent requests
+    And we wait up to "2m" for 200 DID documents to be created and updated
+    Then client sends request to "https://orb.domain2.com/sidetree/v1/identifiers" to verify the DID documents that were created and updated with key "newkey_1_1"
+
   @local_cas
   @enable_update_document_store
   Scenario: various 'failure' scenarios for unpublished/published stores

--- a/test/bdd/fixtures/docker-compose.yml
+++ b/test/bdd/fixtures/docker-compose.yml
@@ -157,6 +157,8 @@ services:
       # The lifespan of an anchor reference in PENDING state.
       # Default value: 24h (24 hours)
       - ANCHOR_REF_PENDING_RECORD_LIFESPAN=5m
+#      - UNPUBLISHED_OPERATION_STORE_ENABLED=true
+#      - UNPUBLISHED_OPERATION_STORE_OPERATION_TYPES=create,update
     ports:
       - 48326:443
       - 48327:48327
@@ -305,6 +307,8 @@ services:
       - INCLUDE_PUBLISHED_OPERATIONS_IN_METADATA=true
       - ORB_REQUEST_TOKENS=vct-read=vctread,vct-write=vctwrite
       - VCT_LOG_ENTRIES_STORE_ENABLED=true
+#      - UNPUBLISHED_OPERATION_STORE_ENABLED=true
+#      - UNPUBLISHED_OPERATION_STORE_OPERATION_TYPES=create,update
     ports:
       - 48526:443
       - 48527:48527

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/tidwall/gjson v1.7.4
 	github.com/trustbloc/orb v1.0.0-rc7
-	github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230609191801-793cbea60692
+	github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230622210745-a1b968a815f7
 )
 
 require (

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -1156,8 +1156,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/trustbloc/logutil-go v1.0.0-rc1 h1:rRJbvgQfrlUfyej+mY0nuQJymGqjRW4oZEwKi544F4c=
 github.com/trustbloc/logutil-go v1.0.0-rc1/go.mod h1:JlxT0oZfNKgIlSNtgc001WEeDMxlnAvOM43gNm8DQVc=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230609191801-793cbea60692 h1:8J/lEaFqWfGugvt5u/d5l9OvJoZZpE2XU3bR/U6iKjM=
-github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230609191801-793cbea60692/go.mod h1:jdxAFuorlIwFOGVW6O455/lZqxg2mZkRHNTEolcZdDI=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230622210745-a1b968a815f7 h1:v4Ok2o8bUjTGsS9Vebc0k2DSS2XJWzCVuYOrAA+YFeE=
+github.com/trustbloc/sidetree-core-go v1.0.0-rc5.0.20230622210745-a1b968a815f7/go.mod h1:jdxAFuorlIwFOGVW6O455/lZqxg2mZkRHNTEolcZdDI=
 github.com/trustbloc/vct v1.0.0-rc5 h1:fBn5xFi+D+vtDFu/UncsqwwOIuFfy0KANe470GXriOw=
 github.com/trustbloc/vct v1.0.0-rc5/go.mod h1:TrS5PDqw6RPl4q1ISDys/aZZDZ7bglIXXBsvdBv48dM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=


### PR DESCRIPTION
…re published

Publish an "Update" operation to the queue with a delay if a "Create" operation with the same suffix has not yet been published.

Also de-fragment the operation queue such that operations that have previously failed are grouped contiguously and operations that have no error (thus far) are also grouped contiguously. Grouping (de-fragmenting) the operation queue provides a greater chance that valid operations are successfully processed and are not failed just because the batch failed due to a single "bad" operation.

closes #1583